### PR TITLE
v3.31.14 — state-length hardening at remaining four OAuth call sites (dario#71 completion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ checklist.
 
 ## [Unreleased]
 
+## [3.31.14] - 2026-04-24
+
+### Fixed — OAuth `state` length at the remaining four call sites (dario#71 completion)
+
+v3.31.12 fixed the `state` parameter length (16 → 32 random bytes → 43-char base64url) that Anthropic's `claude.ai/oauth/authorize` endpoint started requiring, but only in `src/accounts.ts` (the `dario accounts add` path). Four other call sites were still generating 22-char states that the same endpoint now rejects with "Invalid request format":
+
+- `src/oauth.ts:startAutoOAuthFlow` — the `dario login` browser flow. Any user without existing Claude Code credentials to shortcut to would have hit the same rejection tetsuco reported in #71. The reason this didn't surface earlier: tetsuco's own `dario login` shortcutted to his pre-existing `claude auth login` session, so his fresh `dario login` never actually ran the OAuth flow.
+- `src/oauth.ts:startManualOAuthFlow` — the `--manual` SSH / headless / container variant. Same rejection, same reason.
+- `src/cc-authorize-probe.ts:buildProbeAuthorizeUrl` — the in-process drift-check probe. With a 22-char state the probe now always receives "Invalid request format" from Anthropic, so `doctor --probe` and drift-watch were reporting false drift regardless of actual upstream state.
+- `scripts/check-cc-authorize-probe.mjs` + `scripts/check-cc-authorize-probe-headless.mjs` — standalone probe scripts used by `cc-drift-watch.yml`. Same false-positive pattern.
+
+All five now use `randomBytes(32)` with an inline comment pointing at #71 as the rationale so the next refactor doesn't accidentally revert. `src/accounts.ts` (already 32 since v3.31.12) is unchanged.
+
+### Added — grep-based invariant test pinning `randomBytes(32)` at every OAuth state call site
+
+New `test/oauth-state-length.mjs`, modeled on `scope-binary-verify.mjs`. Walks `src/` + `scripts/`, regex-scans for `state` assignments that call `randomBytes(N)`, asserts N === 32 at every hit. 6 call sites pinned across 4 files; 7 assertions total (6 per-call-site + 1 "regex still matches at least 4 sites" meta-assertion catching a regex drift / deletion). If a future refactor reverts any call site to `randomBytes(16)` — or introduces a new one at the wrong size — the test fails loudly before the change can land.
+
+50 tests total (up from 49).
+
 ### Fixed — `dario accounts add` now back-fills the `dario login` account into the pool (dario#71 follow-up)
 
 Pool mode activation threshold is "2+ accounts in `~/.dario/accounts/`". Single-account `dario login` credentials live separately at `~/.dario/credentials.json` (plus the CC file + OS keychain fallbacks in `oauth.ts`) and were never migrated into the pool. Practical consequence: a user running `dario login` then `dario accounts add bar` ended up with one account in `accounts/` (`bar`), still-below-threshold, pool mode off, and the original login account orphaned from the pool until they figured out they had to re-`accounts add` it under a second alias. Surfaced by [@tetsuco](https://github.com/askalf/dario/issues/71) at the end of the #71 thread.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "3.31.11",
+  "version": "3.31.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "3.31.11",
+      "version": "3.31.14",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.31.13",
+  "version": "3.31.14",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {

--- a/scripts/check-cc-authorize-probe-headless.mjs
+++ b/scripts/check-cc-authorize-probe-headless.mjs
@@ -65,7 +65,9 @@ function buildAuthorizeUrl(scopes) {
     scope: scopes,
     code_challenge: pkceChallenge(),
     code_challenge_method: 'S256',
-    state: base64url(randomBytes(16)),
+    // 32 bytes — see dario#71. Matches what CC v2.1.116+ sends; shorter
+    // states are rejected with "Invalid request format".
+    state: base64url(randomBytes(32)),
   });
   return `${PINNED.authorizeUrl}?${params.toString()}`;
 }

--- a/scripts/check-cc-authorize-probe.mjs
+++ b/scripts/check-cc-authorize-probe.mjs
@@ -87,7 +87,10 @@ function buildAuthorizeUrl(scopes) {
     scope: scopes,
     code_challenge: pkceChallenge(),
     code_challenge_method: 'S256',
-    state: base64url(randomBytes(16)),
+    // 32 bytes — see dario#71. Shorter states are rejected by Anthropic's
+    // authorize endpoint as "Invalid request format", which would otherwise
+    // make this probe permanently-rejected regardless of actual drift.
+    state: base64url(randomBytes(32)),
   });
   return `${PINNED.authorizeUrl}?${params.toString()}`;
 }

--- a/src/cc-authorize-probe.ts
+++ b/src/cc-authorize-probe.ts
@@ -204,7 +204,11 @@ export function buildProbeAuthorizeUrl(cfg: ProbeConfig): string {
     scope: cfg.scopes,
     code_challenge: pkceChallenge(),
     code_challenge_method: 'S256',
-    state: base64url(randomBytes(16)),
+    // 32 bytes — match what CC v2.1.116+ actually sends. See dario#71.
+    // Shorter states produce "Invalid request format" from Anthropic's
+    // authorize endpoint, which the probe classifier would otherwise mis-
+    // attribute to drift when it's actually our own request shape.
+    state: base64url(randomBytes(32)),
   });
   return `${cfg.authorizeUrl}?${params.toString()}`;
 }

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -236,7 +236,10 @@ async function saveCredentials(creds: CredentialsFile): Promise<void> {
 export async function startAutoOAuthFlow(): Promise<OAuthTokens> {
   const { createServer } = await import('node:http');
   const { codeVerifier, codeChallenge } = generatePKCE();
-  const state = base64url(randomBytes(16));
+  // 32 random bytes → 43-char base64url state. See dario#71 — Anthropic's
+  // authorize endpoint rejects shorter states with "Invalid request format";
+  // CC v2.1.116+ ships 32. Keep in lockstep with CC's entropy-per-state.
+  const state = base64url(randomBytes(32));
 
   return new Promise((resolve, reject) => {
     const server = createServer((req, res) => {
@@ -453,7 +456,8 @@ export function detectHeadlessEnvironment(): string | null {
  */
 export async function startManualOAuthFlow(): Promise<OAuthTokens> {
   const { codeVerifier, codeChallenge } = generatePKCE();
-  const state = base64url(randomBytes(16));
+  // 32 bytes — same reason as startAutoOAuthFlow. See dario#71.
+  const state = base64url(randomBytes(32));
   const cfg = await getOAuthConfig();
   const authUrl = buildManualAuthorizeUrl(cfg, codeChallenge, state);
 

--- a/test/oauth-state-length.mjs
+++ b/test/oauth-state-length.mjs
@@ -1,0 +1,75 @@
+// Invariant: every OAuth `state` parameter generated in dario's codebase
+// must use `randomBytes(32)` → 43-char base64url. Anthropic's authorize
+// endpoint rejects shorter states with "Invalid request format" (dario#71).
+// RFC 6749 only requires state to be "non-guessable," so 16 bytes is
+// spec-compliant, but Anthropic got stricter than spec — and any future
+// regression to `randomBytes(16)` silently breaks OAuth for anyone who
+// hits the flow without shortcutting to existing CC credentials.
+//
+// Strategy: scan every file that imports `randomBytes` from `node:crypto`
+// and look for `state` assignments. Each must use `randomBytes(32)`.
+// Grep-based rather than runtime behavioral — the test is defensive
+// against a refactor that reverts the constant without anyone noticing.
+// Same pattern as `scope-binary-verify.mjs`.
+//
+// Scope: all files under src/ and scripts/. Test files themselves are
+// excluded (they may stub OAuth with fake values).
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..');
+const SCAN_DIRS = [join(repoRoot, 'src'), join(repoRoot, 'scripts')];
+// Extensions that could define an OAuth state call site.
+const EXT = new Set(['.ts', '.mjs', '.js', '.cjs']);
+
+function walk(dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const st = statSync(full);
+    if (st.isDirectory()) walk(full, out);
+    else if (EXT.has(full.slice(full.lastIndexOf('.')))) out.push(full);
+  }
+  return out;
+}
+
+let pass = 0, fail = 0;
+function check(label, cond) {
+  if (cond) { console.log(`  ✅ ${label}`); pass++; }
+  else { console.log(`  ❌ ${label}`); fail++; }
+}
+
+const files = SCAN_DIRS.flatMap(d => walk(d));
+// A state call site looks like: `state: base64url(randomBytes(N))` or
+// `const state = base64url(randomBytes(N))`. The regex accepts either
+// pattern; N is captured so we can assert it's 32.
+const STATE_CALL_RE = /state[\s:=]+[\w.]+\(\s*randomBytes\((\d+)\)/g;
+
+console.log(`\n======================================================================`);
+console.log(`  OAuth state length invariant — randomBytes(32) at every call site`);
+console.log(`======================================================================`);
+
+let callSites = 0;
+for (const f of files) {
+  const src = readFileSync(f, 'utf-8');
+  let m;
+  while ((m = STATE_CALL_RE.exec(src)) !== null) {
+    callSites++;
+    const n = parseInt(m[1], 10);
+    const rel = relative(repoRoot, f).replace(/\\/g, '/');
+    check(`${rel}: state uses randomBytes(32)`, n === 32);
+  }
+}
+
+// Defensive: if scanning finds zero call sites, either the regex drifted
+// or all OAuth code got deleted. Either way we want to know.
+check('at least one OAuth state call site scanned (regex still matches)', callSites >= 4);
+
+console.log(`\n  (scanned ${files.length} files, found ${callSites} OAuth state call sites)`);
+console.log(`\n======================================================================`);
+console.log(`  Results: ${pass} passed, ${fail} failed`);
+console.log(`======================================================================\n`);
+if (fail > 0) process.exit(1);


### PR DESCRIPTION
## Summary

v3.31.12 fixed the OAuth `state` parameter length (`randomBytes(16)` → `randomBytes(32)` → 43-char base64url) that Anthropic's `claude.ai/oauth/authorize` endpoint started requiring in April 2026. That patch only landed in `src/accounts.ts` (the `dario accounts add` path). **Four other call sites were still generating 22-char states** that the same endpoint now rejects with "Invalid request format":

| Location | What breaks |
|---|---|
| `src/oauth.ts:startAutoOAuthFlow` | `dario login` browser flow — any user without existing Claude Code credentials to shortcut to |
| `src/oauth.ts:startManualOAuthFlow` | `dario login --manual` — SSH / container / headless flow |
| `src/cc-authorize-probe.ts:buildProbeAuthorizeUrl` | The in-process drift-check probe backing `doctor --probe` |
| `scripts/check-cc-authorize-probe.mjs` | Standalone probe script used by `cc-drift-watch.yml` |
| `scripts/check-cc-authorize-probe-headless.mjs` | Headless probe variant (Playwright path) |

### Why this hid through three release rounds

@tetsuco's original `dario login` in #71 worked fine, which made it look like the bug was isolated to `accounts add`. It worked because his `dario login` *shortcutted to his pre-existing `claude auth login` session* — the OAuth flow never actually ran. A user without CC installed, or with expired CC credentials, would have hit the same rejection as `accounts add`.

The probes are worse. With `randomBytes(16)` the live Anthropic endpoint now permanently responds "Invalid request format" regardless of actual upstream drift — so `doctor --probe` and the nightly `cc-drift-watch` workflow were reporting false drift signals from themselves.

### Fix

All five sites patched to `randomBytes(32)` with inline comments pointing at #71 as the rationale so a future refactor can't silently revert. `src/accounts.ts` is unchanged — it was already fixed in v3.31.12.

### Drift prevention

New `test/oauth-state-length.mjs`, modeled on `scope-binary-verify.mjs`. Walks `src/` + `scripts/`, regex-scans for `state: ...randomBytes(N)` call sites, asserts `N === 32` at every hit. Plus a meta-assertion that at least 4 sites matched (catches a regex drift or wholesale deletion). If any future change reverts any call site — or introduces a new OAuth state generator at the wrong size — the test fails loudly before the change can land.

6 call sites pinned across 4 files. 7 assertions total. **50 tests (up from 49).**

### Release

Version bumped to **3.31.14** in `package.json` + `package-lock.json`. CHANGELOG entry added under a new `## [3.31.14] - 2026-04-24` heading (above the existing unreleased back-fill entry, which also belongs to this release). Auto-release workflow will tag + publish on merge.

## Test plan

- [x] `npm run build` — clean
- [x] `test/oauth-state-length.mjs` standalone — 7/7 pass
- [x] Full suite — 49/50 (50th flake is `request-queue.mjs` which fails identically on `master`; not related to this change; CI has been green on recent merges so it's a local-env issue on my machine)
