### PR TITLE
v3.31.12 — fix dario accounts add OAuth state-length reject (dario#71)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,24 +1,21 @@
 name: actionlint
 
 # Validates GitHub Actions workflow YAML against actionlint's rule set.
-# We've hit YAML bugs in review that only surfaced at workflow-fire time
-# (wrong string interpolation shape, missing `needs:`, misnamed event
-# triggers); actionlint catches those statically at PR time.
+# Catches interpolation/quoting bugs, bad `needs:` refs, shell-quoting,
+# and untrusted-input-in-run-script injection patterns.
 #
-# Not gated in branch protection yet — run it for a few drift cycles to
-# verify it doesn't trip false positives on our existing workflows, then
-# promote to a required check if clean.
+# Runs on every PR + every push to master, no path filter. `actionlint`
+# is a required status check in branch protection (added 2026-04-23).
+# Path-filtered required checks can never report on PRs that don't touch
+# the filtered paths, which leaves merges permanently blocked — found
+# this in practice when PR #130 (src-only) hit indefinite BLOCK state.
+# Same fix already in place on claude-bridge + deepdive. 30s of CI per
+# unrelated PR is cheaper than the footgun.
 
 on:
   pull_request:
-    paths:
-      - '.github/workflows/**'
-      - '.github/actionlint.yaml'
   push:
     branches: [master]
-    paths:
-      - '.github/workflows/**'
-      - '.github/actionlint.yaml'
   workflow_dispatch: {}
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ checklist.
 
 ## [3.31.12] - 2026-04-24
 
+### CI — actionlint runs on every PR (no path filter)
+
+Drops the `paths:` filter from `actionlint.yml`'s triggers. `actionlint` is in master's required-status-checks list; path-filtered required checks can never report on PRs outside the filter — they sit as permanently-pending and block merge. Caught in practice on PR #130 (src-only OAuth fix) which went to indefinite BLOCK until this was fixed on the branch. Same fix shipped earlier on claude-bridge + deepdive; dario kept the old path-filter until now.
+
 ### Fixed — `dario accounts add` "Invalid request format" (dario#71)
 
 Anthropic's `claude.ai/oauth/authorize` endpoint started rejecting OAuth `state` parameters shorter than what CC generates. Dario shipped `base64url(randomBytes(16))` = 22 chars; CC v2.1.116+ ships `base64url(randomBytes(32))` = 43 chars. Same `client_id`, same scopes, same PKCE, same `redirect_uri`, same parameter order — the only delta between a working CC `/login` URL and a rejected dario URL was `state` length. RFC 6749 only requires `state` to be "non-guessable" and 128 bits of entropy (16 bytes) IS non-guessable, so shorter is spec-compliant, but Anthropic got stricter than spec here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@ checklist.
 
 ### Fixed — `dario accounts add` "Invalid request format" (dario#71)
 
-Anthropic's `claude.ai/oauth/authorize` endpoint started rejecting OAuth state parameters shorter than what CC generates. Dario generated state as `base64url(randomBytes(16))` (22 chars); CC v2.1.116+ generates it as `base64url(randomBytes(32))` (43 chars). Same `client_id`, same scopes, same PKCE, same redirect_uri — only delta between a working CC `/login` URL and a rejected dario URL was state length. RFC 6749 only requires state to be "non-guessable" so shorter is technically spec-compliant, but Anthropic's stricter than spec here.
+Anthropic's `claude.ai/oauth/authorize` endpoint started rejecting OAuth `state` parameters shorter than what CC generates. Dario shipped `base64url(randomBytes(16))` = 22 chars; CC v2.1.116+ ships `base64url(randomBytes(32))` = 43 chars. Same `client_id`, same scopes, same PKCE, same `redirect_uri`, same parameter order — the only delta between a working CC `/login` URL and a rejected dario URL was `state` length. RFC 6749 only requires `state` to be "non-guessable" and 128 bits of entropy (16 bytes) IS non-guessable, so shorter is spec-compliant, but Anthropic got stricter than spec here.
 
-One-line fix in `src/accounts.ts`: `randomBytes(16)` → `randomBytes(32)`. Keep in lockstep with CC's entropy-per-state. Diagnosed via live diff of two byte-identical-except-for-state URLs (ours rejected, CC's accepted).
+One-line fix in `src/accounts.ts`: `randomBytes(16)` → `randomBytes(32)`. Kept in lockstep with CC's entropy-per-state.
 
-Thanks to [@tetsuco](https://github.com/tetsuco) for the patient back-and-forth — v3.31.3 (URL normalization) and v3.31.4 (6-scope restore) both turned out to be correct on their own but insufficient; neither reproduced the failure on our side until we ran `dario accounts add` ourselves against the live endpoint and captured the exact URL.
+Why this took three tries to close. v3.31.3 (URL normalizer) and v3.31.4 (6-scope restore) were both real drift items — dario was separately wrong on those — but neither was *this* issue's root cause. Each fix was driven by code review + tetsuco's captured data, but the URL samples shared had `state=xxx` redacted (correctly — state is random per-flow, sharing looks safe to redact), so the length delta was invisible across the first two rounds. It only surfaced once we ran `dario accounts add` end-to-end on a fresh account on our side and compared an unredacted live URL against CC's `/login` URL. Moral: for OAuth flow bugs like this, redacting `state`/`code_challenge` hides the very delta that diagnoses the break. Running the flow ourselves was the intervention that mattered.
+
+Thanks to [@tetsuco](https://github.com/tetsuco) for the patience through three release rounds and for suggesting we reproduce locally on the last round — that's what turned this from guess-and-ship to a one-line certain fix.
 
 ### CI — auto-release publishes to npm inline (GITHUB_TOKEN can't fire downstream)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ checklist.
 
 ## [Unreleased]
 
+## [3.31.12] - 2026-04-24
+
+### Fixed — `dario accounts add` "Invalid request format" (dario#71)
+
+Anthropic's `claude.ai/oauth/authorize` endpoint started rejecting OAuth state parameters shorter than what CC generates. Dario generated state as `base64url(randomBytes(16))` (22 chars); CC v2.1.116+ generates it as `base64url(randomBytes(32))` (43 chars). Same `client_id`, same scopes, same PKCE, same redirect_uri — only delta between a working CC `/login` URL and a rejected dario URL was state length. RFC 6749 only requires state to be "non-guessable" so shorter is technically spec-compliant, but Anthropic's stricter than spec here.
+
+One-line fix in `src/accounts.ts`: `randomBytes(16)` → `randomBytes(32)`. Keep in lockstep with CC's entropy-per-state. Diagnosed via live diff of two byte-identical-except-for-state URLs (ours rejected, CC's accepted).
+
+Thanks to [@tetsuco](https://github.com/tetsuco) for the patient back-and-forth — v3.31.3 (URL normalization) and v3.31.4 (6-scope restore) both turned out to be correct on their own but insufficient; neither reproduced the failure on our side until we ran `dario accounts add` ourselves against the live endpoint and captured the exact URL.
+
 ### CI — auto-release publishes to npm inline (GITHUB_TOKEN can't fire downstream)
 
 Same class of bug that deepdive just hit with v0.3.0 and that would have bitten dario on the first bot-drift PR merge that exercised the generalized `cc-drift-auto-release.yml` (PR #127): `gh release create` uses `GITHUB_TOKEN`, and GitHub intentionally doesn't fire workflows for events created by `GITHUB_TOKEN` (loop protection). So the `release:published` trigger on `publish.yml` never fires from an auto-created release, and the package doesn't ship.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.31.11",
+  "version": "3.31.12",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -215,7 +215,14 @@ function openBrowser(url: string): void {
 export async function addAccountViaOAuth(alias: string): Promise<AccountCredentials> {
   const cfg = await detectCCOAuthConfig();
   const { codeVerifier, codeChallenge } = generatePKCE();
-  const state = base64url(randomBytes(16));
+  // 32 random bytes → 43-char base64url state. Matches what CC v2.1.116+
+  // ships in `/login` URLs; Anthropic's `/oauth/authorize` endpoint started
+  // rejecting shorter states with "Invalid request format" on 2026-04-23
+  // (dario#71 repro: URL was byte-equivalent to CC's except state was
+  // 22 chars → reject, 43 chars → accept). RFC 6749 only requires
+  // "non-guessable," so shorter is technically legal — Anthropic's stricter
+  // than spec here. Keep in lockstep with CC's bytes-per-random.
+  const state = base64url(randomBytes(32));
 
   return new Promise<AccountCredentials>((resolve, reject) => {
     let port = 0;


### PR DESCRIPTION
## Summary

Fixes [dario#71](https://github.com/askalf/dario/issues/71). Three release rounds on this issue (v3.31.3 URL normalizer, v3.31.4 6-scope restore, then this one) — the first two addressed real drift items but neither was this specific break. Running `dario accounts add` on a fresh account on our side and byte-diffing the live URL against CC's `/login` URL finally exposed the actual cause: **Anthropic's authorize endpoint rejects OAuth `state` parameters shorter than what CC generates**.

## Diagnosis

Captured both URLs during local reproduction on v3.31.11:

**Dario v3.31.11:**
```
...&state=VATV8l_jVr_0QJ33czZoDw
```
state = 22 chars (16 random bytes, base64url)

**CC v2.1.119 /login:**
```
...&state=Ill2Kt5PP3as-DZ360PPuEWv-aJwalRaLD6PLBwHnkU
```
state = 43 chars (32 random bytes, base64url)

Byte-equivalent URLs in every other param (client_id, authorize URL, scope list, redirect_uri, PKCE challenge, method). Only delta: `state` length.

This didn't surface from tetsuco's earlier URL samples because `state=xxx` was redacted (correctly — it's a random per-flow nonce, looks sensible to redact). The redaction hid the very delta that diagnoses the failure. Lesson: when debugging OAuth authorize errors, don't redact `state` or `code_challenge` in diagnostics — they're one-shot and the length format is informative.

## The mechanism

Dario: `base64url(randomBytes(16))` → 22 chars
CC v2.1.116+: `base64url(randomBytes(32))` → 43 chars

RFC 6749 only requires state to be "non-guessable" and 128 bits of entropy (16 bytes) IS non-guessable — so dario was spec-compliant. Anthropic got stricter than spec at some point, likely to match their own CC generator's exact format.

## Fix

One-line change in `src/accounts.ts`:

```ts
-  const state = base64url(randomBytes(16));
+  const state = base64url(randomBytes(32));
```

Plus a comment anchoring the reason + the live-repro evidence.

## Release

Bumps `package.json` to `3.31.12`. On merge, the auto-release workflow (fixed this afternoon to publish inline after the GITHUB_TOKEN gap bit deepdive) cuts the release and ships to npm end-to-end. **First production exercise of the inline-publish path on dario.**

## Test plan

- [ ] Local build green.
- [ ] After merge: `@askalf/dario@3.31.12` on npm within ~3 minutes of merge (single auto-release.yml run).
- [ ] `npm install -g @askalf/dario@3.31.12 && dario accounts add bar3` on my machine → consent page (not "Invalid request format").
- [ ] Close dario#71 with an upgrade instruction + diagnosis note matching tetsuco's own closure style on dario#97.