### PR TITLE
v3.30.7 — --preserve-orchestration-tags flag (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.30.7] - 2026-04-21
+
+### Added — `--preserve-orchestration-tags` flag (dario#78)
+
+Push-back from Gemini's review: dario's default orchestration-tag scrub (`<system-reminder>`, `<env>`, `<thinking>`, `<agent_persona>`, etc.) is right for most callers but *wrong* for workflows that legitimately rely on one of those tags as signal to the model — e.g., a debugging agent that explicitly forwards `<thinking>` so it can observe reasoning traces, or an evaluator that keeps `<env>` for reproducibility. Those workflows were breaking silently under dario.
+
+New CLI flag + env mirror:
+
+- `--preserve-orchestration-tags` (bare) → preserve **all** orchestration tags; the scrub becomes a no-op.
+- `--preserve-orchestration-tags=tag1,tag2` → preserve only the listed tags; everything else in `ORCHESTRATION_TAG_NAMES` is still stripped.
+- `DARIO_PRESERVE_ORCHESTRATION_TAGS=*` or `=tag1,tag2` — env mirror; explicit CLI flag wins when both are set.
+
+Default behaviour unchanged — the flag is strict opt-in. `sanitizeMessages` now takes an optional `preserveTags: Set<string>` argument; internal callers thread the option through `ProxyOptions.preserveOrchestrationTags`. `buildOrchestrationPatterns` and `ORCHESTRATION_TAG_NAMES` are exported so third parties building on top of dario's proxy primitives can reuse the same tag list and pattern-building logic.
+
+Tests extend `test/sanitize-messages.mjs` — 10 new assertions covering preserve-all, preserve-one-tag, undefined-equals-default, pattern-count invariants, and all six branches of `resolvePreserveOrchestrationTags` (bare flag, `=list`, `=*`, env `*`, env list, flag-wins-over-env, whitespace tolerance, empty value).
+
 ## [3.30.6] - 2026-04-21
 
 ### Changed / Added — Tier-1 review-feedback items from `reviews/`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.30.6",
+  "version": "3.30.7",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -240,6 +240,14 @@ async function proxy() {
   const sessionMaxAgeMs = parsePositiveIntFlag('--session-max-age=');
   const sessionPerClient = args.includes('--session-per-client') || undefined;
 
+  // --preserve-orchestration-tags (bare OR =tag1,tag2,...) — opt-out for
+  // workflows that legitimately need <system-reminder>, <thinking>, etc.
+  // preserved on the wire. Default behaviour unchanged (strip all).
+  // dario#78 (Gemini review push-back). Env mirror:
+  //   DARIO_PRESERVE_ORCHESTRATION_TAGS=*           (preserve all)
+  //   DARIO_PRESERVE_ORCHESTRATION_TAGS=thinking,env (preserve listed)
+  const preserveOrchestrationTags = resolvePreserveOrchestrationTags(args, process.env['DARIO_PRESERVE_ORCHESTRATION_TAGS']);
+
   // Non-loopback bind without DARIO_API_KEY turns dario into an open
   // OAuth-subscription relay for anyone on the reachable network. Refuse
   // to start rather than rely on the operator to read the startup banner.
@@ -260,7 +268,36 @@ async function proxy() {
     process.exit(1);
   }
 
-  await startProxy({ port, host, verbose, verboseBodies, model, passthrough, preserveTools, hybridTools, noAutoDetect, strictTls, pacingMinMs, pacingJitterMs, drainOnClose, sessionIdleRotateMs, sessionRotateJitterMs, sessionMaxAgeMs, sessionPerClient });
+  await startProxy({ port, host, verbose, verboseBodies, model, passthrough, preserveTools, hybridTools, noAutoDetect, strictTls, pacingMinMs, pacingJitterMs, drainOnClose, sessionIdleRotateMs, sessionRotateJitterMs, sessionMaxAgeMs, sessionPerClient, preserveOrchestrationTags });
+}
+
+/**
+ * Parse --preserve-orchestration-tags (bare or =value) + env mirror.
+ * Exported for tests.
+ * dario#78.
+ *
+ *   undefined              — flag not passed + env unset → strip all (default)
+ *   Set(['*'])             — flag bare OR value "*"      → preserve all
+ *   Set(['thinking','env']) — value "thinking,env"        → preserve listed
+ */
+export function resolvePreserveOrchestrationTags(
+  args: string[],
+  env: string | undefined,
+): Set<string> | undefined {
+  // Explicit --preserve-orchestration-tags=value wins over everything.
+  const withValue = args.find(a => a.startsWith('--preserve-orchestration-tags='));
+  if (withValue) return parsePreserveTagsValue(withValue.split('=').slice(1).join('='));
+  // Bare flag = preserve all.
+  if (args.includes('--preserve-orchestration-tags')) return new Set(['*']);
+  // Env mirror — explicit flag always wins, checked last.
+  if (env !== undefined) return parsePreserveTagsValue(env);
+  return undefined;
+}
+
+function parsePreserveTagsValue(value: string): Set<string> {
+  const trimmed = value.trim();
+  if (trimmed === '' || trimmed === '*') return new Set(['*']);
+  return new Set(trimmed.split(',').map(s => s.trim()).filter(Boolean));
 }
 
 function parsePositiveIntFlag(prefix: string): number | undefined {
@@ -585,6 +622,16 @@ async function help() {
                              header) its own rotated session id.
                              Default: off (single session across all
                              clients, v3.27 behaviour). (v3.28)
+    --preserve-orchestration-tags[=TAG,TAG]
+                             Opt specific orchestration wrapper tags
+                             (<system-reminder>, <env>, <thinking>,
+                             etc.) out of the scrub. Bare flag =
+                             preserve all. Value form = preserve only
+                             those listed; everything else is still
+                             stripped. Default: strip every tag in
+                             ORCHESTRATION_TAG_NAMES. Env mirror:
+                             DARIO_PRESERVE_ORCHESTRATION_TAGS=*
+                             or =tag1,tag2. (v3.31, dario#78)
     --port=PORT              Port to listen on (default: 3456)
     --host=ADDRESS           Address to bind to (default: 127.0.0.1)
                              Use 0.0.0.0 for LAN; see README for DARIO_API_KEY

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -191,38 +191,67 @@ function filterBillableBetas(betas: string): string {
 
 // Orchestration tags injected by agents (Aider, Cursor, OpenCode, etc.)
 // that confuse Claude when passed through. Strip before forwarding.
-const ORCHESTRATION_TAG_NAMES = [
+export const ORCHESTRATION_TAG_NAMES = [
   'system-reminder', 'env', 'system_information', 'current_working_directory',
   'operating_system', 'default_shell', 'home_directory', 'task_metadata',
   'directories', 'thinking',
   'agent_persona', 'agent_context', 'tool_context', 'persona', 'tool_call',
 ];
-const ORCHESTRATION_PATTERNS = ORCHESTRATION_TAG_NAMES.flatMap(tag => [
-  new RegExp(`<${tag}\\b[^>]*>[\\s\\S]*?<\\/${tag}>`, 'gi'),
-  new RegExp(`<${tag}\\b[^>]*\\/>`, 'gi'),
-]);
+
+/**
+ * Build the regex list that actually strips orchestration tags.
+ *
+ * `preserveTags` selects which tags to KEEP in the outbound body.
+ *   undefined       → strip every tag in ORCHESTRATION_TAG_NAMES (default)
+ *   Set(['*'])      → preserve all tags (strip none)
+ *   Set(['thinking']) → strip everything except `<thinking>...</thinking>`
+ *
+ * Each tag produces two patterns — the wrapper form (`<tag>...</tag>`) and
+ * the self-closing form (`<tag ... />`) — so callers that emit either shape
+ * get the same treatment.
+ *
+ * dario#78 (Gemini review push-back).
+ */
+export function buildOrchestrationPatterns(preserveTags?: Set<string>): RegExp[] {
+  if (preserveTags?.has('*')) return [];
+  const effective = preserveTags
+    ? ORCHESTRATION_TAG_NAMES.filter(tag => !preserveTags.has(tag))
+    : ORCHESTRATION_TAG_NAMES;
+  return effective.flatMap(tag => [
+    new RegExp(`<${tag}\\b[^>]*>[\\s\\S]*?<\\/${tag}>`, 'gi'),
+    new RegExp(`<${tag}\\b[^>]*\\/>`, 'gi'),
+  ]);
+}
+
+const ORCHESTRATION_PATTERNS_DEFAULT = buildOrchestrationPatterns();
 
 /** Strip orchestration wrapper tags from message content. */
-function sanitizeContent(text: string): string {
+function sanitizeContent(text: string, patterns: RegExp[]): string {
   let result = text;
-  for (const pattern of ORCHESTRATION_PATTERNS) {
+  for (const pattern of patterns) {
     pattern.lastIndex = 0;
     result = result.replace(pattern, '');
   }
   return result.replace(/\n{3,}/g, '\n\n').trim();
 }
 
-/** Strip orchestration tags from all messages in a request body. */
-export function sanitizeMessages(body: Record<string, unknown>): void {
+/**
+ * Strip orchestration tags from all messages in a request body.
+ *
+ * Pass `preserveTags` (a Set of tag names, or `Set(['*'])` for all) to
+ * opt any tag out of the scrub. dario#78.
+ */
+export function sanitizeMessages(body: Record<string, unknown>, preserveTags?: Set<string>): void {
   const messages = body.messages as Array<{ role: string; content: unknown }> | undefined;
   if (!messages) return;
+  const patterns = preserveTags === undefined ? ORCHESTRATION_PATTERNS_DEFAULT : buildOrchestrationPatterns(preserveTags);
   for (const msg of messages) {
     if (typeof msg.content === 'string') {
-      msg.content = sanitizeContent(msg.content);
+      msg.content = sanitizeContent(msg.content, patterns);
     } else if (Array.isArray(msg.content)) {
       for (const block of msg.content) {
         if (typeof block === 'object' && block && 'text' in block && typeof (block as { text: string }).text === 'string') {
-          (block as { text: string }).text = sanitizeContent((block as { text: string }).text);
+          (block as { text: string }).text = sanitizeContent((block as { text: string }).text, patterns);
         }
       }
       // Drop text blocks that became empty after orchestration-tag scrubbing.
@@ -356,6 +385,12 @@ interface ProxyOptions {
   sessionRotateJitterMs?: number;  // Uniform jitter on idle threshold (v3.28 — default 0)
   sessionMaxAgeMs?: number;        // Hard cap on session-id lifetime (v3.28 — default off)
   sessionPerClient?: boolean;      // Key sessions by x-session-id/x-client-session-id header (v3.28 — default off)
+  /**
+   * Opt specific orchestration tags out of the scrub. Undefined = strip all
+   * (default, v3.30 and earlier behaviour). Set(['*']) = preserve all.
+   * Set(['thinking','env']) = strip everything except those two. dario#78.
+   */
+  preserveOrchestrationTags?: Set<string>;
 }
 
 export function sanitizeError(err: unknown): string {
@@ -901,7 +936,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
         try {
           const parsed = JSON.parse(body.toString()) as Record<string, unknown>;
           // Strip orchestration tags from messages (Aider, Cursor, etc.)
-          sanitizeMessages(parsed);
+          sanitizeMessages(parsed, opts.preserveOrchestrationTags);
           const result = isOpenAI ? openaiToAnthropic(parsed, modelOverride) : (modelOverride ? { ...parsed, model: modelOverride } : parsed);
           const r = result as Record<string, unknown>;
           requestModel = (r.model as string || '').toLowerCase();

--- a/test/sanitize-messages.mjs
+++ b/test/sanitize-messages.mjs
@@ -7,7 +7,8 @@
 // non-empty". The fix drops empty-text blocks from the content array after
 // sanitization — the remaining real user content is forwarded unchanged.
 
-import { sanitizeMessages } from '../dist/proxy.js';
+import { sanitizeMessages, buildOrchestrationPatterns, ORCHESTRATION_TAG_NAMES } from '../dist/proxy.js';
+import { resolvePreserveOrchestrationTags } from '../dist/cli.js';
 
 let pass = 0, fail = 0;
 function check(name, cond) {
@@ -130,6 +131,85 @@ header('Non-text blocks (tool_use, image) pass through');
   const content = body.messages[0].content;
   check('tool_use preserved', content.some(b => b.type === 'tool_use' && b.name === 'Bash'));
   check('scrubbed-empty text dropped', !content.some(b => b.type === 'text' && b.text === ''));
+}
+
+// ─────────────────────────────────────────────────────────────
+header('dario#78 — preserveTags opt-out: preserve all (Set(["*"]))');
+{
+  const body = {
+    messages: [{
+      role: 'user',
+      content: [
+        { type: 'text', text: '<system-reminder>keep me</system-reminder>' },
+        { type: 'text', text: '<thinking>and me</thinking>' },
+        { type: 'text', text: 'ok' },
+      ],
+    }],
+  };
+  sanitizeMessages(body, new Set(['*']));
+  const content = body.messages[0].content;
+  check('preserve-all keeps all 3 blocks', content.length === 3);
+  check('system-reminder tag survives', content[0].text.includes('<system-reminder>keep me</system-reminder>'));
+  check('thinking tag survives', content[1].text.includes('<thinking>and me</thinking>'));
+  check('plain text survives', content[2].text === 'ok');
+}
+
+header('dario#78 — preserveTags opt-out: preserve one tag (Set(["thinking"]))');
+{
+  const body = {
+    messages: [{
+      role: 'user',
+      content: [
+        { type: 'text', text: '<system-reminder>strip me</system-reminder><thinking>keep me</thinking>' },
+        { type: 'text', text: 'ok' },
+      ],
+    }],
+  };
+  sanitizeMessages(body, new Set(['thinking']));
+  const content = body.messages[0].content;
+  check('2 blocks retained (partial scrub left content in the first)', content.length === 2);
+  check('system-reminder still stripped', !content[0].text.includes('<system-reminder>'));
+  check('thinking preserved', content[0].text.includes('<thinking>keep me</thinking>'));
+  check('plain text untouched', content[1].text === 'ok');
+}
+
+header('dario#78 — preserveTags undefined behaves identically to default');
+{
+  const body1 = { messages: [{ role: 'user', content: [{ type: 'text', text: '<env>a</env>hi' }] }] };
+  const body2 = { messages: [{ role: 'user', content: [{ type: 'text', text: '<env>a</env>hi' }] }] };
+  sanitizeMessages(body1);
+  sanitizeMessages(body2, undefined);
+  check('undefined === default — same output', JSON.stringify(body1) === JSON.stringify(body2));
+}
+
+header('dario#78 — buildOrchestrationPatterns shape');
+{
+  const allPatterns = buildOrchestrationPatterns();
+  check('default patterns = 2 per tag', allPatterns.length === ORCHESTRATION_TAG_NAMES.length * 2);
+  const preserveAllPatterns = buildOrchestrationPatterns(new Set(['*']));
+  check('preserve all → 0 patterns', preserveAllPatterns.length === 0);
+  const preserveTwoPatterns = buildOrchestrationPatterns(new Set(['thinking', 'env']));
+  check('preserve 2 → (total - 2) * 2 patterns', preserveTwoPatterns.length === (ORCHESTRATION_TAG_NAMES.length - 2) * 2);
+}
+
+header('dario#78 — resolvePreserveOrchestrationTags parses CLI + env');
+{
+  check('no flag, no env → undefined',
+    resolvePreserveOrchestrationTags([], undefined) === undefined);
+  const bare = resolvePreserveOrchestrationTags(['--preserve-orchestration-tags'], undefined);
+  check('bare flag → Set(["*"])', bare instanceof Set && bare.has('*') && bare.size === 1);
+  const valued = resolvePreserveOrchestrationTags(['--preserve-orchestration-tags=thinking,env'], undefined);
+  check('flag=list → Set of listed tags', valued instanceof Set && valued.has('thinking') && valued.has('env') && valued.size === 2);
+  const envAll = resolvePreserveOrchestrationTags([], '*');
+  check('env "*" → Set(["*"])', envAll instanceof Set && envAll.has('*') && envAll.size === 1);
+  const envList = resolvePreserveOrchestrationTags([], 'thinking,env');
+  check('env list → Set of listed tags', envList instanceof Set && envList.has('thinking') && envList.size === 2);
+  const flagWinsOverEnv = resolvePreserveOrchestrationTags(['--preserve-orchestration-tags=thinking'], 'env');
+  check('explicit flag wins over env', flagWinsOverEnv instanceof Set && flagWinsOverEnv.has('thinking') && !flagWinsOverEnv.has('env'));
+  const whitespaceTolerant = resolvePreserveOrchestrationTags(['--preserve-orchestration-tags= thinking , env '], undefined);
+  check('value whitespace trimmed', whitespaceTolerant.has('thinking') && whitespaceTolerant.has('env') && whitespaceTolerant.size === 2);
+  const emptyValue = resolvePreserveOrchestrationTags(['--preserve-orchestration-tags='], undefined);
+  check('empty value treated as "*"', emptyValue instanceof Set && emptyValue.has('*'));
 }
 
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #78.

## Summary

Push-back from Gemini's review (landed in v3.30.5 \`reviews/\`): dario's default orchestration-tag scrub strips \`<system-reminder>\`, \`<env>\`, \`<thinking>\`, \`<agent_persona>\`, etc. for the right reason (most agents injecting those confuse Claude when it sees them upstream) but silently breaks workflows that legitimately rely on one of them as signal — debugger agents watching \`<thinking>\`, evaluators preserving \`<env>\` for reproducibility.

## Changes

### New CLI flag + env mirror

| Invocation | Behaviour |
|---|---|
| *(unset)* | Strip every tag in \`ORCHESTRATION_TAG_NAMES\` — default, unchanged |
| \`--preserve-orchestration-tags\` | Preserve **all** tags (scrub is a no-op) |
| \`--preserve-orchestration-tags=thinking,env\` | Preserve only \`<thinking>\` and \`<env>\`; everything else still stripped |
| \`DARIO_PRESERVE_ORCHESTRATION_TAGS=*\` | Env mirror — preserve all |
| \`DARIO_PRESERVE_ORCHESTRATION_TAGS=thinking,env\` | Env mirror — preserve listed |

Explicit CLI flag wins when both are set.

### Internal shape

- \`sanitizeMessages(body, preserveTags?)\` — new optional second arg
- \`ProxyOptions.preserveOrchestrationTags\` — threads through from CLI
- \`buildOrchestrationPatterns(preserveTags?)\` + \`ORCHESTRATION_TAG_NAMES\` — exported so third parties building on dario's proxy primitives can reuse the tag list and pattern construction
- \`resolvePreserveOrchestrationTags(args, env)\` — exported CLI parser for testing

### Tests

\`test/sanitize-messages.mjs\` gains 10 new assertions across four sections:

- Preserve-all semantics (Set(['*']))
- Preserve-one-tag semantics (partial scrub)
- \`undefined\` behaves identically to the historical default
- \`buildOrchestrationPatterns\` pattern-count invariants
- All six branches of \`resolvePreserveOrchestrationTags\` (bare flag, \`=list\`, \`=*\`, env \`*\`, env list, flag-wins-over-env, whitespace tolerance, empty-value-treated-as-all)

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm test\` — 50 files, all green; \`sanitize-messages.mjs\` now 31 pass
- [x] \`npm run drift:sdk\` — clean against CC 2.1.116