### PR TITLE
ci: Dependabot weekly version updates + actionlint workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+# Dependabot version-update config.
+#
+# Security-advisory updates are already on via the repo-level "Dependabot
+# security updates" setting (gh api repos/askalf/dario → security_and_
+# analysis.dependabot_security_updates) and are independent of this file.
+# This file covers *version* updates — catching stale deps before they
+# ship a vuln, not after.
+#
+# Non-major updates are grouped into a single weekly PR per ecosystem to
+# keep noise down; majors still open individually so they get real review.
+# Schedule is Monday 09:00 UTC — lines up with the start of the workweek
+# in US/EU timezones so the PR isn't sitting over a weekend.
+#
+# Dependabot auto-adds a `dependencies` label; no explicit labels: field
+# needed here.
+
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 10
+    groups:
+      non-major:
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: chore
+      include: scope
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      non-major:
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: ci
+      include: scope

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,50 @@
+name: actionlint
+
+# Validates GitHub Actions workflow YAML against actionlint's rule set.
+# We've hit YAML bugs in review that only surfaced at workflow-fire time
+# (wrong string interpolation shape, missing `needs:`, misnamed event
+# triggers); actionlint catches those statically at PR time.
+#
+# Not gated in branch protection yet — run it for a few drift cycles to
+# verify it doesn't trip false positives on our existing workflows, then
+# promote to a required check if clean.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+  push:
+    branches: [master]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install actionlint v1.7.1
+        # Official release tarball, pinned to a specific version. Skipping
+        # SHA256 verification here because actionlint is a CI-only lint
+        # artifact that never ships to users — the supply-chain risk is
+        # a broken build, not a compromised runtime. If this becomes a
+        # required check, revisit with a pinned checksum.
+        run: |
+          set -euo pipefail
+          curl -fsSL -o actionlint.tgz \
+            https://github.com/rhysd/actionlint/releases/download/v1.7.1/actionlint_1.7.1_linux_amd64.tar.gz
+          tar xzf actionlint.tgz actionlint
+          chmod +x actionlint
+          ./actionlint -version
+
+      - name: Run actionlint
+        # -color for readable logs; default shellcheck integration is on,
+        # which is what catches the run: block issues we actually care about.
+        run: ./actionlint -color

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ checklist.
 
 ## [Unreleased]
 
+### CI — Dependabot version updates + actionlint workflow
+
+Two additions to the CI hygiene layer, orthogonal to any runtime change:
+
+1. **`.github/dependabot.yml`** — weekly (Monday 09:00 UTC) version-update PRs for npm and github-actions ecosystems. Non-major updates (minor + patch) grouped into a single PR per ecosystem to keep noise down; majors still open individually so they get real review. Security-advisory updates are unchanged — already on via the repo-level Dependabot security-updates setting, independent of this config.
+
+2. **`.github/workflows/actionlint.yml`** — `actionlint` v1.7.1 runs on any PR that touches `.github/workflows/**` and on pushes to master touching the same paths. Statically catches the class of workflow-YAML bugs we've hit at fire time (wrong interpolation shape, bad `needs:` refs, shell-quoting, etc.). Not required for merge yet; promote to a required status check after one cycle of verifying no false positives on the existing workflow set.
+
 ### CI — operational hygiene: auto-close cc-drift issues, OAuth issue template, stale bot
 
 Three small additions that tighten how the repo handles its own lifecycle, orthogonal to the release / drift loop itself:


### PR DESCRIPTION
## Summary

Two additions to the CI hygiene layer, orthogonal to any runtime change.

- **`.github/dependabot.yml`** — weekly (Monday 09:00 UTC) version-update PRs for npm and github-actions ecosystems. Non-major updates (minor + patch) grouped into a single PR per ecosystem to keep noise down; majors still open individually so they get real review. Security-advisory updates are unchanged — already on via the repo-level Dependabot setting, independent of this file.

- **`.github/workflows/actionlint.yml`** — `actionlint` v1.7.1, runs on any PR touching `.github/workflows/**` and on pushes to master touching the same paths. Statically catches the workflow-YAML bugs we've been hitting at fire time (wrong interpolation shape, missing `needs:`, shell-quoting). Not gated in branch protection on this PR — run it for a cycle first, then promote to required if clean.

Completes the "settings + automation hardening" pass started in #116.

## Test plan

- [ ] CI green (build 18/20/22 + validate-package-json + analyze + the new actionlint self-check).
- [ ] actionlint runs cleanly over the existing workflow set (cc-drift-watch, cc-drift-auto-release, ci, codeql, publish, stale). If it flags anything, fix in this PR before merging so the first green run is clean.
- [ ] First Dependabot run lands Monday 09:00 UTC. `workflow_dispatch` isn't exposed for Dependabot specifically, but it'll pick up new PRs automatically once the config is on master.