### PR TITLE
ci: operational hygiene — close cc-drift issues, auth template, stale bot

### DIFF
--- a/.github/ISSUE_TEMPLATE/oauth-auth-issue.yml
+++ b/.github/ISSUE_TEMPLATE/oauth-auth-issue.yml
@@ -1,0 +1,77 @@
+name: OAuth / auth issue
+description: "`dario login` / `dario accounts add` fails, or your client (OpenClaw, Hermes, etc.) gets 401 through dario"
+title: "[auth] <short summary>"
+labels: [bug, auth]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Two of dario's recurring bug classes are hard to debug without structured data up front — `dario#42/#71` (OAuth scope drift on `accounts add`) and `dario#97` (client-side auth header mismatch). We ship two built-in diagnostics that produce exactly the information needed to triage each:
+        - **`dario doctor --probe`** — hits Anthropic's authorize endpoint with your effective OAuth config; verdict + URL tells us if the server-side policy has flipped against our pinned constants.
+        - **`dario doctor --auth-check`** — one-shot listener that shows what your client actually sends as auth, redacted; rules out client misconfiguration.
+
+        Paste the relevant output below and we can usually resolve in one exchange. If you're on dario < v3.31.7, the `--probe` flag doesn't exist yet — `npm install -g @askalf/dario@latest` first.
+
+  - type: dropdown
+    id: scenario
+    attributes:
+      label: Which flow failed?
+      options:
+        - "`dario login` — fresh OAuth browser flow"
+        - "`dario accounts add <alias>` — adding a second/third account to the pool"
+        - "Client request through dario returns 401"
+        - "Client request through dario returns 429 unexpectedly"
+        - "Other / unsure"
+    validations:
+      required: true
+
+  - type: textarea
+    id: symptom
+    attributes:
+      label: What happened?
+      placeholder: "e.g. browser opened, showed 'Authorization failed — Invalid request format'; curl through dario returns 401 with body 'Invalid or missing API key'"
+    validations:
+      required: true
+
+  - type: textarea
+    id: doctor_probe
+    attributes:
+      label: "`dario doctor --probe` output"
+      description: "Run `dario doctor --probe` and paste the full output. If the probe comes back `inconclusive` due to Cloudflare, also open the `Probe URL` row's URL in your browser and paste what the page says (or 'looked like a normal login page')."
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: doctor_auth_check
+    attributes:
+      label: "`dario doctor --auth-check` output (only for client-side 401 issues)"
+      description: "In one terminal run `DARIO_API_KEY=<your-key> dario doctor --auth-check`. In another, make ONE request from your client (OpenClaw, Hermes, curl, etc.) to the URL dario prints. Paste the full output here — the redacted value preview is what we need to see."
+      render: shell
+    validations:
+      required: false
+
+  - type: input
+    id: client_tool
+    attributes:
+      label: Client tool
+      description: "Which tool are you pointing at dario? (OpenClaw / Hermes / Aider / Cursor / curl / your-own-script / etc.)"
+      placeholder: "e.g. OpenClaw 2026.04.21, or curl, or Aider 0.80"
+    validations:
+      required: false
+
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: "Paste just the first block of `dario doctor` (Identity + Proxy + Auth gate sections — NOT --probe output). Credentials are redacted automatically."
+      render: shell
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+
+        No logs are uploaded automatically; you paste what you want to share. `dario doctor` redacts credentials by design (see `src/doctor.ts` — `redactSecret()` and `scrubPath()`). If you're unsure whether your paste contains something sensitive, read it over first.

--- a/.github/workflows/cc-drift-auto-release.yml
+++ b/.github/workflows/cc-drift-auto-release.yml
@@ -22,6 +22,12 @@ on:
 
 permissions:
   contents: write
+  # `issues: write` is required for the post-release cleanup step that
+  # closes any open `cc-drift` issues matching the CC version just
+  # shipped. The nightly watcher opens those issues on drift detect;
+  # this workflow closes them on release so the issue tracker stays
+  # quiet when the loop completes cleanly.
+  issues: write
 
 jobs:
   release:
@@ -99,8 +105,45 @@ jobs:
             --title "$TAG — CC drift patch" \
             --notes-file body.md
 
+      - name: Close matching cc-drift issues
+        # The bot's branch name encodes the CC version (`bot/cc-drift-
+        # v2.1.120`). The watcher's nightly run opens issues with
+        # titles `CC drift detected: v<version>` and `CC authorize-
+        # probe drift: v<version>` for the same version. Once the
+        # release ships, those issues are resolved — close them so
+        # the tracker shows the loop closed cleanly. Idempotent: if
+        # the issues were already closed (e.g. manual close), `gh
+        # issue close` on a closed issue is a no-op that exits 0.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          # Strip the `bot/cc-drift-v` prefix to get the bare CC
+          # version string. Guard against unexpected branch shapes
+          # (this step only runs when the top-level `if` matched
+          # `bot/cc-drift-*`, but belt + braces).
+          if [[ "$BRANCH" != bot/cc-drift-v* ]]; then
+            echo "Branch $BRANCH doesn't match expected shape; skipping issue cleanup."
+            exit 0
+          fi
+          CC_VERSION="${BRANCH#bot/cc-drift-v}"
+          DARIO_VERSION="${{ steps.ver.outputs.version }}"
+
+          # Search titles covering both the binary-scan and authorize-
+          # probe issue variants. Limits: only open issues with the
+          # `cc-drift` label, only titles matching exactly.
+          for TITLE_PREFIX in "CC drift detected" "CC authorize-probe drift"; do
+            TITLE="${TITLE_PREFIX}: v${CC_VERSION}"
+            NUMBERS=$(gh issue list --label cc-drift --state open --search "in:title \"${TITLE}\"" --json number --jq '.[].number' || echo "")
+            for n in $NUMBERS; do
+              gh issue close "$n" --comment "Resolved by v${DARIO_VERSION} (release: https://github.com/${GITHUB_REPOSITORY}/releases/tag/v${DARIO_VERSION}). Closed automatically by \`cc-drift-auto-release.yml\`."
+              echo "Closed issue #$n"
+            done
+          done
+
       - name: Post-release summary
         run: |
           echo "✓ Released v${{ steps.ver.outputs.version }}"
           echo "✓ Triggered by PR #${{ github.event.pull_request.number }} (head: ${{ github.event.pull_request.head.ref }})"
           echo "→ publish.yml will pick this up and publish to npm"
+          echo "→ cc-drift issues for this CC version have been closed"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,63 @@
+name: Stale issue / PR housekeeping
+
+# Low-key housekeeping that keeps the tracker from accumulating dead
+# threads without being heavy-handed. Conservative defaults for a
+# low-volume repo: 60 days to warn, 14 more to close. Most real
+# issues get attention within 2 months; anything sitting beyond that
+# has usually been superseded or lost context.
+#
+# Exempt labels keep drift-linked items and in-flight work out of the
+# sweep.
+
+on:
+  schedule:
+    # Once a day at 04:30 UTC — well-separated from the hourly
+    # drift-watcher and the cron at :00 most people use.
+    - cron: '30 4 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
+        with:
+          days-before-stale: 60
+          days-before-close: 14
+          stale-issue-label: stale
+          stale-pr-label: stale
+          stale-issue-message: >
+            No activity on this issue for 60 days. Marking as stale. If
+            it's still relevant, leave a comment and we'll take another
+            look — otherwise it'll auto-close in 14 days.
+          stale-pr-message: >
+            No activity on this PR for 60 days. Marking as stale. If
+            it's still in flight, leave a comment or push an update —
+            otherwise it'll auto-close in 14 days.
+          close-issue-message: >
+            Auto-closing after 14 days of no follow-up on stale notice.
+            Feel free to reopen if the issue recurs or if you have new
+            information to share.
+          close-pr-message: >
+            Auto-closing after 14 days of no follow-up on stale notice.
+            Feel free to reopen if you want to pick the work back up.
+          # Exempt labels:
+          #   cc-drift — close automatically when the matching release
+          #     ships (see cc-drift-auto-release.yml). Keep visible
+          #     until then.
+          #   review-feedback — multi-week review-absorption threads
+          #     that are fine sitting open until explicitly closed.
+          #   help-wanted / good-first-issue — open-ended by design.
+          #   pinned — explicit do-not-stale marker.
+          exempt-issue-labels: cc-drift,review-feedback,help-wanted,good-first-issue,pinned
+          exempt-pr-labels: cc-drift,review-feedback,pinned,wip,blocked
+          # Conservative counts per run so the bot doesn't mass-close
+          # on first activation. Adjust later if the tracker grows.
+          operations-per-run: 60
+          # Don't stale items actively being discussed (a comment
+          # within the stale window resets the clock).
+          remove-stale-when-updated: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ checklist.
 
 ## [Unreleased]
 
+### CI — operational hygiene: auto-close cc-drift issues, OAuth issue template, stale bot
+
+Three small additions that tighten how the repo handles its own lifecycle, orthogonal to the release / drift loop itself:
+
+1. `.github/workflows/cc-drift-auto-release.yml` gains a "Close matching cc-drift issues" step. The nightly watcher opens `cc-drift`-labeled issues when it detects drift; this step closes any still-open ones after the matching release ships (matches both `CC drift detected: v<cc>` and `CC authorize-probe drift: v<cc>` title shapes). Idempotent — closing an already-closed issue is a no-op. Previously each drift patch required a manual issue sweep.
+
+2. New `.github/ISSUE_TEMPLATE/oauth-auth-issue.yml` — GitHub issue form for the auth-bug class (`dario#42`/`#71` OAuth scope drift, `dario#97` client-side auth header mismatch). Pre-requests `dario doctor --probe` and `dario doctor --auth-check` output in `render: shell` textareas, so triage data lands in the initial post rather than a back-and-forth. Redaction is handled by doctor's own `redactSecret` / `scrubPath`.
+
+3. New `.github/workflows/stale.yml` — `actions/stale@v9`, once daily at 04:30 UTC. 60 days to warn, 14 more to close. Exempts `cc-drift` (closes automatically on release via the step above), `review-feedback`, `help-wanted`, `good-first-issue`, `pinned`, plus `wip`/`blocked` for PRs. `remove-stale-when-updated: true` — a comment within the window resets the clock. Conservative `operations-per-run: 60` so first activation can't mass-close a backlog.
+
+Repo settings also tightened out-of-band (not in this PR, applied via `gh api`): `pinned` / `wip` / `blocked` / `auth` labels created (referenced by stale exempts + the auth issue template), and `required_conversation_resolution` enabled on master protection so unresolved PR review threads now block merge.
+
 ### CI — auto-release on `bot/cc-drift-*` PR merge
 
 Tightens the drift loop from "bot opens PR → maintainer merges → maintainer manually tags + releases" to "bot opens PR → maintainer merges → npm publish fires within ~3 minutes, no further action."


### PR DESCRIPTION
## Summary

Three small additions that tighten how the repo handles its own lifecycle, orthogonal to the release / drift loop itself.

- **`cc-drift-auto-release.yml`** — new "Close matching cc-drift issues" step. After the release ships, any still-open `cc-drift`-labeled issues with titles matching the CC version just shipped (covers both `CC drift detected: v<cc>` and `CC authorize-probe drift: v<cc>` shapes) get closed with a pointer to the release. Idempotent — no-op on already-closed issues. Previously each drift patch left an issue sweep for the maintainer.

- **`.github/ISSUE_TEMPLATE/oauth-auth-issue.yml`** — new GitHub issue form for the auth-bug class (#42/#71 OAuth scope drift, #97 client-side auth header mismatch). Pre-requests `dario doctor --probe` and `dario doctor --auth-check` output in `render: shell` textareas so triage data lands in the initial post. doctor's existing `redactSecret` / `scrubPath` handle redaction.

- **`.github/workflows/stale.yml`** — new daily `actions/stale@v9` run at 04:30 UTC. 60 days to warn, 14 more to close. Exempts `cc-drift` (closes automatically on release via the step above), `review-feedback`, `help-wanted`, `good-first-issue`, `pinned` for issues, plus `wip`/`blocked` for PRs. `operations-per-run: 60` cap so first activation can't mass-close a backlog. `remove-stale-when-updated: true` resets the clock on comment.

## Out-of-band (not in this PR, applied via gh api)

- Labels created: `pinned`, `wip`, `blocked`, `auth` (referenced by stale exempts + the auth issue template).
- Master branch protection: `required_conversation_resolution: true` — unresolved PR review threads now block merge.

## Test plan

- [ ] CI green on this PR (validate-package-json + build 18/20/22 + analyze).
- [ ] On merge: `cc-drift-auto-release.yml` is updated but only triggers on `bot/cc-drift-*` PR merges — no immediate behaviour change. Next drift patch will exercise the issue-close step.
- [ ] `stale.yml` fires first run at 04:30 UTC next day. `workflow_dispatch` available if earlier validation wanted.
- [ ] OAuth issue template visible at `github.com/askalf/dario/issues/new/choose` with "OAuth / auth issue" option.