### PR TITLE
docs: restore original WHY on dev-client-id defensive check

### DIFF
--- a/src/cc-oauth-detect.ts
+++ b/src/cc-oauth-detect.ts
@@ -225,9 +225,11 @@ export function scanBinaryForOAuthConfig(buf: Buffer): Omit<DetectedOAuthConfig,
   if (!cidMatch || !cidMatch[1]) return null;
   const clientId = cidMatch[1];
 
-  // Defensive: if we somehow matched the dev client_id instead of the prod
-  // block, treat the scan as failed and fall back rather than authenticating
-  // against the wrong Anthropic OAuth client.
+  // Defensive: if we somehow matched the dev client_id, reject — the
+  // anchor should have put us in the prod block, but this guards against
+  // the block being laid out in an unexpected order across builds. Failing
+  // the scan and falling back is safer than authenticating against the
+  // wrong Anthropic OAuth client.
   if (clientId === '22422756-60c9-4084-8eb7-27705fd5cf9a') return null;
 
   let authorizeUrl = FALLBACK.authorizeUrl;


### PR DESCRIPTION
Follow-up nit from #47 review. Reviewer asked to restore two deleted comments in `scanBinaryForOAuthConfig`; the window-slice one came back verbatim but this one got rewritten in the resubmit. Restoring the original wording because it names the specific failure mode the guard exists for — prod config block laid out in an unexpected order across CC builds — which is load-bearing for anyone debugging a future scan regression.

Kept the consequence clause from the rewrite ("falling back is safer than authenticating against the wrong Anthropic OAuth client") so the comment reads start-to-finish instead of just starting with the invariant. Net +2 lines.

Comment-only change. No test or behavior impact.