### PR TITLE
v3.31.11 — partial scope auto-detection via binary-literal scan (review #11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ checklist.
 
 ## [Unreleased]
 
+## [3.31.11] - 2026-04-23
+
+### Added — partial scope auto-detection via binary-literal scan
+
+`scanBinaryForOAuthConfig` now verifies each FALLBACK scope against CC's binary by searching for the scope's quoted-literal form (`"org:create_api_key"`, etc.). If a scope literal is MISSING from the binary, it's dropped from the returned config — dario will no longer send a scope CC no longer ships. Silent when all 6 are present (the common case); only filters when the binary has drifted.
+
+**What this catches:** the class of drift where Anthropic deprecates a scope and CC's next release ships without the literal. Today dario would keep sending the stale scope until a user hit the "Invalid request format" page (same class as dario#42, #71) and filed an issue. Now it self-heals on startup as soon as the user upgrades CC.
+
+**What this does NOT catch:** the opposite direction — Anthropic starts accepting a NEW scope we don't know about. Adding requires server-side confirmation; the binary-literal scan can't verify that. That direction still needs the live probe (`dario doctor --probe` or the nightly `scripts/check-cc-authorize-probe.mjs`).
+
+Detection is defense-in-depth, not a replacement for the probe. FALLBACK.scopes remains the ground truth; verification just filters, never adds.
+
+New export: `filterScopesByBinaryPresence(buf, expected)` — pure, safe to unit-test. 11 new assertions in `test/scope-binary-verify.mjs` covering all-present / subset / missing-org-create / empty / substring false-positive / empty-expected / single-quote-guard cases.
+
 ## [3.31.10] - 2026-04-23
 
 ### Added — `dario config`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.31.10",
+  "version": "3.31.11",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {

--- a/src/cc-oauth-detect.ts
+++ b/src/cc-oauth-detect.ts
@@ -297,22 +297,51 @@ export function scanBinaryForOAuthConfig(buf: Buffer): Omit<DetectedOAuthConfig,
   const tokenMatch = /TOKEN_URL\s*:\s*"(https:\/\/[^"]*\/oauth\/token[^"]*)"/.exec(prodBlock);
   if (tokenMatch && tokenMatch[1]) tokenUrl = tokenMatch[1];
 
-  // Scopes are NOT detected from the binary. Previous versions of this
-  // scanner anchored on `"user:profile ` and regex-captured the first
-  // contiguous quoted run of scopes, but that anchor matches an error/help
-  // message string literal (used by `claude setup-token` error output) that
-  // contains only 4 of the 6 actual scopes. The real scope array is stored
-  // as a constant-reference array — `dY8 = [B9H, TI, "user:sessions:...", ...]`
-  // — where the first two elements are minified variable references, not
-  // literal strings, so no regex can reliably extract the full list. And the
-  // runtime-computed union `n36` only exists after `Array.from(new Set(...))`
-  // executes, which we can't evaluate from a static scan.
+  // Scopes can't be EXTRACTED from the binary — the real scope array is
+  // stored as a constant-reference array (`dY8 = [B9H, TI, "user:sessions:
+  // ...", ...]`) where the first elements are minified variable references,
+  // not literal strings, so no regex resolves the full list statically.
   //
-  // Given that scopes rarely change across CC releases (Anthropic adds or
-  // removes maybe one per major version), hardcoding them in FALLBACK is
-  // more reliable than scanning. If Anthropic changes the scope list, the
-  // fix is a one-line FALLBACK update in a dario release.
-  return { clientId, authorizeUrl, tokenUrl, scopes: FALLBACK.scopes };
+  // But we CAN verify them: every scope CC uses does appear as a quoted
+  // literal string somewhere in the binary (either in the scope array
+  // itself when not minified to a variable ref, or in help-text /
+  // error-message references that name scopes by literal). Scan for each
+  // FALLBACK scope's quoted literal; if any go missing, drop those
+  // scopes from the returned config and log a warning.
+  //
+  // This catches one class of drift the hardcoded FALLBACK doesn't: a
+  // future CC release that REMOVES a scope from the active set — Anthropic
+  // deprecates `user:file_upload` in CC v2.2.0, say — would leave dario
+  // sending a stale scope that the server now rejects, same failure mode
+  // as #42 / #71. Binary verification catches it at startup without
+  // waiting for a user to hit the "Invalid request format" page.
+  //
+  // It does NOT catch the opposite direction (Anthropic starts accepting
+  // a new scope CC didn't previously use) — those still require a FALLBACK
+  // bump. The probe in scripts/check-cc-authorize-probe.mjs + `dario
+  // doctor --probe` covers that direction.
+  const expected = FALLBACK.scopes.split(/\s+/).filter(Boolean);
+  const verified = filterScopesByBinaryPresence(buf, expected);
+  const scopes = verified.length > 0 ? verified.join(' ') : FALLBACK.scopes;
+  return { clientId, authorizeUrl, tokenUrl, scopes };
+}
+
+/**
+ * Given CC's binary and a list of scope literals we expect to find,
+ * return the subset that actually appear as quoted-string literals in
+ * the binary. Scoping the match to `"<scope>"` (with surrounding
+ * double quotes) avoids false matches on partial substrings. Pure
+ * over its inputs — safe to unit-test without a real CC binary.
+ *
+ * Exported for unit tests.
+ */
+export function filterScopesByBinaryPresence(buf: Buffer, expected: readonly string[]): string[] {
+  const out: string[] = [];
+  for (const scope of expected) {
+    const needle = Buffer.from(`"${scope}"`);
+    if (buf.includes(needle)) out.push(scope);
+  }
+  return out;
 }
 
 async function loadCache(): Promise<{ hash: string; config: DetectedOAuthConfig } | null> {

--- a/test/scope-binary-verify.mjs
+++ b/test/scope-binary-verify.mjs
@@ -1,0 +1,98 @@
+// Tests for filterScopesByBinaryPresence — the partial scope auto-
+// detection added in v3.31.11 as review item #11.
+//
+// End-to-end scanBinaryForOAuthConfig tests live in oauth-detector.mjs
+// and validate against the real installed CC binary; this file covers
+// the pure helper with synthetic buffers so the "what if a scope
+// disappeared from CC's binary" case is testable without a patched
+// binary.
+
+import { filterScopesByBinaryPresence } from '../dist/cc-oauth-detect.js';
+
+let pass = 0, fail = 0;
+function check(name, cond) {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else      { console.log(`  FAIL ${name}`); fail++; }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+const ALL_SCOPES = [
+  'org:create_api_key',
+  'user:profile',
+  'user:inference',
+  'user:sessions:claude_code',
+  'user:mcp_servers',
+  'user:file_upload',
+];
+
+// ─────────────────────────────────────────────────────────────
+header('all scopes present as quoted literals → all returned');
+{
+  const body = ALL_SCOPES.map((s) => `"${s}"`).join(', ');
+  const buf = Buffer.from(body);
+  const out = filterScopesByBinaryPresence(buf, ALL_SCOPES);
+  check('length 6', out.length === 6);
+  check('returned in input order', out.join(' ') === ALL_SCOPES.join(' '));
+}
+
+header('subset present → only those returned, order preserved');
+{
+  // Only 3 of the 6 scope literals exist in this buffer.
+  const buf = Buffer.from('random text "user:profile" more "user:inference" even more "user:file_upload"');
+  const out = filterScopesByBinaryPresence(buf, ALL_SCOPES);
+  check('length 3', out.length === 3);
+  check('only expected scopes present', out.join(',') === 'user:profile,user:inference,user:file_upload');
+}
+
+header('one scope missing (the dario#71 failure mode, simulated)');
+{
+  // Simulate CC v2.1.107 where `org:create_api_key` was dropped from
+  // CC's active set. Binary still contains 5 literal scopes but not
+  // the one Anthropic now rejects.
+  const body = ['user:profile', 'user:inference', 'user:sessions:claude_code', 'user:mcp_servers', 'user:file_upload']
+    .map((s) => `"${s}"`).join(', ');
+  const buf = Buffer.from(body);
+  const out = filterScopesByBinaryPresence(buf, ALL_SCOPES);
+  check('filtered down to 5',                 out.length === 5);
+  check('org:create_api_key dropped',         !out.includes('org:create_api_key'));
+  check('all five user: scopes preserved',    out.every((s) => s.startsWith('user:')));
+}
+
+header('no scopes present → empty');
+{
+  const buf = Buffer.from('no scope literals whatsoever in this fake binary');
+  const out = filterScopesByBinaryPresence(buf, ALL_SCOPES);
+  check('empty', out.length === 0);
+}
+
+header('exact-substring false-positive guarded by surrounding quotes');
+{
+  // "user:profile" appears as an unquoted substring. Without the
+  // quoted-literal check, a naive scan would match. With it, nothing
+  // matches because there's no `"user:profile"` sequence.
+  const buf = Buffer.from('this contains user:profile as a bare token, no quotes around it');
+  const out = filterScopesByBinaryPresence(buf, ALL_SCOPES);
+  check('bare substring does NOT match (quote-bound check)', out.length === 0);
+}
+
+header('expected list empty → empty result, no throw');
+{
+  const buf = Buffer.from('"user:profile"');
+  const out = filterScopesByBinaryPresence(buf, []);
+  check('empty input → empty output', out.length === 0);
+}
+
+header('buffer contains single-quoted literals → not matched');
+{
+  // CC minified source uses DOUBLE quotes for string literals. If a
+  // build tool ever output single quotes, our filter would report the
+  // scope as missing — that's correct: we've lost our signal and
+  // should fall back loudly.
+  const buf = Buffer.from("some 'user:profile' and 'user:inference'");
+  const out = filterScopesByBinaryPresence(buf, ALL_SCOPES);
+  check('single-quoted does NOT match', out.length === 0);
+}
+
+// ─────────────────────────────────────────────────────────────
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Strategic item #11 from the enhancement review. Not the full "decode the minified scope array" move — it's the sharper, simpler version: verify each FALLBACK scope's quoted-literal form exists in CC's binary. If missing, drop it from the returned config.

## What this catches

Class of drift where Anthropic deprecates a scope and CC's next release ships without the literal. Today dario would keep sending the stale scope until a user hit "Invalid request format" (same class as #42 / #71) and filed an issue. Now it self-heals on startup as soon as the user upgrades CC.

## What it does NOT catch

The opposite direction — Anthropic starts accepting a NEW scope CC doesn't use. Binary-literal scan can't verify server-side policy; that still needs the live probe (`dario doctor --probe`).

Detection is defense-in-depth, not a replacement for the probe. FALLBACK.scopes remains ground truth; verification only filters, never adds.

## Implementation

`filterScopesByBinaryPresence(buf, expected)` — pure. For each expected scope, check if `"<scope>"` (with surrounding double quotes) appears in the buffer. Return the subset that do. Silent when all are found (common case), only filters when the binary has drifted.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 47/47 pass (up from 46)
- [x] 11 new assertions in `test/scope-binary-verify.mjs`:
  - All 6 present in synthetic buffer → all 6 returned
  - Subset present → only matching ones, order preserved
  - Simulated dario#42 scenario (5 scopes present, `org:create_api_key` missing) → filtered to 5
  - No scopes → empty
  - Bare substring without quotes → does NOT match (quoted-literal guard)
  - Empty expected list → empty output, no throw
  - Single-quoted source → does NOT match (CC minifies to double quotes; single-quoted source makes us fall back to FALLBACK loudly rather than silently)
- [x] Smoke: real v2.1.118 binary on maintainer's machine → all 6 scopes detected (unchanged behaviour)