### PR TITLE
ci: auto-release publishes to npm inline (GITHUB_TOKEN downstream-workflow gap)

### DIFF
--- a/.github/workflows/cc-drift-auto-release.yml
+++ b/.github/workflows/cc-drift-auto-release.yml
@@ -3,21 +3,36 @@ name: Auto release on version bump
 # Fires on merge of ANY PR to master. Exits early unless package.json's
 # `version` field differs from the parent commit's — so PRs that don't
 # touch version are cheap no-ops (~10s). When the version did change,
-# creates the matching `vX.Y.Z` tag + GitHub release from the CHANGELOG
-# section for that version. publish.yml then fires on `release:published`
-# and runs `npm publish --access public --provenance`.
+# this workflow:
+#   1. Builds + smoke-tests the package.
+#   2. Creates the matching `vX.Y.Z` tag + GitHub release (CHANGELOG
+#      section extracted as release notes).
+#   3. Runs `npm publish --access public --provenance` inline.
+#
+# Why inline-publish rather than relying on publish.yml's `release:
+# published` trigger: GitHub intentionally doesn't fire downstream
+# workflows for events created by GITHUB_TOKEN (loop protection), so
+# `gh release create` here would create the release but NOT kick
+# publish.yml. Hit exactly this on deepdive v0.3.0 — required a manual
+# delete+recreate of the release. Inlining means the chain is a single
+# workflow run. See deepdive#18 for the context.
+#
+# publish.yml stays in place for the *manual* release case — a
+# maintainer running `gh release create` locally does trigger
+# release:published (since that release isn't from GITHUB_TOKEN), so
+# ad-hoc releases flow through publish.yml as before.
 #
 # Filename retains `cc-drift-` prefix for git-blame continuity with the
-# originally-named workflow; the scope generalized on 2026-04-23 after
-# v3.31.8–3.31.11 landed on master without reaching npm (the previous
-# `startsWith('bot/cc-drift-')` gate meant manual feature PRs never
-# triggered release). See v3.31.11 release notes.
+# originally-named workflow; the scope was generalized on 2026-04-23
+# after v3.31.8–3.31.11 landed on master without reaching npm (see
+# v3.31.11 release notes).
 #
-# End-to-end loops now covered:
+# End-to-end loops covered:
 # - CC drift bot: auto-drafter opens `bot/cc-drift-v<X>` PR → maintainer
-#   merges → this fires → release + npm + close matching drift issues.
+#   merges → this fires → build + release + npm publish + close matching
+#   drift issues.
 # - Manual feature PR with version bump: maintainer merges → this fires
-#   → release + npm. No issue-close step (nothing bot-tracked to close).
+#   → build + release + npm publish. No issue-close step.
 # - Any merge without version change: this fires, exits in seconds.
 
 on:
@@ -27,11 +42,12 @@ on:
 
 permissions:
   contents: write
+  # id-token: write required for `npm publish --provenance` SLSA
+  # attestation.
+  id-token: write
   # `issues: write` is required for the post-release cleanup step that
   # closes any open `cc-drift` issues matching the CC version just
-  # shipped. The nightly watcher opens those issues on drift detect;
-  # this workflow closes them on release so the issue tracker stays
-  # quiet when the loop completes cleanly.
+  # shipped.
   issues: write
 
 jobs:
@@ -84,6 +100,32 @@ jobs:
             exit 1
           fi
 
+      # ─── Build + smoke pipeline (mirrors publish.yml) ──────────────
+      # We do this BEFORE cutting the GitHub release, so a failing
+      # build/smoke aborts everything — no release, no npm publish, no
+      # half-shipped state.
+
+      - name: Set up Node
+        if: steps.ver.outputs.changed == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: npm ci
+        if: steps.ver.outputs.changed == 'true'
+        run: npm ci
+
+      - name: build
+        if: steps.ver.outputs.changed == 'true'
+        run: npm run build
+
+      - name: --help smoke
+        if: steps.ver.outputs.changed == 'true'
+        run: node dist/cli.js help
+
+      # ─── Release + publish ─────────────────────────────────────────
+
       - name: Extract release notes from CHANGELOG
         id: notes
         if: steps.ver.outputs.changed == 'true'
@@ -117,12 +159,18 @@ jobs:
             echo ""
             echo "---"
             echo ""
-            echo "Triggered by auto-release workflow on merge of a PR that bumped \`package.json\` version. Publishing to npm handled by \`publish.yml\` on this release's \`published\` event."
+            echo "Built + tested + npm-published inline by \`cc-drift-auto-release.yml\` on this run. See the workflow log for the provenance-attested publish output."
           } > body.md
 
           gh release create "$TAG" \
             --title "$TAG" \
             --notes-file body.md
+
+      - name: npm publish
+        if: steps.ver.outputs.changed == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance
 
       - name: Close matching cc-drift issues
         if: |
@@ -182,7 +230,7 @@ jobs:
         run: |
           echo "✓ Released v${{ steps.ver.outputs.version }}"
           echo "✓ Triggered by PR #${{ github.event.pull_request.number }} (head: $PR_HEAD_REF)"
-          echo "→ publish.yml will pick this up and publish to npm"
+          echo "✓ Published to npm (with SLSA provenance)"
           if [[ "$PR_HEAD_REF" == bot/cc-drift-v* ]]; then
             echo "→ matching cc-drift issues were closed"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ checklist.
 
 ## [Unreleased]
 
+### CI — auto-release publishes to npm inline (GITHUB_TOKEN can't fire downstream)
+
+Same class of bug that deepdive just hit with v0.3.0 and that would have bitten dario on the first bot-drift PR merge that exercised the generalized `cc-drift-auto-release.yml` (PR #127): `gh release create` uses `GITHUB_TOKEN`, and GitHub intentionally doesn't fire workflows for events created by `GITHUB_TOKEN` (loop protection). So the `release:published` trigger on `publish.yml` never fires from an auto-created release, and the package doesn't ship.
+
+Worked on dario so far only because every release to date was a manual `gh release create` by the maintainer (human-token events do trigger downstream workflows). The automated path was latent and untested.
+
+Fix mirrors deepdive: inline the build + smoke + `npm publish` steps into `cc-drift-auto-release.yml` itself. Chain is now a single run: PR merge → build → smoke → `gh release create` → `npm publish --access public --provenance`. `publish.yml` stays in place for the manual-release case. Added `id-token: write` to the workflow permissions for SLSA provenance.
+
+Next drift-bot PR merge (or any manually-merged version bump) will exercise the full chain without a maintainer touchpoint.
+
 ### CI — auto-release triggers on any version bump, not just bot PRs
 
 Root-cause fix for the v3.31.8–v3.31.11 release gap: four manually-merged feature PRs bumped `package.json` version but never reached npm, because `cc-drift-auto-release.yml`'s trigger was gated on `startsWith(head.ref, 'bot/cc-drift-')`. Manual PRs missed the release pipeline entirely; the CHANGELOG claimed those versions existed, npm disagreed.


### PR DESCRIPTION
## Summary

Mirrors the fix just shipped to deepdive (askalf/deepdive#18). Dario's \`cc-drift-auto-release.yml\` had the same latent bug — would have bitten the first bot-drift PR merge that exercised the generalized version-bump path (added in #127 today).

## The bug

\`gh release create\` runs under \`GITHUB_TOKEN\`, and GitHub [intentionally doesn't fire downstream workflows for GITHUB_TOKEN-created events](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) (loop protection). So \`publish.yml\`'s \`release:published\` trigger **never fires** for an auto-release. The release exists on GitHub but the package never reaches npm.

## Why this didn't show on dario before

Every dario release to date (v3.31.2–v3.31.7 and the v3.31.11 bundle I cut this afternoon) was a **manual** \`gh release create\` from my own shell. Manual releases use a human PAT, which IS attributable to the user and DOES fire downstream workflows. The automated path that #127 enabled was latent until exercised.

Deepdive's v0.3.0 release just hit it — auto-release created the tag+release but publish.yml didn't fire. Had to delete+recreate from my shell to kick publish. That caught the bug for the whole class of repos.

## Fix (mirrors deepdive)

- Inline the build + smoke + \`npm publish\` steps into \`cc-drift-auto-release.yml\`. Single workflow run does everything — no inter-workflow trigger needed.
- Added \`id-token: write\` to the workflow permissions (required for \`npm publish --provenance\` SLSA attestation).
- \`publish.yml\` stays in place for the *manual* release case (\`gh release create\` from maintainer shell still fires it cleanly).

## Chain before / after

**Before (broken for automated path):**
\`\`\`
bot-drift PR merge → cc-drift-auto-release.yml → gh release create → [chain breaks]
                    (GITHUB_TOKEN release event doesn't fire publish.yml)
\`\`\`

**After:**
\`\`\`
bot-drift PR merge → cc-drift-auto-release.yml → build + smoke →
                    gh release create → npm publish --access public --provenance
                    [→ close matching cc-drift issues]
\`\`\`

Single run, single token context.

## Test plan

- [ ] actionlint green.
- [ ] This PR doesn't bump \`package.json.version\`, so the workflow's version-changed gate short-circuits on merge — no release cut, no publish attempt. Verify in the Actions log.
- [ ] Next actual version bump merge (bot or manual) exercises the full chain end-to-end. If it ships to npm without a delete+recreate, fix confirmed.