### PR TITLE
v3.31.10 — dario config, dario upgrade, CHANGELOG Unreleased (polish items #8/#9/#10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to this project will be documented in this file.
 
+<!--
+Release convention: land changes under `## [Unreleased]`. At release
+time, rename that heading to `## [X.Y.Z] - YYYY-MM-DD` and add a fresh
+`## [Unreleased]` above it. See CONTRIBUTING for the full release
+checklist.
+-->
+
+## [Unreleased]
+
+## [3.31.10] - 2026-04-23
+
+### Added — `dario config`
+
+Prints the effective dario configuration with credentials redacted. Different intent from `dario doctor`: doctor is "is it working?", config is "what IS it?". Complementary rather than redundant — you paste doctor when debugging a routing failure, you paste config when debugging a port / host / auth / pool misconfiguration.
+
+Sections printed:
+- **Identity** — version + runtime
+- **Proxy (on `dario proxy`)** — port, host, model, effort defaults (with env-var source tagged when overridden)
+- **Auth gate** — `DARIO_API_KEY` set/unset status (never the value), `DARIO_STRICT_TLS`
+- **OAuth** — credentials-file presence + mode + age (never the tokens)
+- **Account pool** — aliases + pool mode
+- **Backends** — configured OpenAI-compat backend names (no keys)
+- **Paths** — every file dario reads/writes on disk
+
+`--json` for machine consumption. Exports `collectEffectiveConfig()`, `formatEffectiveConfig()`, `formatEffectiveConfigJson()`, `formatAge()` for library callers. 15 new assertions in `test/config-report.mjs` covering `formatAge` boundaries, section/row shape, column alignment, JSON round-trip.
+
+### Added — `dario upgrade`
+
+Thin wrapper over `npm install -g @askalf/dario@latest` with a pre-flight check: probes npm for the current `@latest` version (3s timeout, same pattern as the CC upstream check), refuses to run if already on latest, fails with a clear hint if npm is missing. Saves the round-trip of a no-op install when a user's already current and gives them version context before the install runs.
+
+### Changed — `CHANGELOG` uses `## [Unreleased]` section
+
+New convention: changes land under `## [Unreleased]`. At release time, rename to `## [X.Y.Z] - YYYY-MM-DD` and add a fresh `## [Unreleased]` above. HTML-comment at the top of `CHANGELOG.md` documents it for future maintainers.
+
 ## [3.31.9] - 2026-04-23
 
 ### Added — `dario doctor --auth-check`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.31.9",
+  "version": "3.31.10",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -686,6 +686,13 @@ async function help() {
                              DARIO_API_KEY — with redacted previews and
                              a targeted diagnosis (dario#97 class). Use
                              --timeout-ms=N to adjust the 30s default.
+    dario config             Print the effective configuration (port,
+                             host, DARIO_API_KEY state, OAuth status,
+                             pool, backends, paths) with credentials
+                             redacted. Safe to paste into bug reports.
+                             --json for structured output.
+    dario upgrade            npm install -g @askalf/dario@latest with a
+                             pre-flight current-vs-latest check.
 
   Proxy options:
     --model=MODEL            Force a model for all requests
@@ -1060,6 +1067,92 @@ async function version() {
   }
 }
 
+async function config() {
+  const { collectEffectiveConfig, formatEffectiveConfig, formatEffectiveConfigJson } = await import('./config-report.js');
+  const asJson = args.includes('--json');
+  const report = await collectEffectiveConfig();
+  if (asJson) {
+    process.stdout.write(formatEffectiveConfigJson(report) + '\n');
+    return;
+  }
+  console.log('');
+  console.log('  dario — Config');
+  console.log('  ─────────────');
+  console.log('');
+  console.log(formatEffectiveConfig(report));
+}
+
+async function upgrade() {
+  // Thin wrapper over `npm install -g @askalf/dario@latest`. The value
+  // isn't in saving the user typing — it's in the pre-flight (print
+  // current vs. latest version, refuse to run if already on latest,
+  // fail with a clear hint if npm is missing).
+  const { spawnSync } = await import('node:child_process');
+  const { fileURLToPath } = await import('node:url');
+  const { readFile: rf } = await import('node:fs/promises');
+  const dir = join(fileURLToPath(import.meta.url), '..', '..');
+  let currentVersion = 'unknown';
+  try {
+    const pkg = JSON.parse(await rf(join(dir, 'package.json'), 'utf-8'));
+    currentVersion = pkg.version ?? 'unknown';
+  } catch { /* noop */ }
+
+  console.log('');
+  console.log('  dario — Upgrade');
+  console.log('  ──────────────');
+  console.log('');
+  console.log(`  Current: v${currentVersion}`);
+
+  // Probe npm for the latest version first — avoids a long npm install if
+  // the user's already on @latest. 3s timeout keeps the pre-flight short.
+  let latestVersion: string | null = null;
+  try {
+    const res = spawnSync('npm', ['view', '@askalf/dario', 'version'], {
+      encoding: 'utf8',
+      timeout: 3000,
+      shell: process.platform === 'win32',
+    });
+    if (res.status === 0) {
+      const m = /(\d+\.\d+\.\d+(?:[.\-][\w.\-]+)?)/.exec(res.stdout);
+      latestVersion = m ? m[1]! : null;
+    }
+  } catch { /* noop */ }
+
+  if (!latestVersion) {
+    console.log('  Latest: (npm view failed — is npm on PATH? Continuing anyway.)');
+  } else {
+    console.log(`  Latest:  v${latestVersion}`);
+    if (latestVersion === currentVersion) {
+      console.log('');
+      console.log('  Already on the latest release. Nothing to do.');
+      console.log('');
+      return;
+    }
+  }
+
+  console.log('');
+  console.log('  Running: npm install -g @askalf/dario@latest');
+  console.log('');
+
+  const install = spawnSync('npm', ['install', '-g', '@askalf/dario@latest'], {
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  });
+
+  if (install.status !== 0) {
+    console.error('');
+    console.error('  npm install failed. If this is a permissions issue, try:');
+    console.error('    sudo npm install -g @askalf/dario@latest     # POSIX');
+    console.error('    npm install -g @askalf/dario@latest          # Windows (may need admin)');
+    console.error('');
+    process.exit(install.status ?? 1);
+  }
+
+  console.log('');
+  console.log('  Upgrade complete. Run `dario --version` to confirm.');
+  console.log('');
+}
+
 // Main
 const commands: Record<string, () => Promise<void>> = {
   login,
@@ -1073,6 +1166,8 @@ const commands: Record<string, () => Promise<void>> = {
   subagent,
   mcp,
   doctor,
+  config,
+  upgrade,
   help,
   version,
   '--help': help,

--- a/src/config-report.ts
+++ b/src/config-report.ts
@@ -1,0 +1,206 @@
+/**
+ * `dario config` — print effective configuration with credentials redacted.
+ *
+ * Different from `dario doctor`: doctor is "is it working?", config is
+ * "what IS it?". The overlap is intentional — config shows *settings*
+ * (port, host, DARIO_API_KEY state, model defaults) that operators
+ * need to confirm when debugging a client misconfiguration. Doctor
+ * shows *health* (OAuth expiry, template drift, TLS fingerprint
+ * match) that operators need to confirm when debugging a routing
+ * failure.
+ *
+ * Every output row is already safe to paste into a bug report:
+ * credentials are replaced with `set`/`unset` state tags, paths are
+ * left untouched because they're operationally useful, tokens never
+ * appear.
+ */
+
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { homedir } from 'node:os';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export interface ConfigSection {
+  title: string;
+  rows: Array<{ label: string; value: string }>;
+}
+
+export interface ConfigReport {
+  generatedAt: string;
+  version: string;
+  sections: ConfigSection[];
+}
+
+/**
+ * Collect the effective dario configuration the proxy would run with.
+ * Reads env vars, filesystem state (credentials, override files, caches),
+ * account pool, and configured backends. Never reads the actual
+ * credential VALUES — only their presence/absence/path.
+ */
+export async function collectEffectiveConfig(): Promise<ConfigReport> {
+  const sections: ConfigSection[] = [];
+  const home = join(homedir(), '.dario');
+
+  // ── Identity
+  let version = 'unknown';
+  try {
+    const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8')) as { version?: string };
+    version = pkg.version ?? 'unknown';
+  } catch { /* noop */ }
+  sections.push({
+    title: 'Identity',
+    rows: [
+      { label: 'version', value: `v${version}` },
+      { label: 'runtime', value: `node ${process.version} on ${process.platform} ${process.arch}` },
+    ],
+  });
+
+  // ── Proxy bind
+  sections.push({
+    title: 'Proxy (on `dario proxy`)',
+    rows: [
+      { label: 'port', value: envOrDefault('DARIO_PORT', '3456') },
+      { label: 'host', value: envOrDefault('DARIO_HOST', '127.0.0.1') },
+      { label: 'model', value: envOrDefault('DARIO_MODEL', '(passthrough — client picks)') },
+      { label: 'effort', value: envOrDefault('DARIO_EFFORT', '(CC default)') },
+    ],
+  });
+
+  // ── Auth gate
+  sections.push({
+    title: 'Auth gate',
+    rows: [
+      {
+        label: 'DARIO_API_KEY',
+        value: process.env.DARIO_API_KEY
+          ? `set (length ${process.env.DARIO_API_KEY.length}) — x-api-key / Authorization Bearer required`
+          : 'unset — auth not enforced on loopback',
+      },
+      {
+        label: 'DARIO_STRICT_TLS',
+        value: process.env.DARIO_STRICT_TLS === '1' ? 'on' : 'off',
+      },
+    ],
+  });
+
+  // ── OAuth (Claude subscription credentials)
+  const credsPath = join(home, 'credentials.json');
+  const credsInfo = describeCreds(credsPath);
+  sections.push({
+    title: 'OAuth',
+    rows: [
+      { label: 'credentials', value: credsInfo },
+      { label: 'path', value: credsPath },
+    ],
+  });
+
+  // ── Pool
+  try {
+    const { listAccountAliases } = await import('./accounts.js');
+    const aliases = await listAccountAliases();
+    sections.push({
+      title: 'Account pool',
+      rows: [
+        { label: 'mode', value: aliases.length === 0 ? 'single-account (no pool)' : `pool of ${aliases.length}` },
+        ...(aliases.length > 0 ? [{ label: 'aliases', value: aliases.join(', ') }] : []),
+      ],
+    });
+  } catch {
+    sections.push({
+      title: 'Account pool',
+      rows: [{ label: 'mode', value: '(check failed)' }],
+    });
+  }
+
+  // ── Backends
+  try {
+    const { listBackends } = await import('./openai-backend.js');
+    const backends = await listBackends();
+    sections.push({
+      title: 'OpenAI-compat backends',
+      rows: [
+        { label: 'count', value: String(backends.length) },
+        ...(backends.length > 0
+          ? [{ label: 'names', value: backends.map((b) => b.name).join(', ') }]
+          : []),
+      ],
+    });
+  } catch {
+    sections.push({
+      title: 'OpenAI-compat backends',
+      rows: [{ label: 'count', value: '(check failed)' }],
+    });
+  }
+
+  // ── Paths (everything dario reads/writes on disk)
+  sections.push({
+    title: 'Paths',
+    rows: [
+      { label: 'home', value: home },
+      { label: 'credentials', value: credsPath },
+      { label: 'accounts', value: join(home, 'accounts') },
+      { label: 'oauth cache', value: join(home, 'cc-oauth-cache-v6.json') },
+      { label: 'oauth override', value: join(home, 'oauth-config.override.json') },
+      { label: 'template cache', value: join(home, 'template-cache.json') },
+    ],
+  });
+
+  return {
+    generatedAt: new Date().toISOString(),
+    version,
+    sections,
+  };
+}
+
+function envOrDefault(name: string, dflt: string): string {
+  return process.env[name] ? `${process.env[name]}  (from ${name})` : dflt;
+}
+
+function describeCreds(path: string): string {
+  if (!existsSync(path)) return 'not authenticated (run `dario login`)';
+  try {
+    const s = statSync(path);
+    const mode = (s.mode & 0o777).toString(8);
+    const age = formatAge(Date.now() - s.mtimeMs);
+    return `present (mode ${mode}, last updated ${age} ago)`;
+  } catch {
+    return 'present (stat failed)';
+  }
+}
+
+// Exported for unit tests.
+export function formatAge(ms: number): string {
+  const s = Math.max(0, Math.round(ms / 1000));
+  if (s < 60) return `${s}s`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h`;
+  const d = Math.round(h / 24);
+  return `${d}d`;
+}
+
+/**
+ * Pretty-print a ConfigReport as aligned ASCII. Same approach as
+ * doctor's formatChecks — plain text, no colors, pasteable.
+ */
+export function formatEffectiveConfig(report: ConfigReport): string {
+  const lines: string[] = [];
+  for (const section of report.sections) {
+    lines.push(`  ${section.title}`);
+    lines.push(`  ${'─'.repeat(section.title.length)}`);
+    const labelWidth = section.rows.reduce((n, r) => Math.max(n, r.label.length), 0);
+    for (const r of section.rows) {
+      lines.push(`    ${r.label.padEnd(labelWidth)}  ${r.value}`);
+    }
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+/** Structured envelope for `dario config --json`. */
+export function formatEffectiveConfigJson(report: ConfigReport): string {
+  return JSON.stringify(report, null, 2);
+}

--- a/test/config-report.mjs
+++ b/test/config-report.mjs
@@ -1,0 +1,105 @@
+// Tests for the pure helpers in src/config-report.ts
+// (`dario config` subcommand). collectEffectiveConfig is covered by an
+// end-to-end smoke (`node dist/cli.js config` post-build) since it
+// reads filesystem + accounts/backends modules — no point in a
+// filesystem-mocked unit test.
+
+import {
+  formatAge,
+  formatEffectiveConfig,
+  formatEffectiveConfigJson,
+} from '../dist/config-report.js';
+
+let pass = 0, fail = 0;
+function check(name, cond) {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else      { console.log(`  FAIL ${name}`); fail++; }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+// ─────────────────────────────────────────────────────────────
+header('formatAge');
+{
+  check('<1s → 0s', formatAge(0) === '0s');
+  check('30s', formatAge(30_000) === '30s');
+  check('59s', formatAge(59_000) === '59s');
+  check('1m (60s → 1m)', formatAge(60_000) === '1m');
+  check('1h', formatAge(60 * 60_000) === '1h');
+  check('1d', formatAge(24 * 60 * 60_000) === '1d');
+  check('negative → 0s', formatAge(-5000) === '0s');
+}
+
+// ─────────────────────────────────────────────────────────────
+header('formatEffectiveConfig — shape');
+{
+  const report = {
+    generatedAt: '2026-04-23T00:00:00.000Z',
+    version: '3.31.9',
+    sections: [
+      {
+        title: 'Identity',
+        rows: [
+          { label: 'version', value: 'v3.31.9' },
+          { label: 'runtime', value: 'node v22 on linux' },
+        ],
+      },
+      {
+        title: 'Auth gate',
+        rows: [
+          { label: 'DARIO_API_KEY', value: 'unset' },
+          { label: 'longer_label',  value: 'on' },
+        ],
+      },
+    ],
+  };
+  const out = formatEffectiveConfig(report);
+  check('contains first section title',  out.includes('Identity'));
+  check('contains second section title', out.includes('Auth gate'));
+  check('contains a divider line',       out.includes('────────'));
+  check('contains values',               out.includes('v3.31.9') && out.includes('unset'));
+
+  // Rows within the same section are aligned — the shorter label gets
+  // padded to the width of the longer one, so the VALUE column is at
+  // the same index across rows. Longer of the two test labels is
+  // "DARIO_API_KEY" (13 chars). Value starts at: 4 (leading indent) +
+  // 13 (padded label) + 2 (separator) = column 19.
+  const EXPECTED_VALUE_COL = 4 + 13 + 2;
+  const authLines = out.split('\n').filter((l) => /DARIO_API_KEY|longer_label/.test(l));
+  check('both Auth gate rows rendered', authLines.length === 2);
+  if (authLines.length === 2) {
+    const row1Value = authLines[0].slice(EXPECTED_VALUE_COL);
+    const row2Value = authLines[1].slice(EXPECTED_VALUE_COL);
+    check('row 1 value at expected column (starts with "unset")', row1Value.startsWith('unset'));
+    check('row 2 value at expected column (starts with "on")',    row2Value.startsWith('on'));
+  }
+}
+
+header('formatEffectiveConfig — empty sections');
+{
+  const out = formatEffectiveConfig({
+    generatedAt: '2026-04-23T00:00:00.000Z',
+    version: '3.31.9',
+    sections: [],
+  });
+  check('empty sections → empty-ish output', out.trim() === '');
+}
+
+// ─────────────────────────────────────────────────────────────
+header('formatEffectiveConfigJson — round-trip');
+{
+  const report = {
+    generatedAt: '2026-04-23T00:00:00.000Z',
+    version: '3.31.9',
+    sections: [
+      { title: 'S1', rows: [{ label: 'a', value: 'b' }] },
+    ],
+  };
+  const parsed = JSON.parse(formatEffectiveConfigJson(report));
+  check('version field round-trips',      parsed.version === '3.31.9');
+  check('sections array length preserved', Array.isArray(parsed.sections) && parsed.sections.length === 1);
+  check('row round-trips',                 parsed.sections[0].rows[0].label === 'a' && parsed.sections[0].rows[0].value === 'b');
+}
+
+// ─────────────────────────────────────────────────────────────
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Batches the three polish items from the enhancement review.

## #9 — `dario config`

New subcommand. Prints effective configuration with credentials redacted. Complement to `dario doctor` (which answers "is it working?"): config answers "what IS it?". Safe to paste into bug reports — no credentials, only state tags.

Sections: Identity, Proxy defaults, Auth gate (`DARIO_API_KEY` set/unset state — never the value), OAuth (credentials file presence/mode/age — no tokens), Account pool, Backends, Paths.

`--json` for machine consumption. Exports: `collectEffectiveConfig()`, `formatEffectiveConfig()`, `formatEffectiveConfigJson()`, `formatAge()`.

## #10 — `dario upgrade`

`npm install -g @askalf/dario@latest` with a pre-flight check: probes npm for current `@latest` (3s timeout), refuses to run if already on latest (no-op install saved), clear hint if npm is missing.

## #8 — CHANGELOG `## [Unreleased]` section

New release convention: changes land under `## [Unreleased]`. At release, rename to `## [X.Y.Z] - YYYY-MM-DD` and add fresh `## [Unreleased]` above. HTML comment documents it for future maintainers.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 46/46 pass (up from 45)
- [x] 15 new assertions in `test/config-report.mjs` covering `formatAge` boundaries, section/row shape, column alignment, JSON round-trip
- [x] Manual smoke: `dario config` prints expected sections; `dario config --json` emits valid JSON; `dario upgrade` pre-flight (didn't actually install — verified it prints current/latest versions and the `already on latest` branch)