### PR TITLE
v3.31.3 — normalize OAuth authorize URL to claude.ai (#71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.31.3] - 2026-04-22
+
+### Fixed — `dario accounts add` OAuth authorize URL regression (dario#71)
+
+@tetsuco reported that `dario accounts add <alias>` was hitting Anthropic's "Invalid request format" page on the authorize step. Fresh `claude /login` in Claude Code itself opened `https://claude.ai/oauth/authorize` directly and worked; dario opened `https://claude.com/cai/oauth/authorize` which 307-redirected to claude.ai and got rejected. Same client_id, same scope list, same PKCE, same everything else. Anthropic's edge started rejecting requests arriving via the redirect hop while accepting direct requests.
+
+dario scans `CLAUDE_AI_AUTHORIZE_URL` as a literal string out of CC's binary, and CC ships `"https://claude.com/cai/oauth/authorize"` there. But CC at runtime opens the claude.ai URL directly — the runtime doesn't use that literal verbatim.
+
+- New `normalizeAuthorizeUrl(url)` helper — rewrites the exact literal `https://claude.com/cai/oauth/authorize` to `https://claude.ai/oauth/authorize`, pass-through for every other URL. Applied in the binary extractor and the manual-override applier.
+- `FALLBACK.authorizeUrl` bumped to the normalized URL so fresh-install / scan-failure users hit the correct endpoint.
+- `CACHE_PATH` bumped `cc-oauth-cache-v4.json` → `cc-oauth-cache-v5.json` to invalidate caches populated with the pre-normalization URL. Same invalidation pattern as v3.19.4 (-v3 → -v4 for the 6-scope rotation).
+
+Narrow by design — only the exact legacy URL is rewritten, so operator-supplied staging/IDP overrides pass through untouched. Tests in `test/oauth-authorize-url-normalize.mjs` (11 assertions) pin both the rewrite and the pass-through contract. `test/oauth-detector.mjs` updated to the v5 cache path and the normalized URL.
+
+No behaviour change for users whose dario had already successfully completed an OAuth flow — their `~/.dario/credentials.json` is unchanged. Only affects new `dario login` and `dario accounts add <alias>` flows.
+
 ## [3.31.2] - 2026-04-22
 
 ### Changed — Verbose log line on 401 auth rejects (dario#97, #98)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.31.2",
+  "version": "3.31.3",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {

--- a/src/cc-oauth-detect.ts
+++ b/src/cc-oauth-detect.ts
@@ -57,12 +57,36 @@ export interface DetectedOAuthConfig {
 type OAuthFields = Pick<DetectedOAuthConfig, 'clientId' | 'authorizeUrl' | 'tokenUrl' | 'scopes'>;
 type OAuthOverride = Partial<OAuthFields>;
 
+/**
+ * Normalize the authorize URL to match what CC uses at runtime.
+ *
+ * The CC binary ships `CLAUDE_AI_AUTHORIZE_URL: "https://claude.com/cai/oauth/authorize"`
+ * as a literal string, but at runtime CC's `/login` opens
+ * `https://claude.ai/oauth/authorize` directly (empirically verified against
+ * CC v2.1.116 by tetsuco in dario#71). Historically the claude.com edge
+ * 307-redirected to claude.ai and the browser followed; recent Anthropic-side
+ * changes made the post-redirect validation start returning "Invalid request
+ * format", while direct requests to claude.ai continue to work. This normalizer
+ * rewrites the legacy URL wherever it appears (binary extraction, manual
+ * override, cached config) so dario matches CC's runtime behaviour.
+ *
+ * Intentionally narrow: only the exact legacy URL is rewritten. Any other
+ * operator-supplied URL (e.g. a staging endpoint via override) passes through.
+ */
+export function normalizeAuthorizeUrl(url: string): string {
+  if (url === 'https://claude.com/cai/oauth/authorize') {
+    return 'https://claude.ai/oauth/authorize';
+  }
+  return url;
+}
+
 // Last-resort fallback if CC binary can't be found or scanned.
 // These values are the CC v2.1.104 PROD OAuth config, extracted from
-// the `nh$` object in the shipped binary.
+// the `nh$` object in the shipped binary. authorizeUrl is normalized —
+// see normalizeAuthorizeUrl() above for why this matters (dario#71).
 const FALLBACK: DetectedOAuthConfig = {
   clientId: '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
-  authorizeUrl: 'https://claude.com/cai/oauth/authorize',
+  authorizeUrl: 'https://claude.ai/oauth/authorize',
   tokenUrl: 'https://platform.claude.com/v1/oauth/token',
   // Scopes match CC v2.1.107+ interactive login: the 5-scope user-only set.
   // Between CC v2.1.104 and v2.1.107, Anthropic's authorize endpoint flipped
@@ -85,10 +109,12 @@ const FALLBACK: DetectedOAuthConfig = {
 // would drift out of sync silently.
 export const FALLBACK_FOR_DRIFT_CHECK: Readonly<DetectedOAuthConfig> = FALLBACK;
 
-// -v4 suffix invalidates v3.x caches populated with the 6-scope list that
-// Anthropic now rejects (dario #42). On upgrade, users regenerate the cache
-// with the new FALLBACK scopes automatically — no manual clear required.
-const CACHE_PATH = join(homedir(), '.dario', 'cc-oauth-cache-v4.json');
+// -v5 suffix invalidates v3.x caches populated with the pre-normalized
+// authorize URL that now fails "Invalid request format" via the 307-redirect
+// hop (dario#71). On upgrade, users regenerate the cache with the normalized
+// FALLBACK.authorizeUrl automatically — no manual clear required. Previous
+// bump was -v3 → -v4 in v3.19.4 for the 6-scope → 5-scope rotation (dario#42).
+const CACHE_PATH = join(homedir(), '.dario', 'cc-oauth-cache-v5.json');
 const DEFAULT_OVERRIDE_PATH = join(homedir(), '.dario', 'oauth-config.override.json');
 
 function candidatePaths(): string[] {
@@ -183,9 +209,16 @@ function applyManualOverride(config: DetectedOAuthConfig, override: OAuthOverrid
   if (!override) return config;
   warnOnNonHttpsOverride('authorizeUrl', override.authorizeUrl);
   warnOnNonHttpsOverride('tokenUrl', override.tokenUrl);
+  // Normalize any override-supplied authorizeUrl too — users who pasted the
+  // legacy claude.com URL into ~/.dario/oauth-config.override.json pre-#71
+  // shouldn't be silently broken after upgrade.
+  const normalizedOverride = { ...override };
+  if (normalizedOverride.authorizeUrl) {
+    normalizedOverride.authorizeUrl = normalizeAuthorizeUrl(normalizedOverride.authorizeUrl);
+  }
   return {
     ...config,
-    ...override,
+    ...normalizedOverride,
     source: 'override',
   };
 }
@@ -244,7 +277,7 @@ export function scanBinaryForOAuthConfig(buf: Buffer): Omit<DetectedOAuthConfig,
 
   let authorizeUrl = FALLBACK.authorizeUrl;
   const authMatch = /CLAUDE_AI_AUTHORIZE_URL\s*:\s*"([^"]+)"/.exec(prodBlock);
-  if (authMatch && authMatch[1]) authorizeUrl = authMatch[1];
+  if (authMatch && authMatch[1]) authorizeUrl = normalizeAuthorizeUrl(authMatch[1]);
 
   let tokenUrl = FALLBACK.tokenUrl;
   const tokenMatch = /TOKEN_URL\s*:\s*"(https:\/\/[^"]*\/oauth\/token[^"]*)"/.exec(prodBlock);

--- a/test/oauth-authorize-url-normalize.mjs
+++ b/test/oauth-authorize-url-normalize.mjs
@@ -1,0 +1,82 @@
+// Tests for normalizeAuthorizeUrl (dario#71).
+//
+// The CC binary ships `CLAUDE_AI_AUTHORIZE_URL:"https://claude.com/cai/oauth/authorize"`
+// as a literal, but CC at runtime opens `https://claude.ai/oauth/authorize`
+// directly. Anthropic's edge started returning "Invalid request format" for
+// requests arriving via the 307 hop, while accepting direct requests. The
+// normalizer rewrites the legacy URL to match CC's runtime behaviour.
+//
+// These tests pin the rewrite behaviour AND the deliberate narrowness of it:
+// any other URL (including operator-supplied overrides pointing elsewhere)
+// must pass through untouched.
+
+import { normalizeAuthorizeUrl, FALLBACK_FOR_DRIFT_CHECK } from '../dist/cc-oauth-detect.js';
+
+let pass = 0, fail = 0;
+function check(name, cond) {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else      { console.log(`  FAIL ${name}`); fail++; }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+// ─────────────────────────────────────────────────────────────
+header('normalizeAuthorizeUrl — legacy URL gets rewritten');
+{
+  check('legacy claude.com URL → claude.ai',
+    normalizeAuthorizeUrl('https://claude.com/cai/oauth/authorize') ===
+      'https://claude.ai/oauth/authorize');
+}
+
+header('normalizeAuthorizeUrl — anything else passes through');
+{
+  check('already-normalized URL unchanged',
+    normalizeAuthorizeUrl('https://claude.ai/oauth/authorize') ===
+      'https://claude.ai/oauth/authorize');
+
+  // Operator-supplied staging / override URLs must pass through unchanged.
+  // The normalizer is deliberately narrow — it rewrites exactly one URL.
+  check('operator staging override passes through',
+    normalizeAuthorizeUrl('https://staging.claude.ai/oauth/authorize') ===
+      'https://staging.claude.ai/oauth/authorize');
+  check('self-hosted IDP passes through',
+    normalizeAuthorizeUrl('https://idp.example.com/oauth/authorize') ===
+      'https://idp.example.com/oauth/authorize');
+
+  // No substring / prefix match — only exact string. A URL that *contains*
+  // the legacy path must not trigger the rewrite.
+  check('trailing-slash variant does NOT match',
+    normalizeAuthorizeUrl('https://claude.com/cai/oauth/authorize/') ===
+      'https://claude.com/cai/oauth/authorize/');
+  check('query-string variant does NOT match',
+    normalizeAuthorizeUrl('https://claude.com/cai/oauth/authorize?foo=bar') ===
+      'https://claude.com/cai/oauth/authorize?foo=bar');
+  check('different casing does NOT match',
+    normalizeAuthorizeUrl('https://claude.com/CAI/oauth/authorize') ===
+      'https://claude.com/CAI/oauth/authorize');
+  check('http (non-https) variant does NOT match',
+    normalizeAuthorizeUrl('http://claude.com/cai/oauth/authorize') ===
+      'http://claude.com/cai/oauth/authorize');
+}
+
+header('normalizeAuthorizeUrl — edge inputs');
+{
+  check('empty string passes through',
+    normalizeAuthorizeUrl('') === '');
+  check('unrelated URL passes through',
+    normalizeAuthorizeUrl('https://example.com/oauth') ===
+      'https://example.com/oauth');
+}
+
+// ─────────────────────────────────────────────────────────────
+header('FALLBACK — pinned to the normalized URL');
+{
+  // The last-resort fallback that ships when binary scanning fails must
+  // already be normalized — users who hit the fallback path (no CC installed,
+  // or scan failure) shouldn't be broken by the legacy URL regression.
+  check('FALLBACK.authorizeUrl is the claude.ai URL',
+    FALLBACK_FOR_DRIFT_CHECK.authorizeUrl === 'https://claude.ai/oauth/authorize');
+}
+
+// ─────────────────────────────────────────────────────────────
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);

--- a/test/oauth-detector.mjs
+++ b/test/oauth-detector.mjs
@@ -26,7 +26,9 @@ import { readFile, unlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir, tmpdir } from 'node:os';
 
-const CACHE_PATH = join(homedir(), '.dario', 'cc-oauth-cache-v4.json');
+// Stays in sync with CACHE_PATH in src/cc-oauth-detect.ts. Bumped v4 → v5
+// in dario#71 for the claude.com → claude.ai authorizeUrl normalization.
+const CACHE_PATH = join(homedir(), '.dario', 'cc-oauth-cache-v5.json');
 const PROD_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
 const DEAD_DEV_CLIENT_ID = '22422756-60c9-4084-8eb7-27705fd5cf9a';
 const OVERRIDE_CLIENT_ID = '11111111-2222-4333-8444-555555555555';
@@ -121,8 +123,12 @@ async function main() {
     pass: cfg1.clientId !== DEAD_DEV_CLIENT_ID,
   });
   checks.push({
-    name: 'authorizeUrl uses claude.com/cai/oauth/authorize',
-    pass: cfg1.authorizeUrl === 'https://claude.com/cai/oauth/authorize',
+    // The binary literal is claude.com/cai/oauth/authorize, but normalizeAuthorizeUrl
+    // rewrites it to claude.ai/oauth/authorize to match what CC opens at runtime
+    // (dario#71). Anthropic's edge started rejecting requests that arrive via the
+    // 307-redirect hop, while direct claude.ai requests continue to work.
+    name: 'authorizeUrl is normalized to claude.ai/oauth/authorize',
+    pass: cfg1.authorizeUrl === 'https://claude.ai/oauth/authorize',
   });
   checks.push({
     name: 'tokenUrl uses platform.claude.com/v1/oauth/token',


### PR DESCRIPTION
Closes #71.

## Root cause

[@tetsuco](https://github.com/tetsuco) reported that `dario accounts add <alias>` was hitting Anthropic's "Invalid request format" page on the authorize step. After a thorough 3-way scope diagnostic, tetsuco confirmed:

- CC v2.1.116's `/login` opens `https://claude.ai/oauth/authorize` **directly** — works.
- dario opens `https://claude.com/cai/oauth/authorize` — which 307-redirects to claude.ai — and the request is rejected at claude.ai with "Invalid request format".
- Same `client_id`, same 6-scope list, same PKCE S256, same `redirect_uri` shape, same `state` parameter.

The only meaningful difference: CC goes to claude.ai directly; dario arrives via the 307 hop. Anthropic's edge changed its validation at some point to reject requests that arrive via the redirect, while still accepting direct requests.

**Why dario has been using the legacy URL:** the binary-extraction path (`src/cc-oauth-detect.ts:246`) scans `CLAUDE_AI_AUTHORIZE_URL` as a literal string out of the CC binary, and CC ships `"https://claude.com/cai/oauth/authorize"` there. At runtime, CC doesn't use that literal verbatim — it opens the claude.ai URL directly. Dario was faithfully reading the wrong source of truth.

## Fix

New `normalizeAuthorizeUrl(url)` helper at the top of `src/cc-oauth-detect.ts`:

```ts
export function normalizeAuthorizeUrl(url: string): string {
  if (url === 'https://claude.com/cai/oauth/authorize') {
    return 'https://claude.ai/oauth/authorize';
  }
  return url;
}
```

Applied in three places:

1. **Binary extractor** — after regex-extracting the literal, before returning.
2. **Manual-override applier** — so users who pasted the legacy URL into `~/.dario/oauth-config.override.json` pre-#71 aren't silently broken after upgrade.
3. **`FALLBACK.authorizeUrl`** — for fresh-install / scan-failure users.

`CACHE_PATH` bumped `cc-oauth-cache-v4.json` → `cc-oauth-cache-v5.json`. On upgrade, existing caches are abandoned and regenerated with the normalized URL. Same invalidation pattern as v3.19.4 (-v3 → -v4 for the 6-scope rotation in #42).

## Deliberately narrow

The rewrite matches **exactly one string**. Variants (trailing slash, query-string, different casing, http instead of https, operator staging URLs, self-hosted IDP URLs) all pass through untouched. 11 new assertions in `test/oauth-authorize-url-normalize.mjs` pin both behaviours — rewrite AND pass-through.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 42/42 suites green (adds `oauth-authorize-url-normalize.mjs`)
- [x] Manual cache-invalidation verified: `rm ~/.dario/cc-oauth-cache-v5.json && node -e "..."` returns `source=detected` with normalized URL
- [ ] **After merge:** @tetsuco to verify that `dario accounts add bar` succeeds on v3.31.3 — the flow should skip the 307 and get a working authorize page

## User impact

- Users with working `~/.dario/credentials.json` see **zero** behaviour change. Existing tokens continue to work.
- Fresh `dario login` and `dario accounts add` flows now hit the claude.ai endpoint directly, matching CC's runtime behaviour.
- Operators with `DARIO_OAUTH_AUTHORIZE_URL` env or override-file entries pointing at the legacy URL are auto-migrated; entries pointing elsewhere are untouched.