### PR TITLE
ci: drift watcher hourly cadence with npm-version gate (watcher work, part 2)

### DIFF
--- a/.github/workflows/cc-drift-watch.yml
+++ b/.github/workflows/cc-drift-watch.yml
@@ -1,23 +1,96 @@
 name: CC drift watch
 
-# Nightly scan of @anthropic-ai/claude-code@latest against dario's pinned
+# Hourly scan of @anthropic-ai/claude-code@latest against dario's pinned
 # FALLBACK OAuth config, baked request template, and supported-range max.
-# Catches CC-shipped changes the day they land instead of two weeks later
-# when a user files an issue (see dario #40 and #42 for the pattern this
-# is designed to pre-empt).
+# Catches CC-shipped changes the hour they land instead of up to 24 hours
+# later under the old nightly cadence (see dario #40 / #42 for the
+# motivating pattern this is designed to pre-empt).
+#
+# Hourly runs are gated: only the cheap `version_check` job runs every
+# hour — it fetches CC's latest version from the npm registry and early-
+# exits if we've already run a full check against that version. The
+# heavyweight `check` job only fires when the npm version has changed,
+# so the cost is roughly 24 fast-gate runs per day + 1 full run per
+# CC release (historically ~1/week).
 
 on:
   schedule:
-    # 02:00 UTC daily — after west-coast business hours, before EU morning
-    - cron: '0 2 * * *'
-  workflow_dispatch: {}
+    # Every hour at :00. Early-exit via cache means only the gate job
+    # actually does work unless CC's npm latest has changed since the
+    # last full run.
+    - cron: '0 * * * *'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: Bypass the version cache (always run full check)
+        required: false
+        default: 'false'
+        type: choice
+        options: ['false', 'true']
 
 permissions:
   contents: read
   issues: write
 
 jobs:
+  # Cheap gate: one curl to npm's registry + a cache lookup. ~5–10s per
+  # run including the runner's own boot cost. Outputs `should_run` =
+  # true when CC's npm latest is a version we haven't full-checked yet.
+  version_check:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.probe.outputs.version }}
+      should_run: ${{ steps.gate.outputs.should_run }}
+    steps:
+      - name: Fetch CC latest version from npm registry
+        id: probe
+        run: |
+          set -eo pipefail
+          # Single HTTP GET. Fails the job on network error / bad JSON so
+          # a registry outage doesn't silently mask drift.
+          VERSION=$(curl -sS --fail --max-time 15 \
+            https://registry.npmjs.org/@anthropic-ai/claude-code/latest \
+            | node -pe "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")
+          if [ -z "$VERSION" ]; then
+            echo "Empty version from npm registry — aborting."
+            exit 1
+          fi
+          echo "CC latest on npm: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Cache sentinel (keyed on CC version)
+        id: version_cache
+        uses: actions/cache@v4
+        with:
+          # The path is a tiny marker file; only its presence matters.
+          # The cache KEY is what gates: if we've ever saved a cache
+          # with this CC version's key, we've full-checked that version.
+          path: .cc-version-sentinel
+          key: cc-drift-checked-${{ steps.probe.outputs.version }}
+
+      - name: Gate — run full check only when version changed (or --force)
+        id: gate
+        run: |
+          FORCED='${{ inputs.force }}'
+          if [ "$FORCED" = "true" ]; then
+            echo "Manual --force=true — running full check regardless of cache."
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.version_cache.outputs.cache-hit }}" = "true" ]; then
+            echo "CC v${{ steps.probe.outputs.version }} already full-checked (cache hit). Skipping."
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "CC v${{ steps.probe.outputs.version }} is new since the last full check — proceeding."
+            # Write the sentinel so the cache action saves this version
+            # as "seen" at job end. The mark is per-version (key) not
+            # per-run — same version across hours = cache hit.
+            mkdir -p $(dirname .cc-version-sentinel)
+            touch .cc-version-sentinel
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          fi
+
   check:
+    needs: version_check
+    if: needs.version_check.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ checklist.
 
 ## [Unreleased]
 
+### CI — drift watcher cadence: daily → hourly, with npm-version gate
+
+The drift watcher previously ran nightly at `02:00 UTC`. That's a 0–24h latency between a CC release landing on npm and dario noticing. Users who upgraded CC in that window hit drift before the watcher flagged it.
+
+New cadence: cron runs every hour (`0 * * * *`). A lightweight `version_check` gate job runs first — one HTTP GET to npm's registry for `@anthropic-ai/claude-code@latest`, a cache lookup keyed on that version. The heavyweight `check` job only fires when the version has changed (cache miss) or `workflow_dispatch` input `force=true`. Cache key is the version string itself, so the sentinel persists across hourly runs until Anthropic publishes a new version.
+
+Cost: ~24 cheap gate runs/day (~5–10s each on GHA) + one full run per CC release. Less total work than the old nightly because the nightly did the full tarball-download + binary-scan + template-extraction every run regardless of whether anything changed.
+
+Detection-latency impact: the recent `#42 → #71` cadence (two drift incidents in 8 days) would have had its window cut from 0–24h to 0–1h.
+
 ### CI — headless-Chromium authorize probe unblocks the nightly drift watcher
 
 The existing `scripts/check-cc-authorize-probe.mjs` is blocked by Cloudflare's bot challenge from GitHub Actions IPs — the probe's own docstring admits "the probe is most useful when a maintainer runs it locally after the binary-scan watcher flags scope drift." That isn't preventative; by the time the maintainer runs it, a user has already hit the drift.


### PR DESCRIPTION
Part 2 of the watcher-hardening arc. Cut detection-latency floor from 24h to 1h.

## Problem

Current watcher is `cron: '0 2 * * *'` — once a day at 02:00 UTC. When Anthropic publishes a drift-causing CC change (new scope, rotated URL, binary-shape change), any user who upgrades CC in the 0–24h window before the next nightly hits the drift before dario's watcher has a chance to flag it. For the recent `#42 → #71` cadence (two incidents in 8 days) the 24h floor is material.

## Fix

- Cron runs hourly (`0 * * * *`).
- A lightweight `version_check` gate job fires first: one HTTP GET to npm's registry, reads `@anthropic-ai/claude-code@latest.version`, caches by that version string.
- The heavyweight `check` job (drift scan + headless probe + issue open/close) runs **only** when the cache misses — i.e. Anthropic has published a new CC version since our last full check. Hourly runs after the version sentinel is warm skip the full check entirely.
- `workflow_dispatch` gains a `force` boolean input that bypasses the cache for on-demand re-runs.

## Cost

~24 cheap gate runs/day at ~5–10s each + one full run per CC release. Net **less** work than the old nightly because the nightly fetched tarballs and scanned binaries on every run regardless of whether anything had changed. Well within GHA's free tier.

## Detection-latency impact

| | Old nightly | New hourly-gated |
|---|---|---|
| Best case (publish @ 01:59 UTC) | ~1 min | ~1 min |
| Worst case (publish @ 02:01 UTC) | ~24 h | ~1 h |
| Average (uniform publish times) | ~12 h | ~30 min |

## Test plan

- [x] `yaml.safe_load` passes on the updated workflow
- [x] Two-job structure: `version_check` outputs `should_run`; `check` runs under `needs: version_check` + `if: needs.version_check.outputs.should_run == 'true'`
- [x] `actions/cache@v4` key uses the version string so same-version across runs = cache hit = skip
- [x] Manual override via `workflow_dispatch` input `force=true` bypasses the cache
- [ ] First CI run post-merge: verify the gate job runs quickly, the check job is skipped on matching version, and `workflow_dispatch --force=true` exercises the full path

## Merge order

Interacts with [#112](https://github.com/askalf/dario/pull/112) (headless probe) — both change this workflow file. The file in this PR already includes #112's changes, so if #112 lands first, rebase is trivial. If this lands first, #112 will need a conflict resolution that takes the sections from both. I have context on either path.