### PR TITLE
v3.30.2 — agent sdk positioning + sdk drift watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.30.2] - 2026-04-19
+
+### Added — Claude Agent SDK positioning + metadata-only drift watcher
+
+- **README: Claude Agent SDK audience.** Adds Agent SDK users to the "Who this is for" list and to the Agent compatibility table. One-line config (`baseURL: 'http://localhost:3456'`) turns dario into an OAuth-subscription backend for any `@anthropic-ai/claude-agent-sdk` app — the SDK and CC share the same tool schema as of CC v2.1.114 / Agent SDK 0.2.x, so no translation work is needed on the agent's side.
+- **`scripts/check-sdk-drift.mjs` (wired as `npm run drift:sdk`).** Metadata-only drift watcher that compares `@anthropic-ai/claude-code`, `@anthropic-ai/claude-agent-sdk`, and `@anthropic-ai/sdk` (Stainless transport) versions against dario's bundled template. Complements the heavy `check-cc-drift.mjs` (which downloads the 235MB native CC binary and scans it) — this one runs in seconds via `npm view` only, and flags `cc_version` or `x-stainless-package-version` drift as a fast pre-check suitable for high-frequency gating.
+
 ## [3.30.1] - 2026-04-19
 
 ### Changed — Drift patches for CC v2.1.114 wire shape

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Something broken? `dario doctor` prints a single aggregated health report — da
 - **Teams running local or hosted OpenAI-compat servers** (LiteLLM, vLLM, Ollama, Groq, OpenRouter, self-hosted) who want one stable local endpoint every tool can reuse.
 - **Anyone building AI coding tools** who wants provider independence without writing an OpenAI ↔ Anthropic translator themselves.
 - **Claude Max / Pro subscribers** who want their subscription usable from every tool on their machine, not just Claude Code.
+- **[Claude Agent SDK](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk) users** who want OAuth-subscription routing under the SDK. Point `baseURL: 'http://localhost:3456'` and dario translates API-key calls into your Claude Max auth — agent code stays identical.
 - **Power users on multi-agent workloads** who want multi-account pooling, session stickiness, and in-flight 429 failover on their own machine, against their own subscriptions.
 - **Operators who care about wire-level fidelity** — the fingerprint tightening in v3.22 – v3.28 means proxy mode's divergence from CC is observable (via `dario doctor`) and tunable (flags + env vars for each axis).
 
@@ -276,7 +277,7 @@ Dario's built-in `TOOL_MAP` carries **~66 schema-verified entries** covering the
 
 | Agent | Covered tool names (subset) |
 |---|---|
-| Claude Code | default — CC's own tools |
+| Claude Code / Claude Agent SDK | default — CC / SDK tools (same schema as of CC v2.1.114 / `@anthropic-ai/claude-agent-sdk@0.2.x`) |
 | Cline / Roo Code / Kilo Code | `execute_command`, `write_to_file`, `replace_in_file`, `apply_diff`, `list_files`, `search_files`, `read_file` |
 | Cursor | `run_terminal_cmd`, `edit_file`, `search_replace`, `codebase_search`, `grep_search`, `file_search`, `list_dir`, `read_file` (`target_file`) |
 | Windsurf | `run_command`, `view_file`, `write_to_file`, `replace_file_content`, `find_by_name`, `grep_search`, `list_dir`, `search_web`, `read_url_content` |

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "e2e": "node test/e2e.mjs",
     "compat": "node test/compat.mjs",
     "lint:pkg": "node scripts/check-package-json.mjs",
+    "drift:sdk": "node scripts/check-sdk-drift.mjs",
     "fix:pkg": "node -e \"const fs=require('fs');fs.writeFileSync('package.json',JSON.stringify(JSON.parse(fs.readFileSync('package.json','utf-8')),null,2)+'\\n')\""
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.30.1",
+  "version": "3.30.2",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {

--- a/scripts/check-sdk-drift.mjs
+++ b/scripts/check-sdk-drift.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * Claude Agent SDK drift watcher — cheap, metadata-only.
+ *
+ * Fetches @anthropic-ai/claude-agent-sdk metadata from npm (no download) and
+ * compares three upstream signals against what dario's bundled template is
+ * pinned to:
+ *
+ *   1. Agent SDK version — tracks the CC-parity cadence (e.g. 0.2.114 ↔ CC 2.1.114)
+ *   2. Stainless low-level SDK version — the `@anthropic-ai/sdk` dep, whose
+ *      version ends up on the wire as `x-stainless-package-version`
+ *   3. CC version string the Agent SDK's major mirrors
+ *
+ * Complements scripts/check-cc-drift.mjs (which downloads the ~235MB native
+ * binary and scans it). This check runs in seconds on metadata alone and is
+ * suitable for high-frequency signals or pre-release gating where downloading
+ * the full CC binary is too heavy.
+ *
+ * Exits 1 on any drift (stale pinned constants) and 0 when everything aligns.
+ * JSON report to stdout.
+ */
+
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+
+function npmView(pkg, field) {
+  const out = execSync(`npm view ${pkg} ${field} --json`, { encoding: 'utf-8' });
+  return JSON.parse(out);
+}
+
+function loadBundled() {
+  return JSON.parse(readFileSync(join(ROOT, 'src/cc-template-data.json'), 'utf-8'));
+}
+
+function run() {
+  const bundled = loadBundled();
+  const bundledStainless = bundled.header_values?.['x-stainless-package-version'];
+  const bundledUa = bundled.header_values?.['user-agent'];
+  const bundledCcVersion = bundled._version;
+
+  const agentSdkVersion = npmView('@anthropic-ai/claude-agent-sdk', 'version');
+  const agentSdkDeps = npmView('@anthropic-ai/claude-agent-sdk', 'dependencies');
+  const stainlessRange = agentSdkDeps?.['@anthropic-ai/sdk'];
+  const upstreamStainless = stainlessRange ? String(stainlessRange).replace(/^[\^~>=\s]+/, '') : null;
+  const ccVersion = npmView('@anthropic-ai/claude-code', 'version');
+
+  const drift = [];
+
+  if (ccVersion && bundledCcVersion && ccVersion !== bundledCcVersion) {
+    drift.push({
+      field: 'cc_version',
+      bundled: bundledCcVersion,
+      upstream: ccVersion,
+      source: '@anthropic-ai/claude-code@latest',
+    });
+  }
+
+  if (upstreamStainless && bundledStainless && upstreamStainless !== bundledStainless) {
+    drift.push({
+      field: 'x-stainless-package-version',
+      bundled: bundledStainless,
+      upstream: upstreamStainless,
+      source: `@anthropic-ai/claude-agent-sdk@${agentSdkVersion}.dependencies[@anthropic-ai/sdk]`,
+    });
+  }
+
+  const report = {
+    checkedAt: new Date().toISOString(),
+    bundled: {
+      cc_version: bundledCcVersion,
+      stainless: bundledStainless,
+      user_agent: bundledUa,
+    },
+    upstream: {
+      cc_version: ccVersion,
+      agent_sdk_version: agentSdkVersion,
+      stainless_dep: upstreamStainless,
+    },
+    drift,
+    status: drift.length === 0 ? 'clean' : 'drift',
+  };
+
+  console.log(JSON.stringify(report, null, 2));
+  process.exit(drift.length === 0 ? 0 : 1);
+}
+
+run();


### PR DESCRIPTION
## Summary

Two small additions that build on the CC → Claude Agent SDK migration uncovered in #57.

- **README: position dario as an Agent SDK backend.** Agent SDK is API-key-only; dario's OAuth-subscription routing gives Agent SDK users Claude Max access via `baseURL: http://localhost:3456`. Added to the "Who this is for" list and the Agent compatibility table. Same tool schema as CC so no translation work needed on the agent's side.
- **`scripts/check-sdk-drift.mjs`** (`npm run drift:sdk`): metadata-only drift watcher that compares `@anthropic-ai/claude-code`, `@anthropic-ai/claude-agent-sdk`, and `@anthropic-ai/sdk` (Stainless) versions against dario's bundled template. Complements the heavy `check-cc-drift.mjs` (which downloads the 235MB native CC binary and scans it). This one runs in seconds via `npm view` only, suitable for high-frequency pre-checks.

## Context — what the investigation turned up

Follow-up from #57's MITM: the full "template generation from SDK source" idea turns out to be partial — CC's system prompt is in the native binary, not the Agent SDK. What IS derivable: tool schemas (in `sdk-tools.d.ts`), Stainless version dep, Agent SDK version. The new watcher surfaces those signals as a complement to the binary scan rather than replacing it.

Subagent-bridge retirement (another idea from #57) turned out not to apply — `src/subagent.ts` installs a markdown subagent definition, not a transport-layer bridge, so the SDK migration doesn't affect it.

Stainless-client light-touch path is deferred — meaningful savings require validating passthrough subscription auth against Agent SDK 0.2.x body shape, which is a policy test not a code task.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 48 files, all green
- [x] `npm run drift:sdk` — clean report on current pins
- [x] `npm run lint:pkg` — package.json canonical