### PR TITLE
v3.30.9 — bounded request queue replaces unbounded semaphore (#80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.30.9] - 2026-04-21
+
+### Changed — Bounded request queue replaces unbounded semaphore (dario#80)
+
+Push-back from Gemini's review: the v3.30.x-and-earlier concurrency control was a 10-slot semaphore with an unbounded FIFO waiting behind it. Under high client fan-out this produced two pathological modes — unbounded waiters stacking up in process memory and no way for the operator to see or tune it, and long-tail latency where the 61st concurrent request would silently wait forever for a slot that wasn't coming any time soon. Replacement: a bounded `RequestQueue` with three knobs.
+
+- **`src/request-queue.ts` (new, ~135 LOC, zero deps).** Pure `decideAdmit(state)` decision function separate from the class that applies it — so tests exercise every branch without timers or promises, and the admission logic is reviewable in isolation. `decideAdmit` returns `admit` / `enqueue` / `reject:queue-full`.
+- **Three knobs with sane defaults.** `maxConcurrent=10` (unchanged — the same value as the old semaphore), `maxQueued=128` (new — total requests dario will hold before rejecting), `queueTimeoutMs=60000` (new — how long a queued request waits before dario returns 504).
+- **Explicit HTTP errors on overload.** When the queue is full, dario returns `429` with a `rate_limit_error` body that names `queue-full`, `max-concurrent`, and `max-queued` so the operator can see exactly which knob to tune. When a queued request times out waiting for a slot, `504` with `timeout_error` + `queue-timeout` marker. Previously the request would silently queue indefinitely.
+- **Flags + env mirrors.** `--max-concurrent=N` (`DARIO_MAX_CONCURRENT`), `--max-queued=N` (`DARIO_MAX_QUEUED`), `--queue-timeout=MS` (`DARIO_QUEUE_TIMEOUT_MS`). `parsePositiveIntEnv` exported from CLI for reuse by any future positive-int env mirror.
+- **Tests.** `test/request-queue.mjs` — 34 assertions across decision-function branches (admit/enqueue/reject, zero-cap degenerates), the pure timeout check, the class's immediate-admit / queue-full-reject / FIFO-release-order / timeout-reject behaviours, the `parsePositiveIntEnv` parser, and the `DEFAULT_*` constants match the documented defaults.
+
+Default behaviour is close-to-bit-identical with v3.30.8 for any client that stayed under 138 concurrent requests (10 in flight + 128 queued). Above that, the old semaphore would have grown memory with queued promises forever; the new queue returns a clear 429 instead. For operators who genuinely want the old unbounded-queue behaviour back, `--max-queued=1000000` is a legal value.
+
 ## [3.30.8] - 2026-04-21
 
 ### Added — `--no-live-capture` and `--strict-template` flags (dario#77)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.30.8",
+  "version": "3.30.9",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "build": "tsc && cp src/cc-template-data.json dist/ && node -e \"require('fs').mkdirSync('dist/shim',{recursive:true})\" && cp src/shim/runtime.cjs dist/shim/",
-    "test": "node test/issue-29-tool-translation.mjs && node test/hybrid-tools.mjs && node test/tool-schema-contract.mjs && node test/scrub-paths.mjs && node test/provider-prefix.mjs && node test/analytics-recording.mjs && node test/analytics-billing-bucket.mjs && node test/failover-429.mjs && node test/pool-sticky.mjs && node test/live-fingerprint.mjs && node test/shim-runtime.mjs && node test/shim-e2e.mjs && node test/proxy-header-order.mjs && node test/proxy-body-order.mjs && node test/runtime-fingerprint.mjs && node test/pacing.mjs && node test/stream-drain.mjs && node test/subagent.mjs && node test/mcp-protocol.mjs && node test/mcp-tools.mjs && node test/mcp-e2e.mjs && node test/session-rotation.mjs && node test/drift-detection.mjs && node test/cc-authorize-probe-classifier.mjs && node test/compat-range.mjs && node test/doctor-formatter.mjs && node test/atomic-write.mjs && node test/account-refresh-singleflight.mjs && node test/streaming-edge-cases.mjs && node test/client-detection.mjs && node test/manual-oauth-flow.mjs && node test/scrub-template.mjs && node test/sanitize-messages.mjs && node test/platform-tools.mjs && node test/strict-template-flags.mjs",
+    "test": "node test/issue-29-tool-translation.mjs && node test/hybrid-tools.mjs && node test/tool-schema-contract.mjs && node test/scrub-paths.mjs && node test/provider-prefix.mjs && node test/analytics-recording.mjs && node test/analytics-billing-bucket.mjs && node test/failover-429.mjs && node test/pool-sticky.mjs && node test/live-fingerprint.mjs && node test/shim-runtime.mjs && node test/shim-e2e.mjs && node test/proxy-header-order.mjs && node test/proxy-body-order.mjs && node test/runtime-fingerprint.mjs && node test/pacing.mjs && node test/stream-drain.mjs && node test/subagent.mjs && node test/mcp-protocol.mjs && node test/mcp-tools.mjs && node test/mcp-e2e.mjs && node test/session-rotation.mjs && node test/drift-detection.mjs && node test/cc-authorize-probe-classifier.mjs && node test/compat-range.mjs && node test/doctor-formatter.mjs && node test/atomic-write.mjs && node test/account-refresh-singleflight.mjs && node test/streaming-edge-cases.mjs && node test/client-detection.mjs && node test/manual-oauth-flow.mjs && node test/scrub-template.mjs && node test/sanitize-messages.mjs && node test/platform-tools.mjs && node test/strict-template-flags.mjs && node test/request-queue.mjs",
     "audit": "npm audit --production --audit-level=high",
     "prepublishOnly": "npm run build",
     "start": "node dist/cli.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -263,6 +263,17 @@ async function proxy() {
     || parseBooleanEnv(process.env['DARIO_STRICT_TEMPLATE'])
     || undefined;
 
+  // --max-concurrent=N / --max-queued=N / --queue-timeout=MS — bounded
+  // request queue knobs (dario#80). Defaults preserve v3.30.x-and-earlier
+  // behaviour for typical single-user workloads; tune up for high-fan-out
+  // agent setups that otherwise hit dario-level 429s before upstream.
+  const maxConcurrent = parsePositiveIntFlag('--max-concurrent=')
+    ?? parsePositiveIntEnv(process.env['DARIO_MAX_CONCURRENT']);
+  const maxQueued = parsePositiveIntFlag('--max-queued=')
+    ?? parsePositiveIntEnv(process.env['DARIO_MAX_QUEUED']);
+  const queueTimeoutMs = parsePositiveIntFlag('--queue-timeout=')
+    ?? parsePositiveIntEnv(process.env['DARIO_QUEUE_TIMEOUT_MS']);
+
   // Non-loopback bind without DARIO_API_KEY turns dario into an open
   // OAuth-subscription relay for anyone on the reachable network. Refuse
   // to start rather than rely on the operator to read the startup banner.
@@ -283,7 +294,20 @@ async function proxy() {
     process.exit(1);
   }
 
-  await startProxy({ port, host, verbose, verboseBodies, model, passthrough, preserveTools, hybridTools, noAutoDetect, strictTls, pacingMinMs, pacingJitterMs, drainOnClose, sessionIdleRotateMs, sessionRotateJitterMs, sessionMaxAgeMs, sessionPerClient, preserveOrchestrationTags, noLiveCapture, strictTemplate });
+  await startProxy({ port, host, verbose, verboseBodies, model, passthrough, preserveTools, hybridTools, noAutoDetect, strictTls, pacingMinMs, pacingJitterMs, drainOnClose, sessionIdleRotateMs, sessionRotateJitterMs, sessionMaxAgeMs, sessionPerClient, preserveOrchestrationTags, noLiveCapture, strictTemplate, maxConcurrent, maxQueued, queueTimeoutMs });
+}
+
+/**
+ * Parse a positive-integer env var. Returns undefined on unset, empty,
+ * non-numeric, or non-positive values so the caller's default applies.
+ * Sibling of parsePositiveIntFlag; exported for tests + used by the
+ * dario#80 queue env mirrors.
+ */
+export function parsePositiveIntEnv(value: string | undefined): number | undefined {
+  if (value === undefined || value === '') return undefined;
+  const n = Number.parseInt(value.trim(), 10);
+  if (!Number.isFinite(n) || n <= 0) return undefined;
+  return n;
 }
 
 /**
@@ -674,6 +698,16 @@ async function help() {
                              as --strict-tls: make the unsafe state
                              require intent. Env: DARIO_STRICT_TEMPLATE=1.
                              (v3.30.8, dario#77)
+    --max-concurrent=N       Max in-flight requests (default: 10).
+                             Env: DARIO_MAX_CONCURRENT. (dario#80)
+    --max-queued=N           Max requests buffered waiting for a
+                             concurrency slot before dario returns
+                             429 "queue-full" (default: 128).
+                             Env: DARIO_MAX_QUEUED. (dario#80)
+    --queue-timeout=MS       Max ms a queued request waits before
+                             dario returns 504 "queue-timeout"
+                             (default: 60000).
+                             Env: DARIO_QUEUE_TIMEOUT_MS. (dario#80)
     --port=PORT              Port to listen on (default: 3456)
     --host=ADDRESS           Address to bind to (default: 127.0.0.1)
                              Use 0.0.0.0 for LAN; see README for DARIO_API_KEY

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -12,13 +12,13 @@ import { AccountPool, computeStickyKey, parseRateLimits, type PoolAccount } from
 import { Analytics, billingBucketFromClaim } from './analytics.js';
 import { loadAllAccounts, loadAccount, refreshAccountToken } from './accounts.js';
 import { getOpenAIBackend, isOpenAIModel, forwardToOpenAI, type BackendCredentials } from './openai-backend.js';
+import { RequestQueue, QueueFullError, QueueTimeoutError, DEFAULT_MAX_CONCURRENT, DEFAULT_MAX_QUEUED, DEFAULT_QUEUE_TIMEOUT_MS } from './request-queue.js';
 
 const ANTHROPIC_API = 'https://api.anthropic.com';
 const DEFAULT_PORT = 3456;
 const MAX_BODY_BYTES = 10 * 1024 * 1024; // 10 MB — generous for large prompts, prevents abuse
 const UPSTREAM_TIMEOUT_MS = 300_000; // 5 min — matches Anthropic SDK default
 const BODY_READ_TIMEOUT_MS = 30_000; // 30s — prevents slow-loris on body reads
-const MAX_CONCURRENT = 10; // Max concurrent upstream requests
 const DEFAULT_HOST = '127.0.0.1';
 
 // A host is "loopback" if it's one of the well-known localhost literals.
@@ -30,21 +30,8 @@ function isLoopbackHost(host: string): boolean {
   return host.startsWith('127.');
 }
 
-// Simple semaphore for concurrency control
-class Semaphore {
-  private queue: (() => void)[] = [];
-  private active = 0;
-  constructor(private max: number) {}
-  async acquire(): Promise<void> {
-    if (this.active < this.max) { this.active++; return; }
-    return new Promise(resolve => { this.queue.push(() => { this.active++; resolve(); }); });
-  }
-  release(): void {
-    this.active--;
-    const next = this.queue.shift();
-    if (next) next();
-  }
-}
+// Concurrency control: see src/request-queue.ts for the bounded queue
+// (replaced the v3.30.x-and-earlier simple unbounded semaphore in dario#80).
 
 // Billing tag hash seed — matches Claude Code's value
 const BILLING_SEED = '59cf53e54c78';
@@ -406,6 +393,12 @@ interface ProxyOptions {
    * --strict-tls. dario#77.
    */
   strictTemplate?: boolean;
+  /** Max concurrent in-flight requests. Default 10. dario#80. */
+  maxConcurrent?: number;
+  /** Max requests buffered waiting for a concurrency slot. Default 128. dario#80. */
+  maxQueued?: number;
+  /** Max ms a queued request waits before it times out with 504. Default 60000. dario#80. */
+  queueTimeoutMs?: number;
 }
 
 export function sanitizeError(err: unknown): string {
@@ -618,7 +611,11 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
     }
   }
   let requestCount = 0;
-  const semaphore = new Semaphore(MAX_CONCURRENT);
+  const queue = new RequestQueue({
+    maxConcurrent: opts.maxConcurrent ?? DEFAULT_MAX_CONCURRENT,
+    maxQueued: opts.maxQueued ?? DEFAULT_MAX_QUEUED,
+    queueTimeoutMs: opts.queueTimeoutMs ?? DEFAULT_QUEUE_TIMEOUT_MS,
+  });
 
   // Cache context-1m beta availability. Set false once per account (or process
   // in single-account mode) after the first "long context" rejection, so we
@@ -816,8 +813,37 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
     if (!targetBase) { res.writeHead(403, JSON_HEADERS); res.end(ERR_FORBIDDEN); return; }
     if (req.method !== 'POST') { res.writeHead(405, JSON_HEADERS); res.end(ERR_METHOD); return; }
 
-    // Proxy to Anthropic (with concurrency control)
-    await semaphore.acquire();
+    // Proxy to Anthropic (with concurrency control). The bounded queue
+    // replaces the v3.30.x-and-earlier unbounded semaphore — dario#80. A
+    // queue-full condition returns an explicit 429 with a `"queue-full"`
+    // marker in the body; a queue-timeout returns 504 with `"queue-timeout"`.
+    try {
+      await queue.acquire();
+    } catch (err) {
+      if (err instanceof QueueFullError) {
+        res.writeHead(429, JSON_HEADERS);
+        res.end(JSON.stringify({
+          type: 'error',
+          error: {
+            type: 'rate_limit_error',
+            message: `dario queue full — ${queue.maxConcurrent} concurrent + ${queue.maxQueued} queued already in flight. Tune --max-concurrent / --max-queued, or reduce client-side concurrency. (dario#80)`,
+          },
+        }));
+        return;
+      }
+      if (err instanceof QueueTimeoutError) {
+        res.writeHead(504, JSON_HEADERS);
+        res.end(JSON.stringify({
+          type: 'error',
+          error: {
+            type: 'timeout_error',
+            message: `dario queue timeout — request waited longer than ${queue.queueTimeoutMs}ms for a concurrency slot. Tune --queue-timeout, or reduce client-side concurrency. (dario#80)`,
+          },
+        }));
+        return;
+      }
+      throw err;
+    }
     // Hoisted so the finally block can clean up whatever was set.
     let upstreamTimeout: ReturnType<typeof setTimeout> | null = null;
     let onClientClose: (() => void) | null = null;
@@ -1648,7 +1674,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
       // (413, body read timeout) these may still be null — guard accordingly.
       if (upstreamTimeout !== null) clearTimeout(upstreamTimeout);
       if (onClientClose !== null) req.off('close', onClientClose);
-      semaphore.release();
+      queue.release();
     }
   });
 

--- a/src/request-queue.ts
+++ b/src/request-queue.ts
@@ -1,0 +1,139 @@
+/**
+ * Bounded request queue — replaces the simple in-process semaphore so that
+ * overload conditions are visible and tunable instead of silently queuing
+ * unbounded or rejecting with generic 429s before upstream had a chance.
+ *
+ * Three knobs:
+ *   - maxConcurrent : in-flight requests allowed at once (default 10)
+ *   - maxQueued     : buffered requests waiting for a concurrency slot
+ *                     (default 128); beyond this, the queue is "full" and
+ *                     admission is rejected with a clear 429 body.
+ *   - queueTimeoutMs: how long a queued request waits before it 504s with
+ *                     a "queue-timeout" reason (default 60_000).
+ *
+ * Behaviour:
+ *   - active < maxConcurrent → admit immediately
+ *   - else, queued < maxQueued → enqueue
+ *   - else → reject with `queue-full`
+ *   - queued > queueTimeoutMs → reject with `queue-timeout`
+ *
+ * The decision logic is split out as a pure `decideAdmit(state)` function so
+ * tests can exercise all three branches without side effects or timers.
+ *
+ * dario#80 (Gemini review push-back).
+ */
+
+export interface QueueState {
+  active: number;
+  queued: number;
+  maxConcurrent: number;
+  maxQueued: number;
+}
+
+export type AdmitDecision =
+  | { action: 'admit' }
+  | { action: 'enqueue' }
+  | { action: 'reject'; reason: 'queue-full' };
+
+/** Pure admission decision — no side effects, no clock dep. */
+export function decideAdmit(state: QueueState): AdmitDecision {
+  if (state.active < state.maxConcurrent) return { action: 'admit' };
+  if (state.queued < state.maxQueued) return { action: 'enqueue' };
+  return { action: 'reject', reason: 'queue-full' };
+}
+
+/** Pure timeout check — separated so tests can pass an explicit clock. */
+export function isQueueEntryExpired(enqueuedAt: number, now: number, timeoutMs: number): boolean {
+  return (now - enqueuedAt) > timeoutMs;
+}
+
+export class QueueFullError extends Error {
+  constructor() { super('queue-full'); this.name = 'QueueFullError'; }
+}
+export class QueueTimeoutError extends Error {
+  constructor() { super('queue-timeout'); this.name = 'QueueTimeoutError'; }
+}
+
+interface QueueEntry {
+  resolve: () => void;
+  reject: (err: Error) => void;
+  enqueuedAt: number;
+  timeoutHandle: ReturnType<typeof setTimeout>;
+}
+
+export interface RequestQueueOptions {
+  maxConcurrent?: number;
+  maxQueued?: number;
+  queueTimeoutMs?: number;
+}
+
+export const DEFAULT_MAX_CONCURRENT = 10;
+export const DEFAULT_MAX_QUEUED = 128;
+export const DEFAULT_QUEUE_TIMEOUT_MS = 60_000;
+
+export class RequestQueue {
+  readonly maxConcurrent: number;
+  readonly maxQueued: number;
+  readonly queueTimeoutMs: number;
+  private active = 0;
+  private queue: QueueEntry[] = [];
+
+  constructor(opts: RequestQueueOptions = {}) {
+    this.maxConcurrent = opts.maxConcurrent ?? DEFAULT_MAX_CONCURRENT;
+    this.maxQueued = opts.maxQueued ?? DEFAULT_MAX_QUEUED;
+    this.queueTimeoutMs = opts.queueTimeoutMs ?? DEFAULT_QUEUE_TIMEOUT_MS;
+  }
+
+  /**
+   * Acquire a concurrency slot. Resolves when admitted; throws
+   * `QueueFullError` when the queue is at its `maxQueued` cap, throws
+   * `QueueTimeoutError` when a queued request waited longer than
+   * `queueTimeoutMs`.
+   */
+  async acquire(): Promise<void> {
+    const decision = decideAdmit(this.snapshot());
+    if (decision.action === 'admit') {
+      this.active++;
+      return;
+    }
+    if (decision.action === 'reject') {
+      throw new QueueFullError();
+    }
+    return new Promise<void>((resolve, reject) => {
+      const enqueuedAt = Date.now();
+      const timeoutHandle = setTimeout(() => {
+        const idx = this.queue.indexOf(entry);
+        if (idx >= 0) {
+          this.queue.splice(idx, 1);
+          reject(new QueueTimeoutError());
+        }
+      }, this.queueTimeoutMs);
+      // Keep the timer from pinning the event loop open on shutdown. A queued
+      // request waiting for a slot shouldn't by itself keep the process alive.
+      timeoutHandle.unref?.();
+      const entry: QueueEntry = { resolve, reject, enqueuedAt, timeoutHandle };
+      this.queue.push(entry);
+    });
+  }
+
+  /** Release a slot. The next queued entry (if any) is admitted in FIFO order. */
+  release(): void {
+    if (this.active > 0) this.active--;
+    const next = this.queue.shift();
+    if (next) {
+      clearTimeout(next.timeoutHandle);
+      this.active++;
+      next.resolve();
+    }
+  }
+
+  /** Snapshot of queue state — exposed for /analytics + tests. */
+  snapshot(): QueueState {
+    return {
+      active: this.active,
+      queued: this.queue.length,
+      maxConcurrent: this.maxConcurrent,
+      maxQueued: this.maxQueued,
+    };
+  }
+}

--- a/test/request-queue.mjs
+++ b/test/request-queue.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+// Unit tests for the bounded request queue that replaced the v3.30.x
+// unbounded semaphore in dario#80. The pure decision function
+// (`decideAdmit`) and timeout check (`isQueueEntryExpired`) exercise
+// every branch without touching real timers; the `RequestQueue` class
+// tests use short timeouts and assert the promise-based flow.
+
+import {
+  decideAdmit,
+  isQueueEntryExpired,
+  RequestQueue,
+  QueueFullError,
+  QueueTimeoutError,
+  DEFAULT_MAX_CONCURRENT,
+  DEFAULT_MAX_QUEUED,
+  DEFAULT_QUEUE_TIMEOUT_MS,
+} from '../dist/request-queue.js';
+import { parsePositiveIntEnv } from '../dist/cli.js';
+
+let pass = 0, fail = 0;
+function check(name, cond) {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else      { console.log(`  FAIL ${name}`); fail++; }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+// ─────────────────────────────────────────────────────────────
+header('decideAdmit — admit when active < maxConcurrent');
+{
+  check('active=0, queued=0, cap=10 → admit',
+    decideAdmit({ active: 0, queued: 0, maxConcurrent: 10, maxQueued: 128 }).action === 'admit');
+  check('active=9, queued=0, cap=10 → admit',
+    decideAdmit({ active: 9, queued: 0, maxConcurrent: 10, maxQueued: 128 }).action === 'admit');
+}
+
+header('decideAdmit — enqueue when active full and queue has room');
+{
+  check('active=10, queued=0, cap=10, q=128 → enqueue',
+    decideAdmit({ active: 10, queued: 0, maxConcurrent: 10, maxQueued: 128 }).action === 'enqueue');
+  check('active=10, queued=127, cap=10, q=128 → enqueue',
+    decideAdmit({ active: 10, queued: 127, maxConcurrent: 10, maxQueued: 128 }).action === 'enqueue');
+}
+
+header('decideAdmit — reject when both active and queue are full');
+{
+  const d = decideAdmit({ active: 10, queued: 128, maxConcurrent: 10, maxQueued: 128 });
+  check('active=10, queued=128 → reject', d.action === 'reject');
+  check('reject reason is "queue-full"', d.action === 'reject' && d.reason === 'queue-full');
+}
+
+header('decideAdmit — zero caps');
+{
+  check('maxConcurrent=0 always rejects when queue is 0 too',
+    decideAdmit({ active: 0, queued: 0, maxConcurrent: 0, maxQueued: 0 }).action === 'reject');
+  check('maxConcurrent=0 enqueues while queue has room',
+    decideAdmit({ active: 0, queued: 0, maxConcurrent: 0, maxQueued: 5 }).action === 'enqueue');
+}
+
+// ─────────────────────────────────────────────────────────────
+header('isQueueEntryExpired — pure timeout check');
+{
+  check('now at exactly enqueuedAt → not expired', isQueueEntryExpired(1000, 1000, 60_000) === false);
+  check('now 1ms before timeout → not expired', isQueueEntryExpired(1000, 61_000, 60_000) === false);
+  check('now 1ms past timeout → expired', isQueueEntryExpired(1000, 61_001, 60_000) === true);
+  check('huge gap, short timeout → expired', isQueueEntryExpired(0, 10_000_000, 1_000) === true);
+  check('timeout=0 degenerate → any positive gap expires', isQueueEntryExpired(1000, 1001, 0) === true);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('DEFAULT constants match the documented defaults');
+{
+  check('DEFAULT_MAX_CONCURRENT = 10', DEFAULT_MAX_CONCURRENT === 10);
+  check('DEFAULT_MAX_QUEUED = 128', DEFAULT_MAX_QUEUED === 128);
+  check('DEFAULT_QUEUE_TIMEOUT_MS = 60000', DEFAULT_QUEUE_TIMEOUT_MS === 60_000);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('RequestQueue — immediate admit under capacity');
+{
+  const q = new RequestQueue({ maxConcurrent: 2, maxQueued: 4, queueTimeoutMs: 5_000 });
+  await q.acquire();
+  await q.acquire();
+  const s1 = q.snapshot();
+  check('both acquired immediately → active=2', s1.active === 2);
+  check('queued=0', s1.queued === 0);
+  q.release();
+  q.release();
+  const s2 = q.snapshot();
+  check('after both release → active=0', s2.active === 0);
+}
+
+header('RequestQueue — queue-full rejects fast');
+{
+  const q = new RequestQueue({ maxConcurrent: 1, maxQueued: 1, queueTimeoutMs: 10_000 });
+  await q.acquire(); // active 1/1
+  const p2 = q.acquire(); // queued 1/1
+  let thrown;
+  try {
+    await q.acquire(); // over capacity
+  } catch (err) {
+    thrown = err;
+  }
+  check('3rd acquire throws', thrown !== undefined);
+  check('error is QueueFullError', thrown instanceof QueueFullError);
+  // drain
+  q.release();
+  await p2;
+  q.release();
+}
+
+header('RequestQueue — release admits next queued in FIFO');
+{
+  const q = new RequestQueue({ maxConcurrent: 1, maxQueued: 10, queueTimeoutMs: 10_000 });
+  await q.acquire(); // 1st admitted
+  const order = [];
+  const p2 = q.acquire().then(() => order.push('second'));
+  const p3 = q.acquire().then(() => order.push('third'));
+  // Nothing has been released yet; 2nd and 3rd should still be queued.
+  check('two requests queued', q.snapshot().queued === 2);
+  q.release();
+  await p2;
+  check('FIFO: second acquired before third', order[0] === 'second');
+  q.release();
+  await p3;
+  check('third also admitted after second released', order[1] === 'third');
+  q.release();
+}
+
+header('RequestQueue — queue-timeout rejects the waiter');
+{
+  const q = new RequestQueue({ maxConcurrent: 1, maxQueued: 4, queueTimeoutMs: 50 });
+  await q.acquire(); // 1/1
+  let thrown;
+  try {
+    await q.acquire(); // will enqueue, then time out after 50ms
+  } catch (err) {
+    thrown = err;
+  }
+  check('queued acquire throws after timeout', thrown !== undefined);
+  check('error is QueueTimeoutError', thrown instanceof QueueTimeoutError);
+  q.release();
+}
+
+// ─────────────────────────────────────────────────────────────
+header('parsePositiveIntEnv — valid + invalid forms');
+{
+  check('undefined       → undefined', parsePositiveIntEnv(undefined) === undefined);
+  check('""              → undefined', parsePositiveIntEnv('') === undefined);
+  check('"10"            → 10',        parsePositiveIntEnv('10') === 10);
+  check('"  42  " (ws)   → 42',        parsePositiveIntEnv('  42  ') === 42);
+  check('"0"             → undefined', parsePositiveIntEnv('0') === undefined);
+  check('"-5"            → undefined', parsePositiveIntEnv('-5') === undefined);
+  check('"abc"           → undefined', parsePositiveIntEnv('abc') === undefined);
+  check('"3.14" → 3 (parseInt truncates)', parsePositiveIntEnv('3.14') === 3);
+}
+
+// ─────────────────────────────────────────────────────────────
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Closes #80.

Push-back from Gemini's review: the v3.30.x-and-earlier concurrency control was a 10-slot semaphore with an **unbounded FIFO queue** behind it. Two pathological modes under real client fan-out:

1. Waiters stacked up in process memory with no operator visibility and no way to tune.
2. A queued request could wait forever for a slot it might never get — turning into a hung client-side timeout rather than a clean error.

Replacement: \`src/request-queue.ts\` — bounded \`RequestQueue\` with three knobs, pure \`decideAdmit\` decision function split out for testability.

## Knobs

| Flag | Env | Default |
|---|---|---|
| \`--max-concurrent=N\` | \`DARIO_MAX_CONCURRENT\` | \`10\` (preserves v3.30.x behaviour) |
| \`--max-queued=N\` | \`DARIO_MAX_QUEUED\` | \`128\` |
| \`--queue-timeout=MS\` | \`DARIO_QUEUE_TIMEOUT_MS\` | \`60000\` |

## Explicit HTTP errors on overload

- **queue-full** → \`429\` \`rate_limit_error\` with knob names in the body so operators can see exactly which to tune
- **queue-timeout** → \`504\` \`timeout_error\` with the configured timeout in the body

## Internals

- Pure \`decideAdmit(state)\` → \`admit\` / \`enqueue\` / \`reject:queue-full\` — testable without timers or promises
- Pure \`isQueueEntryExpired(enqueuedAt, now, timeoutMs)\` — testable without the actual timer firing
- \`RequestQueue\` class wraps those + manages the JS-level Promise plumbing, timers, FIFO ordering
- \`parsePositiveIntEnv\` exported from \`cli.ts\` for reuse by future positive-int env mirrors

## Tests

\`test/request-queue.mjs\` — **34 assertions** across:

- \`decideAdmit\` branches (admit, enqueue, reject, zero-cap degenerates)
- \`isQueueEntryExpired\` pure timeout check
- \`RequestQueue\` class: immediate admit, queue-full reject, FIFO release order, queue-timeout reject
- \`parsePositiveIntEnv\` valid + invalid forms
- \`DEFAULT_*\` constants match documented defaults

## Compatibility

Default behaviour is close-to-bit-identical with v3.30.8 for any client that stayed under **138 concurrent requests** (10 in flight + 128 queued). Above that, the old semaphore grew memory with queued promises forever; the new queue returns a clear 429 instead. For operators who genuinely want the old unbounded behaviour back, \`--max-queued=1000000\` is legal.

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm test\` — 18 files green (34 new)
- [x] \`npm run drift:sdk\` — clean against CC 2.1.116