### PR TITLE
v3.30.5 — bump SUPPORTED_CC_RANGE.maxTested to 2.1.116

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.30.5] - 2026-04-21
+
+### Changed — `SUPPORTED_CC_RANGE.maxTested` → 2.1.116
+
+`src/live-fingerprint.ts` bumps `maxTested` from `2.1.114` to `2.1.116`. dario v3.30.4 re-baked the bundled template against CC 2.1.116 and the MITM check showed zero wire-shape regressions, so the constant that gates the doctor's "installed CC is within tested range" message now reflects what's actually validated. Resolves the cc-drift-watch auto-issue filed against the 2.1.114 ceiling.
+
 ## [3.30.4] - 2026-04-20
 
 ### Added — Platform-scoped tool filtering

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.30.4",
+  "version": "3.30.5",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {

--- a/src/live-fingerprint.ts
+++ b/src/live-fingerprint.ts
@@ -800,7 +800,7 @@ export function _resetInstalledVersionProbeForTest(): void {
  */
 export const SUPPORTED_CC_RANGE = {
   min: '1.0.0',
-  maxTested: '2.1.114',
+  maxTested: '2.1.116',
 } as const;
 
 /**


### PR DESCRIPTION
Closes #63.

v3.30.4 re-baked the bundled template from CC v2.1.116 and the MITM diff confirmed no wire-shape regressions vs 2.1.114. The compat-range ceiling (`SUPPORTED_CC_RANGE.maxTested`) that gates the doctor "installed CC is within tested range" message still pointed at 2.1.114, which is what triggered the cc-drift-watch cron to file #63.

One-line bump of `maxTested` to 2.1.116 in `src/live-fingerprint.ts`. No other changes.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 29/29 in platform-tools, full suite green
- [x] `npm run drift:sdk` — clean