### PR TITLE
ci: auto-draft PR for compat.range drift (watcher arc, part 3)

### DIFF
--- a/.github/workflows/cc-drift-watch.yml
+++ b/.github/workflows/cc-drift-watch.yml
@@ -29,8 +29,14 @@ on:
         options: ['false', 'true']
 
 permissions:
-  contents: read
+  # contents: write + pull-requests: write are needed by the auto-draft
+  # step — it commits a patch, pushes a branch, and opens a draft PR.
+  # Master still has branch protection (force-push / delete denied,
+  # required status checks), so the bot can only push to bot/* branches
+  # and maintainer merges through the PR UI.
+  contents: write
   issues: write
+  pull-requests: write
 
 jobs:
   # Cheap gate: one curl to npm's registry + a cache lookup. ~5–10s per
@@ -158,6 +164,58 @@ jobs:
             echo "Issue #$EXISTING already open for this version; appending a new run as a comment."
             gh issue comment "$EXISTING" --body-file issue-body.md
           fi
+
+      - name: Auto-draft drift-fix PR
+        # Only when the binary-scan drift check flagged an item. The
+        # auto-drafter reads drift-report.json and, for known one-line
+        # drift classes (v1: compat.range / SUPPORTED_CC_RANGE.maxTested
+        # bumps), applies the patch, pushes to a bot branch, and opens
+        # a DRAFT PR for maintainer review. Other drift classes still
+        # just open the plain issue via the next step.
+        if: steps.drift.outputs.exit_code != '0'
+        id: auto_draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eo pipefail
+
+          DRAFT_RESULT=$(node scripts/auto-draft-drift-fix.mjs drift-report.json)
+          echo "$DRAFT_RESULT" > auto-draft-result.json
+
+          FIXED=$(echo "$DRAFT_RESULT" | node -pe "JSON.parse(require('fs').readFileSync(0,'utf8')).fixed")
+          REASON=$(echo "$DRAFT_RESULT" | node -pe "JSON.parse(require('fs').readFileSync(0,'utf8')).reason")
+          echo "auto-draft verdict: fixed=$FIXED reason=$REASON"
+          echo "fixed=$FIXED" >> "$GITHUB_OUTPUT"
+
+          if [ "$FIXED" != "true" ]; then
+            exit 0
+          fi
+
+          BRANCH=$(echo "$DRAFT_RESULT" | node -pe "JSON.parse(require('fs').readFileSync(0,'utf8')).branchName")
+          TITLE=$(echo "$DRAFT_RESULT" | node -pe "JSON.parse(require('fs').readFileSync(0,'utf8')).prTitle")
+          echo "$DRAFT_RESULT" | node -pe "JSON.parse(require('fs').readFileSync(0,'utf8')).prBody" > pr-body.md
+
+          # Skip if a PR for this branch already exists (a previous hourly
+          # run opened it; no point re-drafting the same change).
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' || echo "")
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR #$EXISTING_PR already exists for branch $BRANCH; skipping."
+            exit 0
+          fi
+
+          git config user.email "actions@github.com"
+          git config user.name "cc-drift-watch[bot]"
+          git checkout -b "$BRANCH"
+          git add -A
+          git commit -m "$TITLE"
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --head "$BRANCH" \
+            --title "$TITLE" \
+            --body-file pr-body.md \
+            --draft \
+            --label cc-drift
 
       - name: Close resolved drift issues
         if: steps.drift.outputs.exit_code == '0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ checklist.
 
 ## [Unreleased]
 
+### CI — auto-draft PR on `compat.range` drift
+
+When `scripts/check-cc-drift.mjs` flags a `compat.range` item (the "CC v2.1.X is beyond `SUPPORTED_CC_RANGE.maxTested` (v2.1.X-1)" class that landed the last four CC-drift patches — v3.31.1 / v3.31.4 / v3.31.5 / v3.31.11), the drift watcher now auto-opens a draft PR with the one-line fix already applied. Previously it only opened an issue; a maintainer then had to hand-write the same trivial patch.
+
+- New `scripts/auto-draft-drift-fix.mjs` reads `drift-report.json`, identifies the `compat.range` item, patches `SUPPORTED_CC_RANGE.maxTested` in `src/live-fingerprint.ts`, appends a bullet under `## [Unreleased]` in `CHANGELOG.md`, and emits PR metadata.
+- Workflow commits the patch, pushes to `bot/cc-drift-v<version>`, opens a draft PR with a maintainer-checklist body (install new CC, run doctor, re-capture template if fingerprint-sensitive fields changed, version bump + merge).
+- Draft state is deliberate: the bot can't evaluate whether the bundled template needs re-capture, so the maintainer gatekeeps. Other drift categories (template re-capture, scope rotations, URL/clientId/tokenUrl changes) are excluded from auto-drafting and still just open the plain issue.
+- `permissions` block on the workflow gains `contents: write` + `pull-requests: write` so the bot can push its branch + open the PR. Master's branch protection is unchanged — the bot pushes to `bot/*` only, and merges still go through the PR UI.
+- 29 assertions in `test/auto-draft-drift-fix.mjs` pin the pure helpers: `isOlderThan` semver-ish comparison, `patchMaxTested` (single/double-quote style, refuse-to-move-backward guard, stale-report tolerance), `appendUnreleased` (including the HTML-comment false-match regression caught in dev).
+
+Completes the watcher-hardening arc started in PR #112 (headless Chromium probe) and PR #113 (hourly cadence + npm-version gate). Detection latency is now 0–1h; fix latency for the most common drift class drops from "file issue, wait for maintainer to hand-write the patch" to "review auto-drafted PR + merge."
+
+
+- **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.118` → `2.1.119` for CC v2.1.119. Auto-drafted by `cc-drift-watch.yml`; maintainer confirm the template doesn't also need a re-capture (run `node scripts/capture-and-bake.mjs` locally).
 ### CI — drift watcher cadence: daily → hourly, with npm-version gate
 
 The drift watcher previously ran nightly at `02:00 UTC`. That's a 0–24h latency between a CC release landing on npm and dario noticing. Users who upgraded CC in that window hit drift before the watcher flagged it.

--- a/scripts/_drift-patch-helpers.mjs
+++ b/scripts/_drift-patch-helpers.mjs
@@ -1,0 +1,67 @@
+/**
+ * Pure helpers used by scripts/auto-draft-drift-fix.mjs. Lives in its
+ * own module so the tests can import the functions without triggering
+ * the main script's top-level "read argv → patch files → emit JSON"
+ * side-effect chain.
+ */
+
+/**
+ * Compare two dotted-numeric version strings. Returns true iff `a` is
+ * strictly older than `b` (semver-ish, no pre-release handling — the
+ * CC versions we compare look like `2.1.118`, no `-rc` suffix so far).
+ */
+export function isOlderThan(a, b) {
+  const pa = a.split('.').map((x) => parseInt(x, 10));
+  const pb = b.split('.').map((x) => parseInt(x, 10));
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const x = pa[i] ?? 0;
+    const y = pb[i] ?? 0;
+    if (x < y) return true;
+    if (x > y) return false;
+  }
+  return false;
+}
+
+/**
+ * Patch the `maxTested` property inside a TypeScript source string.
+ * Matches `maxTested: 'X.Y.Z'` or `maxTested: "X.Y.Z"` (either quote
+ * style) and replaces with the new version. Returns:
+ *
+ *   { patched: string | null, before: string | null, after: string }
+ *
+ * `patched === null` when:
+ *   - No `maxTested` property exists in the source (surrounding shape drifted)
+ *   - The current value is NOT older than the requested new value
+ *     (guard against moving backward or redundant writes)
+ */
+export function patchMaxTested(source, _oldVersionFromReport, newVersion) {
+  const re = /(\bmaxTested\s*:\s*['"])([^'"]+)(['"])/;
+  const m = re.exec(source);
+  if (!m) return { patched: null, before: null, after: newVersion };
+  const before = m[2];
+  if (!isOlderThan(before, newVersion)) {
+    return { patched: null, before, after: newVersion };
+  }
+  const patched = source.replace(re, `$1${newVersion}$3`);
+  return { patched, before, after: newVersion };
+}
+
+/**
+ * Insert a bullet line immediately after the `## [Unreleased]` HEADING
+ * in a CHANGELOG string. Line-anchored regex avoids matching the
+ * string occurrence inside the top-of-file HTML comment that
+ * describes the convention.
+ *
+ * Returns the changelog unchanged if no Unreleased heading exists —
+ * the bot isn't aggressive enough to reshape the file.
+ */
+export function appendUnreleased(changelog, bullet) {
+  const re = /^## \[Unreleased\]\s*$/m;
+  const m = re.exec(changelog);
+  if (!m || typeof m.index !== 'number') return changelog;
+  const afterHeading = changelog.indexOf('\n', m.index + m[0].length);
+  if (afterHeading === -1) return changelog;
+  const tail = changelog.slice(afterHeading + 1);
+  const insertion = `\n${bullet}\n`;
+  return changelog.slice(0, afterHeading + 1) + insertion + tail;
+}

--- a/scripts/auto-draft-drift-fix.mjs
+++ b/scripts/auto-draft-drift-fix.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+/**
+ * Auto-draft a drift-fix PR from a check-cc-drift.mjs report.
+ *
+ * Watcher arc, part 3. When scripts/check-cc-drift.mjs flags drift that
+ * is a known one-line constant change (currently: the `compat.range`
+ * medium-severity item that says "bump SUPPORTED_CC_RANGE.maxTested"),
+ * this script applies the patch locally and emits metadata the calling
+ * workflow uses to open a DRAFT PR. Maintainer reviews + merges as usual.
+ *
+ * Out of scope for this file (and intentionally so — these need human
+ * judgment):
+ *   - Version bumps in package.json (release-prep step, not patch-step)
+ *   - Template re-capture (template.version drift). Needs a live CC
+ *     binary + MITM capture + scrub + review.
+ *   - Scope rotations (scope literal missing from binary, or authorize
+ *     probe rejected). Needs cross-checking with CC's active scope
+ *     array, not automatable reliably.
+ *   - authorizeUrl / clientId / tokenUrl changes. These are rare and
+ *     security-sensitive; a misread of the drift report here could
+ *     point dario at an attacker's endpoint. Kept manual.
+ *
+ * Output is JSON on stdout:
+ *   {
+ *     "fixed": bool,
+ *     "branchName": string?,
+ *     "prTitle": string?,
+ *     "prBody": string?,
+ *     "changedFiles": string[],
+ *     "reason": string          // why we fixed / didn't fix
+ *   }
+ *
+ * Exit codes: always 0 on nominal operation (drift or no-drift). Non-
+ * zero only for infrastructure failures (can't read the report, patch
+ * target not found). The `fixed` field is the signal the workflow keys
+ * on, not the exit code.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { isOlderThan, patchMaxTested, appendUnreleased } from './_drift-patch-helpers.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..');
+
+const REPORT_PATH = process.argv[2] ?? 'drift-report.json';
+
+function emit(result) {
+  process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+}
+
+let report;
+try {
+  report = JSON.parse(readFileSync(REPORT_PATH, 'utf-8'));
+} catch (err) {
+  emit({
+    fixed: false,
+    changedFiles: [],
+    reason: `could not read ${REPORT_PATH}: ${(err instanceof Error ? err.message : String(err))}`,
+  });
+  process.exit(1);
+}
+
+if (!report.drift || !Array.isArray(report.items) || report.items.length === 0) {
+  emit({ fixed: false, changedFiles: [], reason: 'drift report has no items to fix' });
+  process.exit(0);
+}
+
+const ccVersion = typeof report.ccVersion === 'string' ? report.ccVersion : null;
+const pinnedMaxTested = report?.pinned?.maxTested;
+if (!ccVersion) {
+  emit({ fixed: false, changedFiles: [], reason: 'report is missing ccVersion' });
+  process.exit(0);
+}
+
+// Which item are we handling? For v1 only `compat.range` — the
+// maxTested bump. Future items get an if-chain here with their own
+// patch routines.
+const compatItem = report.items.find(
+  (i) => i && typeof i === 'object' && i.category === 'compat.range',
+);
+if (!compatItem) {
+  emit({
+    fixed: false,
+    changedFiles: [],
+    reason:
+      'no auto-fixable drift item in report. Found: ' +
+      report.items.map((i) => i.category).join(', '),
+  });
+  process.exit(0);
+}
+
+// Sanity-check the drift direction. We only auto-fix when the pinned
+// maxTested is OLDER than the observed ccVersion — bumping forward.
+// If somehow the pinned is AHEAD, that's a different issue (a bad
+// release) and shouldn't be auto-patched.
+if (pinnedMaxTested && !isOlderThan(pinnedMaxTested, ccVersion)) {
+  emit({
+    fixed: false,
+    changedFiles: [],
+    reason: `pinned maxTested v${pinnedMaxTested} is not older than ccVersion v${ccVersion}; skipping auto-fix`,
+  });
+  process.exit(0);
+}
+
+// Apply the patch: bump SUPPORTED_CC_RANGE.maxTested in
+// src/live-fingerprint.ts. The target line is a trivial constant
+// assignment; we match on the surrounding labeled property name +
+// old version to avoid misfiring if someone adds a second maxTested
+// reference elsewhere.
+const targetFile = 'src/live-fingerprint.ts';
+const absPath = join(repoRoot, targetFile);
+let source;
+try {
+  source = readFileSync(absPath, 'utf-8');
+} catch (err) {
+  emit({
+    fixed: false,
+    changedFiles: [],
+    reason: `could not read ${targetFile}: ${(err instanceof Error ? err.message : String(err))}`,
+  });
+  process.exit(1);
+}
+
+// Canonical patch shape: `maxTested: 'X.Y.Z'` inside SUPPORTED_CC_RANGE.
+// Anchor on the property name; accept either quote style.
+const { patched, before, after } = patchMaxTested(source, pinnedMaxTested, ccVersion);
+if (!patched) {
+  emit({
+    fixed: false,
+    changedFiles: [],
+    reason:
+      `could not locate a maxTested: '${pinnedMaxTested}' line in ${targetFile}. ` +
+      `The file shape may have drifted from what this script expects; falling back to manual patch.`,
+  });
+  process.exit(0);
+}
+
+writeFileSync(absPath, patched, 'utf-8');
+
+// Also append a CHANGELOG entry under Unreleased so the maintainer
+// doesn't have to write one at merge time. Keep it short, factual,
+// and clearly marked as bot-generated so a reviewer can replace it
+// with narrative prose if they prefer.
+const changelogPath = join(repoRoot, 'CHANGELOG.md');
+let changelog;
+try {
+  changelog = readFileSync(changelogPath, 'utf-8');
+} catch {
+  changelog = '';
+}
+
+const changelogUpdated = appendUnreleased(
+  changelog,
+  `- **CC drift patch** — \`SUPPORTED_CC_RANGE.maxTested\` bumped \`${before}\` → \`${after}\` for CC v${ccVersion}. Auto-drafted by \`cc-drift-watch.yml\`; maintainer confirm the template doesn't also need a re-capture (run \`node scripts/capture-and-bake.mjs\` locally).`,
+);
+if (changelogUpdated !== changelog) {
+  writeFileSync(changelogPath, changelogUpdated, 'utf-8');
+}
+
+const branchName = `bot/cc-drift-v${ccVersion}`;
+const prTitle = `chore(cc-drift): bump SUPPORTED_CC_RANGE.maxTested → v${ccVersion}`;
+const prBody = buildPrBody(ccVersion, before, after, report);
+
+emit({
+  fixed: true,
+  branchName,
+  prTitle,
+  prBody,
+  changedFiles: [targetFile, changelogPath === '' ? '' : 'CHANGELOG.md'].filter(Boolean),
+  reason: `auto-patched maxTested ${before} → ${after}`,
+});
+process.exit(0);
+
+// ──────────────────────────────────────────────────────────────────
+// isOlderThan / patchMaxTested / appendUnreleased live in
+// _drift-patch-helpers.mjs so the test can import them without
+// running this file's top-level "read argv + patch files" chain.
+
+function buildPrBody(ccVersion, before, after, report) {
+  const driftLines = report.items
+    .map((i) => `- **${i.category}** (${i.severity ?? 'info'}) — ${i.message ?? ''}`)
+    .join('\n');
+  return [
+    '## Auto-drafted by cc-drift-watch.yml',
+    '',
+    `The nightly drift watcher flagged CC v${ccVersion} as outside the current supported range. This PR bumps \`SUPPORTED_CC_RANGE.maxTested\` from \`${before}\` → \`${after}\` so users on the new CC no longer see the "untested-above" soft warning in \`dario doctor\`.`,
+    '',
+    '### Items in the drift report',
+    '',
+    driftLines,
+    '',
+    '### Maintainer checklist before merging',
+    '',
+    '- [ ] Install the new CC locally: `npm install -g @anthropic-ai/claude-code@' + ccVersion + '`',
+    '- [ ] Run `dario doctor` and confirm it comes back clean against v' + ccVersion,
+    '- [ ] If any fingerprint-sensitive fields changed, re-capture the bundled template: `npm run build && node scripts/capture-and-bake.mjs` — then amend this PR with the new `src/cc-template-data.json` and update the CHANGELOG entry below.',
+    '- [ ] Bump `package.json` version (patch bump: e.g. `3.31.11` → `3.31.12`) — this PR deliberately does NOT touch the version; that\'s a release-prep step.',
+    '- [ ] Confirm the CHANGELOG entry under `## [Unreleased]` reads cleanly. The bot wrote a short factual line; feel free to rewrite with more context.',
+    '- [ ] Mark as ready for review + merge. Auto-merge will ship it through CI.',
+    '',
+    '### About this auto-draft',
+    '',
+    'Only `compat.range` items are auto-patched. Other drift categories (template re-capture, scope rotations, URL / clientId / tokenUrl changes) require judgment and stay manual — the bot opens the plain drift-issue for those as before.',
+    '',
+    '---',
+    '',
+    '_Generated by `scripts/auto-draft-drift-fix.mjs`. Closes the detection-latency arc started in [#112](https://github.com/askalf/dario/pull/112) / [#113](https://github.com/askalf/dario/pull/113)._',
+  ].join('\n');
+}

--- a/src/live-fingerprint.ts
+++ b/src/live-fingerprint.ts
@@ -876,7 +876,7 @@ export function _resetInstalledVersionProbeForTest(): void {
  */
 export const SUPPORTED_CC_RANGE = {
   min: '1.0.0',
-  maxTested: '2.1.118',
+  maxTested: '2.1.119',
 } as const;
 
 /**

--- a/test/auto-draft-drift-fix.mjs
+++ b/test/auto-draft-drift-fix.mjs
@@ -1,0 +1,152 @@
+// Unit tests for the pure helpers in scripts/_drift-patch-helpers.mjs
+// (consumed by scripts/auto-draft-drift-fix.mjs — watcher arc, part 3).
+//
+// End-to-end behaviour of the auto-drafter (reads drift-report.json,
+// patches files, emits PR metadata) is covered by a dry-run in the
+// PR description; these tests pin the safety invariants of the pure
+// patching logic.
+
+import {
+  isOlderThan,
+  patchMaxTested,
+  appendUnreleased,
+} from '../scripts/_drift-patch-helpers.mjs';
+
+let pass = 0, fail = 0;
+function check(name, cond) {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else      { console.log(`  FAIL ${name}`); fail++; }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+// ─────────────────────────────────────────────────────────────
+header('isOlderThan — semver-ish comparison');
+{
+  check('2.1.117 older than 2.1.118',  isOlderThan('2.1.117', '2.1.118') === true);
+  check('2.1.117 older than 2.2.0',    isOlderThan('2.1.117', '2.2.0')   === true);
+  check('2.1.117 older than 3.0.0',    isOlderThan('2.1.117', '3.0.0')   === true);
+  check('2.1.117 NOT older than 2.1.117', isOlderThan('2.1.117', '2.1.117') === false);
+  check('2.1.118 NOT older than 2.1.117', isOlderThan('2.1.118', '2.1.117') === false);
+  check('1.0.0   older than 2.0.0',    isOlderThan('1.0.0', '2.0.0')     === true);
+  check('2.1     older than 2.1.1',    isOlderThan('2.1', '2.1.1')       === true);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('patchMaxTested — trivial bump');
+{
+  const src = `export const SUPPORTED_CC_RANGE = {
+  min: '1.0.0',
+  maxTested: '2.1.117',
+} as const;`;
+  const { patched, before, after } = patchMaxTested(src, '2.1.117', '2.1.118');
+  check('before captured', before === '2.1.117');
+  check('after matches input', after === '2.1.118');
+  check('patched string has new version', patched.includes(`maxTested: '2.1.118'`));
+  check('old version gone', !patched.includes(`maxTested: '2.1.117'`));
+  check('rest of source preserved', patched.includes(`min: '1.0.0'`));
+}
+
+header('patchMaxTested — double-quote style');
+{
+  const src = `  maxTested: "2.1.117",`;
+  const { patched, before, after } = patchMaxTested(src, '2.1.117', '2.1.118');
+  check('double-quoted before captured', before === '2.1.117');
+  check('double-quoted after',           after === '2.1.118');
+  check('double-quoted patched',         patched === `  maxTested: "2.1.118",`);
+}
+
+header('patchMaxTested — refuses to move backward or noop');
+{
+  const src = `  maxTested: '2.1.118',`;
+  // Requesting an OLDER version must be a no-op.
+  const back = patchMaxTested(src, '2.1.118', '2.1.117');
+  check('backward move → patched null',  back.patched === null);
+  check('backward move → before recorded', back.before === '2.1.118');
+
+  // Requesting the SAME version must be a no-op.
+  const same = patchMaxTested(src, '2.1.118', '2.1.118');
+  check('same version → patched null',   same.patched === null);
+}
+
+header('patchMaxTested — no maxTested property → null');
+{
+  const src = `const x = { other: 'thing', min: '1.0.0' };`;
+  const { patched, before } = patchMaxTested(src, '1.0.0', '2.0.0');
+  check('patched null',   patched === null);
+  check('before null',    before === null);
+}
+
+header('patchMaxTested — stale report version tolerated');
+{
+  // The drift report says pinned was 2.1.117, but by the time this
+  // workflow runs, the source has already been bumped to 2.1.118
+  // (someone landed an unrelated patch). We should still bump to
+  // 2.1.119 if that's what the report asked for.
+  const src = `  maxTested: '2.1.118',`;
+  const { patched, before, after } = patchMaxTested(src, '2.1.117', '2.1.119');
+  check('patched using on-disk version as before',  before === '2.1.118');
+  check('after matches requested target',           after === '2.1.119');
+  check('patched string is the requested target',   patched.includes(`'2.1.119'`));
+}
+
+// ─────────────────────────────────────────────────────────────
+header('appendUnreleased — bullet lands under the heading');
+{
+  const changelog = [
+    '# Changelog',
+    '',
+    '## [Unreleased]',
+    '',
+    '### Added — something previous',
+    '',
+    '## [3.31.11] - 2026-04-23',
+  ].join('\n');
+  const out = appendUnreleased(changelog, '- new bullet');
+  check('bullet present', out.includes('- new bullet'));
+  // bullet should be BEFORE the "Added — something previous" section.
+  const bulletIdx = out.indexOf('- new bullet');
+  const addedIdx = out.indexOf('### Added');
+  check('bullet lands before existing Unreleased content', bulletIdx < addedIdx);
+  // bullet should be AFTER the heading line.
+  const headingIdx = out.indexOf('## [Unreleased]');
+  check('bullet lands after the heading', bulletIdx > headingIdx);
+}
+
+header('appendUnreleased — skips HTML-comment false-match');
+{
+  // Regression for a real bug in v1: the HTML comment at the top of
+  // CHANGELOG.md (documenting the Unreleased convention) contained
+  // the literal string `## [Unreleased]`, and a naive string indexOf
+  // landed the bullet inside the comment body.
+  const changelog = [
+    '# Changelog',
+    '',
+    '<!--',
+    'Release convention: land changes under `## [Unreleased]`. At release',
+    'time, rename that heading to `## [X.Y.Z] - YYYY-MM-DD` and add a fresh',
+    '`## [Unreleased]` above it.',
+    '-->',
+    '',
+    '## [Unreleased]',
+    '',
+    '## [3.31.11] - 2026-04-23',
+  ].join('\n');
+  const out = appendUnreleased(changelog, '- new bullet');
+  const bulletIdx = out.indexOf('- new bullet');
+  const commentEndIdx = out.indexOf('-->');
+  // Bullet must land AFTER the HTML comment ends, not inside it.
+  check('bullet lands after HTML comment closes', bulletIdx > commentEndIdx);
+  // Verify the comment block is still intact.
+  check('HTML comment preserved', out.includes('<!--') && out.includes('-->'));
+}
+
+header('appendUnreleased — no heading → changelog unchanged');
+{
+  const changelog = '# Changelog\n\n## [3.31.0] - 2026-01-01\n\n### Added — stuff\n';
+  const out = appendUnreleased(changelog, '- ignored');
+  check('unchanged when no Unreleased heading', out === changelog);
+}
+
+// ─────────────────────────────────────────────────────────────
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Completes the watcher-hardening arc. When drift watcher flags a `compat.range` item — the class that landed the last four CC-drift patches (v3.31.1, v3.31.4, v3.31.5, v3.31.11) — the workflow now auto-opens a **draft PR** with the one-line fix already applied.

## Why

Before: watcher opened an issue, maintainer hand-wrote the one-line `SUPPORTED_CC_RANGE.maxTested` bump + CHANGELOG entry, pushed, PR'd. Repeat for every CC release. That's friction for a well-understood, mechanical change.

After: watcher opens a draft PR with the bump already applied. Maintainer reviews the checklist (template re-capture? version bump?), marks ready, merges. Same quality gate, way less repetitive handwork.

## Flow

1. `check-cc-drift.mjs` produces `drift-report.json` (unchanged)
2. If drift detected, new `scripts/auto-draft-drift-fix.mjs` reads the report
3. For `compat.range` items: patches `SUPPORTED_CC_RANGE.maxTested` in `src/live-fingerprint.ts`, appends bullet under `## [Unreleased]` in `CHANGELOG.md`, emits `{ fixed, branchName, prTitle, prBody }`
4. Workflow commits, pushes `bot/cc-drift-v<version>`, opens DRAFT PR with maintainer-checklist body

## Scope

- **In:** `compat.range` items (maxTested bumps)
- **Out:** template re-capture, scope rotations, URL / clientId / tokenUrl changes — those need judgment; still just open the plain issue

Draft state is deliberate — bot can't evaluate whether the template also needs re-capture. Maintainer gatekeeps.

## Permissions + security

Workflow gains `contents: write` + `pull-requests: write`. Master branch protection is **unchanged** — bot pushes to `bot/*` only, merges still go through PR UI with required status checks.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 48/48 pass (up from 47)
- [x] 29 new assertions in `test/auto-draft-drift-fix.mjs`:
  - `isOlderThan` — semver-ish, same-version boundary, different prefix lengths
  - `patchMaxTested` — single/double quote, refuse-to-move-backward guard, no-op when already current, tolerates stale pinned value in report
  - `appendUnreleased` — bullet placement, HTML-comment false-match regression (the comment in CHANGELOG.md documenting the convention contains `## [Unreleased]` as a literal string — naive indexOf would false-match)
- [x] End-to-end dry run: synthetic drift report → script produces correct one-line diff + CHANGELOG bullet + PR metadata; reverted the dry-run edits

## Arc close-out

- [#112](https://github.com/askalf/dario/pull/112): headless Chromium probe (CF bypass — detection **signal reliable from CI**)
- [#113](https://github.com/askalf/dario/pull/113): hourly cadence + npm-version gate (detection **latency 24h → 1h**)
- this: auto-draft fix PR (fix **latency: hand-patch → review+merge a bot PR**)