### PR TITLE
v3.31.15 — fix cli.ts import side effects + RequestQueue unrefTimers option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ checklist.
 
 ## [Unreleased]
 
+## [3.31.15] - 2026-04-24
+
+### Fixed — `cli.ts` import now side-effect-free (uncovered while chasing a pre-existing request-queue test flake)
+
+Importing `dist/cli.js` (e.g. `import { parsePositiveIntEnv } from '../dist/cli.js'` from the request-queue test) used to auto-run the CLI — read `process.argv`, default `command = 'proxy'`, invoke `startProxy()` — because the Bun auto-relaunch block and handler dispatch ran at module top level. In the test, this triggered proxy startup → "Not authenticated" → `process.exit(1)` racing the test and killing the subprocess. The flake was hiding the fact that `cli.ts` wasn't safe to import at all — any library consumer or future programmatic use of `startProxy` / `getStatus` from a caller that also wanted a helper from `cli.ts` would have hit the same implicit side effect.
+
+Both side effects (Bun auto-relaunch, handler dispatch) are now gated behind a `import.meta.url === pathToFileURL(process.argv[1]).href` main-entry check. When dario runs as the entry point, behavior is identical. When imported as a module, neither side effect fires.
+
+### Fixed — `RequestQueue` timeout fires under test conditions (`unrefTimers` option added)
+
+Only surfaced after the `cli.ts` fix above — the CLI-import side effect was exiting the test subprocess before it ever reached the timeout section. `RequestQueue#acquire` was calling `timeoutHandle.unref?.()` unconditionally. Production-correct (a leaked queue entry shouldn't by itself pin the proxy alive on shutdown), but breaks the queue-timeout test: when the queue is the only pending work on the event loop, an unref'd timer lets Node exit *before* the timeout fires, so the expected reject never arrives and the test hangs on top-level await.
+
+New `unrefTimers` option on `RequestQueueOptions`, default `true` (preserves existing production behavior). The one test case that hits the queue-timeout path now passes `unrefTimers: false` so the timer keeps the loop alive long enough for the 50ms timeout to fire. Full 50-test suite now passes cleanly under `node --test` — the pre-existing `request-queue.mjs` flake is gone.
+
 ## [3.31.14] - 2026-04-24
 
 ### Fixed — OAuth `state` length at the remaining four call sites (dario#71 completion)
@@ -27,8 +41,6 @@ All five now use `randomBytes(32)` with an inline comment pointing at #71 as the
 ### Added — grep-based invariant test pinning `randomBytes(32)` at every OAuth state call site
 
 New `test/oauth-state-length.mjs`, modeled on `scope-binary-verify.mjs`. Walks `src/` + `scripts/`, regex-scans for `state` assignments that call `randomBytes(N)`, asserts N === 32 at every hit. 6 call sites pinned across 4 files; 7 assertions total (6 per-call-site + 1 "regex still matches at least 4 sites" meta-assertion catching a regex drift / deletion). If a future refactor reverts any call site to `randomBytes(16)` — or introduces a new one at the wrong size — the test fails loudly before the change can land.
-
-50 tests total (up from 49).
 
 ### Fixed — `dario accounts add` now back-fills the `dario login` account into the pool (dario#71 follow-up)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "3.31.14",
+  "version": "3.31.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "3.31.14",
+      "version": "3.31.15",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.31.14",
+  "version": "3.31.15",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,35 +13,24 @@
 // ── Bun auto-relaunch ──
 // Bun's TLS fingerprint matches Claude Code's runtime (both use Bun/BoringSSL).
 // If Bun is installed and we're running on Node, relaunch under Bun for
-// network-level fingerprint fidelity.
-if (!('Bun' in globalThis) && !process.env.DARIO_NO_BUN) {
-  try {
-    const { execFileSync } = await import('node:child_process');
-    // Check if bun exists
-    execFileSync('bun', ['--version'], { stdio: 'ignore', timeout: 3000 });
-    // Relaunch under bun
-    const { spawn } = await import('node:child_process');
-    const child = spawn('bun', ['run', ...process.argv.slice(1)], {
-      stdio: 'inherit',
-      env: { ...process.env, DARIO_NO_BUN: '1' },
-    });
-    child.on('exit', (code) => process.exit(code ?? 0));
-    // Prevent this process from continuing
-    await new Promise(() => {});
-  } catch {
-    // Bun not available, continue with Node
-  }
-}
+// network-level fingerprint fidelity. Moved below into the main-entry guard
+// at the bottom of the file so importing this module (e.g. from tests that
+// just want `parsePositiveIntEnv`) doesn't trigger a Bun relaunch or any
+// other startup side effect.
 
 import { unlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { pathToFileURL } from 'node:url';
 import { startAutoOAuthFlow, startManualOAuthFlow, detectHeadlessEnvironment, getStatus, refreshTokens, loadCredentials } from './oauth.js';
 import { startProxy, sanitizeError } from './proxy.js';
 import { VALID_EFFORT_VALUES, type EffortValue } from './cc-template.js';
 import { listAccountAliases, loadAllAccounts, addAccountViaOAuth, removeAccount, ensureLoginCredentialsInPool, MIGRATED_LOGIN_ALIAS } from './accounts.js';
 import { listBackends, saveBackend, removeBackend, type BackendCredentials } from './openai-backend.js';
 
+// `args` / `command` at module scope — command handlers below close over
+// `args` to read their own flags. Reading argv is harmless on import; only
+// the handler dispatch at the bottom is gated behind the main-entry check.
 const args = process.argv.slice(2);
 const command = args[0] ?? 'proxy';
 
@@ -1194,14 +1183,45 @@ const commands: Record<string, () => Promise<void>> = {
   '-V': version,
 };
 
-const handler = commands[command];
-if (!handler) {
-  console.error(`Unknown command: ${command}`);
-  console.error('Run `dario help` for usage.');
-  process.exit(1);
-}
+// Main-entry guard. Only run the Bun auto-relaunch and handler dispatch when
+// this module is the direct entry point — importing it (from tests or for
+// a library helper like `parsePositiveIntEnv`) must NOT start the proxy.
+// Before this guard, `import { parsePositiveIntEnv } from './cli.js'` would
+// fall through to `command = args[0] ?? 'proxy'` and fire `handler()`, which
+// tried to run `startProxy()` and failed the test with "Not authenticated".
+const isDirectEntry =
+  typeof process.argv[1] === 'string' &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
 
-handler().catch(err => {
-  console.error('Fatal error:', sanitizeError(err));
-  process.exit(1);
-});
+if (isDirectEntry) {
+  // Bun auto-relaunch for TLS fingerprint fidelity. Only meaningful when
+  // dario is the direct entry — if we're imported, whoever imported us
+  // already chose their runtime.
+  if (!('Bun' in globalThis) && !process.env.DARIO_NO_BUN) {
+    try {
+      const { execFileSync, spawn } = await import('node:child_process');
+      execFileSync('bun', ['--version'], { stdio: 'ignore', timeout: 3000 });
+      const child = spawn('bun', ['run', ...process.argv.slice(1)], {
+        stdio: 'inherit',
+        env: { ...process.env, DARIO_NO_BUN: '1' },
+      });
+      child.on('exit', (code) => process.exit(code ?? 0));
+      // Prevent this process from continuing
+      await new Promise(() => {});
+    } catch {
+      // Bun not available, continue with Node
+    }
+  }
+
+  const handler = commands[command];
+  if (!handler) {
+    console.error(`Unknown command: ${command}`);
+    console.error('Run `dario help` for usage.');
+    process.exit(1);
+  }
+
+  handler().catch(err => {
+    console.error('Fatal error:', sanitizeError(err));
+    process.exit(1);
+  });
+}

--- a/src/request-queue.ts
+++ b/src/request-queue.ts
@@ -65,6 +65,16 @@ export interface RequestQueueOptions {
   maxConcurrent?: number;
   maxQueued?: number;
   queueTimeoutMs?: number;
+  /**
+   * Whether timeout timers are `unref`'d so they don't by themselves keep
+   * the Node event loop alive. Default `true` — appropriate for the proxy,
+   * where a leaked queue entry should never hang shutdown. Pass `false` in
+   * tests where the queue is the only pending work on the loop: an
+   * `unref`'d timer won't fire in that case (Node exits with "unsettled
+   * top-level await" before the 50ms timeout elapses), so the reject the
+   * test is waiting for never arrives.
+   */
+  unrefTimers?: boolean;
 }
 
 export const DEFAULT_MAX_CONCURRENT = 10;
@@ -75,6 +85,7 @@ export class RequestQueue {
   readonly maxConcurrent: number;
   readonly maxQueued: number;
   readonly queueTimeoutMs: number;
+  readonly unrefTimers: boolean;
   private active = 0;
   private queue: QueueEntry[] = [];
 
@@ -82,6 +93,7 @@ export class RequestQueue {
     this.maxConcurrent = opts.maxConcurrent ?? DEFAULT_MAX_CONCURRENT;
     this.maxQueued = opts.maxQueued ?? DEFAULT_MAX_QUEUED;
     this.queueTimeoutMs = opts.queueTimeoutMs ?? DEFAULT_QUEUE_TIMEOUT_MS;
+    this.unrefTimers = opts.unrefTimers ?? true;
   }
 
   /**
@@ -110,7 +122,8 @@ export class RequestQueue {
       }, this.queueTimeoutMs);
       // Keep the timer from pinning the event loop open on shutdown. A queued
       // request waiting for a slot shouldn't by itself keep the process alive.
-      timeoutHandle.unref?.();
+      // Opt-out for tests — see `unrefTimers` comment in RequestQueueOptions.
+      if (this.unrefTimers) timeoutHandle.unref?.();
       const entry: QueueEntry = { resolve, reject, enqueuedAt, timeoutHandle };
       this.queue.push(entry);
     });

--- a/test/request-queue.mjs
+++ b/test/request-queue.mjs
@@ -128,7 +128,12 @@ header('RequestQueue — release admits next queued in FIFO');
 
 header('RequestQueue — queue-timeout rejects the waiter');
 {
-  const q = new RequestQueue({ maxConcurrent: 1, maxQueued: 4, queueTimeoutMs: 50 });
+  // `unrefTimers: false` — this test is the only thing on the event loop,
+  // and the default-unref'd timer would let the process exit before the
+  // 50ms timeout fires, hanging forever on the `await q.acquire()` below.
+  // Production code (`src/proxy.ts`) takes the default `unrefTimers: true`
+  // so a leaked queue entry can't pin the proxy alive on shutdown.
+  const q = new RequestQueue({ maxConcurrent: 1, maxQueued: 4, queueTimeoutMs: 50, unrefTimers: false });
   await q.acquire(); // 1/1
   let thrown;
   try {


### PR DESCRIPTION
## Summary

Two linked fixes that surfaced while cleaning up the pre-existing `request-queue.mjs` test flake that had been failing locally for months (and was presumably green in CI by some coincidence of test ordering, since CI-side the auto-release chain has been passing).

### 1. `cli.ts` import was running the CLI as a side effect

`src/cli.ts` had two top-level side effects that fired at module load:

- Bun auto-relaunch block (checks for `bun`, execs it with current argv)
- Handler dispatch (`command = args[0] ?? 'proxy'`, then `handler().catch(...)`)

When `test/request-queue.mjs` did `import { parsePositiveIntEnv } from '../dist/cli.js'`, those side effects fired in the subprocess: `command` defaulted to `'proxy'`, the proxy handler called `getStatus()`, which printed "Not authenticated" and called `process.exit(1)` — killing the test subprocess mid-run.

That made `request-queue.mjs` always fail locally, while masking the fact that `cli.ts` wasn't safe to import at all. Any future library-style consumer or programmatic use of `cli.ts`'s exports would have hit the same implicit side effect.

**Fix:** both side effects gated behind a `import.meta.url === pathToFileURL(process.argv[1]).href` main-entry check. Direct `dario` invocation is byte-identical in behavior; `import`-ing the module is now side-effect-free.

### 2. `RequestQueue` timeout timer was unref'd, breaking the test

Only surfaced *after* the cli.ts fix. Previously the test subprocess died before the queue-timeout section ran.

`RequestQueue#acquire` called `timeoutHandle.unref?.()` unconditionally. In production (proxy context) that's correct — a leaked queue entry shouldn't by itself pin the process alive on shutdown. In the test, the queue is the only pending work on the event loop, so an unref'd timer lets Node exit before the 50ms timeout fires, and the expected reject never arrives.

**Fix:** new `unrefTimers` option on `RequestQueueOptions`, default `true` (preserves existing production behavior). The one test case that hits the timeout path now passes `unrefTimers: false`.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 50/50 pass (up from 49 green + 1 pre-existing flake)
- [x] Standalone `node test/request-queue.mjs` — 34/34 pass
- [x] CLI invocation: `node dist/cli.js --help` still works
- [ ] Post-merge: confirm auto-release tags v3.31.15 and publishes to npm

## Version

Bumped `package.json` + `package-lock.json` to **3.31.15**. CHANGELOG entry under new `## [3.31.15] - 2026-04-24` heading (above v3.31.14 which shipped the state-length completion earlier today).
