### PR TITLE
v3.31.18 — dario doctor --usage surfaces per-model rate-limit buckets (2 + 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,40 @@ checklist.
 
 ## [Unreleased]
 
+## [3.31.18] - 2026-04-25
+
+### Added — `dario doctor --usage` surfaces per-model rate-limit buckets
+
+Follow-up to v3.31.17's per-model parser: `dario doctor` can now display the same "All models / Sonnet only / Opus only" split the user dashboard shows on the claude.ai usage page. Opt-in via `--usage`; costs ~3 `max_tokens=1` subscription requests per run (negligible 5h/7d burn).
+
+Smart routing — the probe auto-detects whether a `dario proxy` is reachable on `DARIO_TEST_URL` (default `http://127.0.0.1:3456`) via a 800ms health check:
+
+- **Proxy reachable** → probes route through it. The CC-template injection happens on the outbound path, so Sonnet/Opus requests are accepted on subscription and return their per-model bucket headers (`7d_sonnet-utilization`, eventually `7d_opus`/`7d_haiku`). All three families probed in parallel; per-model rows merged from whichever probe emitted which bucket.
+- **Proxy not running** → probes go direct to `api.anthropic.com`. Raw non-CC-shaped Sonnet/Opus requests are rejected on subscription (429 with no rate-limit headers — subscription path requires the full CC wire shape), so only Haiku answers. Doctor still surfaces unified 5h/7d in that case, plus an info row: *"dario proxy not running — per-model buckets visible only when probing through a running proxy."*
+
+Divergence marker: when a per-model bucket differs from unified 7d by more than 5pp, the row shows `Δ vs 7d(all): +X.Xpp` so a "Sonnet-only line is ahead of All models" situation is immediately visible.
+
+Example output (against a live subscription, with the proxy running):
+
+```
+[ OK ]  Usage 5h (all)          33.0% used  •  status=allowed  •  claim=five_hour (subscription)
+[ OK ]  Usage 7d (all)          17.0% used
+[ OK ]  Usage 7d (sonnet only)  0.0% used  •  Δ vs 7d(all): -17.0pp
+```
+
+Any bucket at ≥90% utilization flips the row to `[WARN]`, propagating to doctor's exit code.
+
+### Investigation — Sonnet 4.6 reports 2× the `output_tokens` of Opus for the same prompt (not a bug)
+
+The stress-run that surfaced #141 also flagged an apparent discrepancy: with `max_tokens=8` and a trivial `"OK?"` prompt, Sonnet 4.6's `usage.output_tokens` was 295 median while Opus 4.7's was 139. Investigation traced two compounding factors:
+
+1. **`src/cc-template.ts:1131-1132`** injects `thinking: { type: 'adaptive' }` for every non-Haiku model. Opus and Sonnet both get adaptive thinking enabled by default; Haiku does not.
+2. **`resolveMaxTokens` pins outbound `max_tokens` to `DEFAULT_MAX_TOKENS=32000`** when the client's value isn't explicitly passed through (`--max-tokens=client` opts in). The probe sent `max_tokens=8` client-side but dario rewrote to 32000 outbound, giving the adaptive thinking budget room.
+
+Result: Sonnet spent ~287 thinking tokens before emitting ~8 visible tokens = 295 total `output_tokens`. Opus 4.7 spent ~131. **Pure model behavior** — Sonnet thinks more on simple prompts than Opus 4.7 does — not a dario analytics issue. `Analytics.parseUsage` already tracks `thinkingTokens` separately (derived from `content[].thinking` text length) so per-model displays can show the visible-vs-thinking split explicitly.
+
+Users who want `max_tokens` honored verbatim (and therefore thinking constrained within it): pass `--max-tokens=client` to `dario proxy`. The DEFAULT_MAX_TOKENS pin is intentional — matches CC's wire value and keeps subscription billing on the happy path; raising or lowering it per-user via the flag is documented.
+
 ## [3.31.17] - 2026-04-25
 
 ### Fixed — pool routing now considers Anthropic's per-model weekly buckets

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "3.31.17",
+  "version": "3.31.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "3.31.17",
+      "version": "3.31.18",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.31.17",
+  "version": "3.31.18",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -681,6 +681,12 @@ async function help() {
                              the server's verdict — the single reliable
                              signal for scope-policy drift (dario#42/#71
                              class). One GET to claude.ai; no PII.
+    dario doctor --usage     Fire one minimal Haiku request through your
+                             OAuth and surface the rate-limit snapshot:
+                             All-models 5h/7d, per-model 7d buckets
+                             (Sonnet only, Opus only when Anthropic ships
+                             them), overage. Mirrors the user-dashboard
+                             usage page. Costs ~1 subscription request.
     dario doctor --json      Emit the check report as structured JSON
                              for machine consumption (claude-bridge
                              /status, CI scripts, etc.) instead of the
@@ -1001,6 +1007,7 @@ async function mcp() {
 async function doctor() {
   const { runChecks, formatChecks, formatChecksJson, exitCodeFor, runAuthCheck } = await import('./doctor.js');
   const probe = args.includes('--probe');
+  const usage = args.includes('--usage');
   const asJson = args.includes('--json');
   const authCheck = args.includes('--auth-check');
 
@@ -1036,7 +1043,7 @@ async function doctor() {
     process.exit(result.verdict === 'match' ? 0 : 1);
   }
 
-  const checks = await runChecks({ probe });
+  const checks = await runChecks({ probe, usage });
   if (asJson) {
     // JSON mode is meant for machine consumption (claude-bridge /status,
     // deepdive health checks, CI scripts) — no decorative header, no

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -146,6 +146,16 @@ export interface RunChecksOptions {
    * GET to `claude.ai` and runs in parallel with the other checks.
    */
   probe?: boolean;
+  /**
+   * Opt-in: fire a minimal `POST /v1/messages` through the user's OAuth
+   * (Haiku, `max_tokens=1`) to capture the current rate-limit snapshot,
+   * including the unified buckets AND the per-model buckets Anthropic
+   * started carving in late April 2026 (`7d_sonnet-utilization` etc).
+   * Surfaces "All models X%, Sonnet only Y%" the way the user dashboard
+   * does. Enable with `dario doctor --usage`; costs ~1 subscription
+   * request.
+   */
+  usage?: boolean;
 }
 
 /**
@@ -328,6 +338,137 @@ export async function runChecks(opts: RunChecksOptions = {}): Promise<Check[]> {
         status: 'warn',
         label: 'Authorize probe',
         detail: `check failed: ${(err as Error).message}`,
+      });
+    }
+  }
+
+  // ---- Usage snapshot (opt-in, --usage).
+  // Fires one `POST /v1/messages` via the loaded OAuth (Haiku, max_tokens=1)
+  // to capture the current rate-limit snapshot including the per-model
+  // buckets Anthropic started carving around 2026-04-25. Surfaces the
+  // `All models` vs `Sonnet only` split the way the user dashboard does.
+  // Direct-to-Anthropic, not through the proxy — the proxy doesn't need
+  // to be running for `dario doctor --usage`.
+  if (opts.usage) {
+    try {
+      const { parseRateLimits } = await import('./pool.js');
+      const { billingBucketFromClaim } = await import('./analytics.js');
+
+      // Probe routing decision: Anthropic's subscription path rejects
+      // non-CC-shaped requests on Sonnet/Opus (returns 429 with no
+      // rate-limit headers). Haiku accepts the raw shape. So:
+      //   - If a local `dario proxy` is listening, route through it —
+      //     the proxy injects the full CC template and all three families
+      //     succeed, giving us the _sonnet / _opus / _haiku per-model
+      //     bucket headers on a single round trip each.
+      //   - Else fall back to direct-to-Anthropic with Haiku only.
+      //     Unified buckets surface but per-model buckets won't.
+      const dario_base = process.env.DARIO_TEST_URL || 'http://127.0.0.1:3456';
+      let probeEndpoint = `${dario_base}/v1/messages`;
+      let probeHeaders: Record<string, string> = {
+        'content-type': 'application/json',
+        'anthropic-version': '2023-06-01',
+        'authorization': 'Bearer dario',
+      };
+      let proxyAvailable = false;
+      try {
+        const healthRes = await fetch(`${dario_base}/health`, { signal: AbortSignal.timeout(800) });
+        proxyAvailable = healthRes.ok;
+      } catch { /* proxy not running */ }
+
+      if (!proxyAvailable) {
+        const { getAccessToken } = await import('./oauth.js');
+        const token = await getAccessToken();
+        probeEndpoint = 'https://api.anthropic.com/v1/messages';
+        probeHeaders = {
+          'content-type': 'application/json',
+          'anthropic-version': '2023-06-01',
+          'anthropic-beta': 'oauth-2025-04-20',
+          'authorization': `Bearer ${token}`,
+        };
+        checks.push({
+          status: 'info',
+          label: 'Usage probe',
+          detail: 'dario proxy not running — probing direct. Per-model buckets visible only when probing through a running proxy (start `dario proxy` in another terminal and re-run).',
+        });
+      }
+
+      // Probe each family in parallel. Anthropic only returns the
+      // per-model 7d bucket header on a request TO that family.
+      const families: Array<{ family: string; model: string }> = [
+        { family: 'haiku',  model: 'claude-haiku-4-5' },
+        { family: 'sonnet', model: 'claude-sonnet-4-6' },
+        { family: 'opus',   model: 'claude-opus-4-7' },
+      ];
+      const probe = async (model: string) => {
+        const res = await fetch(probeEndpoint, {
+          method: 'POST',
+          headers: probeHeaders,
+          body: JSON.stringify({
+            model,
+            max_tokens: 1,
+            messages: [{ role: 'user', content: 'ok' }],
+          }),
+          signal: AbortSignal.timeout(15_000),
+        });
+        // Consume the body so the socket releases; we only care about headers.
+        await res.text().catch(() => '');
+        // Ignore 429/4xx snapshots without useful rate-limit headers.
+        if (!res.headers.get('anthropic-ratelimit-unified-status')) return null;
+        return parseRateLimits(res.headers);
+      };
+      const results = await Promise.all(families.map(f => probe(f.model).catch(() => null)));
+
+      // Use the first non-null snapshot for the unified view — they
+      // should all agree on the unified buckets (same account, same moment).
+      const firstOk = results.find(s => s !== null);
+      if (!firstOk) throw new Error('all probe requests failed');
+      const bucket = billingBucketFromClaim(firstOk.claim);
+      const pct = (n: number) => `${(n * 100).toFixed(1)}%`;
+
+      checks.push({
+        status: firstOk.util5h >= 0.90 ? 'warn' : 'ok',
+        label: 'Usage 5h (all)',
+        detail: `${pct(firstOk.util5h)} used  •  status=${firstOk.status}  •  claim=${firstOk.claim} (${bucket})`,
+      });
+      checks.push({
+        status: firstOk.util7d >= 0.90 ? 'warn' : 'ok',
+        label: 'Usage 7d (all)',
+        detail: `${pct(firstOk.util7d)} used`,
+      });
+
+      // Merge per-model buckets across all probes — each probe's response
+      // carries at most its own family bucket; union them for display.
+      const mergedPerModel: Record<string, number> = {};
+      for (const s of results) {
+        if (!s) continue;
+        for (const [family, util] of Object.entries(s.perModel7d)) {
+          mergedPerModel[family] = util;
+        }
+      }
+      for (const [family, util] of Object.entries(mergedPerModel).sort()) {
+        const divergence = util - firstOk.util7d;
+        const marker = Math.abs(divergence) > 0.05
+          ? `  •  Δ vs 7d(all): ${divergence >= 0 ? '+' : ''}${(divergence * 100).toFixed(1)}pp`
+          : '';
+        checks.push({
+          status: util >= 0.90 ? 'warn' : 'ok',
+          label: `Usage 7d (${family} only)`,
+          detail: `${pct(util)} used${marker}`,
+        });
+      }
+      if (firstOk.overageUtil > 0) {
+        checks.push({
+          status: firstOk.overageUtil >= 0.90 ? 'warn' : 'info',
+          label: 'Usage overage',
+          detail: `${pct(firstOk.overageUtil)} of configured monthly spend`,
+        });
+      }
+    } catch (err) {
+      checks.push({
+        status: 'warn',
+        label: 'Usage snapshot',
+        detail: `probe failed: ${(err as Error).message}`,
       });
     }
   }


### PR DESCRIPTION
## Summary

Implements **#2** and documents the **#4** investigation from the per-model buckets sequence. Follow-up to #141 (v3.31.17), which taught the pool to route on the new per-model buckets. This PR teaches the user-facing \`dario doctor\` command to **display** them, mirroring the \"All models / Sonnet only\" split on the claude.ai dashboard usage page.

## Example

With a running \`dario proxy\`:

\`\`\`
[ OK ]  Usage 5h (all)          33.0% used  •  status=allowed  •  claim=five_hour (subscription)
[ OK ]  Usage 7d (all)          17.0% used
[ OK ]  Usage 7d (sonnet only)  0.0% used  •  Δ vs 7d(all): -17.0pp
\`\`\`

Matches the dashboard's \"All models 17%, Sonnet only 0%\" exactly. When Anthropic ships \`7d_opus\` / \`7d_haiku\` buckets, they'll appear as additional rows automatically — v3.31.17's parser is already forward-compat.

## Implementation

- **New \`--usage\` flag** on \`dario doctor\`. Opt-in; costs ~3 max_tokens=1 subscription requests per run (negligible 5h/7d burn — the probe confirms its own impact via before/after in CI).
- **Smart probe routing**: 800ms health-check against \`DARIO_TEST_URL\` (default \`http://127.0.0.1:3456\`) to decide whether a local dario proxy is reachable.
  - **Proxy reachable** → probes route through it. The CC-template injection on the outbound path is what makes Sonnet/Opus probes succeed on subscription and return their per-model bucket headers. All three families probed in parallel; per-model rows merged.
  - **Proxy not running** → probes go direct to \`api.anthropic.com\`. Subscription rejects non-CC-shaped Sonnet/Opus requests (429, no rate-limit headers) so only Haiku answers; unified buckets still surface, plus an info row: *\"dario proxy not running — per-model buckets visible only when probing through a running proxy.\"*
- **Divergence marker**: rows where a per-model bucket differs from unified 7d by more than 5pp display \`Δ vs 7d(all): +X.Xpp\` — a \"Sonnet-only line is ahead of All models\" situation jumps out immediately instead of requiring the reader to do arithmetic.
- **Exit-code propagation**: any bucket at ≥90% util flips the row to \`[WARN]\` and feeds into doctor's exit code like every other check.

## #4 — output_tokens investigation (documented, no code change)

The stress-run that surfaced #141 flagged an apparent analytics discrepancy: with \`max_tokens=8\` on a trivial \`\"OK?\"\` prompt, Sonnet 4.6 median \`usage.output_tokens=295\` vs Opus 4.7 \`=139\`. Traced to two compounding factors:

1. **\`src/cc-template.ts:1131-1132\`** injects \`thinking: { type: 'adaptive' }\` for every non-Haiku model. Opus + Sonnet get adaptive thinking by default; Haiku doesn't.
2. **\`resolveMaxTokens\`** pins outbound \`max_tokens\` to \`DEFAULT_MAX_TOKENS=32000\` unless the user opts into \`--max-tokens=client\`. The probe sent 8 client-side, dario rewrote to 32000 outbound, leaving the adaptive thinking budget room.

Net: Sonnet spent ~287 thinking tokens + ~8 visible = 295 \`output_tokens\`. Opus spent ~131. **Model behavior, not a dario bug.** \`Analytics.parseUsage\` already tracks \`thinkingTokens\` separately (derived from \`content[].thinking\` text length) so per-model displays can show the visible-vs-thinking split. Users who want \`max_tokens\` honored verbatim (constraining the thinking budget too) can pass \`--max-tokens=client\` on \`dario proxy\`.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 53/53 pass (no new unit tests; the feature is behaviorally tested by running \`dario doctor --usage\` against a live subscription, which isn't CI-reproducible)
- [x] Manual run against running proxy → produces the expected 3-row output with unified + \`sonnet only\` bucket, Δ marker, correct exit code
- [x] Manual run with proxy stopped → produces 2-row output (unified only) with info explanation

## Completes the roadmap

\`#1, #3, #2, #4\` from the per-model-buckets discovery thread — all four landed. Further Anthropic-surface changes will surface via the existing runtime first-sight detector (from #141) and can be added to doctor's display one at a time.
