### PR TITLE
oauth: add manual override escape hatch for rotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,12 @@ A version marker (`<!-- dario-sub-agent-version: X -->`) embedded in the markdow
 | `DARIO_NO_BUN` | Disable automatic Bun relaunch | unset |
 | `DARIO_MIN_INTERVAL_MS` | Legacy name for `DARIO_PACE_MIN_MS`. Still honored; new name wins when both are set. | — |
 | `DARIO_CC_PATH` | Override path to the Claude Code binary for OAuth detection | auto-detect |
+| `DARIO_OAUTH_CLIENT_ID` | Override the detected Claude OAuth client id as an emergency escape hatch | unset |
+| `DARIO_OAUTH_AUTHORIZE_URL` | Override the detected Claude OAuth authorize URL | unset |
+| `DARIO_OAUTH_TOKEN_URL` | Override the detected Claude OAuth token URL | unset |
+| `DARIO_OAUTH_SCOPES` | Override the detected Claude OAuth scopes | unset |
+| `DARIO_OAUTH_OVERRIDE_PATH` | Override file path for JSON OAuth overrides | `~/.dario/oauth-config.override.json` |
+| `DARIO_OAUTH_DISABLE_OVERRIDE=1` | Ignore env/file OAuth overrides entirely | unset |
 
 ---
 
@@ -643,6 +649,19 @@ Yes — anything that speaks the OpenAI Chat Completions API. Groq, OpenRouter, 
 
 **What happens when Anthropic rotates the OAuth config?**
 Dario auto-detects OAuth config from the installed Claude Code binary. When CC ships a new version with rotated values, dario picks them up on the next run. Cache at `~/.dario/cc-oauth-cache-v4.json`, keyed by the CC binary fingerprint. (Path bumped from v3 → v4 in v3.19.4 to invalidate stale caches across the scope-list change that broke the authorize flow between CC v2.1.104 and v2.1.107.)
+
+If Anthropic rotates the values before the detector is updated, you can temporarily override any field with env vars (`DARIO_OAUTH_CLIENT_ID`, `DARIO_OAUTH_AUTHORIZE_URL`, `DARIO_OAUTH_TOKEN_URL`, `DARIO_OAUTH_SCOPES`) or by writing `~/.dario/oauth-config.override.json`:
+
+```json
+{
+  "clientId": "...",
+  "authorizeUrl": "https://claude.com/cai/oauth/authorize",
+  "tokenUrl": "https://platform.claude.com/v1/oauth/token",
+  "scopes": "user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload"
+}
+```
+
+Env vars win over the file. Set `DARIO_OAUTH_DISABLE_OVERRIDE=1` to force pure auto-detection.
 
 **What happens when Anthropic changes the CC request template?**
 Dario extracts the live request template from your installed Claude Code binary on startup — the system prompt, tool schemas, user-agent, beta flags, header insertion order, static header values, and top-level request-body key order — and uses those to replay requests instead of a version pinned into dario itself. When CC ships a new version with a tweaked template, the next `dario proxy` run picks it up automatically. Drift detection forces a refresh when the installed CC version changes under dario, and the nightly `cc-drift-watch` workflow catches upstream rotations (client_id, URLs, tool set, version) the day they ship on npm.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,6 +61,7 @@ The following are in scope for security reports:
 - Anchors on `BASE_API_URL:"https://api.anthropic.com"` — a literal that only appears inside CC's prod OAuth config block — then extracts `CLIENT_ID`, `CLAUDE_AI_AUTHORIZE_URL`, `TOKEN_URL`, and the full scope list from the surrounding object. A defensive check rejects any scan result matching a known-dead internal `client_id` (see the v3.4.3 CHANGELOG entry for the history).
 - Cached at `~/.dario/cc-oauth-cache-v4.json` keyed by binary fingerprint (sha256 of first 64KB + size + mtime); cache file contains no secrets. Cache version bumped to `-v4` in v3.19.4 when Anthropic's authorize endpoint stopped accepting `org:create_api_key` for the CC client_id — prior caches are invalidated automatically on upgrade.
 - Falls back to hardcoded known-good Claude Code 2.1.104 prod config values if no binary is found or scanning fails — dario remains functional.
+- Optional operator-supplied overrides may be provided via `DARIO_OAUTH_CLIENT_ID`, `DARIO_OAUTH_AUTHORIZE_URL`, `DARIO_OAUTH_TOKEN_URL`, `DARIO_OAUTH_SCOPES`, or `~/.dario/oauth-config.override.json`. These override files contain public OAuth metadata only, not bearer tokens or API secrets.
 
 ### Proxy Security
 - **Binds to `127.0.0.1` by default** — loopback-only and unreachable from other machines.

--- a/src/cc-oauth-detect.ts
+++ b/src/cc-oauth-detect.ts
@@ -216,6 +216,8 @@ export function scanBinaryForOAuthConfig(buf: Buffer): Omit<DetectedOAuthConfig,
   if (anchorIdx === -1) return null;
 
   const windowStart = anchorIdx;
+  // The prod config object is laid out roughly as one line of minified JS.
+  // Take a generous window to be safe across minifier differences.
   const windowEnd = Math.min(buf.length, anchorIdx + 2048);
   const prodBlock = buf.slice(windowStart, windowEnd).toString('latin1');
 
@@ -223,6 +225,9 @@ export function scanBinaryForOAuthConfig(buf: Buffer): Omit<DetectedOAuthConfig,
   if (!cidMatch || !cidMatch[1]) return null;
   const clientId = cidMatch[1];
 
+  // Defensive: if we somehow matched the dev client_id instead of the prod
+  // block, treat the scan as failed and fall back rather than authenticating
+  // against the wrong Anthropic OAuth client.
   if (clientId === '22422756-60c9-4084-8eb7-27705fd5cf9a') return null;
 
   let authorizeUrl = FALLBACK.authorizeUrl;
@@ -230,7 +235,7 @@ export function scanBinaryForOAuthConfig(buf: Buffer): Omit<DetectedOAuthConfig,
   if (authMatch && authMatch[1]) authorizeUrl = authMatch[1];
 
   let tokenUrl = FALLBACK.tokenUrl;
-  const tokenMatch = /TOKEN_URL\s*:\s*"(https:\/\/[^\"]*\/oauth\/token[^\"]*)"/.exec(prodBlock);
+  const tokenMatch = /TOKEN_URL\s*:\s*"(https:\/\/[^"]*\/oauth\/token[^"]*)"/.exec(prodBlock);
   if (tokenMatch && tokenMatch[1]) tokenUrl = tokenMatch[1];
 
   // Scopes are NOT detected from the binary. Previous versions of this

--- a/src/cc-oauth-detect.ts
+++ b/src/cc-oauth-detect.ts
@@ -32,6 +32,10 @@
  * startup only re-scans when the user upgrades Claude Code. The cache suffix
  * is bumped each time scope handling or the fallback config changes, so
  * upgrading dario picks up the new values without a manual cache clear.
+ *
+ * Escape hatch: if Anthropic rotates OAuth metadata before the detector is
+ * updated, operators can temporarily override any detected value via env vars
+ * or ~/.dario/oauth-config.override.json.
  */
 
 import { readFile, writeFile, mkdir, stat, open as openFile } from 'node:fs/promises';
@@ -45,10 +49,13 @@ export interface DetectedOAuthConfig {
   authorizeUrl: string;
   tokenUrl: string;
   scopes: string;
-  source: 'detected' | 'cached' | 'fallback';
+  source: 'detected' | 'cached' | 'fallback' | 'override';
   ccPath?: string;
   ccHash?: string;
 }
+
+type OAuthFields = Pick<DetectedOAuthConfig, 'clientId' | 'authorizeUrl' | 'tokenUrl' | 'scopes'>;
+type OAuthOverride = Partial<OAuthFields>;
 
 // Last-resort fallback if CC binary can't be found or scanned.
 // These values are the CC v2.1.104 PROD OAuth config, extracted from
@@ -82,6 +89,7 @@ export const FALLBACK_FOR_DRIFT_CHECK: Readonly<DetectedOAuthConfig> = FALLBACK;
 // Anthropic now rejects (dario #42). On upgrade, users regenerate the cache
 // with the new FALLBACK scopes automatically — no manual clear required.
 const CACHE_PATH = join(homedir(), '.dario', 'cc-oauth-cache-v4.json');
+const DEFAULT_OVERRIDE_PATH = join(homedir(), '.dario', 'oauth-config.override.json');
 
 function candidatePaths(): string[] {
   const home = homedir();
@@ -113,6 +121,63 @@ function findCCBinary(): string | null {
     if (existsSync(p)) return p;
   }
   return null;
+}
+
+function isOverrideDisabled(): boolean {
+  return process.env['DARIO_OAUTH_DISABLE_OVERRIDE'] === '1';
+}
+
+function getOverridePath(): string {
+  return process.env['DARIO_OAUTH_OVERRIDE_PATH']?.trim() || DEFAULT_OVERRIDE_PATH;
+}
+
+function cleanOverrideValue(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function normalizeOverride(parsed: Record<string, unknown>): OAuthOverride | null {
+  const override: OAuthOverride = {};
+  const clientId = typeof parsed.clientId === 'string' ? cleanOverrideValue(parsed.clientId) : undefined;
+  const authorizeUrl = typeof parsed.authorizeUrl === 'string' ? cleanOverrideValue(parsed.authorizeUrl) : undefined;
+  const tokenUrl = typeof parsed.tokenUrl === 'string' ? cleanOverrideValue(parsed.tokenUrl) : undefined;
+  const scopes = typeof parsed.scopes === 'string' ? cleanOverrideValue(parsed.scopes) : undefined;
+
+  if (clientId) override.clientId = clientId;
+  if (authorizeUrl) override.authorizeUrl = authorizeUrl;
+  if (tokenUrl) override.tokenUrl = tokenUrl;
+  if (scopes) override.scopes = scopes;
+
+  return Object.keys(override).length > 0 ? override : null;
+}
+
+async function loadManualOverride(): Promise<OAuthOverride | null> {
+  if (isOverrideDisabled()) return null;
+
+  const envOverride = normalizeOverride({
+    clientId: process.env['DARIO_OAUTH_CLIENT_ID'],
+    authorizeUrl: process.env['DARIO_OAUTH_AUTHORIZE_URL'],
+    tokenUrl: process.env['DARIO_OAUTH_TOKEN_URL'],
+    scopes: process.env['DARIO_OAUTH_SCOPES'],
+  });
+  if (envOverride) return envOverride;
+
+  try {
+    const raw = await readFile(getOverridePath(), 'utf-8');
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    return normalizeOverride(parsed);
+  } catch {
+    return null;
+  }
+}
+
+function applyManualOverride(config: DetectedOAuthConfig, override: OAuthOverride | null): DetectedOAuthConfig {
+  if (!override) return config;
+  return {
+    ...config,
+    ...override,
+    source: 'override',
+  };
 }
 
 /**
@@ -150,8 +215,6 @@ export function scanBinaryForOAuthConfig(buf: Buffer): Omit<DetectedOAuthConfig,
   const anchorIdx = buf.indexOf(anchor);
   if (anchorIdx === -1) return null;
 
-  // The prod config object is laid out roughly as one line of minified JS.
-  // Take a generous window to be safe across minifier differences.
   const windowStart = anchorIdx;
   const windowEnd = Math.min(buf.length, anchorIdx + 2048);
   const prodBlock = buf.slice(windowStart, windowEnd).toString('latin1');
@@ -160,9 +223,6 @@ export function scanBinaryForOAuthConfig(buf: Buffer): Omit<DetectedOAuthConfig,
   if (!cidMatch || !cidMatch[1]) return null;
   const clientId = cidMatch[1];
 
-  // Defensive: if we somehow matched the dev client_id, reject — the
-  // anchor should have put us in the prod block, but this guards against
-  // the block being laid out in an unexpected order across builds.
   if (clientId === '22422756-60c9-4084-8eb7-27705fd5cf9a') return null;
 
   let authorizeUrl = FALLBACK.authorizeUrl;
@@ -170,7 +230,7 @@ export function scanBinaryForOAuthConfig(buf: Buffer): Omit<DetectedOAuthConfig,
   if (authMatch && authMatch[1]) authorizeUrl = authMatch[1];
 
   let tokenUrl = FALLBACK.tokenUrl;
-  const tokenMatch = /TOKEN_URL\s*:\s*"(https:\/\/[^"]*\/oauth\/token[^"]*)"/.exec(prodBlock);
+  const tokenMatch = /TOKEN_URL\s*:\s*"(https:\/\/[^\"]*\/oauth\/token[^\"]*)"/.exec(prodBlock);
   if (tokenMatch && tokenMatch[1]) tokenUrl = tokenMatch[1];
 
   // Scopes are NOT detected from the binary. Previous versions of this
@@ -221,26 +281,25 @@ export async function detectCCOAuthConfig(): Promise<DetectedOAuthConfig> {
   if (memoized) return memoized;
 
   try {
+    const manualOverride = await loadManualOverride();
     const ccPath = findCCBinary();
     if (!ccPath) {
-      memoized = FALLBACK;
+      memoized = applyManualOverride(FALLBACK, manualOverride);
       return memoized;
     }
 
     const hash = await fingerprintBinary(ccPath);
 
-    // Check cache
     const cached = await loadCache();
     if (cached && cached.hash === hash) {
-      memoized = { ...cached.config, source: 'cached', ccPath, ccHash: hash };
+      memoized = applyManualOverride({ ...cached.config, source: 'cached', ccPath, ccHash: hash }, manualOverride);
       return memoized;
     }
 
-    // Read binary and scan
     const buf = await readFile(ccPath);
     const scanned = scanBinaryForOAuthConfig(buf);
     if (!scanned) {
-      memoized = { ...FALLBACK, ccPath, ccHash: hash };
+      memoized = applyManualOverride({ ...FALLBACK, ccPath, ccHash: hash }, manualOverride);
       return memoized;
     }
 
@@ -252,10 +311,10 @@ export async function detectCCOAuthConfig(): Promise<DetectedOAuthConfig> {
     };
 
     await saveCache(hash, detected);
-    memoized = detected;
+    memoized = applyManualOverride(detected, manualOverride);
     return memoized;
   } catch {
-    memoized = FALLBACK;
+    memoized = applyManualOverride(FALLBACK, await loadManualOverride());
     return memoized;
   }
 }

--- a/test/oauth-detector.mjs
+++ b/test/oauth-detector.mjs
@@ -22,20 +22,36 @@
  */
 
 import { detectCCOAuthConfig, _resetDetectorCache } from '../dist/cc-oauth-detect.js';
-import { readFile, unlink } from 'node:fs/promises';
+import { readFile, unlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { homedir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 
 const CACHE_PATH = join(homedir(), '.dario', 'cc-oauth-cache-v4.json');
 const PROD_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
 const DEAD_DEV_CLIENT_ID = '22422756-60c9-4084-8eb7-27705fd5cf9a';
+const OVERRIDE_CLIENT_ID = '11111111-2222-4333-8444-555555555555';
 
 async function main() {
   console.log('═══════════════════════════════════════════════════════════');
   console.log('  DARIO — CC OAuth AUTO-DETECTOR E2E TEST');
   console.log('═══════════════════════════════════════════════════════════\n');
 
-  // Clean slate
+  const previousDisable = process.env.DARIO_OAUTH_DISABLE_OVERRIDE;
+  const previousOverridePath = process.env.DARIO_OAUTH_OVERRIDE_PATH;
+  const previousOverrideClientId = process.env.DARIO_OAUTH_CLIENT_ID;
+  const previousOverrideAuthorizeUrl = process.env.DARIO_OAUTH_AUTHORIZE_URL;
+  const previousOverrideTokenUrl = process.env.DARIO_OAUTH_TOKEN_URL;
+  const previousOverrideScopes = process.env.DARIO_OAUTH_SCOPES;
+
+  // Clean slate. Force pure auto-detection for the baseline checks so a
+  // local operator override file cannot make this test flaky.
+  process.env.DARIO_OAUTH_DISABLE_OVERRIDE = '1';
+  delete process.env.DARIO_OAUTH_OVERRIDE_PATH;
+  delete process.env.DARIO_OAUTH_CLIENT_ID;
+  delete process.env.DARIO_OAUTH_AUTHORIZE_URL;
+  delete process.env.DARIO_OAUTH_TOKEN_URL;
+  delete process.env.DARIO_OAUTH_SCOPES;
+
   try { await unlink(CACHE_PATH); } catch {}
   _resetDetectorCache();
 
@@ -161,6 +177,22 @@ async function main() {
     pass: cfg2.clientId === cfg1.clientId,
   });
 
+  // Override-file escape hatch test
+  console.log('→ Running detector with manual override file...\n');
+  const overridePath = join(tmpdir(), `dario-oauth-override-${process.pid}.json`);
+  await writeFile(overridePath, JSON.stringify({ clientId: OVERRIDE_CLIENT_ID }, null, 2));
+  process.env.DARIO_OAUTH_DISABLE_OVERRIDE = '0';
+  process.env.DARIO_OAUTH_OVERRIDE_PATH = overridePath;
+  _resetDetectorCache();
+  const cfg3 = await detectCCOAuthConfig();
+  console.log(`  source: ${cfg3.source}`);
+  console.log(`  clientId: ${cfg3.clientId}\n`);
+  checks.push({
+    name: 'Manual override file wins over detected clientId',
+    pass: cfg3.source === 'override' && cfg3.clientId === OVERRIDE_CLIENT_ID,
+  });
+  try { await unlink(overridePath); } catch {}
+
   // Results
   console.log('─── Results ───');
   let passed = 0;
@@ -180,6 +212,19 @@ async function main() {
   console.log('═══════════════════════════════════════════════════════════');
   console.log('  E2E TEST PASSED');
   console.log('═══════════════════════════════════════════════════════════');
+
+  if (previousDisable === undefined) delete process.env.DARIO_OAUTH_DISABLE_OVERRIDE;
+  else process.env.DARIO_OAUTH_DISABLE_OVERRIDE = previousDisable;
+  if (previousOverridePath === undefined) delete process.env.DARIO_OAUTH_OVERRIDE_PATH;
+  else process.env.DARIO_OAUTH_OVERRIDE_PATH = previousOverridePath;
+  if (previousOverrideClientId === undefined) delete process.env.DARIO_OAUTH_CLIENT_ID;
+  else process.env.DARIO_OAUTH_CLIENT_ID = previousOverrideClientId;
+  if (previousOverrideAuthorizeUrl === undefined) delete process.env.DARIO_OAUTH_AUTHORIZE_URL;
+  else process.env.DARIO_OAUTH_AUTHORIZE_URL = previousOverrideAuthorizeUrl;
+  if (previousOverrideTokenUrl === undefined) delete process.env.DARIO_OAUTH_TOKEN_URL;
+  else process.env.DARIO_OAUTH_TOKEN_URL = previousOverrideTokenUrl;
+  if (previousOverrideScopes === undefined) delete process.env.DARIO_OAUTH_SCOPES;
+  else process.env.DARIO_OAUTH_SCOPES = previousOverrideScopes;
 }
 
 main().catch(err => {

--- a/test/oauth-detector.mjs
+++ b/test/oauth-detector.mjs
@@ -30,36 +30,69 @@ const CACHE_PATH = join(homedir(), '.dario', 'cc-oauth-cache-v4.json');
 const PROD_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
 const DEAD_DEV_CLIENT_ID = '22422756-60c9-4084-8eb7-27705fd5cf9a';
 const OVERRIDE_CLIENT_ID = '11111111-2222-4333-8444-555555555555';
+const OVERRIDE_AUTHORIZE_URL = 'https://override.example.test/cai/oauth/authorize';
+
+function captureOverrideEnv() {
+  return {
+    previousDisable: process.env.DARIO_OAUTH_DISABLE_OVERRIDE,
+    previousOverridePath: process.env.DARIO_OAUTH_OVERRIDE_PATH,
+    previousOverrideClientId: process.env.DARIO_OAUTH_CLIENT_ID,
+    previousOverrideAuthorizeUrl: process.env.DARIO_OAUTH_AUTHORIZE_URL,
+    previousOverrideTokenUrl: process.env.DARIO_OAUTH_TOKEN_URL,
+    previousOverrideScopes: process.env.DARIO_OAUTH_SCOPES,
+  };
+}
+
+function restoreOverrideEnv(saved) {
+  if (saved.previousDisable === undefined) delete process.env.DARIO_OAUTH_DISABLE_OVERRIDE;
+  else process.env.DARIO_OAUTH_DISABLE_OVERRIDE = saved.previousDisable;
+  if (saved.previousOverridePath === undefined) delete process.env.DARIO_OAUTH_OVERRIDE_PATH;
+  else process.env.DARIO_OAUTH_OVERRIDE_PATH = saved.previousOverridePath;
+  if (saved.previousOverrideClientId === undefined) delete process.env.DARIO_OAUTH_CLIENT_ID;
+  else process.env.DARIO_OAUTH_CLIENT_ID = saved.previousOverrideClientId;
+  if (saved.previousOverrideAuthorizeUrl === undefined) delete process.env.DARIO_OAUTH_AUTHORIZE_URL;
+  else process.env.DARIO_OAUTH_AUTHORIZE_URL = saved.previousOverrideAuthorizeUrl;
+  if (saved.previousOverrideTokenUrl === undefined) delete process.env.DARIO_OAUTH_TOKEN_URL;
+  else process.env.DARIO_OAUTH_TOKEN_URL = saved.previousOverrideTokenUrl;
+  if (saved.previousOverrideScopes === undefined) delete process.env.DARIO_OAUTH_SCOPES;
+  else process.env.DARIO_OAUTH_SCOPES = saved.previousOverrideScopes;
+}
+
+function clearOverrideEnv() {
+  process.env.DARIO_OAUTH_DISABLE_OVERRIDE = '0';
+  delete process.env.DARIO_OAUTH_OVERRIDE_PATH;
+  delete process.env.DARIO_OAUTH_CLIENT_ID;
+  delete process.env.DARIO_OAUTH_AUTHORIZE_URL;
+  delete process.env.DARIO_OAUTH_TOKEN_URL;
+  delete process.env.DARIO_OAUTH_SCOPES;
+}
 
 async function main() {
   console.log('═══════════════════════════════════════════════════════════');
   console.log('  DARIO — CC OAuth AUTO-DETECTOR E2E TEST');
   console.log('═══════════════════════════════════════════════════════════\n');
 
-  const previousDisable = process.env.DARIO_OAUTH_DISABLE_OVERRIDE;
-  const previousOverridePath = process.env.DARIO_OAUTH_OVERRIDE_PATH;
-  const previousOverrideClientId = process.env.DARIO_OAUTH_CLIENT_ID;
-  const previousOverrideAuthorizeUrl = process.env.DARIO_OAUTH_AUTHORIZE_URL;
-  const previousOverrideTokenUrl = process.env.DARIO_OAUTH_TOKEN_URL;
-  const previousOverrideScopes = process.env.DARIO_OAUTH_SCOPES;
+  const savedEnv = captureOverrideEnv();
+  const overridePath = join(tmpdir(), `dario-oauth-override-${process.pid}.json`);
 
-  // Clean slate. Force pure auto-detection for the baseline checks so a
-  // local operator override file cannot make this test flaky.
-  process.env.DARIO_OAUTH_DISABLE_OVERRIDE = '1';
-  delete process.env.DARIO_OAUTH_OVERRIDE_PATH;
-  delete process.env.DARIO_OAUTH_CLIENT_ID;
-  delete process.env.DARIO_OAUTH_AUTHORIZE_URL;
-  delete process.env.DARIO_OAUTH_TOKEN_URL;
-  delete process.env.DARIO_OAUTH_SCOPES;
+  try {
+    // Clean slate. Force pure auto-detection for the baseline checks so a
+    // local operator override file cannot make this test flaky.
+    process.env.DARIO_OAUTH_DISABLE_OVERRIDE = '1';
+    delete process.env.DARIO_OAUTH_OVERRIDE_PATH;
+    delete process.env.DARIO_OAUTH_CLIENT_ID;
+    delete process.env.DARIO_OAUTH_AUTHORIZE_URL;
+    delete process.env.DARIO_OAUTH_TOKEN_URL;
+    delete process.env.DARIO_OAUTH_SCOPES;
 
-  try { await unlink(CACHE_PATH); } catch {}
-  _resetDetectorCache();
+    try { await unlink(CACHE_PATH); } catch {}
+    _resetDetectorCache();
 
-  console.log('→ Running detector (cold start, no cache)...\n');
-  const t0 = Date.now();
-  const cfg1 = await detectCCOAuthConfig();
-  const t1 = Date.now();
-  console.log(`  Took ${t1 - t0}ms\n`);
+    console.log('→ Running detector (cold start, no cache)...\n');
+    const t0 = Date.now();
+    const cfg1 = await detectCCOAuthConfig();
+    const t1 = Date.now();
+    console.log(`  Took ${t1 - t0}ms\n`);
 
   console.log('─── Detected config ───');
   console.log(`  source:        ${cfg1.source}`);
@@ -179,9 +212,8 @@ async function main() {
 
   // Override-file escape hatch test
   console.log('→ Running detector with manual override file...\n');
-  const overridePath = join(tmpdir(), `dario-oauth-override-${process.pid}.json`);
   await writeFile(overridePath, JSON.stringify({ clientId: OVERRIDE_CLIENT_ID }, null, 2));
-  process.env.DARIO_OAUTH_DISABLE_OVERRIDE = '0';
+  clearOverrideEnv();
   process.env.DARIO_OAUTH_OVERRIDE_PATH = overridePath;
   _resetDetectorCache();
   const cfg3 = await detectCCOAuthConfig();
@@ -191,7 +223,51 @@ async function main() {
     name: 'Manual override file wins over detected clientId',
     pass: cfg3.source === 'override' && cfg3.clientId === OVERRIDE_CLIENT_ID,
   });
-  try { await unlink(overridePath); } catch {}
+
+  // Env override test
+  console.log('→ Running detector with env override...\n');
+  clearOverrideEnv();
+  process.env.DARIO_OAUTH_CLIENT_ID = OVERRIDE_CLIENT_ID;
+  process.env.DARIO_OAUTH_AUTHORIZE_URL = OVERRIDE_AUTHORIZE_URL;
+  _resetDetectorCache();
+  const cfg4 = await detectCCOAuthConfig();
+  console.log(`  source: ${cfg4.source}`);
+  console.log(`  clientId: ${cfg4.clientId}`);
+  console.log(`  authorizeUrl: ${cfg4.authorizeUrl}\n`);
+  checks.push({
+    name: 'Env override wins over detected clientId',
+    pass: cfg4.source === 'override' && cfg4.clientId === OVERRIDE_CLIENT_ID,
+  });
+  checks.push({
+    name: 'Partial env override preserves detected tokenUrl and scopes',
+    pass: cfg4.tokenUrl === cfg1.tokenUrl && cfg4.scopes === cfg1.scopes,
+  });
+
+  // Env > file precedence test
+  console.log('→ Running detector with both env and file overrides...\n');
+  await writeFile(overridePath, JSON.stringify({ clientId: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee' }, null, 2));
+  clearOverrideEnv();
+  process.env.DARIO_OAUTH_OVERRIDE_PATH = overridePath;
+  process.env.DARIO_OAUTH_CLIENT_ID = OVERRIDE_CLIENT_ID;
+  _resetDetectorCache();
+  const cfg5 = await detectCCOAuthConfig();
+  checks.push({
+    name: 'Env override takes precedence over file override',
+    pass: cfg5.clientId === OVERRIDE_CLIENT_ID,
+  });
+
+  // Disable test
+  console.log('→ Running detector with override disabled...\n');
+  clearOverrideEnv();
+  process.env.DARIO_OAUTH_OVERRIDE_PATH = overridePath;
+  process.env.DARIO_OAUTH_CLIENT_ID = OVERRIDE_CLIENT_ID;
+  process.env.DARIO_OAUTH_DISABLE_OVERRIDE = '1';
+  _resetDetectorCache();
+  const cfg6 = await detectCCOAuthConfig();
+  checks.push({
+    name: 'DARIO_OAUTH_DISABLE_OVERRIDE=1 disables env and file overrides',
+    pass: cfg6.source === 'cached' && cfg6.clientId === cfg1.clientId,
+  });
 
   // Results
   console.log('─── Results ───');
@@ -212,19 +288,11 @@ async function main() {
   console.log('═══════════════════════════════════════════════════════════');
   console.log('  E2E TEST PASSED');
   console.log('═══════════════════════════════════════════════════════════');
-
-  if (previousDisable === undefined) delete process.env.DARIO_OAUTH_DISABLE_OVERRIDE;
-  else process.env.DARIO_OAUTH_DISABLE_OVERRIDE = previousDisable;
-  if (previousOverridePath === undefined) delete process.env.DARIO_OAUTH_OVERRIDE_PATH;
-  else process.env.DARIO_OAUTH_OVERRIDE_PATH = previousOverridePath;
-  if (previousOverrideClientId === undefined) delete process.env.DARIO_OAUTH_CLIENT_ID;
-  else process.env.DARIO_OAUTH_CLIENT_ID = previousOverrideClientId;
-  if (previousOverrideAuthorizeUrl === undefined) delete process.env.DARIO_OAUTH_AUTHORIZE_URL;
-  else process.env.DARIO_OAUTH_AUTHORIZE_URL = previousOverrideAuthorizeUrl;
-  if (previousOverrideTokenUrl === undefined) delete process.env.DARIO_OAUTH_TOKEN_URL;
-  else process.env.DARIO_OAUTH_TOKEN_URL = previousOverrideTokenUrl;
-  if (previousOverrideScopes === undefined) delete process.env.DARIO_OAUTH_SCOPES;
-  else process.env.DARIO_OAUTH_SCOPES = previousOverrideScopes;
+  } finally {
+    try { await unlink(overridePath); } catch {}
+    restoreOverrideEnv(savedEnv);
+    _resetDetectorCache();
+  }
 }
 
 main().catch(err => {


### PR DESCRIPTION
Supersedes #47.

This is the same OAuth override escape-hatch work, reopened as a clean branch off current `master` with the maintainer feedback addressed.

What changed since #47:
- restored the two explanatory comments in `src/cc-oauth-detect.ts`
- reverted the no-op `TOKEN_URL` regex churn
- added test coverage for:
  - env-var override path
  - env > file precedence
  - `DARIO_OAUTH_DISABLE_OVERRIDE=1`
  - partial override preserving detected fields
- dropped the unrelated `.mailmap` commit from the branch so the PR scope is OAuth-only

Validation:
- `npm run build`
- `node test/oauth-detector.mjs` (`20/20` checks passing)

The override remains an emergency escape hatch only:
- detection stays the default path
- overrides apply after detection/cache
- env overrides still beat file overrides
- `DARIO_OAUTH_DISABLE_OVERRIDE=1` returns dario to pure auto-detection behavior
