### PR TITLE
v3.31.17 — pool routing for Anthropic's per-model weekly buckets (7d_sonnet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,37 @@ checklist.
 
 ## [Unreleased]
 
+## [3.31.17] - 2026-04-25
+
+### Fixed — pool routing now considers Anthropic's per-model weekly buckets
+
+Anthropic started carving the Max plan's weekly window into per-model sub-buckets sometime around 2026-04-25. Currently observed:
+
+- The unified `7d` bucket still exists (the "All models" line on the user dashboard)
+- A **new dedicated `7d_sonnet` bucket** ships on Sonnet responses only — corresponds to the "Sonnet only" usage line on the dashboard, currently independent from `7d`
+- Opus 4.6 / Opus 4.7 / Haiku 4.5 do not yet have dedicated headers; they're still entirely on the unified buckets
+
+This was found by stress-probing Opus 4.7 + Sonnet 4.6 against dario in production (see [v0 stress run findings — Opus 4.7 currently 1.85× faster than Sonnet 4.6 through dario](https://github.com/askalf/dario/discussions)). The new bucket is on the wire with no documentation that I can find.
+
+**Routing impact before this fix:** dario's `select()` and `selectExcluding()` computed headroom as `1 - max(util5h, util7d)` and ignored the per-model bucket entirely. Once Anthropic starts enforcing the Sonnet bucket, the pool would have happily routed Sonnet requests to an account at 95% on its `7d_sonnet` window because that account looked great on the unified `7d` bucket. Account would 429, dario would failover, but the picker would have made the same wrong call again until enough accounts got rejected.
+
+**Now:**
+
+- `parseRateLimits` scans the full header set with the regex `^anthropic-ratelimit-unified-7d_([a-z0-9-]+)-utilization$`, capturing every per-model bucket Anthropic emits — `_sonnet` today, `_opus` / `_haiku` if/when they ship, no allowlist gate. Lowercase-normalized keys.
+- New `RateLimitSnapshot.perModel7d: Record<string, number>` field stores the captured buckets per account; `EMPTY_SNAPSHOT` initialized with `{}`.
+- New `computeHeadroom(snapshot, family?)` helper folds the per-model bucket into the headroom max when a request's family matches a captured key. Falls back to unified-only headroom when family is null or no matching bucket exists. Replaces ~6 inline `1 - Math.max(util5h, util7d)` sites across `pool.ts`.
+- New `modelFamily(modelId)` helper extracts `opus` / `sonnet` / `haiku` from request model ids — handles `claude-opus-4-7`, `opus`, legacy `claude-3-7-sonnet-…`, lowercase / uppercase, alias / full-id forms.
+- `select()`, `selectSticky()`, `selectExcluding()` now take an optional `family` parameter. `proxy.ts` threads the request's family through at all four call sites (`selectSticky` for the sticky pick, both `selectExcluding` sites for 429 failover). The initial `pool.select()` at request-receive time stays family-less because the body hasn't been parsed yet — same behavior as before this PR for that pre-parse pick.
+- New first-sight detector in `proxy.ts`: when verbose mode encounters a per-model bucket family it hasn't seen this run, log `[dario] new per-model rate-limit bucket observed: 7d_<family>`. Catches future Anthropic rollouts the day they ship instead of the day they start failing routing.
+
+26 new assertions in `test/per-model-buckets.mjs` covering: parser captures `_sonnet` (live header today), parser captures hypothetical `_opus`/`_haiku` (forward-compat), case-insensitive family normalization, headroom unified-only fallback when family not supplied, headroom folds in per-model bucket when family matches, headroom unified-only when family present but no matching bucket, `select(family)` flips routing when one account is sonnet-saturated, `select(family)` partial-signal correctness when only one account has per-model data, `modelFamily` extraction across alias / full-id / legacy / case / non-Claude forms.
+
+Forward-compat by design: if Anthropic ships `7d_opus` next week, dario's parser captures it, the routing decision uses it for Opus requests, and verbose-mode users get a heads-up log on first observation. No code change needed when a new bucket appears.
+
+`test/infra-probe.mjs` (the one-off investigation script that found this) is excluded from the default `npm test` run via the same `EXCLUDED` set as `e2e` / `stress` / `compat`. Kept in the tree as a diagnostic artifact for future Anthropic-changed-something investigations.
+
+53 tests total (up from 50 + 2 from #139).
+
 ## [3.31.16] - 2026-04-24
 
 ### Security — defense-in-depth hardening pass (no known active exploit)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "3.31.16",
+  "version": "3.31.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "3.31.16",
+      "version": "3.31.17",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.31.16",
+  "version": "3.31.17",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -35,6 +35,20 @@ export interface RateLimitSnapshot {
   status: string;
   util5h: number;
   util7d: number;
+  /**
+   * Per-model 7-day utilization buckets — Anthropic carves separate
+   * weekly windows for some model families. As of 2026-04-25 the live
+   * API emits `anthropic-ratelimit-unified-7d_sonnet-utilization` on
+   * Sonnet responses (corresponds to the "Sonnet only" line on the user
+   * dashboard); other families do not yet have dedicated buckets but
+   * the parser scans the header set generically so any future
+   * `7d_<family>` header is captured automatically.
+   *
+   * Keyed by the family suffix as it arrived on the wire (lowercase,
+   * e.g. `sonnet` / `opus` / `haiku`). Empty when no per-model headers
+   * were on the response.
+   */
+  perModel7d: Record<string, number>;
   overageUtil: number;
   claim: string;
   reset: number;
@@ -46,6 +60,7 @@ export const EMPTY_SNAPSHOT: RateLimitSnapshot = {
   status: 'unknown',
   util5h: 0,
   util7d: 0,
+  perModel7d: {},
   overageUtil: 0,
   claim: 'unknown',
   reset: 0,
@@ -78,19 +93,84 @@ interface QueuedRequest {
   enqueuedAt: number;
 }
 
+/**
+ * Match `anthropic-ratelimit-unified-7d_<family>-utilization`. Generic on
+ * `<family>` so a future `7d_opus` / `7d_haiku` (or anything Anthropic
+ * adds without notice) is captured automatically. The family is
+ * normalized to lowercase to match `modelFamily()` output.
+ */
+const PER_MODEL_7D_HEADER = /^anthropic-ratelimit-unified-7d_([a-z0-9-]+)-utilization$/i;
+
 /** Parse an Anthropic response's rate-limit headers into a snapshot. */
 export function parseRateLimits(headers: Headers): RateLimitSnapshot {
   const get = (key: string) => headers.get(`anthropic-ratelimit-unified-${key}`) ?? '';
+  const perModel7d: Record<string, number> = {};
+  // Iterate the full header set — `headers.get` only retrieves known
+  // keys, but Anthropic can add new `7d_<family>-utilization` shapes
+  // unannounced. Scanning the iterator means the parser is automatically
+  // forward-compatible. Real `Headers` instances and test-side mocks
+  // (which implement `.entries()` but not direct iteration) both work
+  // through the explicit `.entries()` call.
+  const entries = (typeof headers.entries === 'function')
+    ? headers.entries()
+    : (headers as unknown as Iterable<[string, string]>);
+  for (const [k, v] of entries as Iterable<[string, string]>) {
+    const m = k.match(PER_MODEL_7D_HEADER);
+    if (m && m[1]) {
+      perModel7d[m[1].toLowerCase()] = parseFloat(v) || 0;
+    }
+  }
   return {
     status: get('status') || 'unknown',
     util5h: parseFloat(get('5h-utilization')) || 0,
     util7d: parseFloat(get('7d-utilization')) || 0,
+    perModel7d,
     overageUtil: parseFloat(get('overage-utilization')) || 0,
     claim: get('representative-claim') || 'unknown',
     reset: parseInt(get('reset')) || 0,
     fallbackPct: parseFloat(get('fallback-percentage')) || 0,
     updatedAt: Date.now(),
   };
+}
+
+/**
+ * Extract the model family (`opus` / `sonnet` / `haiku`) from a request's
+ * model id. Used to look up the per-model 7d bucket in
+ * `RateLimitSnapshot.perModel7d` during routing decisions. Returns null
+ * for non-Claude models or model ids that don't carry a recognizable
+ * family token (those requests just use the unified buckets).
+ *
+ * Generous on input shape: matches `claude-opus-4-7`, `opus`, `claude-3-7-sonnet-…`,
+ * `claude-haiku-4-5`, anything containing the family token. Lowercase-normalized
+ * so it pairs cleanly with `parseRateLimits`'s lowercase family keys.
+ */
+export function modelFamily(modelId: string | null | undefined): string | null {
+  if (!modelId) return null;
+  const m = modelId.toLowerCase();
+  if (m.includes('opus')) return 'opus';
+  if (m.includes('sonnet')) return 'sonnet';
+  if (m.includes('haiku')) return 'haiku';
+  return null;
+}
+
+/**
+ * Compute headroom for a single account given its rate-limit snapshot.
+ * Headroom is the slack between the most-saturated relevant bucket and
+ * full utilization: `1 - max(util5h, util7d, util_per_model_if_known)`.
+ *
+ * When `family` is supplied AND the snapshot has a corresponding per-
+ * model 7d bucket, that bucket is included in the max. When the family
+ * isn't represented in the snapshot (e.g. account hasn't seen a Sonnet
+ * request yet so `7d_sonnet` is unknown), headroom is computed from the
+ * unified buckets only — best-effort, populated on the next response.
+ */
+export function computeHeadroom(snapshot: RateLimitSnapshot, family?: string | null): number {
+  const utils = [snapshot.util5h, snapshot.util7d];
+  if (family) {
+    const perModel = snapshot.perModel7d[family];
+    if (perModel !== undefined) utils.push(perModel);
+  }
+  return 1 - Math.max(...utils);
 }
 
 /**
@@ -165,8 +245,14 @@ export class AccountPool {
     return this.accounts.size;
   }
 
-  /** Select the best account for the next request. */
-  select(): PoolAccount | null {
+  /**
+   * Select the best account for the next request. `family` (when supplied)
+   * is the request's model family (`opus` / `sonnet` / `haiku`); when
+   * present and the account has a matching per-model 7d bucket, that
+   * bucket joins the headroom max. Family-less calls fall back to the
+   * unified-buckets-only headroom — same behavior as before this PR.
+   */
+  select(family?: string | null): PoolAccount | null {
     if (this.accounts.size === 0) return null;
 
     const now = Date.now();
@@ -179,8 +265,8 @@ export class AccountPool {
 
     if (eligible.length > 0) {
       return eligible.reduce((best, curr) => {
-        const bestHeadroom = 1 - Math.max(best.rateLimit.util5h, best.rateLimit.util7d);
-        const currHeadroom = 1 - Math.max(curr.rateLimit.util5h, curr.rateLimit.util7d);
+        const bestHeadroom = computeHeadroom(best.rateLimit, family);
+        const currHeadroom = computeHeadroom(curr.rateLimit, family);
         return currHeadroom > bestHeadroom ? curr : best;
       });
     }
@@ -211,8 +297,8 @@ export class AccountPool {
    *
    * Also performs lazy cleanup of expired bindings (TTL or size cap).
    */
-  selectSticky(stickyKey: string | null): PoolAccount | null {
-    if (!stickyKey) return this.select();
+  selectSticky(stickyKey: string | null, family?: string | null): PoolAccount | null {
+    if (!stickyKey) return this.select(family);
     this.cleanupSticky();
 
     const binding = this.sticky.get(stickyKey);
@@ -222,13 +308,13 @@ export class AccountPool {
       if (bound
         && bound.rateLimit.status !== 'rejected'
         && bound.expiresAt > now + 30_000
-        && (1 - Math.max(bound.rateLimit.util5h, bound.rateLimit.util7d)) > POOL_HEADROOM_FLOOR
+        && computeHeadroom(bound.rateLimit, family) > POOL_HEADROOM_FLOOR
       ) {
         return bound;
       }
     }
 
-    const picked = this.select();
+    const picked = this.select(family);
     if (picked) {
       this.sticky.set(stickyKey, { alias: picked.alias, boundAt: Date.now() });
     }
@@ -278,7 +364,7 @@ export class AccountPool {
   }
 
   /** Select the next-best account, excluding the given set of aliases. */
-  selectExcluding(excluded: Set<string>): PoolAccount | null {
+  selectExcluding(excluded: Set<string>, family?: string | null): PoolAccount | null {
     if (this.accounts.size <= 1) return null;
 
     const now = Date.now();
@@ -291,8 +377,8 @@ export class AccountPool {
 
     if (eligible.length > 0) {
       return eligible.reduce((best, curr) => {
-        const bestHeadroom = 1 - Math.max(best.rateLimit.util5h, best.rateLimit.util7d);
-        const currHeadroom = 1 - Math.max(curr.rateLimit.util5h, curr.rateLimit.util7d);
+        const bestHeadroom = computeHeadroom(best.rateLimit, family);
+        const currHeadroom = computeHeadroom(curr.rateLimit, family);
         return currHeadroom > bestHeadroom ? curr : best;
       });
     }
@@ -340,7 +426,10 @@ export class AccountPool {
       a.rateLimit.status !== 'rejected' &&
       a.expiresAt > now + 30_000,
     );
-    const headrooms = all.map(a => 1 - Math.max(a.rateLimit.util5h, a.rateLimit.util7d));
+    // Status is a pool-wide aggregate; family-agnostic. Per-model
+    // headroom is request-context-specific and only meaningful at
+    // select() time.
+    const headrooms = all.map(a => computeHeadroom(a.rateLimit));
     const avgHeadroom = headrooms.length > 0 ? headrooms.reduce((a, b) => a + b, 0) / headrooms.length : 0;
     const best = this.select();
 
@@ -362,7 +451,7 @@ export class AccountPool {
   async waitForAccount(): Promise<PoolAccount> {
     const immediate = this.select();
     if (immediate) {
-      const headroom = 1 - Math.max(immediate.rateLimit.util5h, immediate.rateLimit.util7d);
+      const headroom = computeHeadroom(immediate.rateLimit);
       if (headroom > POOL_HEADROOM_FLOOR) return immediate;
     }
 
@@ -407,7 +496,7 @@ export class AccountPool {
     while (this.queue.length > 0) {
       const account = this.select();
       if (!account) break;
-      const headroom = 1 - Math.max(account.rateLimit.util5h, account.rateLimit.util7d);
+      const headroom = computeHeadroom(account.rateLimit);
       if (headroom <= POOL_HEADROOM_FLOOR) break;
 
       const entry = this.queue.shift();

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,7 +8,7 @@ import { arch, platform } from 'node:process';
 import { getAccessToken, getStatus } from './oauth.js';
 import { buildCCRequest, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, CC_TEMPLATE, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
 import { describeTemplate, detectDrift, checkCCCompat } from './live-fingerprint.js';
-import { AccountPool, computeStickyKey, parseRateLimits, type PoolAccount } from './pool.js';
+import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, type PoolAccount } from './pool.js';
 import { Analytics, billingBucketFromClaim } from './analytics.js';
 import { loadAllAccounts, loadAccount, refreshAccountToken } from './accounts.js';
 import { getOpenAIBackend, isOpenAIModel, forwardToOpenAI, type BackendCredentials } from './openai-backend.js';
@@ -539,6 +539,11 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
   // Single-account dario keeps its existing code path unchanged.
   const accountsList = await loadAllAccounts();
   const pool = accountsList.length >= 2 ? new AccountPool() : null;
+  // Per-model rate-limit bucket families seen during this proxy run. First-
+  // sight is logged once when verbose so a new Anthropic bucket (e.g. an
+  // eventual `7d_opus`) doesn't slip past unnoticed. Pure observability —
+  // routing already handles unknown families generically.
+  const seenPerModelBuckets = new Set<string>();
   const analytics = pool ? new Analytics() : null;
 
   let status: Awaited<ReturnType<typeof getStatus>>;
@@ -1047,7 +1052,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
             // Rotating off mid-session costs cache-create on every turn.
             stickyKey = computeStickyKey(userMsg);
             if (pool && stickyKey) {
-              const preferred = pool.selectSticky(stickyKey);
+              const preferred = pool.selectSticky(stickyKey, modelFamily(requestModel));
               if (preferred && preferred.alias !== poolAccount?.alias) {
                 poolAccount = preferred;
                 accessToken = preferred.accessToken;
@@ -1281,6 +1286,20 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           } else {
             pool.updateRateLimits(poolAccount.alias, snapshot);
           }
+          // First-sight detector for per-model rate-limit buckets. Anthropic
+          // ships these unannounced — e.g. `7d_sonnet-utilization` appeared
+          // around 2026-04-25 — and verbose-mode users want a heads-up the
+          // first time a new family shows up so they can decide whether to
+          // bump dario's expectations. Pure logging; the routing path
+          // already handles arbitrary family keys (see pool.computeHeadroom).
+          for (const family of Object.keys(snapshot.perModel7d)) {
+            if (!seenPerModelBuckets.has(family)) {
+              seenPerModelBuckets.add(family);
+              if (verbose) {
+                console.log(`[dario] new per-model rate-limit bucket observed: 7d_${family} (util=${snapshot.perModel7d[family]?.toFixed(2)})`);
+              }
+            }
+          }
         }
 
       // Auto-retry without context-1m if it triggers a long-context billing error.
@@ -1369,7 +1388,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
         } else if (upstream.status === 429) {
           // Not a context-1m issue — try pool failover before surfacing to client
           if (pool && poolAccount) {
-            const nextAccount = pool.selectExcluding(triedAliases);
+            const nextAccount = pool.selectExcluding(triedAliases, modelFamily(requestModel));
             if (nextAccount) {
               triedAliases.add(nextAccount.alias);
               poolAccount = nextAccount;
@@ -1427,7 +1446,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
       if (upstream.status === 429) {
         // Try pool failover before surfacing to client
         if (pool && poolAccount) {
-          const nextAccount = pool.selectExcluding(triedAliases);
+          const nextAccount = pool.selectExcluding(triedAliases, modelFamily(requestModel));
           if (nextAccount) {
             triedAliases.add(nextAccount.alias);
             poolAccount = nextAccount;

--- a/test/all.test.mjs
+++ b/test/all.test.mjs
@@ -43,6 +43,7 @@ const EXCLUDED = new Set([
   'all.test.mjs',
   'e2e.mjs',
   'stress.mjs',
+  'infra-probe.mjs',
   'compat.mjs',
   'stealth-test.mjs',
 ]);

--- a/test/infra-probe.mjs
+++ b/test/infra-probe.mjs
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+// One-off investigation: figure out why Opus 4.7 is currently faster than
+// Sonnet 4.6 through dario. Bigger model winning is unusual; either
+// Anthropic moved Opus to a faster inference cluster, Sonnet 4.6 is
+// throttled / under heavier load, or our 12-request sample was noise.
+//
+// What this probe does, per model:
+//   1. 30 sequential requests (no concurrency — measures pure latency,
+//      not parallel throughput) with `max_tokens=8`. Captures total
+//      latency + token-budget so we can estimate per-token rate.
+//   2. 10 streaming requests captures TTFT vs total — splits "how long
+//      to start generating" from "how fast does it generate". An
+//      infra-tier difference shows up most cleanly as TTFT, while a
+//      per-token-rate difference shows up in (total - ttft) / events.
+//   3. Dumps every unique response header value seen, including
+//      `request-id`, `anthropic-organization-id`, `server`, anything
+//      ratelimit-related, and any custom hints Anthropic added recently.
+//
+// Also runs Opus 4.6 + Sonnet 4.7 if available, to disentangle "is it
+// Opus" vs "is it 4.7".
+//
+// Not committed as part of the test suite — diagnostic only.
+
+const BASE = process.env.DARIO_TEST_URL || 'http://127.0.0.1:3456';
+
+const MODELS = [
+  'claude-opus-4-7',
+  'claude-sonnet-4-6',
+  'claude-opus-4-6',     // for the "is it the 4.7 generation?" axis
+  'claude-sonnet-4-7',   // probe — may not exist
+];
+
+const SEQUENTIAL_N = 30;
+const STREAM_N = 10;
+
+function pct(arr, p) {
+  if (!arr.length) return 0;
+  const s = [...arr].sort((a, b) => a - b);
+  const idx = Math.min(s.length - 1, Math.floor((p / 100) * s.length));
+  return s[idx];
+}
+const fmt = ms => `${ms.toFixed(0)}ms`;
+
+async function nonStream(model) {
+  const t0 = performance.now();
+  const res = await fetch(`${BASE}/v1/messages`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'anthropic-version': '2023-06-01',
+      'authorization': 'Bearer dario',
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 8,
+      messages: [{ role: 'user', content: 'OK?' }],
+    }),
+  });
+  const dt = performance.now() - t0;
+  const headers = {};
+  for (const [k, v] of res.headers) headers[k] = v;
+  let body;
+  try { body = await res.json(); } catch { body = null; }
+  const usage = body?.usage || {};
+  return {
+    status: res.status,
+    dt,
+    inputTokens: usage.input_tokens,
+    outputTokens: usage.output_tokens,
+    cacheCreate: usage.cache_creation_input_tokens,
+    cacheRead: usage.cache_read_input_tokens,
+    headers,
+    err: res.status !== 200 ? body : null,
+  };
+}
+
+async function stream(model) {
+  const t0 = performance.now();
+  let firstByteAt = null;
+  let firstTokenAt = null;
+  let events = 0;
+  const res = await fetch(`${BASE}/v1/messages`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'anthropic-version': '2023-06-01',
+      'authorization': 'Bearer dario',
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 24,
+      stream: true,
+      messages: [{ role: 'user', content: 'count 1 to 5' }],
+    }),
+  });
+  if (!res.body) return { status: res.status, dt: performance.now() - t0 };
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    if (firstByteAt === null) firstByteAt = performance.now();
+    const chunk = decoder.decode(value);
+    if (firstTokenAt === null && chunk.includes('content_block_delta')) {
+      firstTokenAt = performance.now();
+    }
+    events += (chunk.match(/^event:/gm) || []).length;
+  }
+  return {
+    status: res.status,
+    dt: performance.now() - t0,
+    ttfb: firstByteAt ? firstByteAt - t0 : null,
+    ttft: firstTokenAt ? firstTokenAt - t0 : null,
+    events,
+  };
+}
+
+async function probe(model) {
+  console.log(`\n${'='.repeat(70)}`);
+  console.log(`  ${model}`);
+  console.log(`${'='.repeat(70)}`);
+
+  // 1. Sequential non-stream
+  console.log(`\n  [seq ${SEQUENTIAL_N}] sequential non-streaming requests...`);
+  const seq = [];
+  let modelExists = true;
+  for (let i = 0; i < SEQUENTIAL_N; i++) {
+    const r = await nonStream(model);
+    if (r.status === 404 || r.status === 400) {
+      console.log(`  → ${r.status} on first attempt: ${JSON.stringify(r.err).slice(0, 200)}`);
+      console.log(`  skipping this model.`);
+      modelExists = false;
+      break;
+    }
+    if (r.status !== 200) {
+      console.log(`  request ${i} failed: ${r.status} — ${JSON.stringify(r.err).slice(0, 100)}`);
+      break;
+    }
+    seq.push(r);
+  }
+  if (!modelExists) return null;
+
+  const lats = seq.map(r => r.dt);
+  const inToks = seq.map(r => r.inputTokens || 0);
+  const outToks = seq.map(r => r.outputTokens || 0);
+  const cacheR = seq.map(r => r.cacheRead || 0);
+
+  console.log(`       ok: ${seq.length}/${SEQUENTIAL_N}`);
+  console.log(`       latency: p50=${fmt(pct(lats, 50))}  p95=${fmt(pct(lats, 95))}  p99=${fmt(pct(lats, 99))}  max=${fmt(Math.max(...lats))}  min=${fmt(Math.min(...lats))}`);
+  console.log(`       tokens : in p50=${pct(inToks, 50)} (cache_read p50=${pct(cacheR, 50)})  out p50=${pct(outToks, 50)}`);
+
+  // Look for first-vs-rest cache speedup (cold-cache cost)
+  if (seq.length >= 5) {
+    const first = seq[0].dt;
+    const restMed = pct(seq.slice(1).map(r => r.dt), 50);
+    const speedup = ((first - restMed) / first * 100).toFixed(1);
+    console.log(`       cache  : first=${fmt(first)}  rest p50=${fmt(restMed)}  cold→warm Δ=${speedup}%`);
+  }
+
+  // 2. Streaming with TTFT
+  console.log(`\n  [stream ${STREAM_N}] streaming requests (split TTFB / TTFT / generation)...`);
+  const sm = [];
+  for (let i = 0; i < STREAM_N; i++) {
+    const r = await stream(model);
+    if (r.status !== 200) { console.log(`  stream ${i} failed: ${r.status}`); break; }
+    sm.push(r);
+  }
+  const ttfb = sm.filter(r => r.ttfb !== null).map(r => r.ttfb);
+  const ttft = sm.filter(r => r.ttft !== null).map(r => r.ttft);
+  const totals = sm.map(r => r.dt);
+  console.log(`       ok: ${sm.length}/${STREAM_N}`);
+  console.log(`       TTFB (first byte) : p50=${fmt(pct(ttfb, 50))}  p95=${fmt(pct(ttfb, 95))}`);
+  console.log(`       TTFT (first token): p50=${fmt(pct(ttft, 50))}  p95=${fmt(pct(ttft, 95))}`);
+  console.log(`       Total stream      : p50=${fmt(pct(totals, 50))}  p95=${fmt(pct(totals, 95))}`);
+  // Generation phase = total − TTFT
+  const genMs = sm.map(r => r.ttft && r.dt ? r.dt - r.ttft : 0).filter(x => x > 0);
+  if (genMs.length) {
+    console.log(`       Generation phase  : p50=${fmt(pct(genMs, 50))}  (i.e. tokens-per-second axis)`);
+  }
+
+  // 3. Header survey — dump every UNIQUE header seen + first value sample
+  console.log(`\n  [headers] unique values across ${seq.length} responses:`);
+  const seen = new Map();   // header → Set of values
+  for (const r of seq) {
+    for (const [k, v] of Object.entries(r.headers)) {
+      // Skip noisy ones we know about (CORS, content-length per body, date)
+      if (['date', 'content-length', 'content-type', 'access-control-allow-origin',
+           'access-control-allow-methods', 'access-control-allow-headers',
+           'access-control-expose-headers', 'access-control-max-age',
+           'cache-control', 'connection'].includes(k)) continue;
+      if (!seen.has(k)) seen.set(k, new Set());
+      seen.get(k).add(v);
+    }
+  }
+  // Sort headers by interesting-ness: anthropic-* first, then alphabetic.
+  const sortedKeys = [...seen.keys()].sort((a, b) => {
+    const aA = a.startsWith('anthropic') || a.startsWith('x-') || a.includes('request-id');
+    const bA = b.startsWith('anthropic') || b.startsWith('x-') || b.includes('request-id');
+    if (aA !== bA) return aA ? -1 : 1;
+    return a.localeCompare(b);
+  });
+  for (const k of sortedKeys) {
+    const vals = [...seen.get(k)];
+    if (vals.length === 1) {
+      console.log(`         ${k}: ${vals[0]}`);
+    } else if (vals.length <= 4) {
+      console.log(`         ${k}: ${vals.length} unique  [${vals.map(v => v.slice(0, 40)).join(', ')}]`);
+    } else {
+      console.log(`         ${k}: ${vals.length} unique values (one per request — likely a request id)`);
+    }
+  }
+
+  return {
+    model,
+    seqP50: pct(lats, 50),
+    seqP95: pct(lats, 95),
+    ttftP50: pct(ttft, 50),
+    ttftP95: pct(ttft, 95),
+    genP50: pct(genMs, 50),
+    headerSurvey: Object.fromEntries(
+      sortedKeys.map(k => {
+        const vals = [...seen.get(k)];
+        return [k, vals.length === 1 ? vals[0] : `${vals.length} unique`];
+      })
+    ),
+  };
+}
+
+console.log(`\nProbe started at ${new Date().toISOString()}`);
+console.log(`Proxy: ${BASE}`);
+
+const summaries = [];
+for (const m of MODELS) {
+  const s = await probe(m);
+  if (s) summaries.push(s);
+}
+
+console.log(`\n${'='.repeat(70)}`);
+console.log(`  CROSS-MODEL SUMMARY`);
+console.log(`${'='.repeat(70)}\n`);
+console.log(`  ${'model'.padEnd(28)}  ${'seq p50'.padStart(10)}  ${'seq p95'.padStart(10)}  ${'ttft p50'.padStart(10)}  ${'ttft p95'.padStart(10)}  ${'gen p50'.padStart(10)}`);
+for (const s of summaries) {
+  console.log(`  ${s.model.padEnd(28)}  ${fmt(s.seqP50).padStart(10)}  ${fmt(s.seqP95).padStart(10)}  ${fmt(s.ttftP50).padStart(10)}  ${fmt(s.ttftP95).padStart(10)}  ${fmt(s.genP50).padStart(10)}`);
+}
+console.log();

--- a/test/per-model-buckets.mjs
+++ b/test/per-model-buckets.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+// Tests for per-model 7d rate-limit buckets — the dario-side handling of
+// the `anthropic-ratelimit-unified-7d_<family>-utilization` headers
+// Anthropic started emitting on Sonnet responses around 2026-04-25
+// (see CHANGELOG entry for context). Three contracts:
+//
+//   1. parseRateLimits captures any `7d_<family>-utilization` header
+//      generically — `_sonnet` today, `_opus`/`_haiku` if/when they ship
+//      tomorrow, no allowlist gate.
+//   2. computeHeadroom takes a family hint and folds the per-model bucket
+//      into the max(util5h, util7d, util_per_model) calculation when the
+//      account has a snapshot for that family. Without the family arg or
+//      a matching bucket key, behavior is identical to pre-PR (max of
+//      the unified buckets only).
+//   3. select(family) routes a Sonnet request to the account with the
+//      most Sonnet headroom even when its unified util5h/util7d is
+//      slightly worse than another account's — i.e. per-model headroom
+//      can flip the routing decision.
+//   4. modelFamily extracts the family token from a request model id
+//      using a reasonable fuzzy match (`claude-opus-4-7` → `opus`).
+
+import { AccountPool, EMPTY_SNAPSHOT, parseRateLimits, computeHeadroom, modelFamily } from '../dist/pool.js';
+
+let pass = 0;
+let fail = 0;
+function check(label, cond, ...rest) {
+  if (cond) { pass++; console.log(`  ✅ ${label}`); }
+  else { fail++; console.log(`  ❌ ${label}`, ...rest); }
+}
+function header(name) {
+  console.log(`\n${'='.repeat(70)}\n  ${name}\n${'='.repeat(70)}`);
+}
+
+// Build a Headers object the way the proxy receives them from upstream.
+function buildHeaders(map) {
+  const h = new Headers();
+  for (const [k, v] of Object.entries(map)) h.set(k, v);
+  return h;
+}
+
+// =====================================================================
+//  parseRateLimits
+// =====================================================================
+header('parseRateLimits — captures unified buckets (regression)');
+{
+  const h = buildHeaders({
+    'anthropic-ratelimit-unified-status': 'allowed',
+    'anthropic-ratelimit-unified-5h-utilization': '0.20',
+    'anthropic-ratelimit-unified-7d-utilization': '0.16',
+    'anthropic-ratelimit-unified-overage-utilization': '0.0',
+    'anthropic-ratelimit-unified-representative-claim': 'five_hour',
+    'anthropic-ratelimit-unified-reset': '1777093800',
+    'anthropic-ratelimit-unified-fallback-percentage': '0.5',
+  });
+  const snap = parseRateLimits(h);
+  check('util5h captured', snap.util5h === 0.2);
+  check('util7d captured', snap.util7d === 0.16);
+  check('claim captured', snap.claim === 'five_hour');
+  check('perModel7d initialized empty when no per-model header present',
+    snap.perModel7d && Object.keys(snap.perModel7d).length === 0);
+}
+
+header('parseRateLimits — captures _sonnet bucket (the live header today)');
+{
+  const h = buildHeaders({
+    'anthropic-ratelimit-unified-status': 'allowed',
+    'anthropic-ratelimit-unified-5h-utilization': '0.21',
+    'anthropic-ratelimit-unified-7d-utilization': '0.16',
+    'anthropic-ratelimit-unified-7d_sonnet-utilization': '0.0',
+    'anthropic-ratelimit-unified-7d_sonnet-status': 'allowed',
+    'anthropic-ratelimit-unified-7d_sonnet-reset': '1777154400',
+  });
+  const snap = parseRateLimits(h);
+  check('perModel7d.sonnet captured', snap.perModel7d.sonnet === 0);
+  check('only utilization is parsed (status/reset would be a separate column)',
+    Object.keys(snap.perModel7d).length === 1);
+}
+
+header('parseRateLimits — captures hypothetical _opus bucket (forward-compat)');
+{
+  // Anthropic hasn't shipped this yet but the parser must not need a
+  // schema bump when they do. Generic `7d_<family>-utilization` match.
+  const h = buildHeaders({
+    'anthropic-ratelimit-unified-7d_opus-utilization': '0.42',
+    'anthropic-ratelimit-unified-7d_haiku-utilization': '0.05',
+  });
+  const snap = parseRateLimits(h);
+  check('perModel7d.opus captured (no allowlist)', snap.perModel7d.opus === 0.42);
+  check('perModel7d.haiku captured', snap.perModel7d.haiku === 0.05);
+}
+
+header('parseRateLimits — case-insensitive family match, lowercase keying');
+{
+  // Anthropic uses lowercase today but defensive check — if they ever ship
+  // an upper/mixed case family token, our perModel7d keys stay lowercase
+  // so callers don't need to second-guess.
+  const h = buildHeaders({
+    'anthropic-ratelimit-unified-7d_Sonnet-utilization': '0.10',
+  });
+  const snap = parseRateLimits(h);
+  check('mixed-case family normalized to lowercase', snap.perModel7d.sonnet === 0.1);
+}
+
+// =====================================================================
+//  computeHeadroom
+// =====================================================================
+header('computeHeadroom — unified-only fallback when family not supplied');
+{
+  const snap = { ...EMPTY_SNAPSHOT, util5h: 0.3, util7d: 0.5, perModel7d: { sonnet: 0.95 } };
+  const headroom = computeHeadroom(snap);
+  check('ignores per-model bucket when no family arg', Math.abs(headroom - 0.5) < 1e-9);
+}
+
+header('computeHeadroom — folds in per-model bucket when family matches');
+{
+  const snap = { ...EMPTY_SNAPSHOT, util5h: 0.3, util7d: 0.5, perModel7d: { sonnet: 0.95 } };
+  const headroom = computeHeadroom(snap, 'sonnet');
+  // max(0.3, 0.5, 0.95) = 0.95 → headroom = 0.05
+  check('headroom for sonnet uses the saturated bucket', Math.abs(headroom - 0.05) < 1e-9);
+}
+
+header('computeHeadroom — family without matching bucket falls back to unified');
+{
+  const snap = { ...EMPTY_SNAPSHOT, util5h: 0.3, util7d: 0.5, perModel7d: { sonnet: 0.95 } };
+  const headroom = computeHeadroom(snap, 'opus');
+  check('opus request without _opus bucket uses unified buckets only',
+    Math.abs(headroom - 0.5) < 1e-9);
+}
+
+// =====================================================================
+//  select(family)
+// =====================================================================
+header('select(family) — flips routing when one account is sonnet-saturated');
+{
+  const pool = new AccountPool();
+  pool.add('account-A', { accessToken: 'a', refreshToken: 'a', expiresAt: Date.now() + 3600_000, deviceId: 'a', accountUuid: 'a' });
+  pool.add('account-B', { accessToken: 'b', refreshToken: 'b', expiresAt: Date.now() + 3600_000, deviceId: 'b', accountUuid: 'b' });
+
+  // A: better unified headroom but Sonnet-saturated
+  pool.updateRateLimits('account-A', {
+    ...EMPTY_SNAPSHOT, util5h: 0.10, util7d: 0.10, perModel7d: { sonnet: 0.99 }, status: 'allowed', updatedAt: Date.now(),
+  });
+  // B: worse unified, but no Sonnet pressure
+  pool.updateRateLimits('account-B', {
+    ...EMPTY_SNAPSHOT, util5h: 0.40, util7d: 0.40, perModel7d: { sonnet: 0.05 }, status: 'allowed', updatedAt: Date.now(),
+  });
+
+  const noFamily = pool.select();
+  check('without family hint, picks A (best unified headroom)', noFamily?.alias === 'account-A');
+
+  const sonnet = pool.select('sonnet');
+  check('with family=sonnet, flips to B (A is sonnet-saturated)', sonnet?.alias === 'account-B');
+
+  const opus = pool.select('opus');
+  check('with family=opus, picks A again (no _opus bucket recorded)', opus?.alias === 'account-A');
+}
+
+header('select(family) — sonnet bucket on one account only, partial signal');
+{
+  // Real-world shape: account A has made a Sonnet request recently
+  // (snapshot has perModel7d.sonnet), account B hasn't (perModel7d empty).
+  // A's per-model bucket is at 50%; B has no per-model data. Routing
+  // should still pick the one with better effective headroom.
+  const pool = new AccountPool();
+  pool.add('A', { accessToken: 'a', refreshToken: 'a', expiresAt: Date.now() + 3600_000, deviceId: 'a', accountUuid: 'a' });
+  pool.add('B', { accessToken: 'b', refreshToken: 'b', expiresAt: Date.now() + 3600_000, deviceId: 'b', accountUuid: 'b' });
+
+  pool.updateRateLimits('A', {
+    ...EMPTY_SNAPSHOT, util5h: 0.10, util7d: 0.10, perModel7d: { sonnet: 0.50 }, status: 'allowed', updatedAt: Date.now(),
+  });
+  pool.updateRateLimits('B', {
+    ...EMPTY_SNAPSHOT, util5h: 0.30, util7d: 0.30, perModel7d: {}, status: 'allowed', updatedAt: Date.now(),
+  });
+
+  // A: max(0.10, 0.10, 0.50) = 0.50 → headroom 0.50
+  // B: max(0.30, 0.30) = 0.30 → headroom 0.70
+  const picked = pool.select('sonnet');
+  check('B wins despite missing per-model snapshot — better effective headroom',
+    picked?.alias === 'B');
+}
+
+// =====================================================================
+//  modelFamily
+// =====================================================================
+header('modelFamily — extracts family token from common model ids');
+{
+  check('opus 4.7 → opus',         modelFamily('claude-opus-4-7') === 'opus');
+  check('sonnet 4.6 → sonnet',     modelFamily('claude-sonnet-4-6') === 'sonnet');
+  check('haiku 4.5 → haiku',       modelFamily('claude-haiku-4-5') === 'haiku');
+  check('alias "opus" → opus',     modelFamily('opus') === 'opus');
+  check('uppercase OK',            modelFamily('CLAUDE-SONNET-4-6') === 'sonnet');
+  check('legacy 3-7-sonnet → sonnet', modelFamily('claude-3-7-sonnet-20250219') === 'sonnet');
+  check('null → null',             modelFamily(null) === null);
+  check('undefined → null',        modelFamily(undefined) === null);
+  check('empty → null',            modelFamily('') === null);
+  check('non-claude id → null',    modelFamily('gpt-4o') === null);
+}
+
+// =====================================================================
+//  Result
+// =====================================================================
+console.log(`\n${'='.repeat(70)}`);
+console.log(`  Results: ${pass} passed, ${fail} failed`);
+console.log(`${'='.repeat(70)}\n`);
+if (fail > 0) process.exit(1);


### PR DESCRIPTION
## Summary

Anthropic carved the Max plan's weekly window into per-model sub-buckets sometime around **2026-04-25**. Found by stress-probing Opus 4.7 + Sonnet 4.6 against dario in production: Sonnet responses now ship a **new dedicated header** —

```
anthropic-ratelimit-unified-7d_sonnet-utilization: 0.0
anthropic-ratelimit-unified-7d_sonnet-status: allowed
anthropic-ratelimit-unified-7d_sonnet-reset: 1777154400
```

— corresponding to the "Sonnet only" line on the user dashboard, currently independent from the unified `7d` bucket. Opus 4.6 / Opus 4.7 / Haiku 4.5 do **not** yet have dedicated headers; they're still entirely on the unified buckets. No public Anthropic documentation announces this.

## Why this matters for the pool

`select()` / `selectSticky()` / `selectExcluding()` computed headroom as `1 - max(util5h, util7d)` and ignored per-model buckets entirely. Once Anthropic starts enforcing the Sonnet bucket (currently 0% on every probe), the pool would have routed Sonnet requests to accounts at 95% on `7d_sonnet` because those accounts looked great on the unified `7d`. The 429 failover code would catch the rejection and rebind, but the picker would have made the same wrong call again until enough accounts got marked rejected — burning latency and burning sticky-key cache locality on every miss.

## Fix

- **`parseRateLimits`** scans the full header set with the regex `^anthropic-ratelimit-unified-7d_([a-z0-9-]+)-utilization$`, capturing every per-model bucket generically. No allowlist — `_sonnet` today, `_opus` / `_haiku` if/when, no schema bump required.
- **New `RateLimitSnapshot.perModel7d: Record<string, number>`** field stores captured buckets per account; `EMPTY_SNAPSHOT` initializes with `{}`.
- **New `computeHeadroom(snapshot, family?)` helper** folds the per-model bucket into the headroom max when a request's family matches a captured key. Falls back to unified-only when family is null or no matching bucket. Replaces ~6 inline `1 - Math.max(util5h, util7d)` sites across `pool.ts`.
- **New `modelFamily(modelId)` helper** extracts `opus` / `sonnet` / `haiku` from request model ids — handles `claude-opus-4-7`, alias `opus`, legacy `claude-3-7-sonnet-…`, case-insensitive, alias / full-id forms.
- **`select()` / `selectSticky()` / `selectExcluding()` take optional `family`**; `proxy.ts` threads it through at all four call sites (`selectSticky` for the sticky pick + both `selectExcluding` sites for 429 failover). The initial pre-parse `pool.select()` stays family-less because the body hasn't been parsed yet.
- **First-sight detector**: when `dario proxy -v` encounters a per-model bucket family it hasn't seen this run, log `[dario] new per-model rate-limit bucket observed: 7d_<family>`. Catches future Anthropic rollouts the day they ship instead of the day they start failing routing.

## What this does NOT do (deferred to follow-up)

Per the user's roadmap (this PR is "1 + 3" of "1, 2, 3, 4"):

- **#2 — `dario doctor` per-model surface.** Display the per-model buckets distinctly in the doctor report when present. Lands next.
- **#4 — Investigate `output_tokens` discrepancy on Sonnet.** The probe also found Sonnet 4.6 reports ~2× the `usage.output_tokens` of Opus for the same prompt + `max_tokens=8`. Possibly thinking-token billing, possibly an analytics quirk. Lands after #2.

## Test coverage

26 new assertions in `test/per-model-buckets.mjs` covering:

- Parser captures `_sonnet` (live header today)
- Parser captures hypothetical `_opus` / `_haiku` (forward-compat — no allowlist)
- Case-insensitive family normalization
- Headroom unified-only fallback when family not supplied
- Headroom folds in per-model bucket when family matches
- Headroom unified-only when family present but no matching bucket
- `select(family)` flips routing when one account is sonnet-saturated
- `select(family)` partial-signal correctness when only one account has per-model data
- `modelFamily` extraction across alias / full-id / legacy / case / non-Claude forms

Plus existing `failover-429.mjs` updated to use a `Headers`-iterable mock (it provides `.entries()`; the parser now uses `.entries()` if present so both real `Headers` and test mocks work).

`test/infra-probe.mjs` (the diagnostic script that found this) is added to the `EXCLUDED` set in `test/all.test.mjs` alongside `e2e` / `stress` / `compat`. Kept as a tree artifact for future Anthropic-changed-something investigations.

**53 tests, up from 52.**

## Test plan

- [x] `npm run build` clean
- [x] `npm test` 53/53 pass
- [x] No behavior change for the family-less code paths (regression-safe for non-pool single-account mode)
- [ ] Post-merge: auto-release tags v3.31.17 + npm publish
