### PR TITLE
v3.30.3 — fix #54 empty text blocks + #58 seven_day billing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.30.3] - 2026-04-19
+
+### Fixed — `dario#54`: Claude CLI on CC v2.1.112 → "text content blocks must be non-empty" 400
+
+`sanitizeMessages` strips orchestration-wrapper tags (`<system-reminder>`, `<env>`, etc.) from message content text blocks in place. CC v2.1.112 splits per-reminder system-reminders into **separate** content blocks — one block per reminder. After scrubbing, each of those blocks becomes `{type:'text',text:''}`, and Anthropic rejects the request upstream with `"messages: text content blocks must be non-empty"`. Reproducer in tetsuco's body dump on #54: three empty text blocks preceding the real `hello` block.
+
+Fix: in `sanitizeMessages`, after in-place scrubbing each block's text, drop blocks that are now `{type:'text',text:''}`. Non-text blocks (`tool_result`, `tool_use`, `image`) pass through regardless. Coverage: new `test/sanitize-messages.mjs` (11 assertions) exercises the 4-block CC v2.1.112 shape, adjacent real-text preservation, `tool_result` passthrough, all-reminder → empty-content-array transition, and non-text-block safety.
+
+### Fixed — `dario#58`: `seven_day` billing claim showed `unknown` bucket + `n/a` overage
+
+Anthropic is rolling out a new subscription rate-limit claim value — `seven_day` (and `seven_day_fallback`) — alongside the legacy `five_hour` / `five_hour_fallback`. Semantics are identical (subscription covered the request), only the representative-claim header string changed. Two display paths in dario hardcoded the five_hour family:
+
+- `billingBucketFromClaim` (`src/analytics.ts`) mapped unknown claims to `'unknown'`, so the proxy log showed `billing: unknown (seven_day, …)` instead of `billing: subscription (seven_day, …)`.
+- The overage-fallback in `src/proxy.ts` treated a missing `anthropic-ratelimit-unified-overage-utilization` header as `'n/a'` on everything except `five_hour[_fallback]`. For `seven_day`-claim accounts the fallback therefore reported `overage: n/a` instead of the correct `0%`.
+
+Both sites extended to also match `seven_day` / `seven_day_fallback`. `test/analytics-billing-bucket.mjs` updated with matching assertions.
+
 ## [3.30.2] - 2026-04-19
 
 ### Added — Claude Agent SDK positioning + metadata-only drift watcher

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.30.2",
+  "version": "3.30.3",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "build": "tsc && cp src/cc-template-data.json dist/ && node -e \"require('fs').mkdirSync('dist/shim',{recursive:true})\" && cp src/shim/runtime.cjs dist/shim/",
-    "test": "node test/issue-29-tool-translation.mjs && node test/hybrid-tools.mjs && node test/tool-schema-contract.mjs && node test/scrub-paths.mjs && node test/provider-prefix.mjs && node test/analytics-recording.mjs && node test/analytics-billing-bucket.mjs && node test/failover-429.mjs && node test/pool-sticky.mjs && node test/live-fingerprint.mjs && node test/shim-runtime.mjs && node test/shim-e2e.mjs && node test/proxy-header-order.mjs && node test/proxy-body-order.mjs && node test/runtime-fingerprint.mjs && node test/pacing.mjs && node test/stream-drain.mjs && node test/subagent.mjs && node test/mcp-protocol.mjs && node test/mcp-tools.mjs && node test/mcp-e2e.mjs && node test/session-rotation.mjs && node test/drift-detection.mjs && node test/cc-authorize-probe-classifier.mjs && node test/compat-range.mjs && node test/doctor-formatter.mjs && node test/atomic-write.mjs && node test/account-refresh-singleflight.mjs && node test/streaming-edge-cases.mjs && node test/client-detection.mjs && node test/manual-oauth-flow.mjs && node test/scrub-template.mjs",
+    "test": "node test/issue-29-tool-translation.mjs && node test/hybrid-tools.mjs && node test/tool-schema-contract.mjs && node test/scrub-paths.mjs && node test/provider-prefix.mjs && node test/analytics-recording.mjs && node test/analytics-billing-bucket.mjs && node test/failover-429.mjs && node test/pool-sticky.mjs && node test/live-fingerprint.mjs && node test/shim-runtime.mjs && node test/shim-e2e.mjs && node test/proxy-header-order.mjs && node test/proxy-body-order.mjs && node test/runtime-fingerprint.mjs && node test/pacing.mjs && node test/stream-drain.mjs && node test/subagent.mjs && node test/mcp-protocol.mjs && node test/mcp-tools.mjs && node test/mcp-e2e.mjs && node test/session-rotation.mjs && node test/drift-detection.mjs && node test/cc-authorize-probe-classifier.mjs && node test/compat-range.mjs && node test/doctor-formatter.mjs && node test/atomic-write.mjs && node test/account-refresh-singleflight.mjs && node test/streaming-edge-cases.mjs && node test/client-detection.mjs && node test/manual-oauth-flow.mjs && node test/scrub-template.mjs && node test/sanitize-messages.mjs",
     "audit": "npm audit --production --audit-level=high",
     "prepublishOnly": "npm run build",
     "start": "node dist/cli.js",

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -53,8 +53,10 @@ export type BillingBucket =
 export function billingBucketFromClaim(claim: string | null | undefined): BillingBucket {
   switch (claim) {
     case 'five_hour':
+    case 'seven_day':
       return 'subscription';
     case 'five_hour_fallback':
+    case 'seven_day_fallback':
       return 'subscription_fallback';
     case 'overage':
       return 'extra_usage';

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -213,7 +213,7 @@ function sanitizeContent(text: string): string {
 }
 
 /** Strip orchestration tags from all messages in a request body. */
-function sanitizeMessages(body: Record<string, unknown>): void {
+export function sanitizeMessages(body: Record<string, unknown>): void {
   const messages = body.messages as Array<{ role: string; content: unknown }> | undefined;
   if (!messages) return;
   for (const msg of messages) {
@@ -225,6 +225,16 @@ function sanitizeMessages(body: Record<string, unknown>): void {
           (block as { text: string }).text = sanitizeContent((block as { text: string }).text);
         }
       }
+      // Drop text blocks that became empty after orchestration-tag scrubbing.
+      // CC v2.1.112 and some client wrappers split per-reminder system-reminders
+      // into separate content blocks; scrubbing leaves each as {type:'text',text:''}
+      // which Anthropic rejects with "text content blocks must be non-empty"
+      // (dario#54). Keep non-text blocks (tool_result, tool_use, image) intact.
+      msg.content = (msg.content as Array<Record<string, unknown>>).filter(b => {
+        if (typeof b !== 'object' || b === null) return false;
+        if ((b as { type?: string }).type === 'text' && (b as { text?: string }).text === '') return false;
+        return true;
+      });
     }
   }
 }
@@ -1377,7 +1387,12 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           let overagePct: string;
           if (overageUtil !== null) {
             overagePct = `${Math.round(parseFloat(overageUtil) * 100)}%`;
-          } else if (billingClaim === 'five_hour' || billingClaim === 'five_hour_fallback') {
+          } else if (
+            billingClaim === 'five_hour'
+            || billingClaim === 'five_hour_fallback'
+            || billingClaim === 'seven_day'
+            || billingClaim === 'seven_day_fallback'
+          ) {
             overagePct = '0%';
           } else {
             overagePct = 'n/a';

--- a/test/analytics-billing-bucket.mjs
+++ b/test/analytics-billing-bucket.mjs
@@ -27,6 +27,8 @@ header('billingBucketFromClaim — maps raw claim to user-friendly bucket');
 {
   check('five_hour → subscription', billingBucketFromClaim('five_hour') === 'subscription');
   check('five_hour_fallback → subscription_fallback', billingBucketFromClaim('five_hour_fallback') === 'subscription_fallback');
+  check('seven_day → subscription', billingBucketFromClaim('seven_day') === 'subscription');
+  check('seven_day_fallback → subscription_fallback', billingBucketFromClaim('seven_day_fallback') === 'subscription_fallback');
   check('overage → extra_usage', billingBucketFromClaim('overage') === 'extra_usage');
   check('api → api', billingBucketFromClaim('api') === 'api');
   check('empty string → unknown', billingBucketFromClaim('') === 'unknown');

--- a/test/sanitize-messages.mjs
+++ b/test/sanitize-messages.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// Unit tests for sanitizeMessages — orchestration-tag scrub on message bodies.
+//
+// dario#54 regression: CC v2.1.112 splits per-reminder system-reminders into
+// separate content blocks. After scrubbing, each becomes {type:'text',text:''},
+// which Anthropic rejects upstream with "messages: text content blocks must be
+// non-empty". The fix drops empty-text blocks from the content array after
+// sanitization — the remaining real user content is forwarded unchanged.
+
+import { sanitizeMessages } from '../dist/proxy.js';
+
+let pass = 0, fail = 0;
+function check(name, cond) {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else      { console.log(`  FAIL ${name}`); fail++; }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+// ─────────────────────────────────────────────────────────────
+header('dario#54 — CC v2.1.112 multi-block system-reminder scrub');
+{
+  // Exact shape from tetsuco's #54 body dump: 3 reminder-only blocks + 1 "hello"
+  const body = {
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: '<system-reminder>\nSkills available: foo, bar\n</system-reminder>' },
+          { type: 'text', text: '<system-reminder>\nSlash commands: /help\n</system-reminder>' },
+          { type: 'text', text: '<system-reminder>\nAnother one\n</system-reminder>' },
+          { type: 'text', text: 'hello' },
+        ],
+      },
+    ],
+  };
+  sanitizeMessages(body);
+  const content = body.messages[0].content;
+  check('3 reminder-only blocks dropped', content.length === 1);
+  check('remaining block is the hello text', content[0].type === 'text' && content[0].text === 'hello');
+  check('no empty-text block survives', !content.some(b => b.type === 'text' && b.text === ''));
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Reminder adjacent to real text in same block is preserved');
+{
+  const body = {
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'what time is it? <system-reminder>ignore this</system-reminder>' },
+        ],
+      },
+    ],
+  };
+  sanitizeMessages(body);
+  const content = body.messages[0].content;
+  check('block kept (had real text alongside reminder)', content.length === 1);
+  check('reminder tag stripped, real text kept', content[0].text === 'what time is it?');
+}
+
+// ─────────────────────────────────────────────────────────────
+header('String content sanitization unchanged');
+{
+  const body = {
+    messages: [
+      {
+        role: 'user',
+        content: '<env>os=linux</env>hello',
+      },
+    ],
+  };
+  sanitizeMessages(body);
+  check('string content scrubbed in place', body.messages[0].content === 'hello');
+}
+
+// ─────────────────────────────────────────────────────────────
+header('tool_result blocks with empty content survive (not text type)');
+{
+  const body = {
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 't1', content: '' },
+          { type: 'text', text: 'follow-up' },
+        ],
+      },
+    ],
+  };
+  sanitizeMessages(body);
+  const content = body.messages[0].content;
+  check('tool_result block survives empty content', content.some(b => b.type === 'tool_result'));
+  check('text block also survives', content.some(b => b.type === 'text' && b.text === 'follow-up'));
+}
+
+// ─────────────────────────────────────────────────────────────
+header('All-reminder message content collapses to empty array');
+{
+  const body = {
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: '<system-reminder>only this</system-reminder>' },
+        ],
+      },
+    ],
+  };
+  sanitizeMessages(body);
+  check('content array emptied when every block scrubbed away', body.messages[0].content.length === 0);
+  // Note: buildCCRequest pops empty trailing turns; this shape flows through to that layer.
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Non-text blocks (tool_use, image) pass through');
+{
+  const body = {
+    messages: [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'u1', name: 'Bash', input: { command: 'ls' } },
+          { type: 'text', text: '<system-reminder>ignored</system-reminder>' },
+        ],
+      },
+    ],
+  };
+  sanitizeMessages(body);
+  const content = body.messages[0].content;
+  check('tool_use preserved', content.some(b => b.type === 'tool_use' && b.name === 'Bash'));
+  check('scrubbed-empty text dropped', !content.some(b => b.type === 'text' && b.text === ''));
+}
+
+// ─────────────────────────────────────────────────────────────
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Closes #54, closes #58.

## #54 — CC v2.1.112 `claude -p hello` → `text content blocks must be non-empty`

tetsuco's body dump on #54 exposed the root cause:

\`\`\`json
"messages":[{"role":"user","content":[
  {"type":"text","text":""},
  {"type":"text","text":""},
  {"type":"text","text":""},
  {"type":"text","text":"hello"}
]}]
\`\`\`

CC v2.1.112 splits per-reminder `<system-reminder>` blocks into **separate** content blocks. `sanitizeMessages` scrubs each block in place, so reminder-only blocks turn into `{type:'text',text:''}` — which Anthropic rejects with exactly the reported error.

**Fix:** after in-place scrubbing, drop text blocks whose `text` is now empty. `tool_result`, `tool_use`, `image` blocks pass through regardless.

## #58 — `seven_day` billing claim showed `unknown` + `n/a` overage

Anthropic is rolling `seven_day` / `seven_day_fallback` as the new subscription rate-limit claim, semantics identical to `five_hour[_fallback]`. Two display paths hardcoded the legacy family:

- `billingBucketFromClaim` → `'unknown'` for `seven_day`
- Overage fallback in `proxy.ts` → `'n/a'` for `seven_day` when the `anthropic-ratelimit-unified-overage-utilization` header was absent

Both sites extended to match `seven_day` / `seven_day_fallback` alongside `five_hour`.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 49 files green (new `sanitize-messages.mjs` = 11 assertions)
- [x] `test/analytics-billing-bucket.mjs` updated with `seven_day` assertions