### PR TITLE
docs(readme): SEO pass on the intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 <p align="center">
   <h1 align="center">dario</h1>
-  <p align="center"><strong>A universal LLM router that runs on your machine.<br>One local endpoint, every provider — Anthropic, OpenAI, Groq, OpenRouter, Ollama, any OpenAI-compat URL. Point your tools at localhost and stop caring which vendor is upstream.</strong></p>
+  <p align="center"><strong>A universal LLM router that runs on your machine.<br>Turn your Claude Max / Pro subscription into a local Claude API — or the Claude Agent SDK into an OAuth-routed backend — alongside OpenAI, Groq, OpenRouter, Ollama, and any OpenAI-compat URL. One endpoint at localhost, every provider behind it, your tools stop caring which vendor is upstream.</strong></p>
 </p>
+
+<p align="center"><em>Your Claude Code subscription as a local API. OAuth-routed, byte-perfect Claude Code fingerprint. Works with every Anthropic-compat tool unchanged.</em></p>
 
 <p align="center">
   <a href="https://www.npmjs.com/package/@askalf/dario"><img src="https://img.shields.io/npm/v/@askalf/dario?color=blue" alt="npm version"></a>


### PR DESCRIPTION
## Summary

Surgical SEO rewrite of the README opening — no functional changes, just surfacing the search terms people actually type when looking for what dario does.

### What changed

- **Opening paragraph.** "Anthropic" → "Claude Max / Pro subscription as a local Claude API — or the Claude Agent SDK into an OAuth-routed backend". Picks up `Claude Max API`, `Claude Pro subscription`, `Claude API`, `Claude Agent SDK`, `OAuth` as organic terms.
- **New sub-tagline** directly under the title: *"Your Claude Code subscription as a local API. OAuth-routed, byte-perfect Claude Code fingerprint. Works with every Anthropic-compat tool unchanged."* Catches the `Claude Code API` long-tail and leads with the differentiator vs LiteLLM / OpenRouter.

### Why

Pure SEO / positioning — dario's unique value (OAuth subscription routing + CC fingerprint replay) was previously buried behind a generic "Anthropic" provider label. Users searching "Claude Max API" or "Claude Agent SDK OAuth backend" wouldn't find dario even though it's exactly what they want.

Tone preserved: still a single-strong paragraph + tagline, no marketing bloat, fits the existing voice.

## Test plan

- [x] `git diff README.md` — 3 insertions, 1 deletion, all in the header block above the badges
- [x] Preview rendered on GitHub — paragraph wraps cleanly, tagline italic