### PR TITLE
ci: pin actions/cache@v5 to SHA (drift-watch policy failure)

### DIFF
--- a/.github/workflows/cc-drift-watch.yml
+++ b/.github/workflows/cc-drift-watch.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Cache sentinel (keyed on CC version)
         id: version_cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           # The path is a tiny marker file; only its presence matters.
           # The cache KEY is what gates: if we've ever saved a cache


### PR DESCRIPTION
## Summary

The hourly CC drift watcher has been failing since #123 merged — Dependabot's v4→v5 bump kept the unpinned \`@v5\` tag, which trips this repo's "all actions pinned to full-length commit SHA" enforcement:

\`\`\`
##[error]The action actions/cache@v5 is not allowed in askalf/dario
because all actions must be pinned to a full-length commit SHA.
\`\`\`

Last two scheduled runs both failed at 6s on "Prepare all required actions" (https://github.com/askalf/dario/actions/runs/24858388395, 24853967806). Only one file affected — the cache step in \`cc-drift-watch.yml\`. Pinning to \`27d5ce7f107fe9357f9df03efb73ab90386fccae\` (current v5 tag target).

### Why Dependabot missed the pin

Dependabot preserves whatever ref style it sees. \`@v4\` (unpinned) was already in master pre-#123 — this bump was only one character shy of clean. Worth a follow-up issue or CODEOWNERS rule to standardize, but out of scope here.

## Test plan

- [ ] actionlint green.
- [ ] Manually trigger the workflow (\`gh workflow run "CC drift watch"\`) post-merge and confirm it reaches the \`check\` job, not the "Prepare all required actions" error.