### PR TITLE
v3.30.1 — drift patches for CC v2.1.114 wire shape

### DIFF
--- a/.github/workflows/cc-drift-watch.yml
+++ b/.github/workflows/cc-drift-watch.yml
@@ -20,9 +20,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: 'npm'
@@ -160,7 +160,7 @@ jobs:
 
       - name: Upload report artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cc-drift-report
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   validate-package-json:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: package.json is valid JSON and canonically formatted
         run: node scripts/check-package-json.mjs
 
@@ -24,8 +24,8 @@ jobs:
       matrix:
         node-version: [18, 20, 22]
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,9 +17,9 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: github/codeql-action/init@v3
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         with:
           languages: javascript-typescript
-      - uses: github/codeql-action/autobuild@v3
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/autobuild@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
+      - uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.30.1] - 2026-04-19
+
+### Changed — Drift patches for CC v2.1.114 wire shape
+
+MITM capture of an active CC v2.1.114 client showed four fingerprint drift points in the body dario builds for Claude-subscription requests. All four are now aligned with what real CC emits.
+
+- **`cache_control` drops `ttl: '1h'`.** CC v2.1.114 now sends `{"type":"ephemeral"}` bare on `system[1]` and `system[2]` cache markers. Dario's `buildCCRequest` and `src/shim/runtime.cjs` `rewriteBody` updated to match. The `CACHE_1H` local in `proxy.ts` is renamed to `CACHE_EPHEMERAL` and the `buildCCRequest` parameter `cache1h` is renamed to `cacheControl` — both the naming and the type (`{type: 'ephemeral'}`) now reflect that these are no longer 1h-scoped.
+- **`max_tokens` lowered from 64000 to 32000.** Matches the value CC v2.1.114 sends for sonnet requests.
+- **`output_config.effort` raised from `'medium'` to `'high'`.** Matches CC v2.1.114's non-haiku default.
+- **`cc_entrypoint` changed from `cli` to `sdk-cli`.** CC has migrated to the Claude Agent SDK (also visible in the `x-stainless-package-version: 0.81.0` header); the billing tag now reflects that entrypoint.
+
+Test fixtures and a few fixture-adjacent assertions in `test/hybrid-tools.mjs`, `test/client-detection.mjs`, `test/issue-29-tool-translation.mjs`, `test/live-fingerprint.mjs`, `test/proxy-body-order.mjs`, `test/shim-runtime.mjs`, and `test/tool-schema-contract.mjs` updated to the new wire shape. Full `npm test` green.
+
 ## [3.30.0] - 2026-04-19
 
 ### Removed — Sealed-sender overflow protocol and mux coordination surface

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.30.0",
+  "version": "3.30.1",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -754,7 +754,7 @@ const TOOL_MAP: Record<string, ToolMapping> = {
 export function buildCCRequest(
   clientBody: Record<string, unknown>,
   billingTag: string,
-  cache1h: { type: 'ephemeral'; ttl: '1h' },
+  cacheControl: { type: 'ephemeral' },
   identity: { deviceId: string; accountUuid: string; sessionId: string },
   opts: { preserveTools?: boolean; hybridTools?: boolean; noAutoDetect?: boolean } = {},
 ): { body: Record<string, unknown>; toolMap: Map<string, ToolMapping>; unmappedTools: string[]; detectedClient?: string } {
@@ -1009,8 +1009,8 @@ export function buildCCRequest(
     messages,
     system: [
       { type: 'text', text: billingTag },
-      { type: 'text', text: CC_AGENT_IDENTITY, cache_control: cache1h },
-      { type: 'text', text: fullSystemPrompt, cache_control: cache1h },
+      { type: 'text', text: CC_AGENT_IDENTITY, cache_control: cacheControl },
+      { type: 'text', text: fullSystemPrompt, cache_control: cacheControl },
     ],
   };
 
@@ -1030,13 +1030,13 @@ export function buildCCRequest(
     }),
   };
 
-  ccRequest.max_tokens = 64000;
+  ccRequest.max_tokens = 32000;
 
   // Model-specific fields — order: thinking, context_management, output_config
   if (!isHaiku) {
     ccRequest.thinking = { type: 'adaptive' };
     ccRequest.context_management = { edits: [{ type: 'clear_thinking_20251015', keep: 'all' }] };
-    ccRequest.output_config = { effort: 'medium' };
+    ccRequest.output_config = { effort: 'high' };
   }
 
   ccRequest.stream = stream;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -906,8 +906,8 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
             const buildTag = computeBuildTag(userMsg, cliVersion);
             const cch = computeCch();
             const fullVersion = `${cliVersion}.${buildTag}`;
-            const billingTag = `x-anthropic-billing-header: cc_version=${fullVersion}; cc_entrypoint=cli; cch=${cch};`;
-            const CACHE_1H = { type: 'ephemeral' as const, ttl: '1h' as const };
+            const billingTag = `x-anthropic-billing-header: cc_version=${fullVersion}; cc_entrypoint=sdk-cli; cch=${cch};`;
+            const CACHE_EPHEMERAL = { type: 'ephemeral' as const };
 
             // Session stickiness: rebind the pre-selected pool account to
             // whatever the sticky-key resolver picks. If this is a new
@@ -950,7 +950,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
               ? poolAccount.identity
               : { deviceId: identity.deviceId, accountUuid: identity.accountUuid, sessionId: preBodySessionId };
             const { body: ccBody, toolMap, detectedClient } = buildCCRequest(
-              r, billingTag, CACHE_1H,
+              r, billingTag, CACHE_EPHEMERAL,
               bodyIdentity,
               {
                 preserveTools: opts.preserveTools ?? false,

--- a/src/shim/runtime.cjs
+++ b/src/shim/runtime.cjs
@@ -145,8 +145,8 @@ function rewriteBody(bodyText, tmpl) {
   const billingTag = body.system[0];
   body.system = [
     billingTag,
-    { type: 'text', text: tmpl.agent_identity, cache_control: { type: 'ephemeral', ttl: '1h' } },
-    { type: 'text', text: tmpl.system_prompt,  cache_control: { type: 'ephemeral', ttl: '1h' } },
+    { type: 'text', text: tmpl.agent_identity, cache_control: { type: 'ephemeral' } },
+    { type: 'text', text: tmpl.system_prompt,  cache_control: { type: 'ephemeral' } },
   ];
   body.tools = tmpl.tools;
   return JSON.stringify(body);

--- a/test/client-detection.mjs
+++ b/test/client-detection.mjs
@@ -87,7 +87,7 @@ check(
 header('4. buildCCRequest — auto-preserve fires for Cline');
 
 const billingTag = 'x-anthropic-billing-header: cc_version=test;';
-const cache1h = { type: 'ephemeral', ttl: '1h' };
+const cache1h = { type: 'ephemeral' };
 const identity = { deviceId: 'd', accountUuid: 'u', sessionId: 's' };
 
 // Cline's real bootstrap: identity line + XML tool declaration. Uses

--- a/test/hybrid-tools.mjs
+++ b/test/hybrid-tools.mjs
@@ -61,7 +61,7 @@ const clientBody = {
   ],
 };
 const billingTag = 'x-anthropic-billing-header: cc_version=test;';
-const cache1h = { type: 'ephemeral', ttl: '1h' };
+const cache1h = { type: 'ephemeral' };
 const identity = { deviceId: 'd', accountUuid: 'u', sessionId: 's' };
 
 const ctx = {
@@ -249,7 +249,7 @@ header('dario#36 — bash/exec reverse translation uses `command`');
   const built = buildCCRequest(
     JSON.parse(JSON.stringify(body)),
     'billing',
-    { type: 'ephemeral', ttl: '1h' },
+    { type: 'ephemeral' },
     { deviceId: 'd', accountUuid: 'a', sessionId: 's' },
     {},
   );
@@ -300,7 +300,7 @@ header('dario#36 — hybrid mode drops unmapped tools');
   const hybrid = buildCCRequest(
     JSON.parse(JSON.stringify(body)),
     'billing',
-    { type: 'ephemeral', ttl: '1h' },
+    { type: 'ephemeral' },
     { deviceId: 'd', accountUuid: 'a', sessionId: 's' },
     { hybridTools: true },
   );
@@ -314,7 +314,7 @@ header('dario#36 — hybrid mode drops unmapped tools');
   const defaultMode = buildCCRequest(
     JSON.parse(JSON.stringify(body)),
     'billing',
-    { type: 'ephemeral', ttl: '1h' },
+    { type: 'ephemeral' },
     { deviceId: 'd', accountUuid: 'a', sessionId: 's' },
     {},
   );
@@ -356,7 +356,7 @@ header('dario#37 — exec wins over process on CC Bash reverse slot');
   const built = buildCCRequest(
     JSON.parse(JSON.stringify(body)),
     'billing',
-    { type: 'ephemeral', ttl: '1h' },
+    { type: 'ephemeral' },
     { deviceId: 'd', accountUuid: 'a', sessionId: 's' },
     {},
   );
@@ -394,7 +394,7 @@ header('dario#37 — exec wins over process on CC Bash reverse slot');
   const built = buildCCRequest(
     JSON.parse(JSON.stringify(body)),
     'billing',
-    { type: 'ephemeral', ttl: '1h' },
+    { type: 'ephemeral' },
     { deviceId: 'd', accountUuid: 'a', sessionId: 's' },
     {},
   );
@@ -448,7 +448,7 @@ header('dario#37 (Glob) — unmapped `image` cannot steal Glob reverse slot');
   const built = buildCCRequest(
     JSON.parse(JSON.stringify(body)),
     'billing',
-    { type: 'ephemeral', ttl: '1h' },
+    { type: 'ephemeral' },
     { deviceId: 'd', accountUuid: 'a', sessionId: 's' },
     {},
   );
@@ -488,7 +488,7 @@ header('dario#37 (Glob) — unmapped `image` cannot steal Glob reverse slot');
   const built = buildCCRequest(
     JSON.parse(JSON.stringify(body)),
     'billing',
-    { type: 'ephemeral', ttl: '1h' },
+    { type: 'ephemeral' },
     { deviceId: 'd', accountUuid: 'a', sessionId: 's' },
     {},
   );
@@ -528,7 +528,7 @@ header('dario#37 (Glob) — streaming: real Glob passes through unchanged');
   const built = buildCCRequest(
     JSON.parse(JSON.stringify(body)),
     'billing',
-    { type: 'ephemeral', ttl: '1h' },
+    { type: 'ephemeral' },
     { deviceId: 'd', accountUuid: 'a', sessionId: 's' },
     {},
   );
@@ -616,7 +616,7 @@ header('dario#36 — drop trailing assistant/empty turns (prefill rejection)');
   const built = buildCCRequest(
     JSON.parse(JSON.stringify(body)),
     'billing',
-    { type: 'ephemeral', ttl: '1h' },
+    { type: 'ephemeral' },
     { deviceId: 'd', accountUuid: 'a', sessionId: 's' },
     { hybridTools: true },
   );
@@ -647,7 +647,7 @@ header('dario#37 — trailing assistant with real content is preserved (runaway 
   const built = buildCCRequest(
     JSON.parse(JSON.stringify(body)),
     'billing',
-    { type: 'ephemeral', ttl: '1h' },
+    { type: 'ephemeral' },
     { deviceId: 'd', accountUuid: 'a', sessionId: 's' },
     {},
   );
@@ -677,7 +677,7 @@ header('dario#36 — well-formed conversation untouched');
   const built = buildCCRequest(
     JSON.parse(JSON.stringify(body)),
     'billing',
-    { type: 'ephemeral', ttl: '1h' },
+    { type: 'ephemeral' },
     { deviceId: 'd', accountUuid: 'a', sessionId: 's' },
     {},
   );

--- a/test/issue-29-tool-translation.mjs
+++ b/test/issue-29-tool-translation.mjs
@@ -50,7 +50,7 @@ const clientBody = {
   ],
 };
 const billingTag = 'x-anthropic-billing-header: cc_version=test;';
-const cache1h = { type: 'ephemeral', ttl: '1h' };
+const cache1h = { type: 'ephemeral' };
 const identity = { deviceId: 'd', accountUuid: 'u', sessionId: 's' };
 
 const { toolMap } = buildCCRequest(clientBody, billingTag, cache1h, identity);

--- a/test/live-fingerprint.mjs
+++ b/test/live-fingerprint.mjs
@@ -57,17 +57,17 @@ header('extractTemplate — pulls agent identity, system prompt, tools, version'
     method: 'POST',
     path: '/v1/messages',
     headers: {
-      'x-anthropic-billing-header': 'cc_version=2.1.200; cc_entrypoint=cli; cch=abc12',
+      'x-anthropic-billing-header': 'cc_version=2.1.200; cc_entrypoint=sdk-cli; cch=abc12',
       'user-agent': 'claude-cli/2.1.200 (external)',
       'anthropic-beta': 'claude-code-20250219,interleaved-thinking-2025-05-14',
     },
     body: {
       model: 'claude-opus-4-5',
-      max_tokens: 64000,
+      max_tokens: 32000,
       system: [
         { type: 'text', text: 'billing tag payload' },
-        { type: 'text', text: 'You are Claude Code, Anthropic\'s official CLI for Claude.', cache_control: { type: 'ephemeral', ttl: '1h' } },
-        { type: 'text', text: 'Large system prompt content here, normally ~25KB. Contains tool-use instructions.', cache_control: { type: 'ephemeral', ttl: '1h' } },
+        { type: 'text', text: 'You are a Claude agent, built on Anthropic\'s Claude Agent SDK.', cache_control: { type: 'ephemeral' } },
+        { type: 'text', text: 'Large system prompt content here, normally ~25KB. Contains tool-use instructions.', cache_control: { type: 'ephemeral' } },
       ],
       tools: [
         { name: 'Bash', description: 'Run a command', input_schema: { type: 'object', properties: { command: { type: 'string' } } } },
@@ -82,7 +82,7 @@ header('extractTemplate — pulls agent identity, system prompt, tools, version'
   check('extraction returned non-null', template !== null);
   check('version extracted from billing header', template?._version === '2.1.200');
   check('source marked as live', template?._source === 'live');
-  check('agent identity pulled from system[1]', template?.agent_identity.includes('Claude Code'));
+  check('agent identity pulled from system[1]', template?.agent_identity.includes('Claude Agent SDK'));
   check('system prompt pulled from system[2]', template?.system_prompt.includes('tool-use instructions'));
   check('3 tools captured', template?.tools.length === 3);
   check('tool_names matches', JSON.stringify(template?.tool_names) === JSON.stringify(['Bash', 'Read', 'Edit']));

--- a/test/proxy-body-order.mjs
+++ b/test/proxy-body-order.mjs
@@ -43,7 +43,7 @@ header('orderBodyForOutbound — captured order is preserved');
 {
   const b = {
     stream: true,
-    max_tokens: 64000,
+    max_tokens: 32000,
     model: 'claude-opus-4-5',
     metadata: { user_id: 'x' },
     system: [{ type: 'text', text: 'hi' }],
@@ -65,7 +65,7 @@ header('orderBodyForOutbound — captured order is preserved');
       JSON.stringify(out).indexOf('"messages"') < JSON.stringify(out).indexOf('"stream"'),
   );
   check('model value round-trips', out.model === 'claude-opus-4-5');
-  check('max_tokens value round-trips', out.max_tokens === 64000);
+  check('max_tokens value round-trips', out.max_tokens === 32000);
   check('nested objects are referenced, not cloned', out.metadata === b.metadata);
 }
 

--- a/test/shim-runtime.mjs
+++ b/test/shim-runtime.mjs
@@ -87,8 +87,8 @@ header('_rewriteBody — system blocks 1+2 and tools replaced; billing tag prese
   check('billing tag (system[0]) preserved', rewritten.system[0].text === 'BILLING_TAG_FROM_HOST');
   check('agent identity (system[1]) replaced', rewritten.system[1].text === 'AGENT_IDENTITY_FROM_TEMPLATE');
   check('system prompt (system[2]) replaced', rewritten.system[2].text === 'SYSTEM_PROMPT_FROM_TEMPLATE');
-  check('agent identity has 1h cache control', rewritten.system[1].cache_control?.ttl === '1h');
-  check('system prompt has 1h cache control', rewritten.system[2].cache_control?.ttl === '1h');
+  check('agent identity has ephemeral cache control', rewritten.system[1].cache_control?.type === 'ephemeral' && rewritten.system[1].cache_control?.ttl === undefined);
+  check('system prompt has ephemeral cache control', rewritten.system[2].cache_control?.type === 'ephemeral' && rewritten.system[2].cache_control?.ttl === undefined);
   check('tools replaced from template', rewritten.tools.length === 1 && rewritten.tools[0].name === 'Read');
   check('messages untouched', rewritten.messages[0].content === 'hi');
   check('model untouched', rewritten.model === 'claude-opus-4-6');

--- a/test/tool-schema-contract.mjs
+++ b/test/tool-schema-contract.mjs
@@ -177,7 +177,7 @@ const { toolMap, unmappedTools } = buildCCRequest(
     stream: false,
   },
   'billing-tag',
-  { type: 'ephemeral', ttl: '1h' },
+  { type: 'ephemeral' },
   { deviceId: 'd', accountUuid: 'a', sessionId: 's' },
   {},
 );


### PR DESCRIPTION
## Summary

MITM capture of a live CC v2.1.114 client revealed four fingerprint drift points in the body dario builds for Claude-subscription requests. All four are now aligned with what real CC emits.

| Field | CC v2.1.114 | Dario pre-patch | Dario post-patch |
|-------|-------------|-----------------|------------------|
| `cache_control` | `{"type":"ephemeral"}` | `{"type":"ephemeral","ttl":"1h"}` | `{"type":"ephemeral"}` |
| `max_tokens` | `32000` | `64000` | `32000` |
| `output_config.effort` | `"high"` | `"medium"` | `"high"` |
| `cc_entrypoint` | `sdk-cli` | `cli` | `sdk-cli` |

- `CACHE_1H` renamed to `CACHE_EPHEMERAL` in `proxy.ts` and `cache1h` parameter renamed to `cacheControl` in `buildCCRequest` — both names now reflect the non-1h-scoped shape.
- `src/shim/runtime.cjs` `rewriteBody` updated to match.
- Test fixtures and assertions updated in `hybrid-tools`, `client-detection`, `issue-29-tool-translation`, `live-fingerprint`, `proxy-body-order`, `shim-runtime`, `tool-schema-contract`.

CC migrated to the Claude Agent SDK (visible via `x-stainless-package-version: 0.81.0` header and `cc_entrypoint=sdk-cli`); the billing tag now reflects that.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — full suite green
- [x] Manual `buildCCRequest` smoke test — output matches CC v2.1.114 wire shape on all four fields