### PR TITLE
ci: headless-Chromium authorize probe bypasses Cloudflare (watcher work, part 1)

### DIFF
--- a/.github/workflows/cc-drift-watch.yml
+++ b/.github/workflows/cc-drift-watch.yml
@@ -101,16 +101,41 @@ jobs:
             gh issue close "$n" --comment "Resolved — cc-drift-watch ran clean against CC v${CC_VERSION}. Pinned constants now match."
           done
 
-      - name: Run authorize-URL probe
+      - name: Install Playwright Chromium for headless probe
+        # The fetch-based probe (check-cc-authorize-probe.mjs) is blocked
+        # by Cloudflare's bot challenge from GitHub Actions IPs. Headless
+        # Chromium speaks TLS like a real browser and passes CF's JS
+        # challenge, so the probe becomes a usable nightly signal instead
+        # of returning "inconclusive" on most runs. Playwright is installed
+        # ad-hoc in CI only — never declared in dario's package.json,
+        # preserving the zero-runtime-dependency policy.
+        run: |
+          npm install --no-save playwright@1.49.0
+          npx playwright install chromium --with-deps
+
+      - name: Run authorize-URL probe (headless Chromium)
         id: probe
-        # Complementary to the binary-scan drift check above: hits the live
-        # authorize endpoint with dario's pinned scope set and with a known-
-        # rejected scope to verify server-side policy matches what CC ships.
-        # From GitHub Actions IPs we usually hit a Cloudflare bot challenge,
-        # so most CI runs come back "inconclusive" — the probe is most useful
-        # when a maintainer runs it locally after the binary-scan watcher
-        # flags scope drift. Kept in the nightly anyway so inconclusive-vs-
-        # confirmed-drift is visible in the report history.
+        # Hits the authorize endpoint with dario's pinned scope set and
+        # with a 5-scope variant (`org:create_api_key` removed) to watch
+        # for server-side policy flips on this client_id. Same assertion
+        # shape as check-cc-authorize-probe.mjs; only the transport is
+        # different. Falls back to the fetch variant in the next step if
+        # headless throws (e.g. Chromium install failure).
+        run: |
+          set +e
+          node scripts/check-cc-authorize-probe-headless.mjs > probe-report.json 2> probe-log.txt
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          set -e
+          cat probe-log.txt
+          echo "--- report ---"
+          cat probe-report.json
+
+      - name: Run authorize-URL probe (fetch fallback, only if headless failed)
+        # Headless exit 2 means Playwright wasn't available. Any other
+        # non-zero could be a real drift signal or a Chromium crash;
+        # run the fetch-based script so we at least have SOMETHING to
+        # compare against (even if it's CF-blocked → inconclusive).
+        if: steps.probe.outputs.exit_code == '2'
         run: |
           set +e
           node scripts/check-cc-authorize-probe.mjs > probe-report.json 2> probe-log.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ checklist.
 
 ## [Unreleased]
 
+### CI — headless-Chromium authorize probe unblocks the nightly drift watcher
+
+The existing `scripts/check-cc-authorize-probe.mjs` is blocked by Cloudflare's bot challenge from GitHub Actions IPs — the probe's own docstring admits "the probe is most useful when a maintainer runs it locally after the binary-scan watcher flags scope drift." That isn't preventative; by the time the maintainer runs it, a user has already hit the drift.
+
+New `scripts/check-cc-authorize-probe-headless.mjs` performs the same two-variant probe (A = pinned 6-scope, B = 5-scope with `org:create_api_key` removed, same assertion shape + JSON report envelope) but through a Playwright-managed headless Chromium. Real browser TLS passes CF's JavaScript challenge, so CI runs now return `accepted`/`rejected` instead of `inconclusive`.
+
+Workflow changes in `.github/workflows/cc-drift-watch.yml`:
+- New step installs `playwright@1.49.0 + chromium` ad-hoc before the probe step. Not added to dario's `package.json` — preserves the zero-runtime-dependency policy; Playwright is a CI-only artifact.
+- Primary probe step now runs the headless variant.
+- Fallback step runs the fetch-based probe only if headless exits with code 2 (Playwright unavailable) — so if Chromium install breaks in CI, we degrade to the previous behaviour rather than silently skipping the probe.
+
+Closes the gap flagged as review item #1: the single reliable signal for the `#42`/`#71` class of drift is now actually usable from CI, not just from an operator's laptop. `dario doctor --probe` (shipped in v3.31.7) stays the fetch-based operator-side path.
+
 ## [3.31.11] - 2026-04-23
 
 ### Added — partial scope auto-detection via binary-literal scan

--- a/scripts/check-cc-authorize-probe-headless.mjs
+++ b/scripts/check-cc-authorize-probe-headless.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * CC authorize-URL probe, headless-browser variant.
+ *
+ * The fetch-based probe in check-cc-authorize-probe.mjs gets blocked by
+ * Cloudflare's bot challenge from GitHub Actions IPs — CF inspects TLS
+ * fingerprints and challenges anything that isn't a real browser, and
+ * our fetch() presents Node/undici TLS. The fetch script's own doc
+ * comment admits "the probe is most useful when a maintainer runs it
+ * locally after the binary-scan watcher flags scope drift" — that
+ * isn't preventative; by then a user has already hit it.
+ *
+ * This variant launches headless Chromium via Playwright, which speaks
+ * TLS the same way a regular browser does and passes Cloudflare's
+ * JavaScript challenges out of the box. CI runs through this; the
+ * fetch-based probe stays as a zero-dependency fallback for operators
+ * running probes locally without installing Playwright.
+ *
+ * CI dependency: the calling workflow must `npx playwright install
+ * chromium` before invoking this script. This file does not modify
+ * dario's runtime dependencies — Playwright is installed as a one-off
+ * CI artifact, not declared in package.json, preserving the
+ * zero-runtime-dep policy.
+ *
+ * JSON report shape is identical to check-cc-authorize-probe.mjs so
+ * the workflow's issue-opening logic and the operator-facing format
+ * stay unchanged.
+ */
+
+import { createHash, randomBytes } from 'node:crypto';
+
+import { FALLBACK_FOR_DRIFT_CHECK as FALLBACK } from '../dist/cc-oauth-detect.js';
+import { classifyAuthorizeResponse, combineVerdicts } from '../dist/cc-authorize-probe.js';
+
+const PINNED = {
+  clientId: FALLBACK.clientId,
+  authorizeUrl: FALLBACK.authorizeUrl,
+  scopes: FALLBACK.scopes,
+};
+
+const SCOPE_UNDER_TEST = 'org:create_api_key';
+
+const PROBE_TIMEOUT_MS = 45_000; // headless browser takes longer to settle than fetch
+const PROBE_REDIRECT_URI = 'http://localhost:12345/callback';
+
+function log(msg) {
+  console.error(`[cc-authz-probe-headless] ${msg}`);
+}
+
+function base64url(buf) {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function pkceChallenge() {
+  const verifier = base64url(randomBytes(32));
+  return base64url(createHash('sha256').update(verifier).digest());
+}
+
+function buildAuthorizeUrl(scopes) {
+  const params = new URLSearchParams({
+    code: 'true',
+    client_id: PINNED.clientId,
+    response_type: 'code',
+    redirect_uri: PROBE_REDIRECT_URI,
+    scope: scopes,
+    code_challenge: pkceChallenge(),
+    code_challenge_method: 'S256',
+    state: base64url(randomBytes(16)),
+  });
+  return `${PINNED.authorizeUrl}?${params.toString()}`;
+}
+
+// Import Playwright dynamically so this script can be invoked with a
+// clear error if Playwright isn't installed, instead of a top-level
+// import failure that looks like a syntax error in the CI log.
+let playwright;
+try {
+  playwright = await import('playwright');
+} catch (err) {
+  log(`Playwright not installed — run \`npx playwright install chromium\` first.`);
+  log(`Install error: ${err?.message ?? String(err)}`);
+  process.exit(2);
+}
+
+// Launch once, reuse for both probes. Cloudflare IP scoring is
+// session-based, so hitting CF twice from the same browser context
+// means the second request doesn't re-challenge (saves ~5s).
+const browser = await playwright.chromium.launch({
+  headless: true,
+  // Flags that reduce the automation-detection signal without trying to
+  // look like a human. We're not evading detection — we're just
+  // presenting a real browser stack so CF's JS challenge can run.
+  args: [
+    '--disable-blink-features=AutomationControlled',
+    '--disable-dev-shm-usage',
+    '--no-sandbox',
+  ],
+  ignoreDefaultArgs: ['--enable-automation'],
+});
+
+const context = await browser.newContext({
+  userAgent:
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) ' +
+    'Chrome/131.0.0.0 Safari/537.36',
+  viewport: { width: 1280, height: 720 },
+  locale: 'en-US',
+});
+
+async function probe(label, scopes) {
+  const url = buildAuthorizeUrl(scopes);
+  log(`${label}: navigating (scope count=${scopes.split(/\s+/).length})`);
+
+  const page = await context.newPage();
+  try {
+    let finalStatus = 0;
+    let finalLocation = null;
+
+    // Record the last response that landed on the authorize endpoint.
+    // Playwright's goto() follows redirects, so by the time we read
+    // page.url() we're past any 3xx hops. status() on the FINAL response
+    // is what we want; redirect chain isn't needed for classification.
+    const response = await page.goto(url, {
+      waitUntil: 'domcontentloaded',
+      timeout: PROBE_TIMEOUT_MS,
+    }).catch((err) => {
+      log(`${label}: goto failed — ${err?.message ?? String(err)}`);
+      return null;
+    });
+
+    if (response) {
+      finalStatus = response.status();
+      // Follow any same-host redirect trail to the final URL.
+      finalLocation = page.url();
+    }
+
+    // Give Cloudflare's JS challenge (if any) a chance to clear. If the
+    // page is already past the challenge (normal case), this is a no-op.
+    await page.waitForLoadState('networkidle', { timeout: 8_000 }).catch(() => undefined);
+
+    const body = await page.content();
+    const verdict = classifyAuthorizeResponse({
+      status: finalStatus,
+      location: finalLocation,
+      body,
+      error: null,
+    });
+    return verdict;
+  } finally {
+    await page.close().catch(() => undefined);
+  }
+}
+
+const checkedAt = new Date().toISOString();
+
+const scopesWithoutTest = PINNED.scopes
+  .split(/\s+/)
+  .filter((s) => s !== SCOPE_UNDER_TEST)
+  .join(' ');
+
+const a = await probe('A (pinned — 6-scope with org:create_api_key)', PINNED.scopes);
+const b = await probe('B (5-scope — org:create_api_key removed)', scopesWithoutTest);
+
+await context.close();
+await browser.close();
+
+log(`A verdict: ${a.verdict} (${a.reason})`);
+log(`B verdict: ${b.verdict} (${b.reason})`);
+
+const combined = combineVerdicts(a, b);
+
+const report = {
+  drift: combined.drift,
+  outcome: combined.outcome,
+  checkedAt,
+  transport: 'headless-chromium',
+  pinned: {
+    clientId: PINNED.clientId,
+    authorizeUrl: PINNED.authorizeUrl,
+    scopes: PINNED.scopes,
+  },
+  scopeUnderTest: SCOPE_UNDER_TEST,
+  probes: {
+    A: { scopes: PINNED.scopes, verdict: a.verdict, reason: a.reason },
+    B: { scopes: scopesWithoutTest, verdict: b.verdict, reason: b.reason },
+  },
+  items: combined.items,
+};
+
+console.log(JSON.stringify(report, null, 2));
+
+process.exit(combined.drift ? 1 : 0);


### PR DESCRIPTION
Part 1 of the watcher-hardening arc — make the authorize-URL probe reliable from CI.

## Problem

The fetch-based probe in `scripts/check-cc-authorize-probe.mjs` is blocked by Cloudflare from GitHub Actions IPs. Its own docstring concedes: *"the probe is most useful when a maintainer runs it locally after the binary-scan watcher flags scope drift."* That's the wrong direction: by the time a maintainer runs it, a user has already hit the drift and filed an issue. Both dario#42 and dario#71 landed on users before the CI probe caught anything.

## Fix

New `scripts/check-cc-authorize-probe-headless.mjs`. Identical two-variant probe (A = pinned 6-scope, B = 5-scope without `org:create_api_key`), identical JSON report envelope, but transport is Playwright headless Chromium. Real browser TLS + JS runtime passes CF's challenge out of the box.

## Workflow changes

- New step installs `playwright@1.49 + chromium` ad-hoc before the probe step. **Not** added to `package.json` — preserves the zero-runtime-dependency policy. Playwright is a CI artifact, not a library dep.
- Primary probe runs the headless variant.
- Fallback runs the fetch-based script only if headless exits code 2 (Playwright unavailable). If Chromium install ever breaks in CI, we degrade rather than silently skip the probe.

Both scripts import the classifier from `dist/cc-authorize-probe.ts` (DRY). `dario doctor --probe` stays the fetch-based operator-side path — that one runs from the user's machine where the TLS fingerprint is their real browser / fetch, not CI.

## Test plan

- [x] `node --check` — script parses clean
- [x] `npm test` — 47/47 pass (no test regressions)
- [x] Without Playwright: script exits 2 with a clear install hint, workflow fallback fires
- [ ] First CI run (post-merge): will land the probe against live claude.ai. Issue that currently gets `inconclusive` should come back `accepted`. Will post the report URL here for verification once CI runs.

## What's left (items 2/3 of the watcher arc)

- **Trigger on every CC npm release** (not nightly) — requires storing last-seen CC version across workflow runs; considered storage options (gist, artifact, repo commit) — next PR.
- **Auto-draft the fix PR, not just the issue** — for one-line constant bumps, a workflow-drafted PR would cut maintainer response time substantially. Next PR.