### PR TITLE
feat(accounts): back-fill `dario login` creds into pool on first `accounts add`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ checklist.
 
 ## [Unreleased]
 
+### Fixed — `dario accounts add` now back-fills the `dario login` account into the pool (dario#71 follow-up)
+
+Pool mode activation threshold is "2+ accounts in `~/.dario/accounts/`". Single-account `dario login` credentials live separately at `~/.dario/credentials.json` (plus the CC file + OS keychain fallbacks in `oauth.ts`) and were never migrated into the pool. Practical consequence: a user running `dario login` then `dario accounts add bar` ended up with one account in `accounts/` (`bar`), still-below-threshold, pool mode off, and the original login account orphaned from the pool until they figured out they had to re-`accounts add` it under a second alias. Surfaced by [@tetsuco](https://github.com/askalf/dario/issues/71) at the end of the #71 thread.
+
+New helper `ensureLoginCredentialsInPool(alias = 'login')` in `src/accounts.ts`:
+
+- No-op when `accounts/` is non-empty (idempotent — won't stomp existing pool state).
+- No-op when no credentials are reachable anywhere (`loadCredentials()` covers `~/.dario/credentials.json`, `~/.claude/.credentials.json`, and the OS keychain).
+- Otherwise, writes `accounts/<alias>.json` with the tokens + scopes from the credentials file and identity (`deviceId` / `accountUuid`) from `detectClaudeIdentity()` — the same source single-account mode already uses, so the migrated account's wire-identity matches what `dario login` was sending.
+- Never destructive. `credentials.json` (if present) is left untouched, so if the user later drops below the 2+ threshold via `dario accounts remove`, single-account mode falls back to it cleanly.
+
+Wired into the CLI on the first `dario accounts add`: runs the back-fill (with user-visible message) before kicking off the OAuth flow for the new alias, so the second `add` actually trips the 2+ threshold on its own. Skipped when the user explicitly picks `login` as their `add` alias — their intent wins, no silent alias swap.
+
+No routing changes. The pool's `add()` accepts the migrated `PoolAccount` entry as a first-class member — weighted headroom routing, session stickiness, in-flight 429 failover, and per-account background refresh all key off `Map<alias, PoolAccount>` without caring about provenance.
+
+17 new assertions in `test/ensure-login-in-pool.mjs` covering: no-creds null path, happy-path migration (token + scope + identity shape), idempotency on re-call, skip when accounts/ is pre-populated, and safe-alias rejection on traversal input. Isolation via HOME/USERPROFILE temp-dir override so the test never touches the real user's `~/.dario`. 49 tests total (up from 48).
+
 ## [3.31.13] - 2026-04-24
 
 ### Template — re-captured against live CC v2.1.119 (dario#129)

--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ dario accounts list
 dario proxy
 ```
 
+If you already have a single-account `dario login` set up and run `dario accounts add <alias>` for the first time, dario **back-fills** your existing login credentials into the pool under the reserved alias `login` before running OAuth for the new alias. Net effect: your first `accounts add` gives you two pool accounts (login + new alias), pool mode activates immediately. Back-fill is one-shot, idempotent, and never touches your existing `credentials.json` — if you later `dario accounts remove` below the 2+ threshold, single-account mode reads it unchanged. Skipped if you explicitly pick `login` as the new alias — your intent wins.
+
 Each request picks the account with the highest headroom:
 
 ```

--- a/README.md
+++ b/README.md
@@ -762,6 +762,17 @@ Yes — anything that speaks the OpenAI Chat Completions API. Groq, OpenRouter, 
 **Something's wrong. Where do I start?**
 `dario doctor`. One command, one aggregated report — dario version, Node, platform, runtime/TLS classification, CC binary compat, template source + age + drift, OAuth status, pool state, backends, sub-agent install state, home dir. Exit code 1 if any check fails. Paste the output when you file an issue. (If you're inside Claude Code, `dario subagent install` once and then ask CC to "use the dario sub-agent to run doctor" — same output, no context switch.)
 
+**OpenClaw returns 401 after I set `DARIO_API_KEY` (or upgrade past v3.30.6).**
+If you run `dario proxy --host=0.0.0.0` (non-loopback), dario requires `DARIO_API_KEY` to be set so it's not an open subscription relay. OpenClaw 2026.2.17+ prefers `~/.openclaw/agents/main/agent/auth-profiles.json` over `openclaw.json`'s `apiKey` field or the `ANTHROPIC_API_KEY` env var — so if you have a stale Anthropic token in `auth-profiles.json` from an earlier setup, OpenClaw sends *that* token instead of `dario`, and dario rejects the request with `Authorization present but value mismatch` (visible under `dario proxy -v`, added in v3.31.2).
+
+Three fixes, in order of simplicity:
+
+1. **Use loopback.** `dario proxy --host=127.0.0.1` — auth only enforced on non-loopback binds, no `DARIO_API_KEY` required, no OpenClaw changes. Best if you don't actually need LAN reach to dario.
+2. **Delete the Anthropic auth profile.** Remove the `"anthropic:default"` entry from `~/.openclaw/agents/main/agent/auth-profiles.json`. OpenClaw then falls back through the config chain and picks up `ANTHROPIC_API_KEY=dario` from the env. Confirmed working by [@tetsuco in #97](https://github.com/askalf/dario/issues/97).
+3. **Overwrite the auth profile.** `openclaw models auth paste-token --provider anthropic` and paste `dario`. Replaces whatever key was in there — keep a backup if you use it elsewhere.
+
+Diagnose with `dario proxy -v` — the reject log (v3.31.2+) reports header-name only (never the value, since it may be a real credential you mistyped) and tells you which of the three configs is actually being hit.
+
 **What happens when Anthropic rotates the OAuth config?**
 Dario auto-detects OAuth config from the installed Claude Code binary. When CC ships a new version with rotated values, dario picks them up on the next run. Cache at `~/.dario/cc-oauth-cache-v6.json`, keyed by the CC binary fingerprint. The cache path version bumps each time the canonical OAuth config shape changes so stale caches regenerate automatically on upgrade — v3 → v4 in v3.19.4 (scope-list flip CC v2.1.104 → v2.1.107), v4 → v5 in v3.31.3 (authorize URL `claude.com/cai/` → `claude.ai/` host normalization), v5 → v6 in v3.31.4 (6-scope restore after CC v2.1.116).
 

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -2,10 +2,15 @@
  * Multi-account credential storage.
  *
  * Accounts live at `~/.dario/accounts/<alias>.json`. Single-account dario
- * still uses `~/.dario/credentials.json` and does not touch this module.
- * When `~/.dario/accounts/` contains 2+ files the proxy activates pool mode
- * (see pool.ts). Each account has its own independent OAuth lifecycle and
- * can refresh without affecting the others.
+ * uses `~/.dario/credentials.json` (plus the CC file + OS keychain fallback
+ * paths in oauth.ts). When `~/.dario/accounts/` contains 2+ files the proxy
+ * activates pool mode (see pool.ts). Each account has its own independent
+ * OAuth lifecycle and can refresh without affecting the others.
+ *
+ * `ensureLoginCredentialsInPool` (below) bridges the two stores on the
+ * first `dario accounts add` — it promotes the user's existing login
+ * credentials into the pool under a reserved alias so that adding a
+ * second account actually trips the 2+ threshold and activates pooling.
  *
  * OAuth config (client_id, scopes, authorize URL, token URL) comes from
  * dario's cc-oauth-detect scanner — the same source the single-account
@@ -17,6 +22,7 @@ import { homedir } from 'node:os';
 import { randomUUID, randomBytes, createHash } from 'node:crypto';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { detectCCOAuthConfig } from './cc-oauth-detect.js';
+import { loadCredentials } from './oauth.js';
 
 const DARIO_DIR = join(homedir(), '.dario');
 const ACCOUNTS_DIR = join(DARIO_DIR, 'accounts');
@@ -350,4 +356,68 @@ export async function addAccountViaOAuth(alias: string): Promise<AccountCredenti
 
 export function getAccountsDir(): string {
   return ACCOUNTS_DIR;
+}
+
+/**
+ * Alias reserved for credentials auto-migrated from the single-account
+ * `dario login` store. Named `login` so it's semantically obvious where
+ * the entry came from and unlikely to collide with user-chosen aliases
+ * like `work`, `personal`, etc. If a user specifically requests `login`
+ * as the alias for `dario accounts add`, the caller falls back to
+ * `default` so the migration doesn't step on the user's intent.
+ */
+export const MIGRATED_LOGIN_ALIAS = 'login';
+
+/**
+ * Promote the user's existing single-account `dario login` credentials
+ * (`~/.dario/credentials.json`, `~/.claude/.credentials.json`, or OS
+ * keychain — whichever `loadCredentials` finds) into the pool under a
+ * reserved alias.
+ *
+ * Why: the pool activation threshold is 2+ accounts in `~/.dario/accounts/`.
+ * A user with one `dario login` account + one `dario accounts add bar`
+ * ends up with only one account in `accounts/` (bar), pool mode never
+ * trips, and the login account is effectively orphaned while pool is off.
+ * Calling this on the first `dario accounts add` back-fills the login
+ * account into the pool so the second `add` crosses the threshold.
+ *
+ * Idempotent: no-op if `accounts/` already has any entry, no-op if no
+ * credentials are reachable anywhere. Returns the alias written to, or
+ * `null` when nothing happened.
+ *
+ * The source `credentials.json` (if present) is left untouched — single-
+ * account mode still reads it if the user later `accounts remove`s down
+ * below the pool threshold. Migration is copy-only, never destructive.
+ *
+ * @param preferredAlias caller may request a specific alias. If it's
+ *   already the reserved `login` (or collides), falls back to `default`.
+ */
+export async function ensureLoginCredentialsInPool(
+  alias: string = MIGRATED_LOGIN_ALIAS,
+): Promise<string | null> {
+  if (!safeAliasPath(alias)) return null;
+
+  const existing = await listAccountAliases();
+  if (existing.length > 0) return null;
+
+  const creds = await loadCredentials();
+  const tok = creds?.claudeAiOauth;
+  if (!tok?.accessToken || !tok?.refreshToken) return null;
+
+  const identity = (await detectClaudeIdentity()) ?? {
+    deviceId: randomUUID(),
+    accountUuid: randomUUID(),
+  };
+
+  await saveAccount({
+    alias,
+    accessToken: tok.accessToken,
+    refreshToken: tok.refreshToken,
+    expiresAt: tok.expiresAt,
+    scopes: tok.scopes ?? [],
+    deviceId: identity.deviceId,
+    accountUuid: identity.accountUuid,
+  });
+
+  return alias;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,7 +39,7 @@ import { homedir } from 'node:os';
 import { startAutoOAuthFlow, startManualOAuthFlow, detectHeadlessEnvironment, getStatus, refreshTokens, loadCredentials } from './oauth.js';
 import { startProxy, sanitizeError } from './proxy.js';
 import { VALID_EFFORT_VALUES, type EffortValue } from './cc-template.js';
-import { listAccountAliases, loadAllAccounts, addAccountViaOAuth, removeAccount } from './accounts.js';
+import { listAccountAliases, loadAllAccounts, addAccountViaOAuth, removeAccount, ensureLoginCredentialsInPool, MIGRATED_LOGIN_ALIAS } from './accounts.js';
 import { listBackends, saveBackend, removeBackend, type BackendCredentials } from './openai-backend.js';
 
 const args = process.argv.slice(2);
@@ -481,6 +481,24 @@ async function accounts() {
       console.error(`[dario] Account "${alias}" already exists. Remove it first with \`dario accounts remove ${alias}\`.`);
       process.exit(1);
     }
+
+    // If the user has `dario login` credentials on disk or in the keychain
+    // and the pool is empty, migrate those credentials into the pool first.
+    // Otherwise the new account lives alone in accounts/, pool mode never
+    // trips the 2+ threshold, and the login account is orphaned from the
+    // pool until the user figures out they have to re-`accounts add` it.
+    // Skip silently when the user explicitly picks the reserved alias —
+    // their intent wins, they can run `accounts add` again for the login
+    // migration under a different alias.
+    if (existing.length === 0 && alias !== MIGRATED_LOGIN_ALIAS) {
+      const migrated = await ensureLoginCredentialsInPool();
+      if (migrated) {
+        console.log('');
+        console.log(`  Migrated your existing \`dario login\` account into the pool as "${migrated}".`);
+        console.log(`  (Pool mode activates on 2+ accounts — this back-fill plus "${alias}" crosses that.)`);
+      }
+    }
+
     console.log('');
     console.log(`  Adding account "${alias}" to the pool...`);
     console.log('');

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@ export {
   removeAccount,
   refreshAccountToken,
   addAccountViaOAuth,
+  ensureLoginCredentialsInPool,
+  MIGRATED_LOGIN_ALIAS,
   getAccountsDir,
 } from './accounts.js';
 export type { AccountCredentials } from './accounts.js';

--- a/test/ensure-login-in-pool.mjs
+++ b/test/ensure-login-in-pool.mjs
@@ -1,0 +1,167 @@
+// Tests for ensureLoginCredentialsInPool — the back-fill that promotes a
+// user's `dario login` credentials into the pool on their first
+// `dario accounts add`. Covers:
+//
+//   1. No credentials anywhere + empty accounts/ → null (nothing to do)
+//   2. Valid credentials.json + empty accounts/ → migrates, writes
+//      accounts/<alias>.json with tokens + scopes from the creds file and
+//      identity populated from detectClaudeIdentity (or random fallback)
+//   3. Idempotency — second call after a successful migration returns null
+//      (accounts/ is no longer empty, guard short-circuits)
+//   4. Skip when accounts/ already has an entry — even if credentials.json
+//      is present and valid, migration doesn't happen
+//   5. Invalid alias input (traversal / unsafe chars) returns null without
+//      writing anything
+//
+// Isolation strategy: point HOME + USERPROFILE at a mkdtemp'd directory
+// BEFORE dynamically importing the accounts module. Because accounts.ts
+// computes `DARIO_DIR = join(homedir(), '.dario')` at module evaluation
+// time, the override only takes effect if env is set before import.
+// `all.test.mjs` spawns each test as its own subprocess, so this override
+// is fully isolated from other test files and from the user's real dir.
+
+import { mkdtemp, writeFile, mkdir, rm, readdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let pass = 0, fail = 0;
+function check(label, cond) {
+  if (cond) { console.log(`  ✅ ${label}`); pass++; }
+  else { console.log(`  ❌ ${label}`); fail++; }
+}
+function header(label) {
+  console.log(`\n======================================================================`);
+  console.log(`  ${label}`);
+  console.log(`======================================================================`);
+}
+
+// Temp home + env override must happen BEFORE importing the module under
+// test, because DARIO_DIR is evaluated at import time.
+const tmpHome = await mkdtemp(join(tmpdir(), 'dario-migrate-test-'));
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+const dariDir = join(tmpHome, '.dario');
+const accountsDir = join(dariDir, 'accounts');
+const credentialsPath = join(dariDir, 'credentials.json');
+await mkdir(dariDir, { recursive: true });
+
+const { ensureLoginCredentialsInPool, listAccountAliases, loadAccount, saveAccount, removeAccount, MIGRATED_LOGIN_ALIAS } =
+  await import('../dist/accounts.js');
+
+// Helper — clear accounts/ between tests without nuking the dir itself.
+async function resetAccounts() {
+  try {
+    const entries = await readdir(accountsDir);
+    for (const f of entries) {
+      const alias = f.replace(/\.json$/, '');
+      await removeAccount(alias);
+    }
+  } catch { /* dir may not exist yet */ }
+}
+
+async function writeFakeCreds() {
+  await writeFile(credentialsPath, JSON.stringify({
+    claudeAiOauth: {
+      accessToken: 'test-access-token-abc',
+      refreshToken: 'test-refresh-token-xyz',
+      expiresAt: Date.now() + 3_600_000,
+      scopes: ['user:profile', 'user:inference', 'user:sessions:claude_code'],
+    },
+  }, null, 2), { mode: 0o600 });
+}
+
+async function clearCreds() {
+  try { await rm(credentialsPath); } catch { /* already gone */ }
+}
+
+// ======================================================================
+//  1. No creds + empty accounts → null
+// ======================================================================
+header('no creds + empty accounts → returns null, writes nothing');
+{
+  await resetAccounts();
+  await clearCreds();
+  const result = await ensureLoginCredentialsInPool();
+  check('returns null', result === null);
+  const aliases = await listAccountAliases();
+  check('accounts/ still empty', aliases.length === 0);
+}
+
+// ======================================================================
+//  2. Valid creds + empty accounts → migrates to "login"
+// ======================================================================
+header('valid creds + empty accounts → migrates under reserved alias');
+{
+  await resetAccounts();
+  await writeFakeCreds();
+  const result = await ensureLoginCredentialsInPool();
+  check('returns the reserved alias', result === MIGRATED_LOGIN_ALIAS);
+  check('reserved alias is "login" (documented contract)', MIGRATED_LOGIN_ALIAS === 'login');
+  const aliases = await listAccountAliases();
+  check('accounts/ now has exactly one entry', aliases.length === 1);
+  check('that entry is the reserved alias', aliases[0] === MIGRATED_LOGIN_ALIAS);
+  const migrated = await loadAccount(MIGRATED_LOGIN_ALIAS);
+  check('access token copied from credentials.json', migrated?.accessToken === 'test-access-token-abc');
+  check('refresh token copied from credentials.json', migrated?.refreshToken === 'test-refresh-token-xyz');
+  check('scopes copied from credentials.json', Array.isArray(migrated?.scopes) && migrated.scopes.length === 3);
+  check('deviceId populated (either from CC or random UUID fallback)', typeof migrated?.deviceId === 'string' && migrated.deviceId.length > 0);
+  check('accountUuid populated (either from CC or random UUID fallback)', typeof migrated?.accountUuid === 'string' && migrated.accountUuid.length > 0);
+}
+
+// ======================================================================
+//  3. Idempotency — second call after successful migration returns null
+// ======================================================================
+header('second call after migration → returns null (accounts/ no longer empty)');
+{
+  // Don't reset — state from test 2 still present.
+  const result = await ensureLoginCredentialsInPool();
+  check('returns null on re-call', result === null);
+  const aliases = await listAccountAliases();
+  check('accounts/ still has the one migrated entry', aliases.length === 1);
+}
+
+// ======================================================================
+//  4. Skip when accounts/ already has an entry — even with valid creds
+// ======================================================================
+header('pre-existing pool entry → migration skipped');
+{
+  await resetAccounts();
+  await writeFakeCreds();
+  await saveAccount({
+    alias: 'prior-entry',
+    accessToken: 'prior-access',
+    refreshToken: 'prior-refresh',
+    expiresAt: Date.now() + 1_000_000,
+    scopes: [],
+    deviceId: 'prior-device',
+    accountUuid: 'prior-uuid',
+  });
+  const result = await ensureLoginCredentialsInPool();
+  check('returns null', result === null);
+  const aliases = await listAccountAliases();
+  check('accounts/ unchanged (just the prior entry)', aliases.length === 1 && aliases[0] === 'prior-entry');
+  await removeAccount('prior-entry');
+}
+
+// ======================================================================
+//  5. Invalid alias input → null, no write
+// ======================================================================
+header('invalid alias input → returns null, writes nothing');
+{
+  await resetAccounts();
+  await writeFakeCreds();
+  const result = await ensureLoginCredentialsInPool('../evil-traversal');
+  check('returns null for path-traversal alias', result === null);
+  const aliases = await listAccountAliases();
+  check('accounts/ still empty', aliases.length === 0);
+}
+
+// ======================================================================
+//  cleanup
+// ======================================================================
+await rm(tmpHome, { recursive: true, force: true });
+
+console.log(`\n======================================================================`);
+console.log(`  Results: ${pass} passed, ${fail} failed`);
+console.log(`======================================================================\n`);
+if (fail > 0) process.exit(1);


### PR DESCRIPTION
## Summary

Closes the UX gap surfaced by @tetsuco at the end of #71: pool mode activation threshold is "2+ accounts in `~/.dario/accounts/`", but single-account `dario login` credentials live separately at `~/.dario/credentials.json` (plus `~/.claude/.credentials.json` and the OS keychain, via `loadCredentials()`). A user doing `dario login` then `dario accounts add bar` ended up with **one** account in `accounts/` (`bar`), pool mode still off, and the original login account orphaned from the pool until they figured out they had to re-add it manually.

This PR auto back-fills the login credentials into the pool under a reserved alias on the first `dario accounts add`, so the user's second pool member actually trips the 2+ threshold.

## Design

New helper in `src/accounts.ts`:

```ts
export async function ensureLoginCredentialsInPool(
  alias: string = MIGRATED_LOGIN_ALIAS,  // 'login'
): Promise<string | null>
```

Behavior:
- **No-op** when `accounts/` already has ≥1 entry (idempotent — won't stomp existing pool state).
- **No-op** when no credentials are reachable anywhere.
- **Otherwise**, writes `accounts/<alias>.json` with tokens + scopes from `loadCredentials()` and identity (`deviceId` / `accountUuid`) from `detectClaudeIdentity()` — same source single-account mode already uses, so the migrated account's wire-identity matches what `dario login` was sending.
- Never destructive: `credentials.json` (if present) is left untouched. If the user later drops below the 2+ threshold via `accounts remove`, single-account mode falls back to it cleanly.

CLI integration runs the back-fill *before* the OAuth flow for the new alias, with a user-visible message:

```
  Migrated your existing `dario login` account into the pool as "login".
  (Pool mode activates on 2+ accounts — this back-fill plus "bar" crosses that.)

  Adding account "bar" to the pool...
```

Skipped when the user explicitly picks `login` as the new alias — their intent wins, no silent alias swap.

## Why the router didn't need changes

`pool.add()` accepts the migrated `PoolAccount` entry as a first-class member. The pool keys everything off `Map<alias, PoolAccount>` and doesn't care about provenance. Confirmed path-by-path:

- **Weighted headroom routing** — starts with `EMPTY_SNAPSHOT`, updated from first response's `anthropic-ratelimit-unified-*` headers.
- **Session stickiness** — `computeStickyKey` + `StickyBinding` treat the migrated alias identically to OAuth-added ones.
- **In-flight 429 failover** — rebinds sticky key on failover regardless of source.
- **Background refresh** — per-alias 15-min cycle uses the migrated account's own `refreshToken`.
- **Per-account identity** — `detectClaudeIdentity()` pulls from CC's `.claude.json` just like single-account mode does, so fingerprint fidelity is preserved.

## Test coverage

17 new assertions in `test/ensure-login-in-pool.mjs`:

1. No creds + empty `accounts/` → returns null, writes nothing.
2. Valid creds + empty `accounts/` → migrates under reserved alias, verifies token/scope/identity shape.
3. Idempotency — second call returns null (accounts/ no longer empty).
4. Skip when `accounts/` pre-populated (even with valid creds).
5. Invalid alias input (path traversal) returns null, writes nothing.

Isolation: overrides `HOME` + `USERPROFILE` to an `mkdtemp`'d dir *before* dynamic-importing the accounts module so `homedir()` resolves to temp. Each test runs in its own subprocess via `all.test.mjs`, so the env override is fully isolated.

49 tests total (up from 48).

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 49/49 pass (full suite, not just the new file)
- [x] Standalone test run: all 17 new assertions pass
- [ ] Manual: on a machine with `~/.dario/credentials.json` present, run `dario accounts add bar`, confirm:
  - Pre-OAuth message shows the back-fill happened
  - `dario accounts list` after shows both `login` and `bar`
  - `dario proxy` banner reports "Pool mode: 2 accounts loaded"

## Future

Option C (unify storage — `dario login` writes to `accounts/default.json` and `credentials.json` is deprecated) is still available as a cleaner design, but out of scope for maintenance mode. This is the issue-driven UX fix.
