### PR TITLE
v3.30.13 — Hermes Agent compatibility (#88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.30.13] - 2026-04-21
+
+### Added — Hermes Agent compatibility (dario#88)
+
+@vmvarg4 reported on X that dario worked flawlessly for his OpenClaw but broke on his Hermes Agent. Investigation into [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) surfaced two real gaps:
+
+1. **Hermes ships ~40 tools**, 15+ of which have no CC equivalent (`browser_*`, `vision_analyze`, `image_generate`, `skill_*`, `memory`, `session_search`, `cronjob`, `send_message`, `ha_*`, `mixture_of_agents`, `delegate_task`, `execute_code`, `text_to_speech`). Dario's default-mode tool-mapping distributed them onto random CC slots — silently misrouting every Hermes-specific invocation.
+2. **Hermes requests per-model max_tokens up to 128k for Opus 4.7 and 64k for Sonnet.** Dario's 32k pin silently truncated that output capacity.
+
+Shipping two knobs that close the gap without touching every Hermes user's workflow:
+
+- **Hermes identity detection.** `detectTextToolClient` now recognises `"You are Hermes Agent"` and `"created by Nous Research"` in the system prompt. Returns `'hermes'` which flows through the same auto-preserve-tools dispatch used for Cline/Kilo/Roo — tools pass through verbatim, Hermes's non-CC tools route correctly. Override with `--no-auto-detect` if the operator prefers the full CC fingerprint and accepts the routing cost.
+- **`--max-tokens=<N|client>` flag + `DARIO_MAX_TOKENS` env.** Default (unset) pins 32000 (CC 2.1.116's wire value — behaviour unchanged). A number pins that value; `'client'` passes through whatever the client requested. Hermes users running large-output workloads on Opus should set `--max-tokens=client`. Anthropic enforces the per-model ceiling server-side, so too-high values return a clean 400 rather than silently accepting beyond-model-max.
+
+Internal:
+- `resolveMaxTokens(flag, clientBody)` — pure function exported from `src/cc-template.ts`; same shape as `resolveEffort`
+- `DEFAULT_MAX_TOKENS` — constant exported for tests
+- `resolveMaxTokensFlag(args, env)` — exported CLI parser, whitespace-tolerant, case-insensitive for the `"client"` literal, exits on invalid values
+- `ProxyOptions.maxTokens: number | 'client'` — library consumers can set directly
+
+Tests: `test/hermes-compat.mjs` — 31 assertions covering the Hermes identity detection (canonical + Nous-Research-only paths, prompt-wrapping survival, negative controls), `resolveMaxTokens` pin + passthrough branches (DEFAULT fallback for missing / non-numeric / zero / negative / float body values), `buildCCRequest` integration (outbound `max_tokens` matches flag), `resolveMaxTokensFlag` CLI parsing (flag precedence over env, case-insensitive `client`, whitespace), invalid-value subprocess-exit check.
+
+README Hermes row updated with the full picture: mapped tools, auto-preserve identity anchors, `--max-tokens=client` recommendation for large-output workloads.
+
 ## [3.30.12] - 2026-04-21
 
 ### Changed — `npm test` runs through `node --test` (dario#79)

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Dario's built-in `TOOL_MAP` carries **~66 schema-verified entries** covering the
 | GitHub Copilot | `run_in_terminal`, `insert_edit_into_file`, `semantic_search`, `codebase_search`, `list_dir`, `fetch_webpage` |
 | OpenHands | `execute_bash`, `str_replace_editor` |
 | OpenClaw | `exec`, `process`, `web_search`, `web_fetch`, `browser`, `message` |
-| Hermes | `terminal`, `patch`, `web_extract`, `clarify` |
+| Hermes Agent (Nous Research) | `terminal`, `process`, `read_file`, `write_file`, `patch`, `search_files`, `web_search`, `web_extract`, `todo` mapped directly. Hermes-specific tools (`browser_*`, `vision_analyze`, `image_generate`, `skill_*`, `memory`, `session_search`, `cronjob`, `send_message`, `ha_*`, `mixture_of_agents`, `delegate_task`, `execute_code`, `text_to_speech`) have no CC equivalent and auto-preserve through the identity detector (`You are Hermes Agent` or `created by Nous Research` in the system prompt flips dario into preserve-tools for Hermes sessions automatically — v3.30.13). Also consider `--max-tokens=client` so Hermes's 64k/128k per-model caps survive dario's outbound pin. |
 
 Text-tool clients (Cline / Kilo Code / Roo Code and forks) are auto-detected via system-prompt fingerprint and automatically flipped into preserve-tools mode, because mixing CC's `tools` array with their XML protocol makes the model emit `<function_calls><invoke>` that their parsers can't read. If you run dario specifically for fingerprint fidelity and would rather pick `--preserve-tools` yourself, `--no-auto-detect` (v3.20.1, aka `--no-auto-preserve`) disables the heuristic — explicit operator choice then wins.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.30.12",
+  "version": "3.30.13",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -230,14 +230,32 @@ export function scrubFrameworkIdentifiers(text: string): string {
  * names like "Cline" / "Roo" are still present. Tool-protocol
  * markers are scrub-proof on their own.
  *
- * Returns the matched family (`cline` / `kilo` / `roo` / `cline-like`)
- * or null when no text-tool protocol signature is present.
+ * Returns the matched family (`cline` / `kilo` / `roo` / `cline-like` /
+ * `hermes`) or null when no signature is present.
+ *
+ * Hermes Agent (Nous Research) is a different case from the Cline family —
+ * it uses the standard Anthropic JSON tool-use protocol (not XML). But it
+ * ships ~40 tools, 15+ of which have no CC equivalent (browser_*, vision_*,
+ * image_generate, text_to_speech, skills_*, memory, session_search,
+ * cronjob, send_message, ha_*, mixture_of_agents, delegate_task, …). In
+ * default mode dario distributes unmapped tools onto random CC slots which
+ * silently misroutes them. preserve-tools is the correct default for
+ * Hermes for the same outcome as Cline (client's tool schema passes
+ * through untouched) even though the reason is different. The function
+ * conflates both cases because the downstream dispatch is identical.
+ * Reported via @vmvarg4 on X after the v3.30.5 marketing push.
  */
 export function detectTextToolClient(systemText: string): string | null {
   if (!systemText) return null;
   if (/\bYou are Cline\b/.test(systemText)) return 'cline';
   if (/\bYou are Kilo Code\b/.test(systemText)) return 'kilo';
   if (/\bYou are Roo\b/.test(systemText)) return 'roo';
+  // Hermes Agent (Nous Research) — canonical opener from agent/prompt_builder.py.
+  // Also accept "created by Nous Research" as a secondary anchor since
+  // downstream forks may edit the leading identity line but tend to keep
+  // attribution intact.
+  if (/\bYou are Hermes Agent\b/.test(systemText)) return 'hermes';
+  if (/\bcreated by Nous Research\b/.test(systemText)) return 'hermes';
   // Protocol-signature fallback — unique to the Cline family and its
   // forks; survives a forked system prompt that edited the identity
   // string out but kept the tool protocol intact.
@@ -780,6 +798,29 @@ const TOOL_MAP: Record<string, ToolMapping> = {
  * Replaces the entire request structure — tools, fields, ordering — with
  * what real CC sends. Only the conversation content is preserved.
  */
+/** Default outbound max_tokens when neither a passthrough nor an explicit value is set. Matches CC 2.1.116's wire default. */
+export const DEFAULT_MAX_TOKENS = 32000;
+
+/**
+ * Resolve the outbound `max_tokens` value.
+ *
+ *   undefined / 32000 etc. → number pins outbound (preserves dario's CC-wire default)
+ *   'client' → extract from `clientBody.max_tokens`; fall back to DEFAULT_MAX_TOKENS
+ *              when the client didn't send a value or sent something non-numeric
+ *
+ * dario#88 (Hermes compat — Hermes requests up to 128k for Opus 4.7, 64k for
+ * Sonnet; pinning to 32k silently truncated its output capacity).
+ */
+export function resolveMaxTokens(flag: number | 'client' | undefined, clientBody: Record<string, unknown>): number {
+  if (flag === undefined) return DEFAULT_MAX_TOKENS;
+  if (flag === 'client') {
+    const clientMT = clientBody.max_tokens;
+    if (typeof clientMT === 'number' && Number.isFinite(clientMT) && clientMT > 0) return Math.floor(clientMT);
+    return DEFAULT_MAX_TOKENS;
+  }
+  return flag;
+}
+
 /** Valid values for the `--effort` flag. `'client'` passes through the client's own `output_config.effort` (falling back to `'high'` if the client didn't send one). dario#87. */
 export type EffortValue = 'low' | 'medium' | 'high' | 'xhigh' | 'client';
 export const VALID_EFFORT_VALUES: ReadonlyArray<EffortValue> = ['low', 'medium', 'high', 'xhigh', 'client'];
@@ -810,7 +851,7 @@ export function buildCCRequest(
   billingTag: string,
   cacheControl: { type: 'ephemeral' },
   identity: { deviceId: string; accountUuid: string; sessionId: string },
-  opts: { preserveTools?: boolean; hybridTools?: boolean; noAutoDetect?: boolean; effort?: EffortValue } = {},
+  opts: { preserveTools?: boolean; hybridTools?: boolean; noAutoDetect?: boolean; effort?: EffortValue; maxTokens?: number | 'client' } = {},
 ): { body: Record<string, unknown>; toolMap: Map<string, ToolMapping>; unmappedTools: string[]; detectedClient?: string } {
 
   const model = clientBody.model as string || 'claude-sonnet-4-6';
@@ -1084,7 +1125,7 @@ export function buildCCRequest(
     }),
   };
 
-  ccRequest.max_tokens = 32000;
+  ccRequest.max_tokens = resolveMaxTokens(opts.maxTokens, clientBody);
 
   // Model-specific fields — order: thinking, context_management, output_config
   if (!isHaiku) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -286,6 +286,15 @@ async function proxy() {
   // and revert to default if subscription billing breaks.
   const effort = resolveEffortFlag(args, process.env['DARIO_EFFORT']);
 
+  // --max-tokens=<N|client> — override outbound max_tokens (dario#88,
+  // Hermes compat). Default unset pins 32000 (CC 2.1.116's wire default).
+  // 'client' passes through whatever the client sent (Hermes requests up
+  // to 128k for Opus 4.7, 64k for Sonnet — default pin silently truncates
+  // their output capacity). Anthropic enforces a per-model ceiling on
+  // the server side, so passing through a too-high value returns a clean
+  // 400 rather than silently accepting beyond-model-max.
+  const maxTokens = resolveMaxTokensFlag(args, process.env['DARIO_MAX_TOKENS']);
+
   // Non-loopback bind without DARIO_API_KEY turns dario into an open
   // OAuth-subscription relay for anyone on the reachable network. Refuse
   // to start rather than rely on the operator to read the startup banner.
@@ -306,7 +315,25 @@ async function proxy() {
     process.exit(1);
   }
 
-  await startProxy({ port, host, verbose, verboseBodies, model, passthrough, preserveTools, hybridTools, noAutoDetect, strictTls, pacingMinMs, pacingJitterMs, drainOnClose, sessionIdleRotateMs, sessionRotateJitterMs, sessionMaxAgeMs, sessionPerClient, preserveOrchestrationTags, noLiveCapture, strictTemplate, maxConcurrent, maxQueued, queueTimeoutMs, effort });
+  await startProxy({ port, host, verbose, verboseBodies, model, passthrough, preserveTools, hybridTools, noAutoDetect, strictTls, pacingMinMs, pacingJitterMs, drainOnClose, sessionIdleRotateMs, sessionRotateJitterMs, sessionMaxAgeMs, sessionPerClient, preserveOrchestrationTags, noLiveCapture, strictTemplate, maxConcurrent, maxQueued, queueTimeoutMs, effort, maxTokens });
+}
+
+/**
+ * Parse `--max-tokens=<N|client>` + `DARIO_MAX_TOKENS` env (dario#88).
+ * Numeric values pin; `client` (case-insensitive) = passthrough client's
+ * max_tokens; unset = dario's default pin applies. Invalid values exit
+ * non-zero with guidance. Exported for tests.
+ */
+export function resolveMaxTokensFlag(args: string[], env: string | undefined): number | 'client' | undefined {
+  const withValue = args.find(a => a.startsWith('--max-tokens='));
+  const raw = withValue ? withValue.slice('--max-tokens='.length) : env;
+  if (raw === undefined || raw === '') return undefined;
+  const normalized = raw.trim();
+  if (normalized.toLowerCase() === 'client') return 'client';
+  const n = Number.parseInt(normalized, 10);
+  if (Number.isFinite(n) && n > 0) return n;
+  console.error(`[dario] Invalid --max-tokens value: ${JSON.stringify(raw)}. Must be a positive integer or the literal "client".`);
+  process.exit(1);
 }
 
 /**
@@ -749,6 +776,16 @@ async function help() {
                              to 'overage' billing; watch -v logs for
                              representative-claim changes.
                              Env: DARIO_EFFORT. (dario#87)
+    --max-tokens=<N|client>  Override outbound max_tokens. Default
+                             (unset) pins 32000 (CC 2.1.116 wire default).
+                             Set a number to pin that value; set 'client'
+                             to pass through the client's requested
+                             max_tokens (Hermes requests 64k–128k; the
+                             default pin silently truncates its output
+                             capacity). Anthropic enforces the per-model
+                             ceiling server-side, so too-high values
+                             return a clean 400.
+                             Env: DARIO_MAX_TOKENS. (dario#88)
     --port=PORT              Port to listen on (default: 3456)
     --host=ADDRESS           Address to bind to (default: 127.0.0.1)
                              Use 0.0.0.0 for LAN; see README for DARIO_API_KEY

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -407,6 +407,16 @@ interface ProxyOptions {
    * dario#87.
    */
   effort?: EffortValue;
+  /**
+   * Override the outbound `max_tokens` value. Default (undefined) pins
+   * `32000` — CC 2.1.116's wire default, below Anthropic's per-model
+   * limits. A number pins a specific value. `'client'` passes through
+   * whatever the client requested (up to Anthropic's per-model ceiling
+   * on the server side). Hermes (and other agents) request up to 128k
+   * for Opus and 64k for Sonnet; the default 32k pin silently truncates
+   * their output capacity. dario#88 (Hermes compat).
+   */
+  maxTokens?: number | 'client';
 }
 
 export function sanitizeError(err: unknown): string {
@@ -1051,6 +1061,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
                 hybridTools: opts.hybridTools ?? false,
                 noAutoDetect: opts.noAutoDetect ?? false,
                 effort: opts.effort,
+                maxTokens: opts.maxTokens,
               },
             );
 

--- a/test/hermes-compat.mjs
+++ b/test/hermes-compat.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// Hermes Agent compatibility tests — dario#88.
+//
+// Covers the two pieces that landed in v3.30.13:
+//   1. detectTextToolClient returns 'hermes' on Hermes's canonical
+//      system-prompt identity lines so buildCCRequest's auto-preserve-
+//      tools path fires for Hermes sessions.
+//   2. resolveMaxTokens + --max-tokens flag: the pin / client-passthrough
+//      logic that keeps Hermes's 64k/128k per-model caps from being
+//      silently truncated to dario's 32k default.
+
+import {
+  detectTextToolClient,
+  buildCCRequest,
+  resolveMaxTokens,
+  DEFAULT_MAX_TOKENS,
+} from '../dist/cc-template.js';
+import { resolveMaxTokensFlag } from '../dist/cli.js';
+
+let pass = 0, fail = 0;
+function check(name, cond) {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else      { console.log(`  FAIL ${name}`); fail++; }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+// ─────────────────────────────────────────────────────────────
+header('detectTextToolClient — Hermes Agent identity');
+{
+  const canonical = "You are Hermes Agent, an intelligent AI assistant created by Nous Research. You are helpful, knowledgeable, and direct.";
+  check('canonical opener → "hermes"', detectTextToolClient(canonical) === 'hermes');
+
+  const nousOnly = "The assistant is a coding agent created by Nous Research, operating within a CLI harness.";
+  check('"created by Nous Research" alone → "hermes"', detectTextToolClient(nousOnly) === 'hermes');
+
+  check('Cline prompt NOT matched as hermes',
+    detectTextToolClient('You are Cline, an AI software engineer') === 'cline');
+
+  check('generic prompt without Hermes markers → null',
+    detectTextToolClient('You are Claude, an AI assistant from Anthropic') === null);
+}
+
+header('detectTextToolClient — Hermes detection survives prompt wrapping');
+{
+  // Hermes's actual opener is wrapped in a broader system prompt; make sure
+  // surrounding context doesn't defeat the regex anchor.
+  const wrapped = `Some user preamble goes here.
+
+You are Hermes Agent, an intelligent AI assistant created by Nous Research. You are helpful, knowledgeable, and direct.
+
+<env>cwd=/home/user</env>`;
+  check('detects Hermes identity even when wrapped in surrounding context',
+    detectTextToolClient(wrapped) === 'hermes');
+}
+
+// ─────────────────────────────────────────────────────────────
+header('resolveMaxTokens — number pin paths');
+{
+  check('undefined → DEFAULT_MAX_TOKENS',
+    resolveMaxTokens(undefined, {}) === DEFAULT_MAX_TOKENS);
+  check('32000 → 32000', resolveMaxTokens(32000, {}) === 32000);
+  check('128000 → 128000 (opus ceiling)', resolveMaxTokens(128000, {}) === 128000);
+  check('1 → 1 (absurd but legal per-value)', resolveMaxTokens(1, {}) === 1);
+}
+
+header('resolveMaxTokens — client passthrough');
+{
+  check('client, no max_tokens in body → DEFAULT fallback',
+    resolveMaxTokens('client', {}) === DEFAULT_MAX_TOKENS);
+  check('client, body.max_tokens = 64000 (Hermes sonnet default) → 64000',
+    resolveMaxTokens('client', { max_tokens: 64000 }) === 64000);
+  check('client, body.max_tokens = 128000 (Hermes opus default) → 128000',
+    resolveMaxTokens('client', { max_tokens: 128000 }) === 128000);
+  check('client, non-numeric body value → DEFAULT fallback',
+    resolveMaxTokens('client', { max_tokens: 'big' }) === DEFAULT_MAX_TOKENS);
+  check('client, zero body value → DEFAULT fallback',
+    resolveMaxTokens('client', { max_tokens: 0 }) === DEFAULT_MAX_TOKENS);
+  check('client, negative body value → DEFAULT fallback',
+    resolveMaxTokens('client', { max_tokens: -10 }) === DEFAULT_MAX_TOKENS);
+  check('client, float body value → floored to integer',
+    resolveMaxTokens('client', { max_tokens: 64000.9 }) === 64000);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('buildCCRequest — maxTokens option reaches outbound body');
+{
+  const identity = { deviceId: 'D', accountUuid: 'A', sessionId: 'S' };
+  const cacheControl = { type: 'ephemeral' };
+  const billingTag = 'billing';
+
+  const def = buildCCRequest(
+    { model: 'claude-sonnet-4-6', messages: [{ role: 'user', content: 'hi' }], stream: false },
+    billingTag, cacheControl, identity,
+  ).body;
+  check('default: max_tokens = 32000', def.max_tokens === 32000);
+
+  const pinned = buildCCRequest(
+    { model: 'claude-opus-4-7', messages: [{ role: 'user', content: 'hi' }], stream: false },
+    billingTag, cacheControl, identity,
+    { maxTokens: 128000 },
+  ).body;
+  check('pinned: max_tokens = 128000', pinned.max_tokens === 128000);
+
+  const passthrough = buildCCRequest(
+    { model: 'claude-sonnet-4-6', max_tokens: 64000, messages: [{ role: 'user', content: 'hi' }], stream: false },
+    billingTag, cacheControl, identity,
+    { maxTokens: 'client' },
+  ).body;
+  check('client-passthrough: 64000 flows through from body', passthrough.max_tokens === 64000);
+
+  const passthroughNoneBody = buildCCRequest(
+    { model: 'claude-sonnet-4-6', messages: [{ role: 'user', content: 'hi' }], stream: false },
+    billingTag, cacheControl, identity,
+    { maxTokens: 'client' },
+  ).body;
+  check('client-passthrough with no body.max_tokens → DEFAULT fallback',
+    passthroughNoneBody.max_tokens === DEFAULT_MAX_TOKENS);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('resolveMaxTokensFlag — CLI parsing');
+{
+  check('no flag, no env → undefined',
+    resolveMaxTokensFlag([], undefined) === undefined);
+  check('--max-tokens=64000 → 64000',
+    resolveMaxTokensFlag(['--max-tokens=64000'], undefined) === 64000);
+  check('--max-tokens=client → "client"',
+    resolveMaxTokensFlag(['--max-tokens=client'], undefined) === 'client');
+  check('--max-tokens=CLIENT (case) → "client"',
+    resolveMaxTokensFlag(['--max-tokens=CLIENT'], undefined) === 'client');
+  check('--max-tokens=  128000  (whitespace) → 128000',
+    resolveMaxTokensFlag(['--max-tokens=  128000  '], undefined) === 128000);
+  check('env DARIO_MAX_TOKENS=64000 → 64000',
+    resolveMaxTokensFlag([], '64000') === 64000);
+  check('env client → "client"',
+    resolveMaxTokensFlag([], 'client') === 'client');
+  check('flag wins over env',
+    resolveMaxTokensFlag(['--max-tokens=32000'], '128000') === 32000);
+  check('empty env → undefined',
+    resolveMaxTokensFlag([], '') === undefined);
+}
+
+header('resolveMaxTokensFlag — invalid values exit non-zero');
+{
+  const { spawnSync } = await import('node:child_process');
+  const result = spawnSync(process.execPath, [
+    '-e',
+    `import('./dist/cli.js').then(({ resolveMaxTokensFlag }) => { resolveMaxTokensFlag(['--max-tokens=abc'], undefined); });`,
+  ], { cwd: process.cwd(), encoding: 'utf-8', timeout: 5_000 });
+  check('non-numeric, non-client value → non-zero exit', result.status !== 0);
+  check('stderr names the "client" literal', /positive integer or the literal "client"/.test(result.stderr));
+}
+
+// ─────────────────────────────────────────────────────────────
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
@vmvarg4 reported on X: dario works flawlessly for his OpenClaw but fails on Hermes Agent, all on the same machine. Investigation into [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) (v0.10.0) surfaced two gaps dario's default path was silently falling through.

## The gaps

1. **Hermes ships ~40 tools, 15+ with no CC equivalent** — \`browser_*\`, \`vision_analyze\`, \`image_generate\`, \`skill_*\`, \`memory\`, \`session_search\`, \`cronjob\`, \`send_message\`, \`ha_*\`, \`mixture_of_agents\`, \`delegate_task\`, \`execute_code\`, \`text_to_speech\`. Default mode distributed them onto random CC tool slots. Hermes received unexpected shapes, workflows broke.
2. **Hermes requests per-model \`max_tokens\` up to 128k (Opus 4.7) / 64k (Sonnet).** Dario's 32k pin silently truncated Hermes's output capacity — real problem on long-generation workloads.

## What ships

### Hermes identity detection (auto-preserve-tools)

\`detectTextToolClient\` in \`src/cc-template.ts\` now matches:

- \`You are Hermes Agent\` (canonical opener from \`hermes-agent/agent/prompt_builder.py\`)
- \`created by Nous Research\` (secondary anchor — survives prompts where forks edit the identity line)

Returns \`'hermes'\`, which flows through the same auto-preserve-tools dispatch used for Cline / Kilo Code / Roo. Tools pass through verbatim. Hermes's 40-tool vocabulary routes correctly. Override with \`--no-auto-detect\` if the operator prefers the full CC fingerprint and accepts the misroute cost.

### \`--max-tokens=<N|client>\` flag + \`DARIO_MAX_TOKENS\` env

| Invocation | Outbound |
|---|---|
| *(unset)* | \`32000\` (unchanged — CC 2.1.116 wire default) |
| \`--max-tokens=64000\` | \`64000\` (pinned) |
| \`--max-tokens=128000\` | \`128000\` (Opus 4.7 ceiling) |
| \`--max-tokens=client\` | Whatever the client body requested; falls back to 32000 if client didn't send |
| \`DARIO_MAX_TOKENS=64000\` | env mirror |

Anthropic enforces the per-model ceiling server-side, so too-high values return a clean 400 rather than silently accepting beyond-model-max.

## Internal

- \`resolveMaxTokens(flag, clientBody)\` — pure fn exported from \`cc-template.ts\`, mirrors \`resolveEffort\`'s shape
- \`DEFAULT_MAX_TOKENS\` — constant exported for tests
- \`resolveMaxTokensFlag(args, env)\` — exported CLI parser; whitespace-tolerant, case-insensitive for the \`client\` literal, exits non-zero on invalid values
- \`ProxyOptions.maxTokens: number | 'client'\` — library consumers can set directly

## Tests

\`test/hermes-compat.mjs\` — **31 assertions**:

- Hermes identity detection (canonical opener → \`'hermes'\`, Nous-Research-only anchor, prompt-wrapping survival, negative controls that confirm Cline / generic prompts don't false-positive)
- \`resolveMaxTokens\` pin + passthrough branches (DEFAULT fallback for missing / non-numeric / zero / negative / float body values)
- \`buildCCRequest\` integration: outbound \`max_tokens\` matches flag — default 32000, pinned 128000, client-passthrough 64000, client-with-missing-body falls back to default
- \`resolveMaxTokensFlag\` CLI parsing: flag precedence over env, case-insensitive \`client\`, whitespace tolerance, empty-env → undefined
- Invalid-value subprocess exit check

## README

Hermes row expanded from \`terminal / patch / web_extract / clarify\` (4 tools) to the full picture — which ~9 Hermes tools map cleanly, which 15+ fall into preserve-tools territory, the identity-detector anchors, and the \`--max-tokens=client\` recommendation for large-output workloads.

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm test\` — 40 files green (31 new in hermes-compat, others unchanged)
- [x] \`npm run drift:sdk\` — clean against CC 2.1.116