### PR TITLE
v3.29.0 — MUX_COORD_SECRET auth lane for mux lender mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.28.0",
+  "version": "3.29.0",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Bumps `@askalf/dario` to **v3.29.0**.
- Cuts release on accumulated master changes since v3.28.0 (b2668f3..13da309), headlined by the **MUX_COORD_SECRET** auth lane in `proxy.ts` — a new production auth path that lets the mux envelope-seal gateway forward borrow requests to a lender's local dario without needing the lender's API key.

## What's in this release

- **feat(proxy): MUX_COORD_SECRET auth lane** — second auth lane alongside `DARIO_API_KEY` / `Authorization: Bearer`. Extracted `authenticateRequest(headers, apiKeyBuf, mcsBuf)`, added `x-mux-coord-secret` to CORS allowed headers, startup banner enumerates both lanes. 22-assertion unit test (`test/mux-coord-secret.mjs`) covers match / Bearer / wrong / missing / short / cross-lane rejection / dual-lane both-and-either / array-valued header / empty string. (#48 squash)
- **infra(cc-drift-watch)**: repair against CC v2.1.114 native-binary layout (fetch platform package from `optionalDependencies` + scan the Bun-packed native binary), scope-literal scan, live authorize-URL probe with CF-challenge-aware classifier. (#48 squash)
- **chore**: drop orphan manual scripts `test/claims-test.mjs` + `test/stealth-deep.mjs` (superseded by automated suites). (082610c)
- **docs**: README refreshed to reflect v3.20 – v3.28 state (MCP, sub-agent, fingerprint axes, session rotation). (803118d)

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 48/48 pass locally
- [ ] CI green on this PR
- [ ] After merge: tag `v3.29.0` → GitHub release → `publish.yml` publishes to npm with provenance
- [ ] `npm view @askalf/dario version` reports `3.29.0`