### PR TITLE
feat: Add OpenClaw tool mappings and missing CC tools

### DIFF
--- a/src/cc-template-data.json
+++ b/src/cc-template-data.json
@@ -857,6 +857,137 @@
         ],
         "additionalProperties": false
       }
+    },
+    {
+      "name": "Browser",
+      "description": "Control a web browser to navigate websites, take screenshots, and interact with web pages.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": [
+              "open",
+              "navigate",
+              "click",
+              "type",
+              "screenshot",
+              "snapshot",
+              "close"
+            ]
+          },
+          "url": {
+            "type": "string"
+          },
+          "selector": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "action"
+        ]
+      }
+    },
+    {
+      "name": "TodoRead",
+      "description": "Read the current todo list.",
+      "input_schema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "NotebookRead",
+      "description": "Read a Jupyter notebook file.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "notebook_path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "notebook_path"
+        ]
+      }
+    },
+    {
+      "name": "MCPListTools",
+      "description": "List all available tools from connected MCP servers.",
+      "input_schema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "MCPCallTool",
+      "description": "Call a tool from an MCP server.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "server": {
+            "type": "string"
+          },
+          "tool": {
+            "type": "string"
+          },
+          "arguments": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "server",
+          "tool",
+          "arguments"
+        ]
+      }
+    },
+    {
+      "name": "TaskCreate",
+      "description": "Create a new task.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "in_progress",
+              "done"
+            ]
+          }
+        },
+        "required": [
+          "description"
+        ]
+      }
+    },
+    {
+      "name": "TaskUpdate",
+      "description": "Update an existing task.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      }
     }
   ],
   "tool_names": [

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -70,6 +70,21 @@ const TOOL_MAP: Record<string, ToolMapping> = {
   browse: { ccTool: 'WebFetch', translateArgs: (a) => ({ url: a.url || '' }) },
   notebook: { ccTool: 'NotebookEdit' },
   notebook_edit: { ccTool: 'NotebookEdit' },
+  // OpenClaw tool mappings
+  browser: { ccTool: 'Browser', translateArgs: (a) => ({ action: a.action || 'open', url: a.url, selector: a.selector, text: a.text }) },
+  message: { ccTool: 'AskUserQuestion', translateArgs: (a) => ({ question: a.message || a.content || (a.to ? 'Message to ' + a.to + ': ' + (a.message || a.content || '') : a.message || a.content || '') }) },
+  todo_read: { ccTool: 'TodoRead' },
+  todo_write: { ccTool: 'TodoWrite', translateArgs: (a) => ({ todos: a.todos || [] }) },
+  mcp_list: { ccTool: 'MCPListTools' },
+  mcp_call: { ccTool: 'MCPCallTool', translateArgs: (a) => ({ server: a.server || '', tool: a.tool || a.name || '', arguments: a.arguments || a.args || {} }) },
+  mcp_list_tools: { ccTool: 'MCPListTools' },
+  mcp_call_tool: { ccTool: 'MCPCallTool', translateArgs: (a) => ({ server: a.server || '', tool: a.tool || a.name || '', arguments: a.arguments || a.args || {} }) },
+  task_create: { ccTool: 'TaskCreate', translateArgs: (a) => ({ description: a.description || a.name || '', status: a.status || 'pending' }) },
+  task_update: { ccTool: 'TaskUpdate', translateArgs: (a) => ({ id: a.id, status: a.status, description: a.description }) },
+  enter_plan_mode: { ccTool: 'EnterPlanMode' },
+  exit_plan_mode: { ccTool: 'ExitPlanMode' },
+  enter_worktree: { ccTool: 'EnterWorktree', translateArgs: (a) => ({ path: a.path }) },
+  exit_worktree: { ccTool: 'ExitWorktree' },
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR adds missing Claude Code tool definitions and OpenClaw-specific tool mappings to enable full tool compatibility when routing requests through Dario.

## Changes

### New Tool Definitions (cc-template-data.json)
- **Browser** - Browser control for web automation
- **TodoRead** - Read todo list
- **NotebookRead** - Read Jupyter notebooks  
- **MCPListTools** - List MCP server tools
- **MCPCallTool** - Call MCP server tools
- **TaskCreate** - Create tasks
- **TaskUpdate** - Update tasks

### New Tool Mappings (cc-template.ts)
Added mappings for OpenClaw tools:
- `browser` → Browser
- `message` → AskUserQuestion
- `todo_read/write` → TodoRead/TodoWrite
- `mcp_list/call` → MCPListTools/MCPCallTool
- `mcp_list_tools/mcp_call_tool` → MCPListTools/MCPCallTool
- `task_create/update` → TaskCreate/TaskUpdate
- `enter/exit_plan_mode` → EnterPlanMode/ExitPlanMode
- `enter/exit_worktree` → EnterWorktree/ExitWorktree

## Motivation

When OpenClaw routes requests through Dario to Claude Code, tool calls like `browser`, `message`, `process`, etc. were being stripped or misrouted because the CC template only had 11 tool definitions while Claude Code supports 25+. This caused a mismatch between the system prompt (which mentions all tools) and the actual tool list sent to Claude.

## Testing

Tested with OpenClaw smart-router → Dario → Claude Code flow. Tool calls now work correctly for all mapped tools.

## Related

Fixes tool call parsing mismatch reported in OpenClaw deployments using Dario as the Claude provider.