### PR TITLE
v3.31.8 — dario doctor --json + CC upstream check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.31.8] - 2026-04-23
+
+### Added — `dario doctor --json`
+
+Structured JSON output from `dario doctor` for machine consumption. Emits `{generatedAt, exitCode, summary: {ok, warn, fail, info}, checks}`. Matches the Check[] array runChecks returns, wrapped in an envelope so callers that can't read process exit codes still see the verdict. Useful for:
+- claude-bridge's `/status` Discord command — can surface dario's OAuth / template / drift state inline
+- deepdive's own health probes — can confirm the dario endpoint it routes through is healthy before sending LLM calls
+- CI scripts — scrape specific checks instead of parsing human output
+
+Pure function `formatChecksJson(checks)` exported for library use. 10 new assertions in `test/doctor-formatter.mjs` covering envelope shape, exit-code field, summary counts, empty-list case.
+
+### Added — `CC upstream` check (npm latest vs installed)
+
+Doctor now runs `npm view @anthropic-ai/claude-code version` (3s timeout, 60s in-process cache) and emits an `[INFO]` row when the installed CC is older than npm's `@latest`. Silent when on-latest or npm unreachable (no noise). Turns the "my npm CC is stale and dario is running against it" gotcha from the v3.31.5 bake into a one-line hint: *"npm latest is v2.1.119 — installed is v2.1.117. Run `npm install -g @anthropic-ai/claude-code@latest` to upgrade."*
+
+Exported `probeNpmLatestCC()` for library callers.
+
 ## [3.31.7] - 2026-04-23
 
 ### Added — `dario doctor --probe` exercises Anthropic's authorize endpoint

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.31.7",
+  "version": "3.31.8",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -674,6 +674,10 @@ async function help() {
                              the server's verdict — the single reliable
                              signal for scope-policy drift (dario#42/#71
                              class). One GET to claude.ai; no PII.
+    dario doctor --json      Emit the check report as structured JSON
+                             for machine consumption (claude-bridge
+                             /status, CI scripts, etc.) instead of the
+                             human-readable table.
 
   Proxy options:
     --model=MODEL            Force a model for all requests
@@ -973,13 +977,22 @@ async function mcp() {
 }
 
 async function doctor() {
-  const { runChecks, formatChecks, exitCodeFor } = await import('./doctor.js');
+  const { runChecks, formatChecks, formatChecksJson, exitCodeFor } = await import('./doctor.js');
   const probe = args.includes('--probe');
+  const asJson = args.includes('--json');
+  const checks = await runChecks({ probe });
+  if (asJson) {
+    // JSON mode is meant for machine consumption (claude-bridge /status,
+    // deepdive health checks, CI scripts) — no decorative header, no
+    // trailing prose, stable shape. Exit code is also surfaced in the
+    // JSON envelope for callers that can't read process exit codes.
+    process.stdout.write(formatChecksJson(checks) + '\n');
+    process.exit(exitCodeFor(checks));
+  }
   console.log('');
   console.log('  dario — Doctor');
   console.log('  ─────────────');
   console.log('');
-  const checks = await runChecks({ probe });
   console.log(formatChecks(checks));
   console.log('');
   const code = exitCodeFor(checks);

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -15,6 +15,7 @@ import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { homedir, platform, arch, release } from 'node:os';
+import { execFileSync } from 'node:child_process';
 import {
   CC_TEMPLATE,
 } from './cc-template.js';
@@ -25,6 +26,7 @@ import {
   findInstalledCC,
   SUPPORTED_CC_RANGE,
   CURRENT_SCHEMA_VERSION,
+  compareVersions,
 } from './live-fingerprint.js';
 import { detectCCOAuthConfig } from './cc-oauth-detect.js';
 import { runAuthorizeProbe } from './cc-authorize-probe.js';
@@ -66,6 +68,69 @@ export function formatChecks(checks: Check[]): string {
  */
 export function exitCodeFor(checks: Check[]): number {
   return checks.some((c) => c.status === 'fail') ? 1 : 0;
+}
+
+/**
+ * Serialize a check report as structured JSON. Lets other tools
+ * (claude-bridge's /status command, deepdive, CI scripts) consume
+ * dario's health programmatically instead of scraping the formatted
+ * text. Emitted by `dario doctor --json`.
+ */
+export function formatChecksJson(checks: Check[]): string {
+  const summary = {
+    ok: checks.filter((c) => c.status === 'ok').length,
+    warn: checks.filter((c) => c.status === 'warn').length,
+    fail: checks.filter((c) => c.status === 'fail').length,
+    info: checks.filter((c) => c.status === 'info').length,
+  };
+  return JSON.stringify(
+    {
+      generatedAt: new Date().toISOString(),
+      exitCode: exitCodeFor(checks),
+      summary,
+      checks,
+    },
+    null,
+    2,
+  );
+}
+
+/**
+ * Ask npm for the latest @anthropic-ai/claude-code version. One 3s
+ * timeout; failures return null so doctor silently drops the check.
+ * Result is cached module-scoped so back-to-back doctor invocations
+ * (e.g. from a wrapping script) don't hammer the npm registry.
+ */
+let _npmLatestCache: { value: string | null; at: number } | null = null;
+const NPM_CACHE_TTL_MS = 60 * 1000;
+
+export function probeNpmLatestCC(): string | null {
+  if (_npmLatestCache && Date.now() - _npmLatestCache.at < NPM_CACHE_TTL_MS) {
+    return _npmLatestCache.value;
+  }
+  let value: string | null = null;
+  try {
+    // `npm view <pkg> version` prints the version as a single line.
+    // 3s timeout keeps doctor responsive even with flaky network /
+    // corporate proxies; stdio ignores stderr so "npm notice" banners
+    // don't pollute stdout parsing.
+    const out = execFileSync('npm', ['view', '@anthropic-ai/claude-code', 'version'], {
+      encoding: 'utf-8',
+      timeout: 3_000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
+      // npm ships as .cmd on Windows; execFile can't spawn it directly
+      // without shell:true. `npm` is not user-overridable here so the
+      // command-injection risk is nil.
+      shell: process.platform === 'win32',
+    });
+    const m = /(\d+\.\d+\.\d+(?:[.\-][\w.\-]+)?)/.exec(out);
+    value = m ? m[1] : null;
+  } catch {
+    value = null;
+  }
+  _npmLatestCache = { value, at: Date.now() };
+  return value;
 }
 
 export interface RunChecksOptions {
@@ -149,6 +214,25 @@ export async function runChecks(opts: RunChecksOptions = {}): Promise<Check[]> {
       label: 'CC binary',
       detail: `v${cc.version} at ${cc.path}  (range: v${SUPPORTED_CC_RANGE.min} – v${SUPPORTED_CC_RANGE.maxTested})`,
     });
+
+    // Stale-upstream probe: compare installed against npm's @latest.
+    // One network hop (3s timeout, 60s in-process cache). Silent on
+    // failure — no check row emitted — since a flaky network
+    // shouldn't turn doctor's output noisy. Only emits when the
+    // installed CC is strictly older than the npm latest.
+    try {
+      const npmLatest = probeNpmLatestCC();
+      if (npmLatest && compareVersions(cc.version, npmLatest) < 0) {
+        checks.push({
+          status: 'info',
+          label: 'CC upstream',
+          detail:
+            `npm latest is v${npmLatest} — installed is v${cc.version}. ` +
+            `Run \`npm install -g @anthropic-ai/claude-code@latest\` to upgrade; ` +
+            `dario's template will re-capture automatically on next startup.`,
+        });
+      }
+    } catch { /* silent */ }
   } else if (cc.path) {
     checks.push({
       status: 'warn',

--- a/test/doctor-formatter.mjs
+++ b/test/doctor-formatter.mjs
@@ -1,5 +1,6 @@
 // Unit tests for the pure parts of `dario doctor` (src/doctor.ts):
 //   - formatChecks: column alignment, status prefixes
+//   - formatChecksJson: structured JSON envelope shape
 //   - exitCodeFor: exit code derivation from check statuses
 //
 // Integration coverage (runChecks() against a real machine) is handled
@@ -7,7 +8,7 @@
 // unit-testing execFileSync probes against fixtures when the whole
 // point is to reflect the current host.
 
-import { formatChecks, exitCodeFor } from '../dist/doctor.js';
+import { formatChecks, formatChecksJson, exitCodeFor } from '../dist/doctor.js';
 
 let pass = 0, fail = 0;
 function check(label, cond) {
@@ -86,6 +87,46 @@ header('exitCodeFor — exit code rules');
     { status: 'fail', label: 'a', detail: '' },
     { status: 'fail', label: 'b', detail: '' },
   ]) === 1);
+}
+
+// ======================================================================
+//  formatChecksJson — structured envelope shape
+// ======================================================================
+header('formatChecksJson — envelope shape');
+{
+  const checks = [
+    { status: 'ok',   label: 'Node',     detail: 'v22.5.1' },
+    { status: 'warn', label: 'CC',       detail: 'untested' },
+    { status: 'info', label: 'Platform', detail: 'linux x64' },
+  ];
+  const parsed = JSON.parse(formatChecksJson(checks));
+  check('exitCode field present and matches exitCodeFor', parsed.exitCode === exitCodeFor(checks));
+  check('summary.ok is 1',   parsed.summary.ok   === 1);
+  check('summary.warn is 1', parsed.summary.warn === 1);
+  check('summary.info is 1', parsed.summary.info === 1);
+  check('summary.fail is 0', parsed.summary.fail === 0);
+  check('checks array preserved',     Array.isArray(parsed.checks) && parsed.checks.length === 3);
+  check('first check round-trips',    parsed.checks[0].label === 'Node' && parsed.checks[0].detail === 'v22.5.1');
+  check('generatedAt is ISO-8601',    typeof parsed.generatedAt === 'string' && /^\d{4}-\d{2}-\d{2}T/.test(parsed.generatedAt));
+}
+
+header('formatChecksJson — fail exits 1');
+{
+  const checks = [
+    { status: 'ok',   label: 'a', detail: '' },
+    { status: 'fail', label: 'b', detail: 'OAuth expired' },
+  ];
+  const parsed = JSON.parse(formatChecksJson(checks));
+  check('exitCode is 1 when any fail', parsed.exitCode === 1);
+  check('summary.fail is 1',           parsed.summary.fail === 1);
+}
+
+header('formatChecksJson — empty checks');
+{
+  const parsed = JSON.parse(formatChecksJson([]));
+  check('empty list → exitCode 0',    parsed.exitCode === 0);
+  check('empty list → all summary 0', Object.values(parsed.summary).every((n) => n === 0));
+  check('empty list → checks: []',    Array.isArray(parsed.checks) && parsed.checks.length === 0);
 }
 
 // ======================================================================


### PR DESCRIPTION
Two small doctor enhancements, items #5 and #7 from the post-v3.31.5 review.

## --json

Structured envelope for machine consumption:

```json
{
  "generatedAt": "2026-04-23T16:30:00.000Z",
  "exitCode": 0,
  "summary": { "ok": 5, "warn": 0, "fail": 0, "info": 7 },
  "checks": [ ... ]
}
```

Use cases:
- **claude-bridge's `/status` Discord command** — can surface dario's OAuth / template / drift state inline
- **deepdive** — can confirm the dario endpoint it routes through is healthy before sending LLM calls
- **CI scripts** — scrape specific checks instead of parsing human output

`formatChecksJson(checks)` exported for library use. 10 new assertions in `test/doctor-formatter.mjs`.

## CC upstream check

`probeNpmLatestCC()` — one shelled-out `npm view @anthropic-ai/claude-code version` (3s timeout, 60s in-process cache). Doctor emits an `[INFO]` row when the installed CC is older than npm's `@latest`. Silent when on-latest or npm unreachable (no false-positive noise).

Turns the v3.31.5-bake footgun ("my npm CC is stale and I didn't notice until I went to bake") into a one-line hint:

```
[INFO]  CC upstream   npm latest is v2.1.119 — installed is v2.1.117.
                      Run `npm install -g @anthropic-ai/claude-code@latest`
                      to upgrade; dario's template will re-capture
                      automatically on next startup.
```

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 44/44 pass
- [x] 10 new assertions in `doctor-formatter.mjs` covering JSON envelope shape (exitCode, summary counts, generatedAt ISO-8601, round-trip, empty-list)
- [x] Manual smoke: `dario doctor --json` produces parseable JSON, `dario doctor` on a stale-npm machine emits the upstream-hint row (verified manually after deliberately downgrading local npm CC)