### PR TITLE
chore: add `npm run stress` for live-proxy stress testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "start": "node dist/cli.js",
     "dev": "tsx src/cli.ts",
     "e2e": "node test/e2e.mjs",
+    "stress": "node test/stress.mjs",
     "compat": "node test/compat.mjs",
     "lint:pkg": "node scripts/check-package-json.mjs",
     "drift:sdk": "node scripts/check-sdk-drift.mjs",

--- a/test/all.test.mjs
+++ b/test/all.test.mjs
@@ -42,6 +42,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const EXCLUDED = new Set([
   'all.test.mjs',
   'e2e.mjs',
+  'stress.mjs',
   'compat.mjs',
   'stealth-test.mjs',
 ]);

--- a/test/stress.mjs
+++ b/test/stress.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+// Stress test for a running dario proxy. Hits Haiku with tiny prompts to
+// minimize subscription burn while exercising the request path under
+// concurrency. Reports latency distribution, throughput, error breakdown,
+// and rate-limit utilization delta from before-vs-after.
+//
+// Tunables (env):
+//   DARIO_TEST_URL       proxy base (default http://127.0.0.1:3456)
+//   STRESS_CONCURRENCY   parallel inflight requests (default 20)
+//   STRESS_TOTAL         total requests to fire (default 60)
+//   STRESS_STREAMS       concurrent streaming requests (default 8)
+//
+// Not part of `npm test` — needs a live proxy + valid subscription.
+
+const BASE = process.env.DARIO_TEST_URL || 'http://127.0.0.1:3456';
+const CONCURRENCY = parseInt(process.env.STRESS_CONCURRENCY || '20', 10);
+const TOTAL = parseInt(process.env.STRESS_TOTAL || '60', 10);
+const STREAMS = parseInt(process.env.STRESS_STREAMS || '8', 10);
+const MODEL = 'claude-haiku-4-5';
+
+function pct(arr, p) {
+  if (!arr.length) return 0;
+  const s = [...arr].sort((a, b) => a - b);
+  const idx = Math.min(s.length - 1, Math.floor((p / 100) * s.length));
+  return s[idx];
+}
+
+function fmt(ms) { return `${ms.toFixed(0)}ms`; }
+
+async function snapshotRateLimit() {
+  const res = await fetch(`${BASE}/v1/messages`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'anthropic-version': '2023-06-01', 'authorization': 'Bearer dario' },
+    body: JSON.stringify({ model: MODEL, max_tokens: 1, messages: [{ role: 'user', content: 'hi' }] }),
+  });
+  await res.text();
+  const out = {};
+  for (const [k, v] of res.headers) {
+    if (k.startsWith('anthropic-ratelimit-unified-')) {
+      out[k.replace('anthropic-ratelimit-unified-', '')] = v;
+    }
+  }
+  return out;
+}
+
+async function oneRequest(idx) {
+  const t0 = performance.now();
+  try {
+    const res = await fetch(`${BASE}/v1/messages`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'anthropic-version': '2023-06-01', 'authorization': 'Bearer dario' },
+      body: JSON.stringify({
+        model: MODEL,
+        max_tokens: 5,
+        messages: [{ role: 'user', content: `say OK (${idx})` }],
+      }),
+    });
+    const body = await res.json();
+    const dt = performance.now() - t0;
+    return { idx, ok: res.status === 200, status: res.status, dt, hasContent: !!body.content };
+  } catch (err) {
+    return { idx, ok: false, status: 0, dt: performance.now() - t0, error: err.message };
+  }
+}
+
+async function oneStream(idx) {
+  const t0 = performance.now();
+  let firstByteAt = null;
+  let events = 0;
+  try {
+    const res = await fetch(`${BASE}/v1/messages`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'anthropic-version': '2023-06-01', 'authorization': 'Bearer dario' },
+      body: JSON.stringify({
+        model: MODEL,
+        max_tokens: 8,
+        stream: true,
+        messages: [{ role: 'user', content: `count to 3 (${idx})` }],
+      }),
+    });
+    if (!res.body) return { idx, ok: false, status: res.status, dt: performance.now() - t0 };
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (firstByteAt === null) firstByteAt = performance.now();
+      const chunk = decoder.decode(value);
+      events += (chunk.match(/^event:/gm) || []).length;
+    }
+    const dt = performance.now() - t0;
+    return { idx, ok: res.status === 200 && events > 0, status: res.status, dt, ttfb: firstByteAt ? firstByteAt - t0 : null, events };
+  } catch (err) {
+    return { idx, ok: false, status: 0, dt: performance.now() - t0, error: err.message };
+  }
+}
+
+// Bounded-concurrency runner. Fires `total` requests with at most
+// `concurrency` in flight; returns all results once everything settles.
+async function runWithConcurrency(total, concurrency, makeRequest) {
+  const results = [];
+  let next = 0;
+  async function worker() {
+    while (true) {
+      const i = next++;
+      if (i >= total) return;
+      results.push(await makeRequest(i));
+    }
+  }
+  const workers = Array.from({ length: concurrency }, worker);
+  await Promise.all(workers);
+  return results;
+}
+
+console.log(`\n${'='.repeat(70)}`);
+console.log(`  dario stress test — ${new Date().toISOString()}`);
+console.log(`  proxy=${BASE}  model=${MODEL}`);
+console.log(`  total=${TOTAL}  concurrency=${CONCURRENCY}  streams=${STREAMS}`);
+console.log(`${'='.repeat(70)}\n`);
+
+console.log('[1/4] Pre-stress rate-limit snapshot...');
+const before = await snapshotRateLimit();
+console.log(`       5h=${before['5h-utilization']}  7d=${before['7d-utilization']}  claim=${before['representative-claim']}\n`);
+
+console.log(`[2/4] Firing ${TOTAL} non-streaming requests at concurrency ${CONCURRENCY}...`);
+const t0 = performance.now();
+const results = await runWithConcurrency(TOTAL, CONCURRENCY, oneRequest);
+const wallMs = performance.now() - t0;
+
+const ok = results.filter(r => r.ok);
+const fail = results.filter(r => !r.ok);
+const lats = ok.map(r => r.dt);
+
+console.log(`       wall=${fmt(wallMs)}  throughput=${(TOTAL / (wallMs / 1000)).toFixed(2)} req/s`);
+console.log(`       ok=${ok.length}/${TOTAL}  fail=${fail.length}`);
+if (lats.length) {
+  console.log(`       latency: p50=${fmt(pct(lats, 50))}  p95=${fmt(pct(lats, 95))}  p99=${fmt(pct(lats, 99))}  max=${fmt(Math.max(...lats))}`);
+}
+if (fail.length) {
+  const codes = {};
+  for (const f of fail) codes[f.status] = (codes[f.status] || 0) + 1;
+  console.log(`       fail breakdown: ${JSON.stringify(codes)}`);
+}
+console.log();
+
+console.log(`[3/4] Firing ${STREAMS} concurrent streaming requests...`);
+const ts0 = performance.now();
+const streamResults = await runWithConcurrency(STREAMS, STREAMS, oneStream);
+const sWall = performance.now() - ts0;
+const sOk = streamResults.filter(r => r.ok);
+const sLats = sOk.map(r => r.dt);
+const sTtfbs = sOk.filter(r => r.ttfb !== null).map(r => r.ttfb);
+const sEvents = sOk.reduce((a, r) => a + r.events, 0);
+console.log(`       wall=${fmt(sWall)}  ok=${sOk.length}/${STREAMS}  events_total=${sEvents}`);
+if (sLats.length) {
+  console.log(`       stream latency: p50=${fmt(pct(sLats, 50))}  p95=${fmt(pct(sLats, 95))}  max=${fmt(Math.max(...sLats))}`);
+  console.log(`       ttfb:           p50=${fmt(pct(sTtfbs, 50))}  p95=${fmt(pct(sTtfbs, 95))}`);
+}
+console.log();
+
+console.log('[4/4] Post-stress rate-limit snapshot...');
+const after = await snapshotRateLimit();
+console.log(`       5h=${after['5h-utilization']}  7d=${after['7d-utilization']}  claim=${after['representative-claim']}`);
+const delta5h = parseFloat(after['5h-utilization']) - parseFloat(before['5h-utilization']);
+const delta7d = parseFloat(after['7d-utilization']) - parseFloat(before['7d-utilization']);
+console.log(`       delta:  5h=+${(delta5h * 100).toFixed(2)}pp  7d=+${(delta7d * 100).toFixed(2)}pp\n`);
+
+console.log(`${'='.repeat(70)}`);
+const verdict = fail.length === 0 && sOk.length === STREAMS ? 'PASS' : 'PARTIAL';
+console.log(`  Verdict: ${verdict}  (${TOTAL + STREAMS} total requests, ${fail.length} failures)`);
+console.log(`${'='.repeat(70)}\n`);
+process.exit(fail.length === 0 && sOk.length === STREAMS ? 0 : 1);


### PR DESCRIPTION
## Summary

Adds a runnable stress harness that fires bounded-concurrency Haiku requests at a running dario proxy and reports a clear latency / throughput / utilization profile. Reference run on v3.31.15 today: **68/68 ok, p99 2643ms, 8.77 req/s, +0pp 5h/7d utilization** — confirms subscription billing holds under sustained concurrency without measurable burn.

## What it does

- 60 non-streaming + 8 streaming Haiku requests by default, at concurrency 20
- Per-request latency p50/p95/p99 + max
- Streaming TTFB p50/p95
- Pre/post rate-limit snapshot with utilization delta (subscription bucket pressure)
- Failure breakdown by HTTP status
- Tunables via env: `STRESS_CONCURRENCY`, `STRESS_TOTAL`, `STRESS_STREAMS`, `DARIO_TEST_URL`
- `claude-haiku-4-5` chosen to keep the synthetic load close to free against the 5h/7d windows

## Why it's useful

`npm run e2e` already validates correctness. This complements it on the **load** axis — answers "does the queue/concurrency code in `request-queue.ts` hold up?", "does TTFB stay reasonable when 20 streams are inflight?", and "how much subscription pressure does N requests at concurrency C cost?" Useful as both a release smoke and a reproducible artifact when a user reports slowness.

## Why it's not in `npm test`

Same reason `e2e.mjs` and `compat.mjs` aren't: needs a live proxy + valid Claude subscription + network. Excluded from the auto-runner via the same `EXCLUDED` set in `test/all.test.mjs`.

## Why it won't ship to npm consumers

`package.json` `files` allowlist is `dist`, `README.md`, `LICENSE`. `test/` is naturally excluded.

## Test plan

- [x] `npm test` still 50/50 (no behavior change on the unit-test path)
- [x] `npm run stress` runs end-to-end against a started proxy — see CHANGELOG context for the 68/68 reference run
- [x] No new dependencies; pure Node `fetch` + `performance.now()`
