### PR TITLE
ci: auto-release on bot/cc-drift-* PR merge (watcher arc, tightening)

### DIFF
--- a/.github/workflows/cc-drift-auto-release.yml
+++ b/.github/workflows/cc-drift-auto-release.yml
@@ -1,0 +1,106 @@
+name: CC drift auto-release
+
+# Fires on merge of any PR whose head branch starts with `bot/cc-drift-`.
+# Those PRs are produced by the auto-drafter in cc-drift-watch.yml and
+# already carry the version bump (package.json + promoted CHANGELOG)
+# at merge time. This workflow reads the merged master's package.json
+# version, creates the matching `vX.Y.Z` tag + GitHub release, and
+# exits — publish.yml then fires on `release:published` and runs the
+# actual `npm publish --access public --provenance`.
+#
+# Net end-to-end loop: CC ships on npm → hourly gate detects → full
+# check + auto-drafter opens draft PR → maintainer reviews + merges →
+# this workflow tags + releases → publish.yml publishes to npm.
+#
+# Scoped tightly: only PRs from `bot/cc-drift-*` trigger. Any other
+# merge to master is untouched.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [master]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    # Three guards stacked so a mis-labeled PR or an unmerged close
+    # (user closed without merging) can never fire a release:
+    #   1. pull_request event type must be `closed` (implicit from `on:`)
+    #   2. `merged == true` rules out close-without-merge
+    #   3. head branch prefix must match the bot-generated name
+    if: |
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'bot/cc-drift-')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master (post-merge state)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Read package.json version
+        id: ver
+        run: |
+          set -eo pipefail
+          VERSION=$(node -pe "require('./package.json').version")
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Refusing to release — package.json version '$VERSION' doesn't match X.Y.Z" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Will release v$VERSION"
+
+      - name: Ensure tag doesn't already exist
+        run: |
+          TAG="v${{ steps.ver.outputs.version }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists — the auto-drafter likely ran on a version that was already released. Aborting to avoid tag-overwrite."
+            exit 1
+          fi
+
+      - name: Extract release notes from CHANGELOG
+        id: notes
+        # Pull the section for this version from CHANGELOG.md so the
+        # GitHub release body shows what was in the bump, not a generic
+        # "see changelog" link. Runs a tiny Node one-liner to avoid
+        # shell-escaping the markdown content.
+        run: |
+          set -eo pipefail
+          VERSION="${{ steps.ver.outputs.version }}"
+          node -e "
+            const fs = require('fs');
+            const md = fs.readFileSync('CHANGELOG.md', 'utf-8');
+            const re = new RegExp('^## \\\\[' + '${VERSION}' + '\\\\][^\\\\n]*\\\\n([\\\\s\\\\S]*?)(?=\\\\n## \\\\[|$)', 'm');
+            const m = re.exec(md);
+            process.stdout.write(m ? m[1].trim() : '(no changelog section found for this version)');
+          " > release-notes.md
+          echo "--- release-notes.md ---"
+          cat release-notes.md
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ steps.ver.outputs.version }}"
+          {
+            echo "Auto-released from merge of [PR #${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})."
+            echo ""
+            cat release-notes.md
+            echo ""
+            echo "---"
+            echo ""
+            echo "Triggered by \`cc-drift-auto-release.yml\` on bot-drift PR merge. Publishing to npm handled by \`publish.yml\` on this release's \`published\` event."
+          } > body.md
+
+          gh release create "$TAG" \
+            --title "$TAG — CC drift patch" \
+            --notes-file body.md
+
+      - name: Post-release summary
+        run: |
+          echo "✓ Released v${{ steps.ver.outputs.version }}"
+          echo "✓ Triggered by PR #${{ github.event.pull_request.number }} (head: ${{ github.event.pull_request.head.ref }})"
+          echo "→ publish.yml will pick this up and publish to npm"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ checklist.
 
 ## [Unreleased]
 
+### CI — auto-release on `bot/cc-drift-*` PR merge
+
+Tightens the drift loop from "bot opens PR → maintainer merges → maintainer manually tags + releases" to "bot opens PR → maintainer merges → npm publish fires within ~3 minutes, no further action."
+
+Two changes in this PR:
+
+1. The **auto-drafter** (`scripts/auto-draft-drift-fix.mjs`) now also bumps `package.json` patch version, promotes `## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD` with a fresh `## [Unreleased]` above, and lands the drift-fix bullet under the new dated heading. Everything a human would otherwise hand-edit at release-prep time.
+
+2. A **new workflow**, `.github/workflows/cc-drift-auto-release.yml`, fires on `pull_request.closed` to `master` when the head branch starts with `bot/cc-drift-` AND `merged == true`. It reads `package.json` from post-merge master, guards against duplicate tags, extracts the matching CHANGELOG section for release notes, and creates the GitHub release. `publish.yml` then fires on `release.published` and runs `npm publish --provenance`.
+
+Three stacked guards on the trigger so nothing unexpected can release:
+- `pull_request.closed` event type
+- `merged == true` (rules out close-without-merge)
+- Head branch prefix `bot/cc-drift-` (rules out any non-bot PR)
+
+New library exports in `scripts/_drift-patch-helpers.mjs`: `bumpPatch(version)`, `bumpPackageJsonPatch(jsonString)`, `promoteUnreleased(changelog, version, date)`, plus `appendUnreleased` gained an optional `heading` parameter (accepts string or regex) so the auto-drafter can append bullets under a specific version heading, not just `## [Unreleased]`.
+
+Tests: 25 new assertions in `test/auto-draft-drift-fix.mjs` — `bumpPatch` across normal / large / 2-segment inputs plus malformed-input rejection; `bumpPackageJsonPatch` round-trip preserving other fields; `promoteUnreleased` heading order invariants; `appendUnreleased` with custom heading regex. 54 total on the drift-patch helpers, 48/48 full suite.
+
+End-to-end on the maintainer's dev machine: one synthetic drift report produces correct one-line patch, correct package.json bump, correct CHANGELOG promotion with bullet placement. Reverted the dry-run before committing.
+
 ### CI — auto-draft PR on `compat.range` drift
 
 When `scripts/check-cc-drift.mjs` flags a `compat.range` item (the "CC v2.1.X is beyond `SUPPORTED_CC_RANGE.maxTested` (v2.1.X-1)" class that landed the last four CC-drift patches — v3.31.1 / v3.31.4 / v3.31.5 / v3.31.11), the drift watcher now auto-opens a draft PR with the one-line fix already applied. Previously it only opened an issue; a maintainer then had to hand-write the same trivial patch.

--- a/scripts/_drift-patch-helpers.mjs
+++ b/scripts/_drift-patch-helpers.mjs
@@ -47,21 +47,87 @@ export function patchMaxTested(source, _oldVersionFromReport, newVersion) {
 }
 
 /**
- * Insert a bullet line immediately after the `## [Unreleased]` HEADING
- * in a CHANGELOG string. Line-anchored regex avoids matching the
- * string occurrence inside the top-of-file HTML comment that
- * describes the convention.
+ * Insert a bullet line immediately after a CHANGELOG heading. Line-
+ * anchored regex avoids matching string occurrences inside HTML
+ * comments. Default: matches `## [Unreleased]`. Can target a specific
+ * version heading via the `heading` parameter (used by the auto-
+ * release flow, where the heading has just been promoted to
+ * `## [X.Y.Z] - date`).
  *
- * Returns the changelog unchanged if no Unreleased heading exists —
- * the bot isn't aggressive enough to reshape the file.
+ * Returns the changelog unchanged if the target heading doesn't
+ * exist — the bot isn't aggressive enough to reshape the file.
  */
-export function appendUnreleased(changelog, bullet) {
+export function appendUnreleased(changelog, bullet, heading = /^## \[Unreleased\]\s*$/m) {
+  const re = typeof heading === 'string' ? new RegExp(`^${escapeRe(heading)}\\s*$`, 'm') : heading;
+  const m = re.exec(changelog);
+  if (!m || typeof m.index !== 'number') return changelog;
+  // Use the heading's START position (m.index) rather than match
+  // length — the regex may greedily consume trailing `\n`s via `\s*`,
+  // which would make `afterHeading` skip past the heading line.
+  const lineEnd = changelog.indexOf('\n', m.index);
+  if (lineEnd === -1) return changelog;
+  const tail = changelog.slice(lineEnd + 1);
+  const insertion = `\n${bullet}\n`;
+  return changelog.slice(0, lineEnd + 1) + insertion + tail;
+}
+
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Bump a dotted-numeric version's LAST component by 1. Pure, returns
+ * a new string. Rejects versions with non-numeric segments. Used by
+ * the auto-drafter to move `3.31.11` → `3.31.12` when producing a
+ * release-ready PR.
+ */
+export function bumpPatch(version) {
+  const parts = version.split('.');
+  if (parts.length < 2) throw new Error(`version must have at least two segments: ${version}`);
+  for (const p of parts) {
+    if (!/^\d+$/.test(p)) throw new Error(`non-numeric segment in version: ${version}`);
+  }
+  const last = parts.length - 1;
+  parts[last] = String(parseInt(parts[last], 10) + 1);
+  return parts.join('.');
+}
+
+/**
+ * Parse a package.json string, bump its `version` field's patch
+ * component, return the updated JSON string. Preserves the original
+ * object shape and two-space indentation (dario's package.json
+ * convention). Throws if `version` isn't present or isn't parseable.
+ */
+export function bumpPackageJsonPatch(pkgJsonString) {
+  const pkg = JSON.parse(pkgJsonString);
+  if (typeof pkg.version !== 'string') {
+    throw new Error('package.json has no version field');
+  }
+  const newVersion = bumpPatch(pkg.version);
+  pkg.version = newVersion;
+  // Preserve trailing newline — dario's package.json has one.
+  return {
+    content: JSON.stringify(pkg, null, 2) + '\n',
+    before: JSON.parse(pkgJsonString).version,
+    after: newVersion,
+  };
+}
+
+/**
+ * Promote the current `## [Unreleased]` section to a dated version
+ * heading and insert a fresh `## [Unreleased]` above it. Mirrors the
+ * CHANGELOG convention documented in the top-of-file HTML comment
+ * (introduced in v3.31.10): at release time, rename Unreleased to
+ * `## [X.Y.Z] - YYYY-MM-DD` and open a new Unreleased above.
+ *
+ * If the changelog has no `## [Unreleased]` heading, returns unchanged.
+ */
+export function promoteUnreleased(changelog, newVersion, date) {
   const re = /^## \[Unreleased\]\s*$/m;
   const m = re.exec(changelog);
   if (!m || typeof m.index !== 'number') return changelog;
-  const afterHeading = changelog.indexOf('\n', m.index + m[0].length);
-  if (afterHeading === -1) return changelog;
-  const tail = changelog.slice(afterHeading + 1);
-  const insertion = `\n${bullet}\n`;
-  return changelog.slice(0, afterHeading + 1) + insertion + tail;
+  const before = changelog.slice(0, m.index);
+  const after = changelog.slice(m.index + m[0].length);
+  const dated = `## [Unreleased]\n\n## [${newVersion}] - ${date}`;
+  return before + dated + after;
 }

--- a/scripts/auto-draft-drift-fix.mjs
+++ b/scripts/auto-draft-drift-fix.mjs
@@ -39,7 +39,13 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { isOlderThan, patchMaxTested, appendUnreleased } from './_drift-patch-helpers.mjs';
+import {
+  isOlderThan,
+  patchMaxTested,
+  appendUnreleased,
+  bumpPackageJsonPatch,
+  promoteUnreleased,
+} from './_drift-patch-helpers.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, '..');
@@ -139,10 +145,34 @@ if (!patched) {
 
 writeFileSync(absPath, patched, 'utf-8');
 
-// Also append a CHANGELOG entry under Unreleased so the maintainer
-// doesn't have to write one at merge time. Keep it short, factual,
-// and clearly marked as bot-generated so a reviewer can replace it
-// with narrative prose if they prefer.
+// Bump package.json's patch version. The downstream `cc-drift-auto-
+// release.yml` workflow fires on merge of this PR, reads the bumped
+// version from master, and tags + cuts the GitHub release from it —
+// which triggers the existing publish workflow on release:published.
+// So the version bump is both the CHANGELOG promotion anchor and the
+// release-cut trigger.
+const pkgPath = join(repoRoot, 'package.json');
+let packageBumpResult = null;
+try {
+  const pkgSource = readFileSync(pkgPath, 'utf-8');
+  packageBumpResult = bumpPackageJsonPatch(pkgSource);
+  writeFileSync(pkgPath, packageBumpResult.content, 'utf-8');
+} catch (err) {
+  emit({
+    fixed: false,
+    changedFiles: [],
+    reason: `could not bump package.json: ${(err instanceof Error ? err.message : String(err))}`,
+  });
+  process.exit(1);
+}
+const newDarioVersion = packageBumpResult.after;
+
+// Update CHANGELOG:
+//   1. Promote `## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD` with a
+//      fresh `## [Unreleased]` above (the convention documented in
+//      the top-of-file HTML comment since v3.31.10).
+//   2. Append the drift-fix bullet under the NEW version heading, so
+//      a reader of the released changelog sees the one-line summary.
 const changelogPath = join(repoRoot, 'CHANGELOG.md');
 let changelog;
 try {
@@ -151,25 +181,33 @@ try {
   changelog = '';
 }
 
+const today = new Date().toISOString().slice(0, 10);
+const promoted = promoteUnreleased(changelog, newDarioVersion, today);
+const driftBullet =
+  `- **CC drift patch** — \`SUPPORTED_CC_RANGE.maxTested\` bumped \`${before}\` → \`${after}\` for CC v${ccVersion}. ` +
+  `Auto-drafted by \`cc-drift-watch.yml\`; maintainer confirm the bundled template doesn't also need a re-capture ` +
+  `(run \`node scripts/capture-and-bake.mjs\` locally, amend this PR).`;
 const changelogUpdated = appendUnreleased(
-  changelog,
-  `- **CC drift patch** — \`SUPPORTED_CC_RANGE.maxTested\` bumped \`${before}\` → \`${after}\` for CC v${ccVersion}. Auto-drafted by \`cc-drift-watch.yml\`; maintainer confirm the template doesn't also need a re-capture (run \`node scripts/capture-and-bake.mjs\` locally).`,
+  promoted,
+  driftBullet,
+  new RegExp(`^## \\[${newDarioVersion}\\] - ${today}\\s*$`, 'm'),
 );
 if (changelogUpdated !== changelog) {
   writeFileSync(changelogPath, changelogUpdated, 'utf-8');
 }
 
 const branchName = `bot/cc-drift-v${ccVersion}`;
-const prTitle = `chore(cc-drift): bump SUPPORTED_CC_RANGE.maxTested → v${ccVersion}`;
-const prBody = buildPrBody(ccVersion, before, after, report);
+const prTitle = `chore(cc-drift): v${newDarioVersion} — maxTested → v${ccVersion}`;
+const prBody = buildPrBody(ccVersion, before, after, newDarioVersion, report);
 
 emit({
   fixed: true,
   branchName,
   prTitle,
   prBody,
-  changedFiles: [targetFile, changelogPath === '' ? '' : 'CHANGELOG.md'].filter(Boolean),
-  reason: `auto-patched maxTested ${before} → ${after}`,
+  newDarioVersion,
+  changedFiles: [targetFile, 'package.json', changelogPath === '' ? '' : 'CHANGELOG.md'].filter(Boolean),
+  reason: `auto-patched maxTested ${before} → ${after}, bumped dario ${packageBumpResult.before} → ${newDarioVersion}`,
 });
 process.exit(0);
 
@@ -178,27 +216,34 @@ process.exit(0);
 // _drift-patch-helpers.mjs so the test can import them without
 // running this file's top-level "read argv + patch files" chain.
 
-function buildPrBody(ccVersion, before, after, report) {
+function buildPrBody(ccVersion, before, after, newDarioVersion, report) {
   const driftLines = report.items
     .map((i) => `- **${i.category}** (${i.severity ?? 'info'}) — ${i.message ?? ''}`)
     .join('\n');
   return [
     '## Auto-drafted by cc-drift-watch.yml',
     '',
-    `The nightly drift watcher flagged CC v${ccVersion} as outside the current supported range. This PR bumps \`SUPPORTED_CC_RANGE.maxTested\` from \`${before}\` → \`${after}\` so users on the new CC no longer see the "untested-above" soft warning in \`dario doctor\`.`,
+    `The drift watcher flagged CC v${ccVersion} as outside the current supported range. This PR:`,
+    '',
+    `1. Bumps \`SUPPORTED_CC_RANGE.maxTested\` from \`${before}\` → \`${after}\` in \`src/live-fingerprint.ts\``,
+    `2. Bumps \`package.json\` version → \`${newDarioVersion}\``,
+    `3. Promotes \`## [Unreleased]\` in \`CHANGELOG.md\` to \`## [${newDarioVersion}] - ${new Date().toISOString().slice(0, 10)}\` and appends the drift-fix bullet`,
     '',
     '### Items in the drift report',
     '',
     driftLines,
     '',
+    '### What happens when you merge this',
+    '',
+    `A separate workflow (\`cc-drift-auto-release.yml\`) fires on merge of any PR whose head branch starts with \`bot/cc-drift-\`. It reads \`package.json\` from master, tags \`v${newDarioVersion}\`, and creates the GitHub release. The existing \`publish.yml\` workflow triggers on release publication and runs \`npm publish --provenance\`. Net: merging this PR ships \`@askalf/dario@${newDarioVersion}\` to npm within ~3 minutes, no further maintainer action.`,
+    '',
     '### Maintainer checklist before merging',
     '',
     '- [ ] Install the new CC locally: `npm install -g @anthropic-ai/claude-code@' + ccVersion + '`',
     '- [ ] Run `dario doctor` and confirm it comes back clean against v' + ccVersion,
-    '- [ ] If any fingerprint-sensitive fields changed, re-capture the bundled template: `npm run build && node scripts/capture-and-bake.mjs` — then amend this PR with the new `src/cc-template-data.json` and update the CHANGELOG entry below.',
-    '- [ ] Bump `package.json` version (patch bump: e.g. `3.31.11` → `3.31.12`) — this PR deliberately does NOT touch the version; that\'s a release-prep step.',
-    '- [ ] Confirm the CHANGELOG entry under `## [Unreleased]` reads cleanly. The bot wrote a short factual line; feel free to rewrite with more context.',
-    '- [ ] Mark as ready for review + merge. Auto-merge will ship it through CI.',
+    '- [ ] **If any fingerprint-sensitive fields changed**, re-capture the bundled template locally (`npm run build && node scripts/capture-and-bake.mjs`) and amend this PR with the updated `src/cc-template-data.json`. The bot cannot re-capture from CI because the bake requires an authenticated CC session.',
+    '- [ ] Confirm the CHANGELOG entry under `## [' + newDarioVersion + ']` reads cleanly. The bot wrote a short factual line; feel free to rewrite with more context.',
+    '- [ ] Mark as ready for review + merge. Auto-merge will ship it through CI, and the auto-release workflow handles the tag + release + npm publish.',
     '',
     '### About this auto-draft',
     '',
@@ -206,6 +251,6 @@ function buildPrBody(ccVersion, before, after, report) {
     '',
     '---',
     '',
-    '_Generated by `scripts/auto-draft-drift-fix.mjs`. Closes the detection-latency arc started in [#112](https://github.com/askalf/dario/pull/112) / [#113](https://github.com/askalf/dario/pull/113)._',
+    '_Generated by `scripts/auto-draft-drift-fix.mjs`. Closes the detection-latency arc: [#112](https://github.com/askalf/dario/pull/112) (CF bypass), [#113](https://github.com/askalf/dario/pull/113) (hourly cadence), [#114](https://github.com/askalf/dario/pull/114) (auto-draft PR)._',
   ].join('\n');
 }

--- a/test/auto-draft-drift-fix.mjs
+++ b/test/auto-draft-drift-fix.mjs
@@ -10,6 +10,9 @@ import {
   isOlderThan,
   patchMaxTested,
   appendUnreleased,
+  bumpPatch,
+  bumpPackageJsonPatch,
+  promoteUnreleased,
 } from '../scripts/_drift-patch-helpers.mjs';
 
 let pass = 0, fail = 0;
@@ -145,6 +148,112 @@ header('appendUnreleased — no heading → changelog unchanged');
   const changelog = '# Changelog\n\n## [3.31.0] - 2026-01-01\n\n### Added — stuff\n';
   const out = appendUnreleased(changelog, '- ignored');
   check('unchanged when no Unreleased heading', out === changelog);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('bumpPatch — increment last segment');
+{
+  check('3.31.11 → 3.31.12',   bumpPatch('3.31.11') === '3.31.12');
+  check('1.0.0 → 1.0.1',       bumpPatch('1.0.0')   === '1.0.1');
+  check('0.0.0 → 0.0.1',       bumpPatch('0.0.0')   === '0.0.1');
+  check('10.9.99 → 10.9.100',  bumpPatch('10.9.99') === '10.9.100');
+  check('2-segment: 1.0 → 1.1', bumpPatch('1.0')    === '1.1');
+}
+
+header('bumpPatch — rejects malformed versions');
+{
+  let threw;
+  try { bumpPatch('1.2.3-rc'); threw = false; } catch { threw = true; }
+  check('pre-release suffix rejected', threw === true);
+  try { bumpPatch('1'); threw = false; } catch { threw = true; }
+  check('single segment rejected', threw === true);
+  try { bumpPatch(''); threw = false; } catch { threw = true; }
+  check('empty rejected', threw === true);
+}
+
+header('bumpPackageJsonPatch');
+{
+  const src = JSON.stringify({
+    name: '@askalf/dario',
+    version: '3.31.11',
+    description: 'test',
+    scripts: { build: 'tsc' },
+  }, null, 2) + '\n';
+  const { content, before, after } = bumpPackageJsonPatch(src);
+  check('before captured',  before === '3.31.11');
+  check('after bumped',     after  === '3.31.12');
+  check('content has new version', content.includes('"version": "3.31.12"'));
+  check('content has old version NO MORE', !content.includes('"version": "3.31.11"'));
+  check('other fields preserved', content.includes('"name": "@askalf/dario"') && content.includes('"scripts"'));
+  check('content ends with newline', content.endsWith('\n'));
+}
+
+header('bumpPackageJsonPatch — rejects missing version');
+{
+  const src = JSON.stringify({ name: 'x' });
+  let threw;
+  try { bumpPackageJsonPatch(src); threw = false; } catch { threw = true; }
+  check('missing version throws', threw === true);
+}
+
+header('promoteUnreleased — promotes and opens fresh Unreleased above');
+{
+  const changelog = [
+    '# Changelog',
+    '',
+    '## [Unreleased]',
+    '',
+    '- **CC drift patch** — maxTested bumped',
+    '',
+    '## [3.31.11] - 2026-04-23',
+    '',
+    '### Added — scope auto-detection',
+  ].join('\n');
+  const out = promoteUnreleased(changelog, '3.31.12', '2026-04-23');
+  check('fresh Unreleased heading still present', out.includes('## [Unreleased]'));
+  check('new dated heading present',              out.includes('## [3.31.12] - 2026-04-23'));
+  check('previous Unreleased content preserved',  out.includes('- **CC drift patch** — maxTested bumped'));
+  check('prior version heading untouched',        out.includes('## [3.31.11] - 2026-04-23'));
+
+  // Order: `## [Unreleased]` should be ABOVE `## [3.31.12]`, which is
+  // above `## [3.31.11]`.
+  const unreleasedIdx = out.indexOf('## [Unreleased]');
+  const newIdx = out.indexOf('## [3.31.12]');
+  const oldIdx = out.indexOf('## [3.31.11]');
+  check('Unreleased above new version',           unreleasedIdx < newIdx);
+  check('new version above old version',          newIdx < oldIdx);
+}
+
+header('promoteUnreleased — no Unreleased heading → unchanged');
+{
+  const changelog = '# Changelog\n\n## [3.31.0] - 2026-01-01\n';
+  const out = promoteUnreleased(changelog, '3.31.1', '2026-02-01');
+  check('unchanged when no Unreleased heading', out === changelog);
+}
+
+header('appendUnreleased — custom heading regex (for auto-drafter)');
+{
+  // After promoteUnreleased, the auto-drafter appends its bullet under
+  // the NEW dated heading, not the fresh Unreleased above it.
+  const changelog = [
+    '# Changelog',
+    '',
+    '## [Unreleased]',
+    '',
+    '## [3.31.12] - 2026-04-23',
+    '',
+  ].join('\n');
+  const out = appendUnreleased(
+    changelog,
+    '- drift bullet',
+    /^## \[3\.31\.12\] - 2026-04-23\s*$/m,
+  );
+  check('bullet present', out.includes('- drift bullet'));
+  const bulletIdx = out.indexOf('- drift bullet');
+  const datedIdx = out.indexOf('## [3.31.12]');
+  const unreleasedIdx = out.indexOf('## [Unreleased]');
+  check('bullet lands after the dated heading', bulletIdx > datedIdx);
+  check('bullet lands BELOW the fresh Unreleased', bulletIdx > unreleasedIdx);
 }
 
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes the drift loop end-to-end. Before this PR: bot opens PR → maintainer merges → maintainer manually bumps version, tags, creates release. After: bot's PR is release-ready, maintainer merges, npm publish fires within ~3 minutes.

## Two changes

### 1. Auto-drafter does release-prep too

`scripts/auto-draft-drift-fix.mjs` now, in addition to the `src/live-fingerprint.ts` maxTested patch, bumps `package.json` patch version and promotes `## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD` in `CHANGELOG.md` (with a fresh `## [Unreleased]` above). The drift-fix bullet lands under the new dated heading.

### 2. New `.github/workflows/cc-drift-auto-release.yml`

Fires on `pull_request.closed` → master when:
- `merged == true`
- head branch starts with `bot/cc-drift-`

Reads `package.json` from post-merge master, guards against duplicate tags, extracts the CHANGELOG section for release notes, creates the GitHub release. `publish.yml` then fires on `release.published` → runs `npm publish --provenance`.

Three stacked guards on the trigger so nothing unexpected can release.

## New helper exports (`scripts/_drift-patch-helpers.mjs`)

- `bumpPatch(version)` — increment last dotted segment
- `bumpPackageJsonPatch(jsonString)` — parse, bump, stringify
- `promoteUnreleased(changelog, version, date)` — rename heading
- `appendUnreleased(changelog, bullet, heading?)` — existing, gained optional `heading` arg for the custom-dated-section case

### Bug fix

Old `appendUnreleased` used `m.index + m[0].length` to find the heading's end. Broke when the regex's `\s*$` greedy suffix consumed trailing newlines (seen on the target heading near end-of-file — the failing case from the new custom-heading tests). Now uses `indexOf('\n', m.index)` deterministically.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 48/48 pass
- [x] 25 new assertions in `test/auto-draft-drift-fix.mjs` (54 total on drift-patch helpers): `bumpPatch` normal/large/2-segment/rejections, `bumpPackageJsonPatch` round-trip + missing-version rejection, `promoteUnreleased` heading-order invariants + no-Unreleased-heading no-op, `appendUnreleased` with custom heading regex
- [x] End-to-end smoke: synthetic drift report `{ccVersion: 2.1.120, pinned: 2.1.119}` → correct one-line maxTested patch, correct package.json bump `3.31.11` → `3.31.12`, correct CHANGELOG promotion with bullet placement. Reverted the dry-run before committing.

## What the full loop looks like now

```
CC v2.1.X publishes on npm
       ↓ (~1h)
cc-drift-watch cron fires; version gate detects new version
       ↓
Full check runs; binary scan + headless Chromium probe
       ↓ (if drift detected)
auto-draft-drift-fix.mjs patches 3 files; workflow pushes bot/cc-drift-v2.1.X
       ↓
Draft PR opens with maintainer checklist
       ↓ (maintainer review + merge)
cc-drift-auto-release.yml fires on merge
       ↓
GitHub release created at vX.Y.Z
       ↓
publish.yml fires on release.published
       ↓
npm publish --access public --provenance
```