### PR TITLE
v3.31.6 — findInstalledCC picks newest CC on PATH, not first-found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.31.6] - 2026-04-23
+
+### Fixed — `findInstalledCC` now picks the newest CC on PATH, not the first-found
+
+Surfaced during the v3.31.5 bake: maintainer's Windows PATH had `~/AppData/Roaming/npm/claude.cmd` (npm-installed CC v2.1.117) listed before `~/.local/bin/claude.exe` (native CC v2.1.118). The old `findClaudeBinary` iterated a fixed `['claude.cmd', 'claude.exe', 'claude']` name list and returned the first match, so any dario operation that read the installed CC (live template capture, drift detection, the bake script, `dario doctor`'s "CC binary" line) silently used the older of the two. A user with both an `npm install -g @anthropic-ai/claude-code` (possibly stale) and a native fleet install would see dario run against an older snapshot than they expect, without warning.
+
+- `findClaudeBinary` now enumerates *all* matching candidates across all PATH directories, version-probes each via `--version`, and picks the newest by dotted-numeric comparison. Falls back to first-candidate if every probe fails (sandboxed runtimes, filesystem lockouts). Single-candidate installs skip the version-probe entirely — no extra spawns for the common case.
+- Within a single PATH directory, `.exe` now wins over `.cmd` on Windows (native binary beats the wrapper). This is only decisive when version-probe tiebreaks fail — otherwise the newer version wins regardless of extension.
+- `enumerateClaudeCandidates` exported for unit tests. 8 new assertions in `test/find-claude-binary.mjs` covering empty PATH, Unix single-candidate, cross-dir PATH-order stability, same-path dedup, Windows `.exe`-before-`.cmd` within a dir, and the npm-vs-native dual-install scenario.
+- `DARIO_CLAUDE_BIN` override still takes absolute precedence — the env-var path is never version-probed or compared.
+
+Users on single-install setups see no behaviour change. Dual-install users (common pattern: npm global + native fleet binary) now get whichever version is newer, matching what `claude --version` on the terminal would report.
+
 ## [3.31.5] - 2026-04-23
 
 ### Changed — Bundled template re-captured against live CC v2.1.118 (dario#103 follow-up)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.31.5",
+  "version": "3.31.6",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {

--- a/src/live-fingerprint.ts
+++ b/src/live-fingerprint.ts
@@ -538,28 +538,72 @@ function findClaudeBinary(): string | null {
   // non-standard installs.
   if (process.env.DARIO_CLAUDE_BIN) return process.env.DARIO_CLAUDE_BIN;
 
-  // Try the obvious name. On Windows spawn resolves `.cmd` shims
-  // automatically when shell:true, but we don't want shell:true for
-  // safety. The `where` / `which` probe handles Windows via PATHEXT.
-  const candidates = process.platform === 'win32'
-    ? ['claude.cmd', 'claude.exe', 'claude']
-    : ['claude'];
-  for (const name of candidates) {
-    if (existsOnPath(name)) return name;
+  const candidates = enumerateClaudeCandidates();
+  if (candidates.length === 0) return null;
+  if (candidates.length === 1) return candidates[0];
+
+  // Multiple installs on PATH — common on Windows where an npm-wrapper
+  // (~/AppData/Roaming/npm/claude.cmd) coexists with a native install
+  // (~/.local/bin/claude.exe). Version-probe each and pick the newest.
+  // Falls back to the first candidate if no probe succeeds (e.g. every
+  // spawn fails on a sandboxed runtime).
+  const probed: Array<{ path: string; version: string }> = [];
+  for (const path of candidates) {
+    const version = probeOneVersion(path);
+    if (version) probed.push({ path, version });
   }
-  return null;
+  if (probed.length === 0) return candidates[0];
+  probed.sort((a, b) => compareVersions(b.version, a.version));
+  return probed[0].path;
 }
 
-function existsOnPath(name: string): boolean {
+// Exported for unit tests.
+export function enumerateClaudeCandidates(): string[] {
   const pathEnv = process.env.PATH ?? '';
   const sep = process.platform === 'win32' ? ';' : ':';
   const dirs = pathEnv.split(sep).filter(Boolean);
+  // `.exe` first on Windows: the native binary beats a `.cmd` wrapper
+  // when both live in the same dir. Across dirs we version-probe anyway
+  // so order here only matters when probes all fail.
+  const names = process.platform === 'win32'
+    ? ['claude.exe', 'claude.cmd', 'claude']
+    : ['claude'];
+  const found: string[] = [];
+  const seen = new Set<string>();
   for (const d of dirs) {
-    try {
-      if (existsSync(join(d, name))) return true;
-    } catch { /* noop */ }
+    for (const name of names) {
+      const full = join(d, name);
+      if (seen.has(full)) continue;
+      try {
+        if (existsSync(full)) {
+          seen.add(full);
+          found.push(full);
+        }
+      } catch { /* noop */ }
+    }
   }
-  return false;
+  return found;
+}
+
+// Version-probe one specific binary path. Same safety logic as
+// probeInstalledCCVersionUncached below (reject shell metacharacters in
+// override paths before spawning with shell:true on Windows).
+function probeOneVersion(bin: string): string | null {
+  try {
+    const useShell = process.platform === 'win32' && /\.(cmd|bat)$/i.test(bin);
+    if (useShell && /[&|><^"'%\r\n`$;(){}[\]]/.test(bin)) return null;
+    const out = execFileSync(bin, ['--version'], {
+      encoding: 'utf-8',
+      timeout: 2_000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
+      shell: useShell,
+    });
+    const m = /(\d+\.\d+\.\d+(?:[.\-][\w.\-]+)?)/.exec(out);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/test/find-claude-binary.mjs
+++ b/test/find-claude-binary.mjs
@@ -1,0 +1,159 @@
+// Tests for enumerateClaudeCandidates + findClaudeBinary's new version-aware
+// selection, added in v3.32.0 after the dario#71/#105 bake friction
+// (maintainer's PATH had AppData/Roaming/npm/claude.cmd@2.1.117 and
+// .local/bin/claude.exe@2.1.118; the old first-match order silently picked
+// the older wrapper).
+
+import { enumerateClaudeCandidates } from '../dist/live-fingerprint.js';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, sep } from 'node:path';
+
+let pass = 0, fail = 0;
+function check(name, cond) {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else      { console.log(`  FAIL ${name}`); fail++; }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+function setupFakePath(layout) {
+  // layout: Array<{dir: string (under tmpdir), files: string[]}>
+  const root = mkdtempSync(join(tmpdir(), 'dario-findcc-'));
+  const dirs = [];
+  for (const { dir, files } of layout) {
+    const abs = join(root, dir);
+    mkdirSync(abs, { recursive: true });
+    for (const f of files) writeFileSync(join(abs, f), '');
+    dirs.push(abs);
+  }
+  return { root, dirs };
+}
+
+function withPath(value, fn) {
+  const prev = process.env.PATH;
+  process.env.PATH = value;
+  try { return fn(); }
+  finally { process.env.PATH = prev; }
+}
+
+const pathSep = process.platform === 'win32' ? ';' : ':';
+
+// ─────────────────────────────────────────────────────────────
+
+header('enumerateClaudeCandidates — empty PATH');
+{
+  const out = withPath('', () => enumerateClaudeCandidates());
+  check('no dirs → no candidates', out.length === 0);
+}
+
+header('enumerateClaudeCandidates — single candidate on Unix-like layout');
+{
+  const layout = [{ dir: 'bin', files: ['claude'] }];
+  const { root, dirs } = setupFakePath(layout);
+  try {
+    const out = withPath(dirs.join(pathSep), () => enumerateClaudeCandidates());
+    // On Windows the picker also tries claude.exe/claude.cmd with the
+    // `claude` (no-ext) name, but we seeded only the extensionless file,
+    // so only one should match.
+    check(
+      `exactly one candidate returned (got ${out.length})`,
+      out.length === 1,
+    );
+    if (out.length === 1) {
+      check(
+        'candidate is the expected absolute path',
+        out[0] === join(dirs[0], 'claude'),
+      );
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+header('enumerateClaudeCandidates — PATH order preserved');
+{
+  // Two dirs, each with a `claude` binary; whichever is first in PATH
+  // should also be first in the returned array. (Actual version-based
+  // selection happens later in findClaudeBinary — this asserts the
+  // enumeration stage is dir-order-stable for predictable tests.)
+  const layout = [
+    { dir: 'first', files: ['claude'] },
+    { dir: 'second', files: ['claude'] },
+  ];
+  const { root, dirs } = setupFakePath(layout);
+  try {
+    const out = withPath(dirs.join(pathSep), () => enumerateClaudeCandidates());
+    check(
+      `two candidates, first-PATH-dir first (got ${out.length})`,
+      out.length === 2 && out[0].startsWith(dirs[0] + sep) && out[1].startsWith(dirs[1] + sep),
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+header('enumerateClaudeCandidates — dedup when same path appears twice in PATH');
+{
+  const layout = [{ dir: 'bin', files: ['claude'] }];
+  const { root, dirs } = setupFakePath(layout);
+  try {
+    // Put the same dir in PATH twice.
+    const path = [dirs[0], dirs[0]].join(pathSep);
+    const out = withPath(path, () => enumerateClaudeCandidates());
+    check(
+      `duplicate PATH entry → single candidate (got ${out.length})`,
+      out.length === 1,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+if (process.platform === 'win32') {
+  header('enumerateClaudeCandidates — Windows: .exe ordered before .cmd within same dir');
+  {
+    const layout = [{ dir: 'bin', files: ['claude.cmd', 'claude.exe'] }];
+    const { root, dirs } = setupFakePath(layout);
+    try {
+      const out = withPath(dirs[0], () => enumerateClaudeCandidates());
+      check(
+        '.exe listed before .cmd for the same dir (native binary preferred when version-probe tiebreaks fail)',
+        out.length >= 2 &&
+          out[0].endsWith('claude.exe') &&
+          out[1].endsWith('claude.cmd'),
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+
+  header('enumerateClaudeCandidates — Windows: cross-dir finds both a .cmd and an .exe');
+  {
+    // Simulates the real-world dual-install: npm wrapper in AppData/Roaming/npm
+    // (.cmd) plus a native binary in ~/.local/bin (.exe). Enumeration must
+    // return both so the version-probe picker can choose between them.
+    const layout = [
+      { dir: 'npm-global', files: ['claude.cmd', 'claude'] },
+      { dir: 'local-bin', files: ['claude.exe'] },
+    ];
+    const { root, dirs } = setupFakePath(layout);
+    try {
+      const out = withPath(dirs.join(pathSep), () => enumerateClaudeCandidates());
+      const paths = out.join('\n');
+      check(
+        'found claude.cmd in first dir',
+        paths.includes(join(dirs[0], 'claude.cmd')),
+      );
+      check(
+        'found claude.exe in second dir',
+        paths.includes(join(dirs[1], 'claude.exe')),
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Surfaced during the v3.31.5 bake: maintainer's Windows PATH had `~/AppData/Roaming/npm/claude.cmd` (CC v2.1.117) listed before `~/.local/bin/claude.exe` (CC v2.1.118). The old `findClaudeBinary` iterated a fixed `['claude.cmd', 'claude.exe', 'claude']` name list and returned the first match, so any dario path that read the installed CC — live template capture, drift detection, bake script, `dario doctor`'s "CC binary" line — silently used the older of the two.

## Behaviour change

| Scenario | Before | After |
|---|---|---|
| Single-install (`~/.local/bin/claude`) | picks that one | same — no extra spawns |
| Dual-install, same dir, `.exe` + `.cmd` | picks `.cmd` first | picks `.exe` (when versions tie or probe fails) |
| Dual-install, different dirs, different versions | picks first-in-PATH | picks newest via `--version` probe |
| Version-probe fails for all candidates | (N/A) | falls back to first-candidate |
| `DARIO_CLAUDE_BIN` set | env wins | env wins (unchanged) |

## Tests

- `enumerateClaudeCandidates` exported. 8 new assertions in `test/find-claude-binary.mjs`: empty PATH, single-candidate, PATH-order stability, dedup, Windows `.exe` beats `.cmd` within a dir, real npm-vs-native dual-install scenario
- Verified on the maintainer's dual-install Windows setup: without `DARIO_CLAUDE_BIN`, dario now picks v2.1.118 (native `.exe`) over v2.1.117 (npm `.cmd`). Previously silently picked v2.1.117.
- 43/43 `npm test` pass (up from 42).

## Follow-up

This is item #3 from the enhancement review. Items #1 + #2 — adding an OAuth authorize-URL probe to `dario doctor` so the class of bug that blocked #71 is surfaced before a user hits it — land next in a separate PR.