### PR TITLE
v3.31.5 — bundled template re-captured against live CC v2.1.118

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.31.5] - 2026-04-23
+
+### Changed — Bundled template re-captured against live CC v2.1.118 (dario#103 follow-up)
+
+Captured a fresh template against `@anthropic-ai/claude-code@2.1.118` (native Windows `.exe` install — the npm-packaged binary on my PATH was still 2.1.117; used `DARIO_CLAUDE_BIN` override to point the bake script at the newer binary). Diffed every fingerprint-sensitive axis against the v2.1.117 bake:
+
+- **Byte-identical:** `system_prompt`, `agent_identity`, `header_order`, `body_field_order`, `anthropic_beta`, `user_agent`, schema version, top-level keys.
+- **Same:** tool count (27 post-scrub) and tool name set.
+- **Cosmetic change:** one line in the `Read` tool `description` — `"To read a directory, use an ls command via the Bash tool."` → `"To list files in a directory, use the registered shell tool."`. Wording-only, no schema / parameter / required-field changes. No functional impact on template replay.
+
+No code changes — just the baked `src/cc-template-data.json` refresh. `SUPPORTED_CC_RANGE.maxTested` was already bumped to 2.1.118 in v3.31.4. After this release, `dario doctor` on a CC v2.1.118 install shows no template-version info line, and the nightly drift watcher reports `items: []` (verified locally against `scripts/check-cc-drift.mjs` pre-PR).
+
 ## [3.31.4] - 2026-04-23
 
 ### Fixed — `dario accounts add` still hitting "Invalid request format" after v3.31.3 (dario#71)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.31.4",
+  "version": "3.31.5",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {

--- a/src/cc-template-data.json
+++ b/src/cc-template-data.json
@@ -1,6 +1,6 @@
 {
-  "_version": "2.1.117",
-  "_captured": "2026-04-22T15:16:42.429Z",
+  "_version": "2.1.118",
+  "_captured": "2026-04-23T15:14:02.377Z",
   "_source": "bundled",
   "_schemaVersion": 3,
   "agent_identity": "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
@@ -622,7 +622,7 @@
     },
     {
       "name": "Read",
-      "description": "Reads a file from the local filesystem. You can access any file directly by using this tool.\nAssume this tool is able to read all files on the machine. If the User provides a path to a file assume that path is valid. It is okay to read a file that does not exist; an error will be returned.\n\nUsage:\n- The file_path parameter must be an absolute path, not a relative path\n- By default, it reads up to 2000 lines starting from the beginning of the file\n- When you already know which part of the file you need, only read that part. This can be important for larger files.\n- Results are returned using cat -n format, with line numbers starting at 1\n- This tool allows Claude Code to read images (eg PNG, JPG, etc). When reading an image file the contents are presented visually as Claude Code is a multimodal LLM.\n- This tool can read PDF files (.pdf). For large PDFs (more than 10 pages), you MUST provide the pages parameter to read specific page ranges (e.g., pages: \"1-5\"). Reading a large PDF without the pages parameter will fail. Maximum 20 pages per request.\n- This tool can read Jupyter notebooks (.ipynb files) and returns all cells with their outputs, combining code, text, and visualizations.\n- This tool can only read files, not directories. To read a directory, use an ls command via the Bash tool.\n- You will regularly be asked to read screenshots. If the user provides a path to a screenshot, ALWAYS use this tool to view the file at the path. This tool will work with all temporary file paths.\n- If you read a file that exists but has empty contents you will receive a system reminder warning in place of file contents.",
+      "description": "Reads a file from the local filesystem. You can access any file directly by using this tool.\nAssume this tool is able to read all files on the machine. If the User provides a path to a file assume that path is valid. It is okay to read a file that does not exist; an error will be returned.\n\nUsage:\n- The file_path parameter must be an absolute path, not a relative path\n- By default, it reads up to 2000 lines starting from the beginning of the file\n- When you already know which part of the file you need, only read that part. This can be important for larger files.\n- Results are returned using cat -n format, with line numbers starting at 1\n- This tool allows Claude Code to read images (eg PNG, JPG, etc). When reading an image file the contents are presented visually as Claude Code is a multimodal LLM.\n- This tool can read PDF files (.pdf). For large PDFs (more than 10 pages), you MUST provide the pages parameter to read specific page ranges (e.g., pages: \"1-5\"). Reading a large PDF without the pages parameter will fail. Maximum 20 pages per request.\n- This tool can read Jupyter notebooks (.ipynb files) and returns all cells with their outputs, combining code, text, and visualizations.\n- This tool can only read files, not directories. To list files in a directory, use the registered shell tool.\n- You will regularly be asked to read screenshots. If the user provides a path to a screenshot, ALWAYS use this tool to view the file at the path. This tool will work with all temporary file paths.\n- If you read a file that exists but has empty contents you will receive a system reminder warning in place of file contents.",
       "input_schema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
@@ -973,7 +973,7 @@
   "anthropic_beta": "claude-code-20250219,interleaved-thinking-2025-05-14,context-management-2025-06-27,prompt-caching-scope-2026-01-05,advisor-tool-2026-03-01,effort-2025-11-24,afk-mode-2026-01-31",
   "header_values": {
     "accept": "application/json",
-    "user-agent": "claude-cli/2.1.117 (external, sdk-cli)",
+    "user-agent": "claude-cli/2.1.118 (external, sdk-cli)",
     "x-stainless-arch": "x64",
     "x-stainless-lang": "js",
     "x-stainless-os": "Windows",
@@ -998,5 +998,5 @@
     "output_config",
     "stream"
   ],
-  "_supportedMaxTested": "2.1.117"
+  "_supportedMaxTested": "2.1.118"
 }


### PR DESCRIPTION
## Summary

Completes [dario#103](https://github.com/askalf/dario/issues/103) follow-up. v3.31.4 bumped `SUPPORTED_CC_RANGE.maxTested` to 2.1.118 but kept the baked template at v2.1.117. This release refreshes the bake from a live capture against CC v2.1.118.

## Fingerprint diff (2.1.117 → 2.1.118)

| Axis | Result |
|---|---|
| system_prompt | byte-identical (12,479 chars) |
| agent_identity | byte-identical |
| header_order | byte-identical |
| body_field_order | byte-identical |
| anthropic_beta | byte-identical |
| user_agent | byte-identical |
| `_schemaVersion` | still 3 |
| tool count | same (27 post-scrub) |
| tool name set | same |
| Read tool description | **cosmetic change** — one line wording only |

The one wording-only diff:

```diff
- This tool can only read files, not directories. To read a directory, use an ls command via the Bash tool.
+ This tool can only read files, not directories. To list files in a directory, use the registered shell tool.
```

Parameters, required fields, input_schema — all unchanged. No functional impact on template replay.

## Verification

- [x] `npm test` — 42/42 pass
- [x] `node scripts/check-cc-drift.mjs` dry-run → `items: []` (no drift)

## Capture setup note for future maintainers

CC v2.1.118 was the native Windows `.exe` at `~/.local/bin/claude.exe`. The npm-packaged copy at `~/AppData/Roaming/npm/claude.cmd` was still v2.1.117 and `claude.cmd` wins over `claude.exe` in `findClaudeBinary`'s Windows order. Used `DARIO_CLAUDE_BIN=...claude.exe` to force the newer binary. Alternative next time: `npm install -g @anthropic-ai/claude-code@latest` first and bake picks it up automatically.