### PR TITLE
ci: fix actionlint's first-run findings (script-injection risk)

### DIFF
--- a/.github/workflows/cc-drift-auto-release.yml
+++ b/.github/workflows/cc-drift-auto-release.yml
@@ -116,8 +116,16 @@ jobs:
         # issue close` on a closed issue is a no-op that exits 0.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pass head.ref via env rather than inline ${{ }} interpolation —
+          # the branch name is attacker-controlled and inline substitution
+          # at shell-parse time would allow script injection via a PR
+          # branch named e.g. `bot/cc-drift-v1.0.0$(malicious)`. The
+          # top-level `if:` on this workflow restricts to bot/cc-drift-*
+          # by prefix, but `startsWith()` doesn't reject trailing shell
+          # metacharacters.
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          BRANCH="${{ github.event.pull_request.head.ref }}"
+          BRANCH="$PR_HEAD_REF"
           # Strip the `bot/cc-drift-v` prefix to get the bare CC
           # version string. Guard against unexpected branch shapes
           # (this step only runs when the top-level `if` matched
@@ -142,8 +150,12 @@ jobs:
           done
 
       - name: Post-release summary
+        env:
+          # head.ref via env: see rationale on the Close step above. Same
+          # attacker-controlled-branch-name class of injection.
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           echo "✓ Released v${{ steps.ver.outputs.version }}"
-          echo "✓ Triggered by PR #${{ github.event.pull_request.number }} (head: ${{ github.event.pull_request.head.ref }})"
+          echo "✓ Triggered by PR #${{ github.event.pull_request.number }} (head: $PR_HEAD_REF)"
           echo "→ publish.yml will pick this up and publish to npm"
           echo "→ cc-drift issues for this CC version have been closed"

--- a/.github/workflows/cc-drift-watch.yml
+++ b/.github/workflows/cc-drift-watch.yml
@@ -89,7 +89,7 @@ jobs:
             # Write the sentinel so the cache action saves this version
             # as "seen" at job end. The mark is per-version (key) not
             # per-run — same version across hours = cache hit.
-            mkdir -p $(dirname .cc-version-sentinel)
+            mkdir -p "$(dirname .cc-version-sentinel)"
             touch .cc-version-sentinel
             echo "should_run=true" >> "$GITHUB_OUTPUT"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Two additions to the CI hygiene layer, orthogonal to any runtime change:
 
 2. **`.github/workflows/actionlint.yml`** — `actionlint` v1.7.1 runs on any PR that touches `.github/workflows/**` and on pushes to master touching the same paths. Statically catches the class of workflow-YAML bugs we've hit at fire time (wrong interpolation shape, bad `needs:` refs, shell-quoting, etc.). Not required for merge yet; promote to a required status check after one cycle of verifying no false positives on the existing workflow set.
 
+First-run findings, fixed in this PR: **script-injection risk** via inline `${{ github.event.pull_request.head.ref }}` interpolation in two `cc-drift-auto-release.yml` steps (a PR branch named `bot/cc-drift-v1.0.0$(…)` would have passed the `startsWith()` guard and parsed at shell-eval time), plus one unquoted `$(dirname …)` in `cc-drift-watch.yml`'s version gate. The branch-name injection was introduced in #116 and caught within the hour — exactly the motivating case for adding this check.
+
 ### CI — operational hygiene: auto-close cc-drift issues, OAuth issue template, stale bot
 
 Three small additions that tighten how the repo handles its own lifecycle, orthogonal to the release / drift loop itself:


### PR DESCRIPTION
## Summary

#117 landed the `actionlint` workflow, and its first run immediately flagged three real findings. One is a security issue in the `cc-drift-auto-release.yml` step added in #116:

1. **Script injection via PR branch name** (`cc-drift-auto-release.yml:120`) — the new \"Close matching cc-drift issues\" step interpolated `github.event.pull_request.head.ref` inline into a shell script. The workflow's top-level `if:` uses `startsWith('bot/cc-drift-')` which doesn't reject trailing shell metacharacters, so a PR branch named e.g. `bot/cc-drift-v1.0.0\$(malicious)` would parse at shell-eval time and execute the injected command with the `GITHUB_TOKEN`'s `issues: write` + `contents: write` perms. **Fix:** pass `head.ref` via the step's `env:` block so the shell reads it at runtime, not parse time.

2. **Same class, pre-existing** (`cc-drift-auto-release.yml:147`) — the Post-release summary step did the same inline interpolation. Predates #116. Same fix.

3. **SC2046 word-splitting** (`cc-drift-watch.yml:92`) — unquoted `\$(dirname .cc-version-sentinel)`. Benign (static path → always `.`), but fix for correctness.

#116 (the change that introduced the injection) merged ~30 minutes before this PR; actionlint caught it on the very next PR — exactly the motivating case for adding the check. Strong argument for promoting actionlint to a required status check after this PR lands.

## Test plan

- [ ] actionlint CI green on this PR (if it still reports the same findings, the env-var rewrite didn't land correctly).
- [ ] Next drift-bot PR merge exercises the fixed `cc-drift-auto-release.yml` — verify the Close-cc-drift-issues + Post-release summary steps still run and the release still tags + publishes.