### PR TITLE
v3.31.16 — security hardening (defense in depth)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,49 @@ checklist.
 
 ## [Unreleased]
 
+## [3.31.16] - 2026-04-24
+
+### Security — defense-in-depth hardening pass (no known active exploit)
+
+A self-audit found two patterns worth tightening even though neither is reachable in the documented threat model (local user trusted, Anthropic mostly trusted, concern is malicious websites + supply-chain). Both fixes are byte-equivalent for legitimate inputs; the change is rejecting the unsafe inputs they should never have been able to reach in the first place.
+
+**1. Browser open path no longer goes through the shell.**
+
+`src/oauth.ts` and `src/accounts.ts` previously used `child_process.exec` with template-string interpolation to dispatch a URL to the OS's URL handler:
+
+```ts
+exec(`start "" "${authUrl}"`, () => {});       // win32
+exec(`open "${authUrl}"`, () => {});           // darwin
+exec(`xdg-open "${authUrl}"`, () => {});       // linux
+```
+
+If a `DARIO_OAUTH_AUTHORIZE_URL` override or a future code path ever surfaced a URL containing `&`, `|`, `^`, `$()`, backtick, or other shell metacharacters, those would have executed under the user's shell. Replaced with a new `src/open-browser.ts` helper that:
+
+- Validates the URL with WHATWG `URL` (rejects malformed input),
+- Allowlists `http:` / `https:` only (rejects `file:`, `javascript:`, `data:`, `vbscript:`, custom schemes),
+- Spawns the platform-specific URL handler (`explorer.exe` / `open` / `xdg-open`) via `execFile` with the URL as a single argv element — no shell, no template interpolation. Windows uses `explorer.exe` instead of `cmd /c start "" "URL"` so cmd's parser never sees the URL even after Node's argv-quoting.
+
+The `openBrowser` import is now also used at the original call sites in `accounts.ts` and `oauth.ts`. Both call sites wrap in `try {} catch {}` because every caller already prints the URL for manual paste — a failed browser-open is non-fatal.
+
+**2. Upstream error response bodies no longer reach `Error.message` raw.**
+
+`accounts.ts:doRefreshAccountToken`, `accounts.ts:addAccountViaOAuth`, `oauth.ts:doExchangeToken`, and `oauth.ts:doRefreshTokens` all sliced the upstream response body into a thrown `Error.message`:
+
+```ts
+throw new Error(`Refresh failed (${res.status}): ${errBody.slice(0, 200)}`);
+```
+
+Anthropic's documented API is not known to echo tokens in error responses, but defense-in-depth: a future API change, an intermediary's debug page, or a CDN error template that captures request headers could surface a token, and we'd rather redact in transit than audit every call site. Extracted the redaction patterns from `proxy.ts:sanitizeError` into a shared `src/redact.ts` module (`SECRET_PATTERNS` + `redactSecrets`) and applied it to all four upstream-body sites. Patterns cover `sk-ant-…` API keys, JWT triples (`eyJhdr.eyJpld.sig`), and `Bearer …` headers. Idempotent — running redaction over an already-redacted string is a no-op.
+
+`proxy.ts:sanitizeError` is now a one-liner over `redactSecrets`; behavior is identical.
+
+### Tests
+
+- `test/open-browser.mjs` (25 assertions) — pins protocol allowlist, malformed URL rejection, per-platform binary selection, shell-metacharacter URLs preserved as a single argv element (the whole point), and the `exec` stub path so the integration of validate + spawn is covered without touching the real OS.
+- `test/redact.mjs` (19 assertions) — redaction of `sk-ant-`, JWTs, `Bearer …`; multi-secret strings; idempotency; preservation of non-secret content; `SECRET_PATTERNS` export shape.
+
+**52 tests total, up from 50.**
+
 ## [3.31.15] - 2026-04-24
 
 ### Fixed — `cli.ts` import now side-effect-free (uncovered while chasing a pre-existing request-queue test flake)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "3.31.15",
+  "version": "3.31.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "3.31.15",
+      "version": "3.31.16",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.31.15",
+  "version": "3.31.16",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -23,6 +23,8 @@ import { randomUUID, randomBytes, createHash } from 'node:crypto';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { detectCCOAuthConfig } from './cc-oauth-detect.js';
 import { loadCredentials } from './oauth.js';
+import { openBrowser } from './open-browser.js';
+import { redactSecrets } from './redact.js';
 
 const DARIO_DIR = join(homedir(), '.dario');
 const ACCOUNTS_DIR = join(DARIO_DIR, 'accounts');
@@ -169,7 +171,10 @@ async function doRefreshAccountToken(creds: AccountCredentials): Promise<Account
 
   if (!res.ok) {
     const errBody = await res.text().catch(() => '');
-    throw new Error(`Refresh failed for ${creds.alias} (${res.status}): ${errBody.slice(0, 200)}`);
+    // Redact tokens / JWTs / Bearer values before they hit the Error
+    // message — defense-in-depth against an upstream that ever echoes a
+    // credential into a 4xx body. See src/redact.ts.
+    throw new Error(`Refresh failed for ${creds.alias} (${res.status}): ${redactSecrets(errBody.slice(0, 200))}`);
   }
 
   const data = await res.json() as {
@@ -205,13 +210,10 @@ function generatePKCE(): { codeVerifier: string; codeChallenge: string } {
   return { codeVerifier, codeChallenge };
 }
 
-function openBrowser(url: string): void {
-  const { exec } = require('node:child_process') as typeof import('node:child_process');
-  const cmd = process.platform === 'win32' ? `start "" "${url}"`
-    : process.platform === 'darwin' ? `open "${url}"`
-    : `xdg-open "${url}"`;
-  exec(cmd, () => { /* ignore */ });
-}
+// `openBrowser` lives in src/open-browser.ts — uses execFile + argv array
+// + URL-protocol allowlist instead of shell interpolation. The previous
+// inline `exec(\`start "" "${url}"\`)` pattern would have shelled out
+// any `&` / `|` / `^` / backtick / `$()` in a URL.
 
 /**
  * Interactive OAuth flow that adds a new account to the pool. Uses dario's
@@ -283,7 +285,7 @@ export async function addAccountViaOAuth(alias: string): Promise<AccountCredenti
 
         if (!tokenRes.ok) {
           const body = await tokenRes.text().catch(() => '');
-          throw new Error(`Token exchange failed (${tokenRes.status}): ${body.slice(0, 200)}`);
+          throw new Error(`Token exchange failed (${tokenRes.status}): ${redactSecrets(body.slice(0, 200))}`);
         }
 
         const tokens = await tokenRes.json() as {
@@ -339,7 +341,7 @@ export async function addAccountViaOAuth(alias: string): Promise<AccountCredenti
       console.log(`  ${authUrl}`);
       console.log();
 
-      openBrowser(authUrl);
+      try { openBrowser(authUrl); } catch { /* non-fatal: user has the URL printed above */ }
     });
 
     server.on('error', (err: Error) => {

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -12,6 +12,7 @@ import { execFile } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { homedir, platform } from 'node:os';
 import { detectCCOAuthConfig } from './cc-oauth-detect.js';
+import { redactSecrets } from './redact.js';
 
 // Manual-flow redirect URI. Anthropic's authorize endpoint special-cases
 // this value (also baked into CC as MANUAL_REDIRECT_URL) to render the
@@ -304,12 +305,12 @@ export async function startAutoOAuthFlow(): Promise<OAuthTokens> {
       console.log(`  If the browser didn't open, visit: ${authUrl}`);
       console.log('');
 
-      // Open browser using platform-specific commands (no external deps)
-      const { exec } = await import('node:child_process');
-      const cmd = process.platform === 'win32' ? `start "" "${authUrl}"`
-        : process.platform === 'darwin' ? `open "${authUrl}"`
-        : `xdg-open "${authUrl}"`;
-      exec(cmd, () => {});
+      // Hardened: openBrowser uses execFile + argv array + URL protocol
+      // allowlist. Previous inline `exec(\`start "" "${authUrl}"\`)`
+      // would have shelled out any `&` / `|` / `^` / backtick / `$()` in
+      // a URL — see src/open-browser.ts.
+      const { openBrowser } = await import('./open-browser.js');
+      try { openBrowser(authUrl); } catch { /* non-fatal: user has the URL printed above */ }
     });
 
     server.on('error', (err: Error) => {
@@ -502,7 +503,9 @@ async function exchangeCodeManual(code: string, codeVerifier: string, state: str
 
   if (!res.ok) {
     const body = await res.text().catch(() => '');
-    throw new Error(`Token exchange failed (HTTP ${res.status}): ${body.slice(0, 200)}`);
+    // See src/redact.ts — strip tokens / JWTs / Bearer values from upstream
+    // body before they surface in the Error message.
+    throw new Error(`Token exchange failed (HTTP ${res.status}): ${redactSecrets(body.slice(0, 200))}`);
   }
 
   const data = await res.json() as {
@@ -574,7 +577,7 @@ async function doRefreshTokens(): Promise<OAuthTokens> {
 
     if (!res.ok) {
       const errBody = await res.text().catch(() => '');
-      console.error(`[dario] Refresh attempt ${attempt + 1}/3 failed: HTTP ${res.status} — ${errBody.slice(0, 200)}`);
+      console.error(`[dario] Refresh attempt ${attempt + 1}/3 failed: HTTP ${res.status} — ${redactSecrets(errBody.slice(0, 200))}`);
       if (res.status === 401 || res.status === 403) {
         throw new Error(`Refresh token rejected (${res.status}). Run \`dario login\` to re-authenticate.`);
       }

--- a/src/open-browser.ts
+++ b/src/open-browser.ts
@@ -1,0 +1,84 @@
+/**
+ * Safe URL → default-browser dispatch.
+ *
+ * Replaces the inline `child_process.exec` template-string patterns that
+ * previously lived in `src/oauth.ts` and `src/accounts.ts`. Those used
+ * shell interpolation of an external URL (`exec(\`start "" "${url}"\`)`,
+ * `exec(\`xdg-open "${url}"\`)`) — defense-in-depth concern: a malicious
+ * `DARIO_OAUTH_AUTHORIZE_URL` override, a backdoored `claude` binary
+ * smuggling a different `CLAUDE_AI_AUTHORIZE_URL` literal through the
+ * cc-oauth-detect scanner, or any future code path that lets a less-
+ * trusted source reach this function would inject shell metacharacters
+ * (`&`, `|`, `>`, `^`, ``$()``, backtick) and execute arbitrary commands.
+ *
+ * Hardened path:
+ *   1. Parse the URL with WHATWG `URL` — throws on malformed input.
+ *   2. Allow only `http:` and `https:` (rejects `file:`, `javascript:`,
+ *      `vbscript:`, `data:`, custom schemes that route through
+ *      registered URL handlers).
+ *   3. Re-serialize via `parsed.toString()` so any pre-parse oddities
+ *      get normalized through the URL spec.
+ *   4. Spawn the platform's URL-handler binary directly with the URL as
+ *      a single argv element — no shell, no template interpolation.
+ *      Windows uses `explorer.exe` (System32 binary, accepts URLs as
+ *      argv, no cmd hop) instead of `cmd /c start`, which would parse
+ *      `&`/`|` as command separators after Node's argv → cmd quoting.
+ *   5. Errors from the spawned process are swallowed: a failed browser
+ *      open is non-fatal because every caller also prints the URL to
+ *      stdout for manual paste.
+ *
+ * Tests use the `exec` option to inject a stub.
+ */
+
+import { execFile, type ExecFileException } from 'node:child_process';
+
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
+
+export interface OpenBrowserOptions {
+  /** Test hook — defaults to node:child_process execFile. */
+  exec?: (
+    file: string,
+    args: readonly string[],
+    callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+  ) => void;
+}
+
+/**
+ * Build the (binary, argv) pair the current platform uses to dispatch a
+ * URL to its default browser. Exported for tests.
+ */
+export function browserDispatchCommand(
+  url: string,
+  platform: NodeJS.Platform = process.platform,
+): { bin: string; args: string[] } {
+  const parsed = new URL(url);
+  if (!ALLOWED_PROTOCOLS.has(parsed.protocol)) {
+    throw new Error(`openBrowser: refusing to open URL with protocol "${parsed.protocol}" (only http/https allowed)`);
+  }
+  const safe = parsed.toString();
+  if (platform === 'win32') {
+    // explorer.exe accepts a URL as a single argv element and routes it
+    // through the registered URL handler. Avoids `cmd /c start "" "URL"`,
+    // which re-parses cmd metacharacters even when called via execFile
+    // because the cmd builtin runs *inside* cmd's parser, not Node's.
+    return { bin: 'explorer.exe', args: [safe] };
+  }
+  if (platform === 'darwin') {
+    return { bin: 'open', args: [safe] };
+  }
+  // Linux / BSD / other Unix.
+  return { bin: 'xdg-open', args: [safe] };
+}
+
+/**
+ * Open `url` in the user's default browser. See module docstring.
+ *
+ * @throws if the URL is malformed or has a protocol other than http/https.
+ *         Browser-launch failures (handler missing, etc.) are swallowed —
+ *         every caller already prints the URL for manual paste.
+ */
+export function openBrowser(url: string, opts: OpenBrowserOptions = {}): void {
+  const { bin, args } = browserDispatchCommand(url);
+  const exec = opts.exec ?? execFile;
+  exec(bin, args, () => { /* non-fatal */ });
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -13,6 +13,7 @@ import { Analytics, billingBucketFromClaim } from './analytics.js';
 import { loadAllAccounts, loadAccount, refreshAccountToken } from './accounts.js';
 import { getOpenAIBackend, isOpenAIModel, forwardToOpenAI, type BackendCredentials } from './openai-backend.js';
 import { RequestQueue, QueueFullError, QueueTimeoutError, DEFAULT_MAX_CONCURRENT, DEFAULT_MAX_QUEUED, DEFAULT_QUEUE_TIMEOUT_MS } from './request-queue.js';
+import { redactSecrets } from './redact.js';
 
 const ANTHROPIC_API = 'https://api.anthropic.com';
 const DEFAULT_PORT = 3456;
@@ -420,12 +421,10 @@ interface ProxyOptions {
 }
 
 export function sanitizeError(err: unknown): string {
-  const msg = err instanceof Error ? err.message : String(err);
-  // Never leak tokens, JWTs, or bearer values in error messages
-  return msg
-    .replace(/sk-ant-[a-zA-Z0-9_-]+/g, '[REDACTED]')
-    .replace(/eyJ[a-zA-Z0-9_-]+\.eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+/g, '[REDACTED_JWT]')
-    .replace(/Bearer\s+[^\s,;]+/gi, 'Bearer [REDACTED]');
+  // Pattern set lives in src/redact.ts so OAuth call sites can run the
+  // same redaction directly on response-body strings without importing
+  // proxy (which imports oauth — would circle).
+  return redactSecrets(err instanceof Error ? err.message : String(err));
 }
 
 /**

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -1,0 +1,40 @@
+/**
+ * Secret redaction for free-form strings emitted by dario.
+ *
+ * Used wherever an externally-sourced string (an upstream HTTP response
+ * body, an exception message, a verbose log line) might transit through
+ * to a place a user can see (stderr, an Error message, a JSON response).
+ * Even though Anthropic's documented API is not known to echo tokens in
+ * error responses, defense-in-depth: a future API change, a CDN error
+ * page that captures the request headers, or an intermediary's debug
+ * dump could surface a token, and we'd rather redact in transit than
+ * audit every call site for novel leak shapes.
+ *
+ * Patterns match formats actually seen in the Anthropic ecosystem:
+ *   - `sk-ant-…`     — long-lived API keys
+ *   - JWT triple     — OAuth access tokens (`eyJhdr.eyJpyld.sig`)
+ *   - `Bearer <…>`   — auth headers, raw or quoted
+ *
+ * Re-exported by `proxy.ts:sanitizeError` so the proxy's existing leak-
+ * shield benefits from any new patterns added here, and consumed
+ * directly by the OAuth code paths in `oauth.ts` / `accounts.ts` for
+ * sanitizing upstream error bodies before they hit `throw new Error`.
+ */
+
+export const SECRET_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/sk-ant-[a-zA-Z0-9_-]+/g, '[REDACTED]'],
+  [/eyJ[a-zA-Z0-9_-]+\.eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+/g, '[REDACTED_JWT]'],
+  [/Bearer\s+[^\s,;]+/gi, 'Bearer [REDACTED]'],
+];
+
+/**
+ * Apply every redaction pattern to a string. Idempotent — running a
+ * pre-redacted string through this is a no-op.
+ */
+export function redactSecrets(s: string): string {
+  let out = s;
+  for (const [pat, repl] of SECRET_PATTERNS) {
+    out = out.replace(pat, repl);
+  }
+  return out;
+}

--- a/test/open-browser.mjs
+++ b/test/open-browser.mjs
@@ -1,0 +1,133 @@
+// Tests for src/open-browser.ts — the hardened replacement for the
+// inline `child_process.exec("start \\"\\" \\"${url}\\"")` patterns that
+// previously lived in src/oauth.ts and src/accounts.ts.
+//
+// Two contracts to pin:
+//   1. URL validation — rejects non-http(s) protocols and obviously-
+//      malformed URLs *before* any spawn.
+//   2. Argv shape — the (bin, args) pair we hand to execFile is correct
+//      per platform and never contains shell metacharacters in the bin
+//      slot. Validated via the exported `browserDispatchCommand` helper
+//      so we don't need to actually spawn anything.
+//
+// We also exercise `openBrowser` end-to-end with a stubbed exec so the
+// integration of validate + dispatch + spawn is covered without touching
+// the real OS.
+
+import { browserDispatchCommand, openBrowser } from '../dist/open-browser.js';
+
+let pass = 0, fail = 0;
+function check(label, cond, ...rest) {
+  if (cond) { console.log(`  ✅ ${label}`); pass++; }
+  else { console.log(`  ❌ ${label}`, ...rest); fail++; }
+}
+function header(label) {
+  console.log(`\n======================================================================`);
+  console.log(`  ${label}`);
+  console.log(`======================================================================`);
+}
+
+// ----------------------------------------------------------------------
+//  URL validation
+// ----------------------------------------------------------------------
+header('browserDispatchCommand — accepts http/https URLs');
+{
+  const a = browserDispatchCommand('http://example.com/foo?bar=baz', 'linux');
+  check('http URL accepted', a.bin === 'xdg-open' && a.args.length === 1);
+  check('URL passed through as single argv element', a.args[0] === 'http://example.com/foo?bar=baz');
+
+  const b = browserDispatchCommand('https://claude.ai/oauth/authorize?code=true', 'darwin');
+  check('https URL accepted', b.bin === 'open');
+  check('URL preserved verbatim', b.args[0] === 'https://claude.ai/oauth/authorize?code=true');
+}
+
+header('browserDispatchCommand — rejects non-http(s) protocols');
+{
+  for (const evil of [
+    'file:///etc/passwd',
+    'javascript:alert(1)',
+    'data:text/html,<script>alert(1)</script>',
+    'vbscript:msgbox(1)',
+    'ftp://example.com/',
+  ]) {
+    let threw = false;
+    try { browserDispatchCommand(evil, 'linux'); } catch { threw = true; }
+    check(`rejects ${evil.slice(0, 30)}…`, threw);
+  }
+}
+
+header('browserDispatchCommand — rejects malformed URLs');
+{
+  for (const evil of [
+    'not a url',
+    '',
+    '   ',
+    'http://',                    // no host
+  ]) {
+    let threw = false;
+    try { browserDispatchCommand(evil, 'linux'); } catch { threw = true; }
+    check(`rejects "${evil}"`, threw);
+  }
+}
+
+// ----------------------------------------------------------------------
+//  Shell-metacharacter URLs are passed verbatim as argv (NOT shelled)
+// ----------------------------------------------------------------------
+header('browserDispatchCommand — shell metacharacters in URL stay in argv (not shelled)');
+{
+  // These are valid URLs (every char is legal in URL query). The point
+  // is that they *would* have been catastrophic in the previous
+  // `exec("xdg-open \\"${url}\\"")` shape because xdg-open would have
+  // received `url & calc.exe`. With argv they're a single element.
+  const evil = 'https://example.com/?x=1&y=$(calc.exe)&z=`whoami`&w=|cat';
+  const cmd = browserDispatchCommand(evil, 'linux');
+  check('shell metacharacters preserved as a single argv element', cmd.args.length === 1 && cmd.args[0] === evil);
+  check('bin is the URL handler binary, not a shell', cmd.bin === 'xdg-open');
+}
+
+// ----------------------------------------------------------------------
+//  Per-platform binary selection
+// ----------------------------------------------------------------------
+header('browserDispatchCommand — per-platform bin');
+{
+  check('win32 → explorer.exe', browserDispatchCommand('https://x.test', 'win32').bin === 'explorer.exe');
+  check('darwin → open',        browserDispatchCommand('https://x.test', 'darwin').bin === 'open');
+  check('linux → xdg-open',     browserDispatchCommand('https://x.test', 'linux').bin === 'xdg-open');
+  check('freebsd → xdg-open',   browserDispatchCommand('https://x.test', 'freebsd').bin === 'xdg-open');
+  // Unknown platforms fall through to xdg-open as the most-common Unix default.
+  check('unknown → xdg-open',   browserDispatchCommand('https://x.test', 'aix').bin === 'xdg-open');
+}
+
+// ----------------------------------------------------------------------
+//  openBrowser — end-to-end with stubbed exec
+// ----------------------------------------------------------------------
+header('openBrowser — invokes execFile with argv (no shell)');
+{
+  let called = null;
+  const stub = (file, args, cb) => {
+    called = { file, args };
+    cb(null, '', '');
+  };
+  openBrowser('https://example.com/?x=1&y=2', { exec: stub });
+  check('exec was called', called !== null);
+  check('exec received URL handler binary, not shell', called && (called.file === 'explorer.exe' || called.file === 'open' || called.file === 'xdg-open'));
+  check('URL passed as single argv element', called && called.args.length === 1 && called.args[0] === 'https://example.com/?x=1&y=2');
+}
+
+header('openBrowser — throws on unsafe protocol before spawning');
+{
+  let called = false;
+  const stub = (_file, _args, cb) => { called = true; cb(null, '', ''); };
+  let threw = false;
+  try { openBrowser('javascript:alert(1)', { exec: stub }); } catch { threw = true; }
+  check('throws synchronously', threw);
+  check('exec was NOT called when validation fails', called === false);
+}
+
+// ----------------------------------------------------------------------
+//  Result
+// ----------------------------------------------------------------------
+console.log(`\n======================================================================`);
+console.log(`  Results: ${pass} passed, ${fail} failed`);
+console.log(`======================================================================\n`);
+if (fail > 0) process.exit(1);

--- a/test/redact.mjs
+++ b/test/redact.mjs
@@ -1,0 +1,82 @@
+// Tests for src/redact.ts — secret redaction patterns shared between
+// proxy.ts:sanitizeError and the OAuth call sites in oauth.ts and
+// accounts.ts that thread upstream response bodies into Error messages.
+
+import { redactSecrets, SECRET_PATTERNS } from '../dist/redact.js';
+
+let pass = 0, fail = 0;
+function check(label, cond, ...rest) {
+  if (cond) { console.log(`  ✅ ${label}`); pass++; }
+  else { console.log(`  ❌ ${label}`, ...rest); fail++; }
+}
+function header(label) {
+  console.log(`\n======================================================================`);
+  console.log(`  ${label}`);
+  console.log(`======================================================================`);
+}
+
+header('redactSecrets — redacts sk-ant-* API keys');
+{
+  const out = redactSecrets('error: sk-ant-api03-abc_123-DEFxyz reached rate limit');
+  check('sk-ant- prefix redacted', !out.includes('sk-ant-api03-abc_123'));
+  check('replacement marker present', out.includes('[REDACTED]'));
+  check('surrounding context preserved', out.startsWith('error: ') && out.endsWith(' reached rate limit'));
+}
+
+header('redactSecrets — redacts JWT tokens (eyJ.eyJ.sig triple)');
+{
+  const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature_value_here';
+  const out = redactSecrets(`got ${jwt} from upstream`);
+  check('JWT redacted', !out.includes('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0'));
+  check('JWT marker present', out.includes('[REDACTED_JWT]'));
+}
+
+header('redactSecrets — redacts Bearer tokens');
+{
+  const out = redactSecrets('Authorization: Bearer abc123def456ghi789 was rejected');
+  check('Bearer value redacted', !out.includes('Bearer abc123def456ghi789'));
+  check('Bearer prefix preserved with marker', out.includes('Bearer [REDACTED]'));
+}
+
+header('redactSecrets — multiple secrets on one line');
+{
+  const input = 'sk-ant-foo and Bearer xyz123 simultaneously';
+  const out = redactSecrets(input);
+  check('sk-ant redacted', !out.includes('sk-ant-foo'));
+  check('Bearer redacted', !out.includes('Bearer xyz123'));
+}
+
+header('redactSecrets — idempotent (redacted string redacts to itself)');
+{
+  const once  = redactSecrets('sk-ant-foo and Bearer xyz123');
+  const twice = redactSecrets(once);
+  check('second pass is a no-op', once === twice, once, twice);
+}
+
+header('redactSecrets — leaves non-secret content untouched');
+{
+  const inputs = [
+    '',
+    'plain error message',
+    'sk-other-foo (not anthropic)',
+    'eyJ-truncated (not a full JWT)',
+    'BearerTypoNoSpace abc',
+  ];
+  for (const s of inputs) {
+    const out = redactSecrets(s);
+    check(`untouched: "${s.slice(0, 30)}…"`, out === s);
+  }
+}
+
+header('SECRET_PATTERNS export — frozen regex set, sane shape');
+{
+  check('exposes at least 3 patterns', SECRET_PATTERNS.length >= 3);
+  for (const tup of SECRET_PATTERNS) {
+    check('each entry is [RegExp, string]', tup[0] instanceof RegExp && typeof tup[1] === 'string');
+  }
+}
+
+console.log(`\n======================================================================`);
+console.log(`  Results: ${pass} passed, ${fail} failed`);
+console.log(`======================================================================\n`);
+if (fail > 0) process.exit(1);


### PR DESCRIPTION
## Summary

Self-audit defense-in-depth pass. **No known active exploit.** Both fixes are byte-equivalent for legitimate inputs; the change is rejecting the unsafe inputs the original code paths should never have been able to reach in the first place.

## Findings → fixes

### 1. Browser dispatch no longer routes through the shell

\`src/oauth.ts:308-312\` and \`src/accounts.ts:202-208\` both used \`child_process.exec\` with template-string interpolation to hand a URL to the OS:

\`\`\`ts
exec(\`start \"\" \"\${authUrl}\"\`, () => {});       // win32
exec(\`open \"\${authUrl}\"\`, () => {});            // darwin
exec(\`xdg-open \"\${authUrl}\"\`, () => {});        // linux
\`\`\`

The URL flows in from \`cfg.authorizeUrl\` (\`detectCCOAuthConfig()\` → CC binary scan) or a user-set \`DARIO_OAUTH_AUTHORIZE_URL\` env override. In the documented threat model both are operator-controlled, so the practical risk today is zero. **But:** a future code path that piped a less-trusted source in, a backdoored \`claude\` binary forging the \`CLAUDE_AI_AUTHORIZE_URL\` literal the scanner extracts, or a typo in a future env-override path — any of those would have shelled out characters like \`&\`, \`|\`, \`^\`, backtick, \`\$()\`.

New \`src/open-browser.ts\`:

- Parses the URL with WHATWG \`URL\` (throws on malformed)
- Allowlists \`http:\` / \`https:\` only — rejects \`file:\`, \`javascript:\`, \`data:\`, \`vbscript:\`, custom schemes
- Spawns the platform's URL handler (\`explorer.exe\` / \`open\` / \`xdg-open\`) via \`execFile\` with the URL as a single argv element. **No shell, no template interpolation.** Windows uses \`explorer.exe\` instead of \`cmd /c start \"\" \"URL\"\` so cmd's parser never sees the URL even after Node's argv-quoting.
- Browser-launch failures are swallowed — every caller already prints the URL for manual paste, so a failed open is non-fatal.

Both call sites in \`accounts.ts\` and \`oauth.ts\` now import the helper and wrap in \`try {} catch {}\`.

### 2. Upstream error response bodies no longer reach \`Error.message\` raw

Four sites threw upstream HTTP body slices into \`Error.message\`:

- \`accounts.ts:doRefreshAccountToken\` — pool refresh
- \`accounts.ts:addAccountViaOAuth\` — token exchange
- \`oauth.ts:doExchangeToken\` — single-account login
- \`oauth.ts:doRefreshTokens\` — single-account refresh-on-retry

Anthropic's documented API isn't known to echo tokens in error responses, but defense-in-depth: a future API change, an intermediary's debug page, a CDN error template that captures request headers — any of these could surface a token. Better to redact in transit than audit every call site for novel leak shapes.

Extracted the patterns from \`proxy.ts:sanitizeError\` into a shared \`src/redact.ts\` (\`SECRET_PATTERNS\` + \`redactSecrets\`):

- \`sk-ant-…\` (long-lived API keys)
- JWT triple \`eyJhdr.eyJpld.sig\` (OAuth access tokens)
- \`Bearer …\` (auth headers, raw or quoted)

Idempotent — running redaction over an already-redacted string is a no-op. \`proxy.ts:sanitizeError\` is now a one-liner over \`redactSecrets\`; behavior identical.

## What's NOT in this PR (audit said \"already mitigated, no PR needed\")

- File permissions: \`0600\` on credential files, \`0700\` on dirs — explicit at every write
- Auth: \`timingSafeEqual()\` for API key compare, no CORS-bypass for non-OPTIONS verbs
- Path traversal: \`safeAliasPath\` + \`safeBackendPath\` — basename + regex allowlist + 0o600 mode
- DNS rebinding: blocked on the response side by the CORS allowlist (browsers refuse mismatched-origin responses)
- TLS: no overrides anywhere; no \`NODE_TLS_REJECT_UNAUTHORIZED\` games
- DoS: \`MAX_BODY_BYTES=10MB\` + \`BODY_READ_TIMEOUT_MS=30s\` + bounded \`RequestQueue\`
- OAuth flow: PKCE-correct, 32-byte state (post-#71), redirect_uri pinned to localhost
- MCP: read-only tools, mutations explicitly blocked at the tool-set level
- Subprocess spawning (\`bun\`, \`npm\`, \`claude\`): all use argument arrays, not shell strings

## Test coverage

- \`test/open-browser.mjs\` — **25 assertions**: protocol allowlist (rejects \`file:\` / \`javascript:\` / \`data:\` / \`vbscript:\` / \`ftp:\`), malformed URL rejection, per-platform binary selection (\`explorer.exe\` / \`open\` / \`xdg-open\`), shell-metacharacter URLs preserved as a single argv element (the whole point of the fix), and the \`exec\` stub path so the integration of validate + spawn is covered without spawning.
- \`test/redact.mjs\` — **19 assertions**: all three patterns; multi-secret strings; idempotency; non-secret content untouched; \`SECRET_PATTERNS\` export shape.

**52 tests total, up from 50.**

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 52/52 pass
- [x] Both new test files pass standalone
- [ ] Post-merge: auto-release tags v3.31.16 + publishes to npm
