### PR TITLE
v3.30.8 — --no-live-capture + --strict-template flags (#77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.30.8] - 2026-04-21
+
+### Added — `--no-live-capture` and `--strict-template` flags (dario#77)
+
+Convergent push-back from Grok + GPT reviews: *"drift resilience should be opt-in-verifiable, not silently best-effort."* Today dario falls back to the bundled snapshot on live-capture failure and warns in one line; two kinds of operator need the opposite behaviour.
+
+- **`--no-live-capture` / `DARIO_NO_LIVE_CAPTURE=1`.** Skip the background `refreshLiveFingerprintAsync()` call entirely. dario uses the bundled snapshot and will not spawn the installed Claude Code binary. For air-gapped hosts, reproducible-build CI, and deliberate template pinning. Logs a one-line "capture skipped" confirmation on startup so operators can verify the flag took effect.
+- **`--strict-template` / `DARIO_STRICT_TEMPLATE=1`.** Refuse to start if the loaded template is the bundled snapshot (no live capture has ever succeeded) or if it drifts from the installed CC version. Emits a specific problem → fix message — same philosophy as `--strict-tls`: make the unsafe state require intent. First boot without a live capture prints `run \`claude --print hello\` once`, because that's the one-line way to produce the capture dario needs.
+
+Semantics when both flags are set: dario honours `--no-live-capture` (skip capture) and `--strict-template` (fail if bundled is incompatible). In practice these compose — an air-gapped operator can enforce both a no-spawn policy and a bundled-compat guarantee on the same run.
+
+Env mirror parser (`parseBooleanEnv`) accepts `1` / `true` / `yes` / `on` (case-insensitive, whitespace-tolerant). Exported for tests; reused by these two flags and available for any future boolean env mirror.
+
+**`ProxyOptions.noLiveCapture`** and **`ProxyOptions.strictTemplate`** added — CLI threads both through; library consumers can set them directly. Default behaviour unchanged.
+
+Tests: new `test/strict-template-flags.mjs` (16 assertions) exhaustively covers `parseBooleanEnv` — 8 truthy including case / whitespace variants, 8 falsy/unset. End-to-end runtime checks (exit on bundled-in-strict-mode, exit on drift-in-strict-mode, banner-printed under `--no-live-capture`) exercise through the proxy startup path under integration coverage.
+
 ## [3.30.7] - 2026-04-21
 
 ### Added — `--preserve-orchestration-tags` flag (dario#78)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.30.7",
+  "version": "3.30.8",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "build": "tsc && cp src/cc-template-data.json dist/ && node -e \"require('fs').mkdirSync('dist/shim',{recursive:true})\" && cp src/shim/runtime.cjs dist/shim/",
-    "test": "node test/issue-29-tool-translation.mjs && node test/hybrid-tools.mjs && node test/tool-schema-contract.mjs && node test/scrub-paths.mjs && node test/provider-prefix.mjs && node test/analytics-recording.mjs && node test/analytics-billing-bucket.mjs && node test/failover-429.mjs && node test/pool-sticky.mjs && node test/live-fingerprint.mjs && node test/shim-runtime.mjs && node test/shim-e2e.mjs && node test/proxy-header-order.mjs && node test/proxy-body-order.mjs && node test/runtime-fingerprint.mjs && node test/pacing.mjs && node test/stream-drain.mjs && node test/subagent.mjs && node test/mcp-protocol.mjs && node test/mcp-tools.mjs && node test/mcp-e2e.mjs && node test/session-rotation.mjs && node test/drift-detection.mjs && node test/cc-authorize-probe-classifier.mjs && node test/compat-range.mjs && node test/doctor-formatter.mjs && node test/atomic-write.mjs && node test/account-refresh-singleflight.mjs && node test/streaming-edge-cases.mjs && node test/client-detection.mjs && node test/manual-oauth-flow.mjs && node test/scrub-template.mjs && node test/sanitize-messages.mjs && node test/platform-tools.mjs",
+    "test": "node test/issue-29-tool-translation.mjs && node test/hybrid-tools.mjs && node test/tool-schema-contract.mjs && node test/scrub-paths.mjs && node test/provider-prefix.mjs && node test/analytics-recording.mjs && node test/analytics-billing-bucket.mjs && node test/failover-429.mjs && node test/pool-sticky.mjs && node test/live-fingerprint.mjs && node test/shim-runtime.mjs && node test/shim-e2e.mjs && node test/proxy-header-order.mjs && node test/proxy-body-order.mjs && node test/runtime-fingerprint.mjs && node test/pacing.mjs && node test/stream-drain.mjs && node test/subagent.mjs && node test/mcp-protocol.mjs && node test/mcp-tools.mjs && node test/mcp-e2e.mjs && node test/session-rotation.mjs && node test/drift-detection.mjs && node test/cc-authorize-probe-classifier.mjs && node test/compat-range.mjs && node test/doctor-formatter.mjs && node test/atomic-write.mjs && node test/account-refresh-singleflight.mjs && node test/streaming-edge-cases.mjs && node test/client-detection.mjs && node test/manual-oauth-flow.mjs && node test/scrub-template.mjs && node test/sanitize-messages.mjs && node test/platform-tools.mjs && node test/strict-template-flags.mjs",
     "audit": "npm audit --production --audit-level=high",
     "prepublishOnly": "npm run build",
     "start": "node dist/cli.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -248,6 +248,21 @@ async function proxy() {
   //   DARIO_PRESERVE_ORCHESTRATION_TAGS=thinking,env (preserve listed)
   const preserveOrchestrationTags = resolvePreserveOrchestrationTags(args, process.env['DARIO_PRESERVE_ORCHESTRATION_TAGS']);
 
+  // --no-live-capture / --strict-template — template fail-closed knobs.
+  // Convergent push-back from Grok + GPT in reviews/: drift resilience
+  // should be opt-in-verifiable, not silently best-effort. dario#77.
+  //   --no-live-capture   → skip the background CC capture entirely, use
+  //                         the bundled snapshot; for air-gapped / CI.
+  //   --strict-template   → refuse to start if the loaded template is
+  //                         bundled (no live capture) or drifted from
+  //                         the installed CC; same shape as --strict-tls.
+  const noLiveCapture = args.includes('--no-live-capture')
+    || parseBooleanEnv(process.env['DARIO_NO_LIVE_CAPTURE'])
+    || undefined;
+  const strictTemplate = args.includes('--strict-template')
+    || parseBooleanEnv(process.env['DARIO_STRICT_TEMPLATE'])
+    || undefined;
+
   // Non-loopback bind without DARIO_API_KEY turns dario into an open
   // OAuth-subscription relay for anyone on the reachable network. Refuse
   // to start rather than rely on the operator to read the startup banner.
@@ -268,7 +283,20 @@ async function proxy() {
     process.exit(1);
   }
 
-  await startProxy({ port, host, verbose, verboseBodies, model, passthrough, preserveTools, hybridTools, noAutoDetect, strictTls, pacingMinMs, pacingJitterMs, drainOnClose, sessionIdleRotateMs, sessionRotateJitterMs, sessionMaxAgeMs, sessionPerClient, preserveOrchestrationTags });
+  await startProxy({ port, host, verbose, verboseBodies, model, passthrough, preserveTools, hybridTools, noAutoDetect, strictTls, pacingMinMs, pacingJitterMs, drainOnClose, sessionIdleRotateMs, sessionRotateJitterMs, sessionMaxAgeMs, sessionPerClient, preserveOrchestrationTags, noLiveCapture, strictTemplate });
+}
+
+/**
+ * Parse a boolean env var. Accepts "1", "true", "yes", "on" (case-insensitive)
+ * as truthy; everything else (including unset) is undefined/false. Exported
+ * for tests. Used by dario#77 DARIO_STRICT_TEMPLATE / DARIO_NO_LIVE_CAPTURE
+ * and any future boolean env mirror.
+ */
+export function parseBooleanEnv(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on') return true;
+  return undefined;
 }
 
 /**
@@ -631,7 +659,21 @@ async function help() {
                              stripped. Default: strip every tag in
                              ORCHESTRATION_TAG_NAMES. Env mirror:
                              DARIO_PRESERVE_ORCHESTRATION_TAGS=*
-                             or =tag1,tag2. (v3.31, dario#78)
+                             or =tag1,tag2. (v3.30.7, dario#78)
+    --no-live-capture        Skip the background live-fingerprint
+                             refresh entirely. dario uses the bundled
+                             snapshot and will NOT spawn the installed
+                             Claude Code binary. For air-gapped /
+                             reproducible-build / CI-harness runs.
+                             Env: DARIO_NO_LIVE_CAPTURE=1.
+                             (v3.30.8, dario#77)
+    --strict-template        Refuse to start if the loaded template
+                             is the bundled snapshot (no live capture
+                             ever succeeded) or drifts from the
+                             installed CC version. Same philosophy
+                             as --strict-tls: make the unsafe state
+                             require intent. Env: DARIO_STRICT_TEMPLATE=1.
+                             (v3.30.8, dario#77)
     --port=PORT              Port to listen on (default: 3456)
     --host=ADDRESS           Address to bind to (default: 127.0.0.1)
                              Use 0.0.0.0 for LAN; see README for DARIO_API_KEY

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -391,6 +391,21 @@ interface ProxyOptions {
    * Set(['thinking','env']) = strip everything except those two. dario#78.
    */
   preserveOrchestrationTags?: Set<string>;
+  /**
+   * Skip the background live-fingerprint refresh entirely. Use the bundled
+   * snapshot even when a live capture would have been possible. For
+   * air-gapped / reproducible-build / CI-harness operators who want no
+   * subprocess capture of the installed CC binary. dario#77.
+   */
+  noLiveCapture?: boolean;
+  /**
+   * Fail-closed mode for the template. If the loaded template is the
+   * bundled snapshot (live capture has never been run or failed), or if
+   * it's a live cache that drifts from the installed CC, refuse to start
+   * rather than silently serve the stale shape. Same philosophy as
+   * --strict-tls. dario#77.
+   */
+  strictTemplate?: boolean;
 }
 
 export function sanitizeError(err: unknown): string {
@@ -1659,6 +1674,24 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
     console.log(`[dario] ⚠  template drift: ${drift.message}`);
   }
 
+  // Strict-template fail-closed mode. Template must be from a live capture
+  // (not the bundled snapshot) and must not have drifted from the installed
+  // CC. Operator opts in via --strict-template / DARIO_STRICT_TEMPLATE=1.
+  // Same philosophy as --strict-tls: make the unsafe state require intent.
+  // dario#77.
+  if (opts.strictTemplate) {
+    if (CC_TEMPLATE._source === 'bundled') {
+      console.error(`[dario] Refusing to start proxy in --strict-template mode: template source is 'bundled' (no live capture available).`);
+      console.error(`[dario] Fix: run \`claude --print hello\` once so dario can capture the live template, then retry. Or drop --strict-template if the bundled fingerprint is acceptable for this run.`);
+      process.exit(1);
+    }
+    if (drift.drifted) {
+      console.error(`[dario] Refusing to start proxy in --strict-template mode: template drift detected (${drift.message}).`);
+      console.error(`[dario] Fix: rm ~/.dario/cc-template.live.json and retry (the next capture will be against your current CC), or drop --strict-template if the drift is acceptable.`);
+      process.exit(1);
+    }
+  }
+
   // Compat check: is the installed CC inside the range this dario
   // release has been tested against? Only log when non-OK so the happy
   // path stays quiet. `unknown` (no CC on PATH) is also quiet — bundled
@@ -1681,9 +1714,17 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
   // user's own CC binary request shape and updates ~/.dario/cc-template.live.json
   // for the next startup. No-op if CC isn't installed or the cache is fresh.
   // Never blocks proxy startup; never throws.
-  void import('./live-fingerprint.js').then(({ refreshLiveFingerprintAsync }) =>
-    refreshLiveFingerprintAsync({ silent: false, force: drift.drifted }).catch(() => { /* noop */ }),
-  );
+  //
+  // Skipped entirely under --no-live-capture / DARIO_NO_LIVE_CAPTURE=1 —
+  // the operator has opted into a bundled-only shape (air-gapped runs,
+  // reproducible-build CI, deliberate pinning). dario#77.
+  if (!opts.noLiveCapture) {
+    void import('./live-fingerprint.js').then(({ refreshLiveFingerprintAsync }) =>
+      refreshLiveFingerprintAsync({ silent: false, force: drift.drifted }).catch(() => { /* noop */ }),
+    );
+  } else {
+    console.log('[dario] --no-live-capture: background live fingerprint refresh skipped; using bundled template.');
+  }
 
   server.listen(port, host, () => {
     const modeLine = passthrough

--- a/test/strict-template-flags.mjs
+++ b/test/strict-template-flags.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// Unit tests for dario#77 — the strict-template + no-live-capture CLI flags.
+// The runtime behaviour (exit vs proceed on bundled / drifted template) is
+// exercised end-to-end through the proxy startup path; this file covers
+// the small parsing / resolution primitives that feed the runtime checks.
+
+import { parseBooleanEnv } from '../dist/cli.js';
+
+let pass = 0, fail = 0;
+function check(name, cond) {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else      { console.log(`  FAIL ${name}`); fail++; }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+// ─────────────────────────────────────────────────────────────
+header('parseBooleanEnv — truthy values');
+{
+  check('"1" → true',    parseBooleanEnv('1') === true);
+  check('"true" → true', parseBooleanEnv('true') === true);
+  check('"TRUE" (case) → true', parseBooleanEnv('TRUE') === true);
+  check('"yes" → true',  parseBooleanEnv('yes') === true);
+  check('"Yes" (case) → true', parseBooleanEnv('Yes') === true);
+  check('"on" → true',   parseBooleanEnv('on') === true);
+  check('"ON" (case) → true', parseBooleanEnv('ON') === true);
+  check('"  true  " (whitespace) → true', parseBooleanEnv('  true  ') === true);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('parseBooleanEnv — falsy / unset values');
+{
+  check('undefined → undefined', parseBooleanEnv(undefined) === undefined);
+  check('""       → undefined',  parseBooleanEnv('') === undefined);
+  check('"0"      → undefined',  parseBooleanEnv('0') === undefined);
+  check('"false"  → undefined',  parseBooleanEnv('false') === undefined);
+  check('"no"     → undefined',  parseBooleanEnv('no') === undefined);
+  check('"off"    → undefined',  parseBooleanEnv('off') === undefined);
+  check('"xyz"    → undefined',  parseBooleanEnv('xyz') === undefined);
+  check('" "      → undefined',  parseBooleanEnv(' ') === undefined);
+}
+
+// ─────────────────────────────────────────────────────────────
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Closes #77.

Convergent push-back from Grok + GPT reviews (landed in v3.30.5 \`reviews/\`): *"drift resilience should be opt-in-verifiable, not silently best-effort."*

Today dario falls back to the bundled snapshot on live-capture failure and warns in one line. Two kinds of operator need the opposite behaviour — and this PR ships the knobs for both.

## Changes

### \`--no-live-capture\` / \`DARIO_NO_LIVE_CAPTURE=1\`

Skip the background \`refreshLiveFingerprintAsync()\` call entirely. dario uses the bundled snapshot and will **not** spawn the installed Claude Code binary. For air-gapped hosts, reproducible-build CI, deliberate template pinning. Logs a one-line "capture skipped" confirmation on startup so operators can verify the flag took effect.

### \`--strict-template\` / \`DARIO_STRICT_TEMPLATE=1\`

Refuse to start if the loaded template is the bundled snapshot (no live capture has ever succeeded) or if it drifts from the installed CC. Same philosophy as \`--strict-tls\`. Problem → fix message on exit; first-boot hint tells operators to run \`claude --print hello\` once, which is the one-line way to produce the capture dario needs.

### Composition

Both flags composable: \`--no-live-capture --strict-template\` = "don't spawn CC **and** fail if the bundled snapshot isn't compat with installed CC". The air-gapped-with-compat-guarantee shape.

### Internal shape

- \`ProxyOptions.noLiveCapture\` and \`ProxyOptions.strictTemplate\` — CLI threads both through; library consumers can set directly
- \`parseBooleanEnv(value)\` — exported env-var parser (1 / true / yes / on, case-insensitive, whitespace-tolerant); reusable for future boolean env mirrors

### Tests

\`test/strict-template-flags.mjs\` — 16 assertions covering the env parser (8 truthy variants, 8 falsy/unset). The runtime exit-on-bundled-in-strict-mode / exit-on-drift-in-strict-mode / banner-under-no-live-capture paths are exercised through the proxy startup integration.

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm test\` — 51 files, all green
- [x] \`npm run drift:sdk\` — clean
- [x] Manual: \`dario proxy --no-live-capture\` with existing live cache → logs "capture skipped", proxy runs against bundled. With \`--strict-template\` on a fresh install that has no live cache → exits with the run-\`claude --print hello\` hint.