### PR TITLE
v3.31.4 — 6-scope OAuth fallback restored + CC 2.1.118 drift (dario#71, #103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.31.4] - 2026-04-23
+
+### Fixed — `dario accounts add` still hitting "Invalid request format" after v3.31.3 (dario#71)
+
+v3.31.3 fixed the authorize-URL host (`claude.com/cai/oauth/authorize` → `claude.ai/oauth/authorize`) but the 5-scope `FALLBACK.scopes` remained — and @tetsuco's CC v2.1.116 `/login` URL, which works, uses the 6-scope list **including** `org:create_api_key`. Anthropic flipped policy back between v2.1.107 (when 5-scope became the only accepted form, dario#42) and v2.1.116 (when 6-scope works again). With the URL fixed but scopes still 5, dario was sending a URL Anthropic now rejects.
+
+- `FALLBACK.scopes` bumped to the 6-scope list with `org:create_api_key` as the first scope — matches what CC v2.1.116's `/login` opens. Scope-list history comment updated with all four known flips on this client_id.
+- `CACHE_PATH` bumped `cc-oauth-cache-v5.json` → `cc-oauth-cache-v6.json` so existing caches (which stored the 5-scope FALLBACK at extract time) regenerate automatically on upgrade.
+- `scripts/check-cc-drift.mjs` `PINNED_OAUTH.authorizeUrl` bumped to the normalized URL and `OAUTH_SCOPES_EXPECTED` to the 6-scope list — drift watcher stays meaningful.
+- `scripts/check-cc-authorize-probe.mjs` flipped: probe A = 6-scope (accepted), probe B = 5-scope (informational; policy may accept both). Previous "known-rejected = 6-scope" assumption no longer holds.
+- `scripts/_authorize-probe-classifier.mjs` `combineVerdicts` updated: A-rejected is still user-facing drift, B-accepted is now info (not medium) because Anthropic may accept both forms.
+
+Tests: `test/oauth-detector.mjs` scope assertions flipped (6-scope set, `org:create_api_key` present as first item); `test/cc-authorize-probe-classifier.mjs` updated for the new A/B semantics.
+
+### Fixed — CC v2.1.118 drift (dario#103)
+
+Nightly drift watcher flagged CC v2.1.118 on npm. `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.117` → `2.1.118`. Baked template stays at v2.1.117 — users on v2.1.118 get a template-version low-severity info in `dario doctor`, not a hard fail. Re-capture against a live v2.1.118 will ship separately once fingerprint-sensitive fields are diffed.
+
 ## [3.31.3] - 2026-04-22
 
 ### Fixed — `dario accounts add` OAuth authorize URL regression (dario#71)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.31.3",
+  "version": "3.31.4",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {

--- a/scripts/_authorize-probe-classifier.mjs
+++ b/scripts/_authorize-probe-classifier.mjs
@@ -93,12 +93,20 @@ export function classifyAuthorizeResponse({ status, location, body, error }) {
 }
 
 /**
- * Combine the verdicts for probe A (pinned scopes) and probe B (pinned
- * scopes + a known-rejected scope) into a single watcher result.
+ * Combine the verdicts for probe A (pinned 6-scope) and probe B (5-scope,
+ * org:create_api_key removed) into a single watcher result.
  *
- *   A must be 'accepted' AND B must be 'rejected' for a clean run.
- *   A 'rejected' → our scopes stopped being accepted (breakage).
- *   B 'accepted' → the rejected scope is now accepted (policy relaxed).
+ *   A must be 'accepted' for a clean run — that's what our users do.
+ *   B's verdict is informational. Post-v2.1.116, Anthropic may accept
+ *     both the 6-scope and 5-scope forms for this client_id. If B is
+ *     rejected, the policy is strict-6-only (matches CC's current
+ *     behaviour). If B is accepted, policy accepts both; not breakage,
+ *     but worth noting so we can tell when it flips again.
+ *
+ *   A 'rejected' → our scopes stopped being accepted (user-facing
+ *     breakage, same class as dario#42 / dario#71).
+ *   B flip (accepted ↔ rejected across runs) → policy tightened or
+ *     relaxed; informational.
  *   Either 'inconclusive' → the whole probe is inconclusive; no drift
  *     claim either way. Report it as info, don't page.
  */
@@ -125,28 +133,33 @@ export function combineVerdicts(a, b) {
       probe: 'A',
       severity: 'high',
       message:
-        `Pinned FALLBACK.scopes no longer accepted by authorize endpoint (${a.reason}). ` +
-        `This is the dario #42 failure mode: users will hit "Invalid request format" on fresh login. ` +
+        `Pinned FALLBACK.scopes (6-scope) no longer accepted by authorize endpoint (${a.reason}). ` +
+        `This is the dario #42 / #71 failure mode: users will hit "Invalid request format" on fresh login. ` +
         `Investigate which scope the server now rejects and update FALLBACK.scopes in src/cc-oauth-detect.ts; ` +
         `bump the cache suffix (CACHE_PATH) so existing users regenerate.`,
     });
   }
 
-  if (b.verdict !== 'rejected') {
+  // B is informational — both 'accepted' and 'rejected' are plausible and
+  // neither is user-facing breakage on its own. Only flag when Anthropic's
+  // policy tightens to reject the 5-scope form, since that confirms our
+  // current 6-scope choice is specifically required (not just accepted).
+  if (b.verdict === 'accepted') {
     items.push({
       probe: 'B',
-      severity: 'medium',
+      severity: 'info',
       message:
-        `The known-rejected scope (org:create_api_key) is no longer rejected (${b.reason}). ` +
-        `Anthropic may have relaxed policy for this client_id. Not a user-facing breakage, but ` +
-        `worth investigating: if the longer set is now accepted, revisit whether dropping ` +
-        `org:create_api_key in FALLBACK.scopes is still the right call.`,
+        `5-scope form (org:create_api_key removed) is ALSO accepted. Anthropic's authorize ` +
+        `endpoint appears permissive for this client_id — both the 6-scope form our users send ` +
+        `and the 5-scope form are accepted. Nothing to fix; recorded so we notice when it flips.`,
     });
   }
 
+  // Drift is only "real" when probe A fails. Probe B observations are info.
+  const hasDrift = items.some((i) => i.severity === 'high');
   return {
-    outcome: items.length > 0 ? 'drift' : 'clean',
-    drift: items.length > 0,
+    outcome: hasDrift ? 'drift' : 'clean',
+    drift: hasDrift,
     items,
   };
 }

--- a/scripts/check-cc-authorize-probe.mjs
+++ b/scripts/check-cc-authorize-probe.mjs
@@ -8,22 +8,29 @@
  * regex resolves, so scanBinaryForOAuthConfig just returns FALLBACK.scopes
  * verbatim. This probe fills that gap.
  *
- * dario #42 is the motivating case: between CC v2.1.104 and v2.1.107,
- * Anthropic's authorize endpoint flipped its policy on `org:create_api_key`
- * for the CC client_id. The 6-scope form (with org:create_api_key) now
- * returns "Invalid request format"; the 5-scope form is the only one
- * accepted. The binary-scan drift watcher stayed green through that flip
- * because neither the client_id nor the URLs changed.
+ * Motivating history: between CC v2.1.104 and v2.1.107 (dario #42) Anthropic
+ * flipped to rejecting `org:create_api_key` for the CC client_id — the
+ * 6-scope form returned "Invalid request format" and the 5-scope form was
+ * the only one accepted. Between v2.1.107 and v2.1.116 (dario #71) Anthropic
+ * flipped BACK — the 6-scope form is accepted and CC's /login uses it. The
+ * binary-scan drift watcher stayed green through both flips because neither
+ * the client_id nor the URLs changed. This probe fills that gap.
  *
  * The probe sends two GET requests to the authorize endpoint:
- *   A — pinned FALLBACK.scopes → expected: accepted (no reject marker,
- *       typically a 302 redirect to login)
- *   B — pinned FALLBACK.scopes + ' org:create_api_key' → expected:
- *       rejected (body contains "Invalid request format")
+ *   A — pinned FALLBACK.scopes (6-scope, includes org:create_api_key as
+ *       the first scope) → expected: accepted (no reject marker, typically
+ *       a 302 redirect to login)
+ *   B — pinned FALLBACK.scopes with `org:create_api_key` removed
+ *       (5-scope form) → expected: outcome uncertain — Anthropic may
+ *       accept both after v2.1.116, in which case the probe reports
+ *       "both accepted" and the next flip in either direction is still
+ *       surfaced as drift
  *
  * Either expectation flipping is drift:
  *   A flipped → our scopes stopped being accepted (breakage incoming)
- *   B flipped → the rejected scope is now accepted (worth investigating)
+ *   B flipped from rejected → accepted → Anthropic now accepts both forms
+ *   B flipped from accepted → rejected → Anthropic now strictly requires
+ *     the 6-scope form (matches current expectation, just confirms)
  *
  * Network errors and unexpected response shapes do NOT exit non-zero —
  * the JSON report records them as inconclusive and the next nightly run
@@ -43,9 +50,10 @@ const PINNED = {
   scopes: FALLBACK.scopes,
 };
 
-// The scope the server started rejecting in the dario #42 window. If this
-// ever stops being rejected, that's information we want to surface.
-const KNOWN_REJECTED_SCOPE = 'org:create_api_key';
+// The scope whose presence / absence has flipped server policy twice on
+// this client_id. We probe both with and without it so we notice the next
+// flip in either direction.
+const SCOPE_UNDER_TEST = 'org:create_api_key';
 
 const PROBE_TIMEOUT_MS = 15_000;
 const PROBE_REDIRECT_URI = 'http://localhost:12345/callback';
@@ -155,8 +163,13 @@ async function probe(label, scopes) {
 
 const checkedAt = new Date().toISOString();
 
-const a = await probe('A (pinned scopes)', PINNED.scopes);
-const b = await probe('B (pinned + known-rejected)', `${PINNED.scopes} ${KNOWN_REJECTED_SCOPE}`);
+const scopesWithoutTest = PINNED.scopes
+  .split(/\s+/)
+  .filter((s) => s !== SCOPE_UNDER_TEST)
+  .join(' ');
+
+const a = await probe('A (pinned — 6-scope with org:create_api_key)', PINNED.scopes);
+const b = await probe('B (5-scope — org:create_api_key removed)', scopesWithoutTest);
 
 log(`A verdict: ${a.verdict} (${a.reason})`);
 log(`B verdict: ${b.verdict} (${b.reason})`);
@@ -172,10 +185,10 @@ const report = {
     authorizeUrl: PINNED.authorizeUrl,
     scopes: PINNED.scopes,
   },
-  knownRejectedScope: KNOWN_REJECTED_SCOPE,
+  scopeUnderTest: SCOPE_UNDER_TEST,
   probes: {
     A: { scopes: PINNED.scopes, verdict: a.verdict, reason: a.reason },
-    B: { scopes: `${PINNED.scopes} ${KNOWN_REJECTED_SCOPE}`, verdict: b.verdict, reason: b.reason },
+    B: { scopes: scopesWithoutTest, verdict: b.verdict, reason: b.reason },
   },
   items: combined.items,
 };

--- a/scripts/check-cc-drift.mjs
+++ b/scripts/check-cc-drift.mjs
@@ -51,24 +51,30 @@ const repoRoot = join(__dirname, '..');
 
 const PINNED_OAUTH = {
   clientId: '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
-  authorizeUrl: 'https://claude.com/cai/oauth/authorize',
+  // CC v2.1.116+ ships this as CLAUDE_AI_AUTHORIZE_URL, matching what CC's
+  // /login opens directly. The legacy claude.com/cai/oauth/authorize edge
+  // still 307-redirects here but Anthropic rejects the redirected request
+  // body (dario#71). FALLBACK + normalizeAuthorizeUrl in
+  // src/cc-oauth-detect.ts keep runtime and drift pinned values aligned.
+  authorizeUrl: 'https://claude.ai/oauth/authorize',
   tokenUrl: 'https://platform.claude.com/v1/oauth/token',
 };
 
 // Scope literals we expect the CC binary to reference. This is the set of
-// scopes CC v2.1.107+ uses for the interactive login flow (matches
-// FALLBACK.scopes in src/cc-oauth-detect.ts). If a scope disappears from
+// scopes CC v2.1.116+ uses for the interactive login flow — matches
+// FALLBACK.scopes in src/cc-oauth-detect.ts. If a scope disappears from
 // the binary, Anthropic removed the constant — usually tracks a server-
-// side policy change (dario #42 pattern).
+// side policy change (dario #42 / #71 pattern).
 //
-// There's no symmetric "forbidden scopes" binary check: `org:create_api_key`
-// is present as a string in the v2.1.114 binary even though the live server
-// rejects it with "Invalid request format". Presence of a string literal
-// doesn't prove CC uses it in the active scope array (that's the whole point
-// of the "scope array is variable-reference" comment in cc-oauth-detect.ts).
-// The authoritative "is this scope currently accepted?" signal lives in the
-// live authorize-probe only.
+// History: v2.1.107 dropped `org:create_api_key` after Anthropic started
+// rejecting it; v2.1.116 restored it after Anthropic flipped back. The
+// binary string literal is not authoritative for "is this scope in the
+// active scope array" (see scanBinaryForOAuthConfig's comment on
+// `dY8 = [B9H, TI, ...]` being variable-referenced), but presence is a
+// necessary precondition — if the literal disappears we know the scope
+// list shrank. The live authorize-probe covers the sufficient direction.
 const OAUTH_SCOPES_EXPECTED = [
+  'org:create_api_key',
   'user:profile',
   'user:inference',
   'user:sessions:claude_code',

--- a/src/cc-oauth-detect.ts
+++ b/src/cc-oauth-detect.ts
@@ -28,7 +28,7 @@
  * "MANUAL_REDIRECT_URL" on platform.claude.com is only used when dario's
  * local HTTP server can't bind a port; dario never hits that path.)
  *
- * Results are cached per-binary-hash at ~/.dario/cc-oauth-cache-v4.json so
+ * Results are cached per-binary-hash at ~/.dario/cc-oauth-cache-v6.json so
  * startup only re-scans when the user upgrades Claude Code. The cache suffix
  * is bumped each time scope handling or the fallback config changes, so
  * upgrading dario picks up the new values without a manual cache clear.
@@ -88,19 +88,30 @@ const FALLBACK: DetectedOAuthConfig = {
   clientId: '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
   authorizeUrl: 'https://claude.ai/oauth/authorize',
   tokenUrl: 'https://platform.claude.com/v1/oauth/token',
-  // Scopes match CC v2.1.107+ interactive login: the 5-scope user-only set.
-  // Between CC v2.1.104 and v2.1.107, Anthropic's authorize endpoint flipped
-  // its policy on `org:create_api_key` for this client_id — the shorter list
-  // is now the only accepted one, and the 6-scope form returns "Invalid
-  // request format". CC's own binary dropped `org:create_api_key` from the
-  // `n36` union to match. Dario #42 (tetsuco, 2026-04-17) surfaced this as
-  // a fresh-login failure on macOS against CC v2.1.107.
+  // Scopes match CC v2.1.116+ interactive login: the 6-scope set including
+  // `org:create_api_key` as the FIRST scope. We previously shipped only 5
+  // scopes based on dario#42's v2.1.107 observation — Anthropic had flipped
+  // to rejecting the 6-scope form and CC's own binary dropped
+  // `org:create_api_key` from its `n36` union. Between v2.1.107 and v2.1.116
+  // Anthropic flipped BACK: v2.1.116's `/login` opens the authorize URL with
+  // all 6 scopes (dario#71, tetsuco, 2026-04-23 — authorize URL diff across
+  // all three scope-variant tests confirmed CC's 6-scope list is the only
+  // one accepted by the current `claude.ai/oauth/authorize` endpoint for
+  // this client_id).
   //
-  // History: dario 3.2.7–3.4.3 once dropped this scope by mistake (misread
-  // of the "Console-only" name); 3.4.4 added it back after users hit auth
-  // failures with the dev client_id accepting it but prod rejecting. That
-  // situation has now inverted — prod rejects the longer list.
-  scopes: 'user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload',
+  // Scope-list history on this client_id:
+  // - dario 3.2.7–3.4.3: 5 scopes (misread "Console-only" name), dropped
+  //   `org:create_api_key` wrongly. Users hit auth failures.
+  // - dario 3.4.4: 6 scopes restored after prod started rejecting 5.
+  // - dario 3.19.5: 5 scopes again, after prod rotated to rejecting 6 on
+  //   CC v2.1.107.
+  // - dario 3.31.4 (this): 6 scopes again, after prod rotated back on
+  //   CC v2.1.116.
+  //
+  // The scope list can't be extracted from the binary reliably (see
+  // extractFromBinary's comment). If Anthropic flips again the fix is one
+  // line here plus a cache-version bump.
+  scopes: 'org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload',
   source: 'fallback',
 };
 
@@ -109,12 +120,15 @@ const FALLBACK: DetectedOAuthConfig = {
 // would drift out of sync silently.
 export const FALLBACK_FOR_DRIFT_CHECK: Readonly<DetectedOAuthConfig> = FALLBACK;
 
-// -v5 suffix invalidates v3.x caches populated with the pre-normalized
-// authorize URL that now fails "Invalid request format" via the 307-redirect
-// hop (dario#71). On upgrade, users regenerate the cache with the normalized
-// FALLBACK.authorizeUrl automatically — no manual clear required. Previous
-// bump was -v3 → -v4 in v3.19.4 for the 6-scope → 5-scope rotation (dario#42).
-const CACHE_PATH = join(homedir(), '.dario', 'cc-oauth-cache-v5.json');
+// -v6 suffix invalidates -v5 caches populated with the 5-scope FALLBACK.
+// Those caches stored scopes from the FALLBACK copy at extract time, so
+// bumping FALLBACK.scopes without bumping the cache version would leave
+// upgraded users still hitting "Invalid request format" until they
+// manually deleted the cache file. On upgrade to v3.31.4 the cache
+// regenerates automatically with the 6-scope set (dario#71). Previous
+// bumps: -v3 → -v4 in v3.19.4 for 6→5 rotation (dario#42); -v4 → -v5 in
+// v3.31.3 for the authorize URL normalization.
+const CACHE_PATH = join(homedir(), '.dario', 'cc-oauth-cache-v6.json');
 const DEFAULT_OVERRIDE_PATH = join(homedir(), '.dario', 'oauth-config.override.json');
 
 function candidatePaths(): string[] {

--- a/src/live-fingerprint.ts
+++ b/src/live-fingerprint.ts
@@ -832,7 +832,7 @@ export function _resetInstalledVersionProbeForTest(): void {
  */
 export const SUPPORTED_CC_RANGE = {
   min: '1.0.0',
-  maxTested: '2.1.117',
+  maxTested: '2.1.118',
 } as const;
 
 /**

--- a/test/cc-authorize-probe-classifier.mjs
+++ b/test/cc-authorize-probe-classifier.mjs
@@ -141,7 +141,15 @@ header('combineVerdicts');
     { verdict: 'accepted', reason: '302 to login' },
     { verdict: 'accepted', reason: '302 to login' },
   );
-  check('B accepted -> drift, medium severity', r.drift === true && r.items.some((i) => i.probe === 'B' && i.severity === 'medium'));
+  // Post-v2.1.116, both 6-scope and 5-scope may both be accepted. That's
+  // informational (we want to know when it flips), not drift — our users
+  // send the 6-scope form and it works either way.
+  check(
+    'A accepted AND B accepted -> clean, info item only',
+    r.drift === false &&
+      r.outcome === 'clean' &&
+      r.items.some((i) => i.probe === 'B' && i.severity === 'info'),
+  );
 }
 
 {
@@ -162,14 +170,20 @@ header('combineVerdicts');
 }
 
 {
-  // Both drifted at once (A rejected AND B accepted). This would mean
-  // the server rotated its entire scope policy — both items should land
-  // in the report so the issue body tells the whole story.
+  // Server flipped to rejecting our 6-scope form AND also accepting the
+  // 5-scope form (both observations at once). A is high-severity breakage;
+  // B is info. Both items should land in the report.
   const r = combineVerdicts(
     { verdict: 'rejected', reason: 'body contains marker' },
     { verdict: 'accepted', reason: '302 to login' },
   );
-  check('A rejected AND B accepted -> both items reported', r.drift === true && r.items.length === 2);
+  check(
+    'A rejected AND B accepted -> drift (on A), both items reported',
+    r.drift === true &&
+      r.items.length === 2 &&
+      r.items.some((i) => i.probe === 'A' && i.severity === 'high') &&
+      r.items.some((i) => i.probe === 'B' && i.severity === 'info'),
+  );
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/test/oauth-detector.mjs
+++ b/test/oauth-detector.mjs
@@ -26,9 +26,11 @@ import { readFile, unlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir, tmpdir } from 'node:os';
 
-// Stays in sync with CACHE_PATH in src/cc-oauth-detect.ts. Bumped v4 → v5
-// in dario#71 for the claude.com → claude.ai authorizeUrl normalization.
-const CACHE_PATH = join(homedir(), '.dario', 'cc-oauth-cache-v5.json');
+// Stays in sync with CACHE_PATH in src/cc-oauth-detect.ts. Bumps:
+//   v3 → v4 (v3.19.4): 6→5 scope rotation (dario#42)
+//   v4 → v5 (v3.31.3): claude.com→claude.ai authorizeUrl normalization (dario#71)
+//   v5 → v6 (v3.31.4): 5→6 scope rotation restoring `org:create_api_key` (dario#71)
+const CACHE_PATH = join(homedir(), '.dario', 'cc-oauth-cache-v6.json');
 const PROD_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
 const DEAD_DEV_CLIENT_ID = '22422756-60c9-4084-8eb7-27705fd5cf9a';
 const OVERRIDE_CLIENT_ID = '11111111-2222-4333-8444-555555555555';
@@ -139,16 +141,20 @@ async function main() {
     pass: cfg1.scopes.includes('user:inference'),
   });
   checks.push({
-    name: 'scopes do NOT include org:create_api_key (Anthropic rejects it for CC client_id since v2.1.107 — dario #42)',
-    pass: !cfg1.scopes.includes('org:create_api_key'),
+    name: 'scopes DO include org:create_api_key (Anthropic re-accepts it for CC client_id as of v2.1.116 — dario #71, 2026-04-23)',
+    pass: cfg1.scopes.includes('org:create_api_key'),
   });
   checks.push({
     name: 'scopes include user:file_upload (missing from v3.4.3 scanner output due to regex picking up help-message literal)',
     pass: cfg1.scopes.includes('user:file_upload'),
   });
   checks.push({
-    name: 'scopes contain exactly 5 items (user-only n36 union post-v2.1.107)',
-    pass: cfg1.scopes.split(/\s+/).length === 5,
+    name: 'scopes contain exactly 6 items (n36 union restored on CC v2.1.116)',
+    pass: cfg1.scopes.split(/\s+/).length === 6,
+  });
+  checks.push({
+    name: 'org:create_api_key is the FIRST scope (matches CC /login URL ordering)',
+    pass: cfg1.scopes.split(/\s+/)[0] === 'org:create_api_key',
   });
 
   // Prove the PROD config block context: find the prod-specific anchor


### PR DESCRIPTION
## Summary

Two fixes, one release.

### dario#71 — `dario accounts add` still broken after v3.31.3

v3.31.3 normalized the authorize-URL host (`claude.com/cai/oauth/authorize` → `claude.ai/oauth/authorize`). Correct fix for half the problem. @tetsuco upgraded and still hit "Invalid request format".

The reason: `FALLBACK.scopes` was still the 5-scope set (no `org:create_api_key`). His CC v2.1.116 `/login` URL — which works — uses the **6-scope** list with `org:create_api_key` first. Anthropic has flipped policy on this scope twice for our client_id:

| CC range | Accepted | dario was sending |
|---|---|---|
| v1.0.0 – v2.1.104 | 6-scope | 6-scope ✓ |
| v2.1.107 – v2.1.115 | 5-scope only | v3.19.5 dropped to 5 ✓ (dario#42) |
| v2.1.116+ | 6-scope | v3.31.3 still 5 ✗ (dario#71) |
| v2.1.116+ (this release) | 6-scope | 6-scope ✓ |

Scope list can't be reliably scanned from the CC binary — the scope array is a variable-reference list (`dY8 = [B9H, TI, ...]`), not literal strings. So `FALLBACK.scopes` is hardcoded; flipping it is the fix.

`CACHE_PATH` bumped v5 → v6 so existing caches (which stored the 5-scope FALLBACK at extract time) regenerate automatically on upgrade.

Drift-watcher scripts updated to stay meaningful:
- `check-cc-drift.mjs` PINNED_OAUTH.authorizeUrl → `claude.ai`, scopes → 6-item list
- `check-cc-authorize-probe.mjs` flipped: A = 6-scope (accepted), B = 5-scope (informational; Anthropic may now accept both)
- `_authorize-probe-classifier.mjs` combineVerdicts: A-rejected remains high-severity breakage, B-accepted now info (both forms permissive isn't user-facing drift)

### dario#103 — CC v2.1.118 drift watcher

`SUPPORTED_CC_RANGE.maxTested` bumped `2.1.117` → `2.1.118`. Bundled template stays at v2.1.117; users on v2.1.118 get a template-version **low**-severity info line in `dario doctor`, not a fail. Re-capture against live v2.1.118 will ship once fingerprint-sensitive fields are diffed — deferred because nothing is broken for users on v2.1.118 right now.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 42/42 pass
- [x] `test/oauth-detector.mjs` flipped to 6-scope assertions (`org:create_api_key` present as first scope, length === 6, cache path v6)
- [x] `test/cc-authorize-probe-classifier.mjs` updated for new A/B semantics (A accepted + B accepted is now info/clean, not drift/medium)
- [x] `node scripts/check-cc-drift.mjs` dry-run: only template.version low-severity remains (expected — didn't re-capture v2.1.118 template)