### PR TITLE
proxy: verbose log line on 401 auth rejects (#97)

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -447,6 +447,22 @@ export function authenticateRequest(
 }
 
 /**
+ * Describe WHY authenticateRequest rejected, for operator-facing logs only.
+ * Header names only — never the value, since a mistyped key could be the
+ * user's real credential for some other provider. Pure over inputs (dario#97).
+ */
+export function describeAuthReject(
+  headers: IncomingMessage['headers'],
+): string {
+  const seenKeyHeader = headers['x-api-key'] !== undefined;
+  const seenAuthHeader = headers['authorization'] !== undefined;
+  if (!seenKeyHeader && !seenAuthHeader) return 'no x-api-key or Authorization header';
+  if (seenKeyHeader && !seenAuthHeader) return 'x-api-key present but value mismatch';
+  if (!seenKeyHeader && seenAuthHeader) return 'Authorization present but value mismatch';
+  return 'both headers present but neither value matches';
+}
+
+/**
  * Enrich Anthropic's unhelpful 429 "Error" body with rate limit details from headers.
  */
 function enrich429(body: string, headers: Headers): string {
@@ -766,7 +782,17 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
       return;
     }
 
-    if (!checkAuth(req)) { res.writeHead(401, JSON_HEADERS); res.end(ERR_UNAUTH); return; }
+    if (!checkAuth(req)) {
+      if (verbose) {
+        // Silent auth rejects are hard to diagnose when a client's config
+        // doesn't quite match what dario expects (dario#97). Emit a
+        // one-line reject log under -v so operators see auth misfires.
+        console.error(`[dario] #${requestCount} 401 rejected (DARIO_API_KEY mismatch): ${describeAuthReject(req.headers)}`);
+      }
+      res.writeHead(401, JSON_HEADERS);
+      res.end(ERR_UNAUTH);
+      return;
+    }
 
     // Status endpoint
     if (urlPath === '/status') {

--- a/test/auth-reject-diagnostic.mjs
+++ b/test/auth-reject-diagnostic.mjs
@@ -1,0 +1,106 @@
+// Tests for describeAuthReject + authenticateRequest (dario#97).
+//
+// describeAuthReject is a pure function over an IncomingMessage.headers-like
+// object. It produces operator-facing reject reasons for the 401 path in
+// proxy.ts — header names only, never values. We also cover the matrix of
+// authenticateRequest outcomes that each reason corresponds to, so a future
+// refactor can't drift the two apart.
+
+import { authenticateRequest, describeAuthReject } from '../dist/proxy.js';
+
+let pass = 0, fail = 0;
+function check(name, cond) {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else      { console.log(`  FAIL ${name}`); fail++; }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+const KEY = Buffer.from('dario');
+
+// ─────────────────────────────────────────────────────────────
+header('describeAuthReject — header-presence matrix');
+{
+  check('neither header → "no ... Authorization header"',
+    describeAuthReject({}) === 'no x-api-key or Authorization header');
+
+  check('only x-api-key → "x-api-key present but value mismatch"',
+    describeAuthReject({ 'x-api-key': 'wrong' }) === 'x-api-key present but value mismatch');
+
+  check('only Authorization → "Authorization present but value mismatch"',
+    describeAuthReject({ authorization: 'Bearer wrong' }) === 'Authorization present but value mismatch');
+
+  check('both headers → "both ... neither value matches"',
+    describeAuthReject({ 'x-api-key': 'wrong', authorization: 'Bearer also-wrong' }) ===
+      'both headers present but neither value matches');
+
+  // Empty-string values are still "present" — node already collapsed them to
+  // string type. Operators should see the header counted as present so they
+  // notice the client is sending empty auth rather than no auth.
+  check('empty x-api-key still counts as present',
+    describeAuthReject({ 'x-api-key': '' }) === 'x-api-key present but value mismatch');
+}
+
+// ─────────────────────────────────────────────────────────────
+header('describeAuthReject — never leaks the provided value');
+{
+  const suspect = 'sk-ant-oat01-real-token-do-not-leak';
+  const reason = describeAuthReject({ 'x-api-key': suspect });
+  check('description does not contain the provided key substring',
+    !reason.includes(suspect));
+  check('description does not contain the "sk-" prefix',
+    !reason.includes('sk-'));
+}
+
+// ─────────────────────────────────────────────────────────────
+header('authenticateRequest — pre-existing matrix still green');
+{
+  // Null key buffer → auth disabled, every request passes.
+  check('null key → always pass (no header)', authenticateRequest({}, null) === true);
+  check('null key → always pass (wrong header)',
+    authenticateRequest({ 'x-api-key': 'whatever' }, null) === true);
+
+  // Key set → validated against both header paths.
+  check('correct x-api-key → pass', authenticateRequest({ 'x-api-key': 'dario' }, KEY) === true);
+  check('wrong x-api-key → fail', authenticateRequest({ 'x-api-key': 'nope' }, KEY) === false);
+
+  check('Authorization: Bearer <key> → pass',
+    authenticateRequest({ authorization: 'Bearer dario' }, KEY) === true);
+  check('Authorization: <key> (no Bearer) → pass',
+    authenticateRequest({ authorization: 'dario' }, KEY) === true);
+  check('Authorization: Bearer <wrong> → fail',
+    authenticateRequest({ authorization: 'Bearer nope' }, KEY) === false);
+
+  check('no header → fail', authenticateRequest({}, KEY) === false);
+
+  // Length-shield: a short provided value must not accidentally match a
+  // prefix-equal longer configured key. timingSafeEqual would throw on
+  // mismatched lengths; authenticateRequest guards with a length check first.
+  check('length mismatch → fail (short provided, long configured)',
+    authenticateRequest({ 'x-api-key': 'd' }, KEY) === false);
+  check('length mismatch → fail (long provided, short configured)',
+    authenticateRequest({ 'x-api-key': 'dariodario' }, KEY) === false);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('describeAuthReject / authenticateRequest — consistency');
+{
+  // Any input that makes authenticateRequest return false should also produce
+  // a non-empty description. No "success" output from describeAuthReject.
+  const cases = [
+    {},
+    { 'x-api-key': 'wrong' },
+    { authorization: 'Bearer wrong' },
+    { 'x-api-key': 'wrong', authorization: 'Bearer also-wrong' },
+    { 'x-api-key': '' },
+  ];
+  for (const h of cases) {
+    const allowed = authenticateRequest(h, KEY);
+    const reason = describeAuthReject(h);
+    check(`reject + non-empty reason for ${JSON.stringify(h)}`,
+      allowed === false && reason.length > 0);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Helps diagnose #97 and every future auth-mismatch report.

## Problem

#97 reports "OpenClaw returns HTTP 401 since v3.30.13" after upgrading from v3.30.5. Confirmed:

- The 401 body `"Invalid or missing API key"` is dario's own `ERR_UNAUTH` (`proxy.ts:742`), identical in v3.30.5 and v3.30.13.
- `authenticateRequest` (`proxy.ts:435`) is byte-identical across v3.30.5..v3.30.13.
- What changed: #74 (v3.30.6) refused to start non-loopback without `DARIO_API_KEY`. The reporter had to set `DARIO_API_KEY=dario`, which for the first time actually enforced auth on incoming requests. OpenClaw was never sending the header dario expected — previous `--host=0.0.0.0` setups silently let every request through because `apiKeyBuf` was `null`.

The auth behaviour is correct. The diagnostic is not: the 401 path was silent. Operators hitting this had no way to tell from dario's side whether the client sent no header, a wrong value, or a different header name.

## What this adds

A single verbose-only log line on every 401 auth rejection, naming which header was present and whether it mismatched. Header names only — never the value, since it may be a real credential the user mistyped.

```
[dario] #0 401 rejected (DARIO_API_KEY mismatch): no x-api-key or Authorization header
[dario] #1 401 rejected (DARIO_API_KEY mismatch): x-api-key present but value mismatch
[dario] #2 401 rejected (DARIO_API_KEY mismatch): Authorization present but value mismatch
[dario] #3 401 rejected (DARIO_API_KEY mismatch): both headers present but neither value matches
```

## Files changed

- `src/proxy.ts` — exported pure `describeAuthReject(headers)` function + call-site at the 401 branch (`:769`). Only fires when `verbose` is set. No behaviour change for users who don't pass `-v`.
- `test/auth-reject-diagnostic.mjs` — 22 assertions covering:
  - The header-presence matrix (none / x-api-key / Authorization / both).
  - Empty-string values still count as "present" (so empty auth is distinguishable from missing auth).
  - Never-leak invariant — the function's output does not contain the provided key substring.
  - Pre-existing `authenticateRequest` behaviour, including the length-shield that prevents prefix-equal false positives.
  - Consistency: every header shape that makes `authenticateRequest` return false also produces a non-empty reject reason.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 41 suites green (up from 40 — auto-discovered new file via `test/all.test.mjs`)
- [x] Manual curl reproduction confirms all four reject shapes produce the right log line
- [x] Correct-auth curl still returns 200 with no spurious reject log

## Won't fix

- The silent reject when `verbose` is OFF. This is a deliberate choice — operators running `dario proxy` without `-v` presumably don't want auth rejects in their terminal. Operators diagnosing #97-shaped issues will run with `-v` anyway.

## User-visible impact

- Zero behaviour change by default.
- With `-v`, every 401 auth reject now prints a one-line diagnosis naming the presence / mismatch shape of the incoming headers.