### PR TITLE
v3.30.10 — --effort flag (#87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.30.10] - 2026-04-21
+
+### Added — `--effort` flag (dario#87)
+
+User-requested on X: can client-side `output_config.effort` pass through, or be set via a flag? Today dario pins `'high'` on every non-haiku request in `buildCCRequest` to match CC 2.1.116's wire default — client values were silently overwritten.
+
+Flag + env mirror:
+
+- `--effort=low` / `medium` / `high` / `xhigh` — pin the outbound value.
+- `--effort=client` — pass through whatever the client sent in `output_config.effort`; fall back to `'high'` when the client didn't include one or sent a non-string.
+- `DARIO_EFFORT=<value>` — env mirror; explicit flag wins when both are set.
+- Invalid values exit non-zero at startup with the list of valid choices printed to stderr.
+
+`--effort=high` (or unset) preserves the v3.30.x default exactly. **Non-`'high'` values may cause Anthropic's classifier to flip requests to `'overage'` billing** — CC's own wire value is a classifier axis and we don't have empirical evidence of which alternates the server currently accepts. Operators opting in should watch `-v` logs for `representative-claim` changes.
+
+Haiku carve-out preserved: non-haiku requests get `output_config.effort`, haiku requests still skip the `output_config` block entirely regardless of flag.
+
+Internal:
+- `resolveEffort(flag, clientBody)` — pure function exported from `src/cc-template.ts`; drives the outbound value and is the single source of truth for the passthrough / fallback logic.
+- `VALID_EFFORT_VALUES` — readonly array exported so third parties can enumerate the supported set.
+- `resolveEffortFlag(args, env)` — exported CLI parser; case-insensitive, whitespace-tolerant; validates + exits on unknown values.
+
+Tests: `test/effort-flag.mjs` — 37 assertions covering the valid-set shape, all pin values, the `'client'` passthrough + fallback branches, the buildCCRequest integration (outbound `output_config.effort` matches the flag), the haiku carve-out, the CLI parser (flag precedence over env, case, whitespace), and the invalid-value subprocess-exit check.
+
 ## [3.30.9] - 2026-04-21
 
 ### Changed — Bounded request queue replaces unbounded semaphore (dario#80)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.30.9",
+  "version": "3.30.10",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "build": "tsc && cp src/cc-template-data.json dist/ && node -e \"require('fs').mkdirSync('dist/shim',{recursive:true})\" && cp src/shim/runtime.cjs dist/shim/",
-    "test": "node test/issue-29-tool-translation.mjs && node test/hybrid-tools.mjs && node test/tool-schema-contract.mjs && node test/scrub-paths.mjs && node test/provider-prefix.mjs && node test/analytics-recording.mjs && node test/analytics-billing-bucket.mjs && node test/failover-429.mjs && node test/pool-sticky.mjs && node test/live-fingerprint.mjs && node test/shim-runtime.mjs && node test/shim-e2e.mjs && node test/proxy-header-order.mjs && node test/proxy-body-order.mjs && node test/runtime-fingerprint.mjs && node test/pacing.mjs && node test/stream-drain.mjs && node test/subagent.mjs && node test/mcp-protocol.mjs && node test/mcp-tools.mjs && node test/mcp-e2e.mjs && node test/session-rotation.mjs && node test/drift-detection.mjs && node test/cc-authorize-probe-classifier.mjs && node test/compat-range.mjs && node test/doctor-formatter.mjs && node test/atomic-write.mjs && node test/account-refresh-singleflight.mjs && node test/streaming-edge-cases.mjs && node test/client-detection.mjs && node test/manual-oauth-flow.mjs && node test/scrub-template.mjs && node test/sanitize-messages.mjs && node test/platform-tools.mjs && node test/strict-template-flags.mjs && node test/request-queue.mjs",
+    "test": "node test/issue-29-tool-translation.mjs && node test/hybrid-tools.mjs && node test/tool-schema-contract.mjs && node test/scrub-paths.mjs && node test/provider-prefix.mjs && node test/analytics-recording.mjs && node test/analytics-billing-bucket.mjs && node test/failover-429.mjs && node test/pool-sticky.mjs && node test/live-fingerprint.mjs && node test/shim-runtime.mjs && node test/shim-e2e.mjs && node test/proxy-header-order.mjs && node test/proxy-body-order.mjs && node test/runtime-fingerprint.mjs && node test/pacing.mjs && node test/stream-drain.mjs && node test/subagent.mjs && node test/mcp-protocol.mjs && node test/mcp-tools.mjs && node test/mcp-e2e.mjs && node test/session-rotation.mjs && node test/drift-detection.mjs && node test/cc-authorize-probe-classifier.mjs && node test/compat-range.mjs && node test/doctor-formatter.mjs && node test/atomic-write.mjs && node test/account-refresh-singleflight.mjs && node test/streaming-edge-cases.mjs && node test/client-detection.mjs && node test/manual-oauth-flow.mjs && node test/scrub-template.mjs && node test/sanitize-messages.mjs && node test/platform-tools.mjs && node test/strict-template-flags.mjs && node test/request-queue.mjs && node test/effort-flag.mjs",
     "audit": "npm audit --production --audit-level=high",
     "prepublishOnly": "npm run build",
     "start": "node dist/cli.js",

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -780,12 +780,37 @@ const TOOL_MAP: Record<string, ToolMapping> = {
  * Replaces the entire request structure — tools, fields, ordering — with
  * what real CC sends. Only the conversation content is preserved.
  */
+/** Valid values for the `--effort` flag. `'client'` passes through the client's own `output_config.effort` (falling back to `'high'` if the client didn't send one). dario#87. */
+export type EffortValue = 'low' | 'medium' | 'high' | 'xhigh' | 'client';
+export const VALID_EFFORT_VALUES: ReadonlyArray<EffortValue> = ['low', 'medium', 'high', 'xhigh', 'client'];
+
+/**
+ * Resolve the outbound `output_config.effort` value.
+ *
+ *   undefined / 'high' → 'high' (current default, matches CC 2.1.116 wire value)
+ *   'low' / 'medium' / 'xhigh' → pin to that value
+ *   'client' → extract from `clientBody.output_config.effort`; fall back
+ *              to 'high' if the client didn't send one or sent a non-string
+ *
+ * Exported for tests.
+ */
+export function resolveEffort(flag: EffortValue | undefined, clientBody: Record<string, unknown>): string {
+  if (flag === undefined) return 'high';
+  if (flag === 'client') {
+    const clientOC = clientBody.output_config as { effort?: unknown } | undefined;
+    const clientEffort = clientOC?.effort;
+    if (typeof clientEffort === 'string' && clientEffort.length > 0) return clientEffort;
+    return 'high';
+  }
+  return flag;
+}
+
 export function buildCCRequest(
   clientBody: Record<string, unknown>,
   billingTag: string,
   cacheControl: { type: 'ephemeral' },
   identity: { deviceId: string; accountUuid: string; sessionId: string },
-  opts: { preserveTools?: boolean; hybridTools?: boolean; noAutoDetect?: boolean } = {},
+  opts: { preserveTools?: boolean; hybridTools?: boolean; noAutoDetect?: boolean; effort?: EffortValue } = {},
 ): { body: Record<string, unknown>; toolMap: Map<string, ToolMapping>; unmappedTools: string[]; detectedClient?: string } {
 
   const model = clientBody.model as string || 'claude-sonnet-4-6';
@@ -1065,7 +1090,11 @@ export function buildCCRequest(
   if (!isHaiku) {
     ccRequest.thinking = { type: 'adaptive' };
     ccRequest.context_management = { edits: [{ type: 'clear_thinking_20251015', keep: 'all' }] };
-    ccRequest.output_config = { effort: 'high' };
+    // output_config.effort default is `'high'` (matches CC 2.1.116's wire
+    // value). `--effort` flag overrides; `'client'` passes through whatever
+    // the client sent (or falls back to `'high'` if the client didn't
+    // include an output_config). See dario#87.
+    ccRequest.output_config = { effort: resolveEffort(opts.effort, clientBody) };
   }
 
   ccRequest.stream = stream;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,6 +38,7 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { startAutoOAuthFlow, startManualOAuthFlow, detectHeadlessEnvironment, getStatus, refreshTokens, loadCredentials } from './oauth.js';
 import { startProxy, sanitizeError } from './proxy.js';
+import { VALID_EFFORT_VALUES, type EffortValue } from './cc-template.js';
 import { listAccountAliases, loadAllAccounts, addAccountViaOAuth, removeAccount } from './accounts.js';
 import { listBackends, saveBackend, removeBackend, type BackendCredentials } from './openai-backend.js';
 
@@ -274,6 +275,17 @@ async function proxy() {
   const queueTimeoutMs = parsePositiveIntFlag('--queue-timeout=')
     ?? parsePositiveIntEnv(process.env['DARIO_QUEUE_TIMEOUT_MS']);
 
+  // --effort=low|medium|high|xhigh|client — override the outbound
+  // output_config.effort (dario#87). Default (unset) pins 'high' to match
+  // CC 2.1.116's wire value. 'client' passes through whatever the client
+  // sent, falling back to 'high' if the client didn't include one.
+  //
+  // Risk: setting effort to a non-CC-default value may cause Anthropic's
+  // classifier to flip requests to 'overage' billing. Users opting in
+  // should watch the `representative-claim` response header via -v logs
+  // and revert to default if subscription billing breaks.
+  const effort = resolveEffortFlag(args, process.env['DARIO_EFFORT']);
+
   // Non-loopback bind without DARIO_API_KEY turns dario into an open
   // OAuth-subscription relay for anyone on the reachable network. Refuse
   // to start rather than rely on the operator to read the startup banner.
@@ -294,7 +306,25 @@ async function proxy() {
     process.exit(1);
   }
 
-  await startProxy({ port, host, verbose, verboseBodies, model, passthrough, preserveTools, hybridTools, noAutoDetect, strictTls, pacingMinMs, pacingJitterMs, drainOnClose, sessionIdleRotateMs, sessionRotateJitterMs, sessionMaxAgeMs, sessionPerClient, preserveOrchestrationTags, noLiveCapture, strictTemplate, maxConcurrent, maxQueued, queueTimeoutMs });
+  await startProxy({ port, host, verbose, verboseBodies, model, passthrough, preserveTools, hybridTools, noAutoDetect, strictTls, pacingMinMs, pacingJitterMs, drainOnClose, sessionIdleRotateMs, sessionRotateJitterMs, sessionMaxAgeMs, sessionPerClient, preserveOrchestrationTags, noLiveCapture, strictTemplate, maxConcurrent, maxQueued, queueTimeoutMs, effort });
+}
+
+/**
+ * Parse the `--effort` flag + `DARIO_EFFORT` env. Validates against the
+ * allowed set; unrecognised values cause a non-zero exit with the list of
+ * valid choices (same philosophy as other strict parsers in this CLI).
+ * Flag value wins over env. Exported for tests. dario#87.
+ */
+export function resolveEffortFlag(args: string[], env: string | undefined): EffortValue | undefined {
+  const withValue = args.find(a => a.startsWith('--effort='));
+  const raw = withValue ? withValue.slice('--effort='.length) : env;
+  if (raw === undefined || raw === '') return undefined;
+  const normalized = raw.trim().toLowerCase();
+  if ((VALID_EFFORT_VALUES as ReadonlyArray<string>).includes(normalized)) {
+    return normalized as EffortValue;
+  }
+  console.error(`[dario] Invalid --effort value: ${JSON.stringify(raw)}. Must be one of: ${VALID_EFFORT_VALUES.join(', ')}.`);
+  process.exit(1);
 }
 
 /**
@@ -708,6 +738,17 @@ async function help() {
                              dario returns 504 "queue-timeout"
                              (default: 60000).
                              Env: DARIO_QUEUE_TIMEOUT_MS. (dario#80)
+    --effort=<low|medium|high|xhigh|client>
+                             Override the outbound output_config.effort
+                             on non-haiku requests. Default (unset)
+                             pins 'high' — matches CC 2.1.116's wire
+                             value. 'client' passes through what the
+                             client sent (falls back to 'high' if none).
+                             WARNING: non-'high' values may cause
+                             Anthropic's classifier to flip requests
+                             to 'overage' billing; watch -v logs for
+                             representative-claim changes.
+                             Env: DARIO_EFFORT. (dario#87)
     --port=PORT              Port to listen on (default: 3456)
     --host=ADDRESS           Address to bind to (default: 127.0.0.1)
                              Use 0.0.0.0 for LAN; see README for DARIO_API_KEY

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { arch, platform } from 'node:process';
 import { getAccessToken, getStatus } from './oauth.js';
-import { buildCCRequest, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, CC_TEMPLATE, type ToolMapping, type RequestContext } from './cc-template.js';
+import { buildCCRequest, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, CC_TEMPLATE, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
 import { describeTemplate, detectDrift, checkCCCompat } from './live-fingerprint.js';
 import { AccountPool, computeStickyKey, parseRateLimits, type PoolAccount } from './pool.js';
 import { Analytics, billingBucketFromClaim } from './analytics.js';
@@ -399,6 +399,14 @@ interface ProxyOptions {
   maxQueued?: number;
   /** Max ms a queued request waits before it times out with 504. Default 60000. dario#80. */
   queueTimeoutMs?: number;
+  /**
+   * Override the outbound `output_config.effort` value on non-haiku
+   * requests. Default (undefined) pins `'high'`, matching CC 2.1.116's
+   * wire value. `'client'` passes through whatever the client sent (or
+   * falls back to `'high'` if the client didn't include an output_config).
+   * dario#87.
+   */
+  effort?: EffortValue;
 }
 
 export function sanitizeError(err: unknown): string {
@@ -1042,6 +1050,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
                 preserveTools: opts.preserveTools ?? false,
                 hybridTools: opts.hybridTools ?? false,
                 noAutoDetect: opts.noAutoDetect ?? false,
+                effort: opts.effort,
               },
             );
 

--- a/test/effort-flag.mjs
+++ b/test/effort-flag.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+// Unit tests for the --effort flag (dario#87). Covers the pure
+// resolveEffort() function, the buildCCRequest integration (effort reaches
+// the outbound body), the CLI parser + env mirror + validation path, and
+// the haiku carve-out (no output_config on haiku regardless of flag).
+
+import { resolveEffort, VALID_EFFORT_VALUES, buildCCRequest } from '../dist/cc-template.js';
+import { resolveEffortFlag } from '../dist/cli.js';
+
+let pass = 0, fail = 0;
+function check(name, cond) {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else      { console.log(`  FAIL ${name}`); fail++; }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+// ─────────────────────────────────────────────────────────────
+header('VALID_EFFORT_VALUES — the allowed set');
+{
+  check('includes low', VALID_EFFORT_VALUES.includes('low'));
+  check('includes medium', VALID_EFFORT_VALUES.includes('medium'));
+  check('includes high', VALID_EFFORT_VALUES.includes('high'));
+  check('includes xhigh', VALID_EFFORT_VALUES.includes('xhigh'));
+  check('includes client', VALID_EFFORT_VALUES.includes('client'));
+  check('length === 5', VALID_EFFORT_VALUES.length === 5);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('resolveEffort — explicit values pin');
+{
+  check('undefined → high (default)', resolveEffort(undefined, {}) === 'high');
+  check('low → low', resolveEffort('low', {}) === 'low');
+  check('medium → medium', resolveEffort('medium', {}) === 'medium');
+  check('high → high', resolveEffort('high', {}) === 'high');
+  check('xhigh → xhigh', resolveEffort('xhigh', {}) === 'xhigh');
+}
+
+header('resolveEffort — client passthrough');
+{
+  check('client, no output_config → high fallback',
+    resolveEffort('client', {}) === 'high');
+  check('client, output_config without effort → high fallback',
+    resolveEffort('client', { output_config: {} }) === 'high');
+  check('client, output_config.effort = "low" → low',
+    resolveEffort('client', { output_config: { effort: 'low' } }) === 'low');
+  check('client, output_config.effort = "xhigh" → xhigh',
+    resolveEffort('client', { output_config: { effort: 'xhigh' } }) === 'xhigh');
+  check('client, non-string effort ignored → high',
+    resolveEffort('client', { output_config: { effort: 42 } }) === 'high');
+  check('client, empty string effort ignored → high',
+    resolveEffort('client', { output_config: { effort: '' } }) === 'high');
+}
+
+// ─────────────────────────────────────────────────────────────
+header('buildCCRequest — effort reaches outbound body');
+{
+  const identity = { deviceId: 'D', accountUuid: 'A', sessionId: 'S' };
+  const cacheControl = { type: 'ephemeral' };
+  const billingTag = 'billing';
+  const clientBody = { model: 'claude-sonnet-4-6', messages: [{ role: 'user', content: 'hi' }], stream: false };
+
+  const defaultBuild = buildCCRequest(clientBody, billingTag, cacheControl, identity);
+  check('default outbound effort = high', defaultBuild.body.output_config?.effort === 'high');
+
+  const lowBuild = buildCCRequest(clientBody, billingTag, cacheControl, identity, { effort: 'low' });
+  check('effort=low → outbound low', lowBuild.body.output_config?.effort === 'low');
+
+  const xhighBuild = buildCCRequest(clientBody, billingTag, cacheControl, identity, { effort: 'xhigh' });
+  check('effort=xhigh → outbound xhigh', xhighBuild.body.output_config?.effort === 'xhigh');
+
+  // client passthrough
+  const clientBodyWithEffort = { ...clientBody, output_config: { effort: 'xhigh' } };
+  const passthroughBuild = buildCCRequest(clientBodyWithEffort, billingTag, cacheControl, identity, { effort: 'client' });
+  check('effort=client + client body.output_config.effort=xhigh → xhigh', passthroughBuild.body.output_config?.effort === 'xhigh');
+
+  const passthroughNoneBuild = buildCCRequest(clientBody, billingTag, cacheControl, identity, { effort: 'client' });
+  check('effort=client + no client output_config → high fallback', passthroughNoneBuild.body.output_config?.effort === 'high');
+}
+
+header('buildCCRequest — haiku carve-out: no output_config regardless of flag');
+{
+  const identity = { deviceId: 'D', accountUuid: 'A', sessionId: 'S' };
+  const cacheControl = { type: 'ephemeral' };
+  const billingTag = 'billing';
+  const haikuBody = { model: 'claude-haiku-4-5', messages: [{ role: 'user', content: 'hi' }], stream: false };
+
+  const defaultHaiku = buildCCRequest(haikuBody, billingTag, cacheControl, identity);
+  check('haiku default: no output_config', defaultHaiku.body.output_config === undefined);
+
+  const xhighHaiku = buildCCRequest(haikuBody, billingTag, cacheControl, identity, { effort: 'xhigh' });
+  check('haiku + effort=xhigh: still no output_config', xhighHaiku.body.output_config === undefined);
+
+  const clientHaiku = buildCCRequest(haikuBody, billingTag, cacheControl, identity, { effort: 'client' });
+  check('haiku + effort=client: still no output_config', clientHaiku.body.output_config === undefined);
+
+  // And haiku should also skip thinking/context_management (existing behaviour)
+  check('haiku: no thinking', defaultHaiku.body.thinking === undefined);
+  check('haiku: no context_management', defaultHaiku.body.context_management === undefined);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('resolveEffortFlag — CLI parsing');
+{
+  check('no flag, no env → undefined',
+    resolveEffortFlag([], undefined) === undefined);
+  check('--effort=low → "low"',
+    resolveEffortFlag(['--effort=low'], undefined) === 'low');
+  check('--effort=xhigh → "xhigh"',
+    resolveEffortFlag(['--effort=xhigh'], undefined) === 'xhigh');
+  check('--effort=CLIENT (case) → "client"',
+    resolveEffortFlag(['--effort=CLIENT'], undefined) === 'client');
+  check('--effort= HIGH (whitespace) → "high"',
+    resolveEffortFlag(['--effort= HIGH '], undefined) === 'high');
+  check('env DARIO_EFFORT=medium → "medium"',
+    resolveEffortFlag([], 'medium') === 'medium');
+  check('flag wins over env',
+    resolveEffortFlag(['--effort=low'], 'xhigh') === 'low');
+  check('empty env → undefined',
+    resolveEffortFlag([], '') === undefined);
+}
+
+// ─────────────────────────────────────────────────────────────
+// Invalid-value rejection path: resolveEffortFlag calls process.exit(1)
+// on invalid input. We can't reasonably assert the exit inline without a
+// subprocess, so just assert the exit HAPPENS via child_process.
+header('resolveEffortFlag — invalid value exits non-zero');
+{
+  const { spawnSync } = await import('node:child_process');
+  const result = spawnSync(process.execPath, [
+    '-e',
+    `import('./dist/cli.js').then(({ resolveEffortFlag }) => { resolveEffortFlag(['--effort=ultra'], undefined); });`,
+  ], { cwd: process.cwd(), encoding: 'utf-8', timeout: 5_000 });
+  check('invalid value → non-zero exit', result.status !== 0);
+  check('stderr names valid values', /low, medium, high, xhigh, client/.test(result.stderr));
+}
+
+// ─────────────────────────────────────────────────────────────
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Closes #87.

User-requested on X by Rustan (@acewhocares): can client-side \`output_config.effort\` pass through, or be set via a flag? Today dario pins \`'high'\` on every non-haiku request in \`buildCCRequest\` to match CC 2.1.116's wire default — client values were silently overwritten.

## New flag + env mirror

| Invocation | Behaviour |
|---|---|
| *(unset)* / \`--effort=high\` | Pin \`'high'\` — preserves v3.30.x default exactly |
| \`--effort=low\` / \`medium\` / \`xhigh\` | Pin outbound \`output_config.effort\` to that value |
| \`--effort=client\` | Pass through whatever the client sent in \`output_config.effort\`; fall back to \`'high'\` if the client didn't include one or sent a non-string |
| \`DARIO_EFFORT=<value>\` | Env mirror; explicit \`--effort=\` flag wins when both are set |

Invalid values exit non-zero at startup with the list of valid choices printed to stderr (same philosophy as other strict parsers in this CLI).

## Risk

**Non-\`'high'\` values may cause Anthropic's classifier to flip requests to \`'overage'\` billing.** CC's own wire value is a classifier axis and we don't have empirical evidence of which alternates the server currently accepts beyond \`'high'\`. Flag is strict opt-in; operators should watch \`-v\` logs for \`representative-claim\` changes after flipping.

## Compatibility

- Default behaviour (unset or \`--effort=high\`) is bit-identical to v3.30.9.
- Haiku carve-out preserved: non-haiku requests get \`output_config\`, haiku requests still skip the entire \`output_config\` block regardless of the flag.

## Internals

- \`resolveEffort(flag, clientBody)\` — pure function exported from \`src/cc-template.ts\`; single source of truth for the passthrough / fallback logic
- \`VALID_EFFORT_VALUES\` — readonly array exported so third parties can enumerate the supported set
- \`resolveEffortFlag(args, env)\` — exported CLI parser; case-insensitive, whitespace-tolerant, exits on unknown values

## Tests

\`test/effort-flag.mjs\` — **37 assertions** covering:

- \`VALID_EFFORT_VALUES\` shape (length, membership)
- \`resolveEffort\` pin paths (low/medium/high/xhigh)
- \`resolveEffort\` \`'client'\` passthrough (with effort, without effort, no output_config, non-string effort, empty effort — all with their documented fallback behaviour)
- \`buildCCRequest\` integration: outbound \`output_config.effort\` matches flag for sonnet; haiku skips \`output_config\` regardless of flag
- \`resolveEffortFlag\` CLI parsing: flag precedence over env, case-insensitive, whitespace-tolerant, empty-env → undefined
- Invalid-value rejection via subprocess exit check + stderr content assertion

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm test\` — 19 files green (37 new assertions on top of 738 existing)
- [x] \`npm run drift:sdk\` — clean against CC 2.1.116