### PR TITLE
v3.31.19 — fix silent-CLI regression on every npm-global install (dario#143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,63 @@ checklist.
 
 ## [Unreleased]
 
+## [3.31.19] - 2026-04-25
+
+### Fixed — silent CLI on every npm-global install (dario#143)
+
+**Critical regression introduced in v3.31.15.** Affects every user who installed dario globally via `npm install -g`. Symptom: every command (`dario doctor`, `dario proxy`, `dario --version`, all of them) prints **nothing** and exits 0. Reported by [@tetsuco in dario#143](https://github.com/askalf/dario/issues/143).
+
+**Root cause.** v3.31.15 (#137) added a main-entry guard so that test files importing `parsePositiveIntEnv` from `cli.js` wouldn't accidentally start the proxy:
+
+```ts
+// Pre-fix — silently broken on npm-global installs
+const isDirectEntry =
+  typeof process.argv[1] === 'string' &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
+```
+
+That works when you invoke `node dist/cli.js` directly, but `npm install -g @askalf/dario` creates a bin shim at `/usr/local/bin/dario` (or `~/.local/bin/dario`, or homebrew's `/opt/homebrew/bin/dario`) that's a **symlink** to `dist/cli.js`. When the user runs `dario`, Node receives:
+
+- `process.argv[1]` = `/usr/local/bin/dario` (the symlink path)
+- `import.meta.url` = `file:///usr/local/lib/node_modules/@askalf/dario/dist/cli.js` (Node already resolved the symlink before evaluating the module)
+
+The strings didn't match → `isDirectEntry` returned false → the entire CLI body (Bun auto-relaunch + handler dispatch) got gated out → silent exit.
+
+The bug hid in the 4 releases between v3.31.15 and v3.31.18 because every test path runs `node test/*.mjs` directly, never through the bin shim, and dev runs of `node dist/cli.js doctor` skip the shim too. Local CI never installed the package globally.
+
+**Fix.** When the strict path compare fails, also resolve `argv[1]` through `realpathSync` and compare again. The symlink canonicalizes to the same on-disk path that `import.meta.url` already represents.
+
+```ts
+export function isMainEntry(argv1, moduleHref, realpath = realpathSync) {
+  if (typeof argv1 !== 'string' || argv1.length === 0) return false;
+  if (moduleHref === pathToFileURL(argv1).href) return true;
+  try { return moduleHref === pathToFileURL(realpath(argv1)).href; }
+  catch { return false; }
+}
+```
+
+Direct invocation matches via the first leg (no behavioral change). Symlinked global-install invocation matches via the second leg. Test-file imports of named exports still match neither leg, preserving the original guard purpose from #137.
+
+`isMainEntry` is now exported from `cli.js` as a pure helper so the contract is testable without a real symlink fixture.
+
+### Tests
+
+11 new assertions in `test/main-entry-guard.mjs`:
+
+- Direct invocation (no symlink) → true
+- Symlink invocation across three install layouts (`/usr/local/bin`, homebrew `/opt/homebrew/bin`, Linux `~/.local/bin`) → true
+- Library import (unrelated argv[1]) → false in three shapes (test runner, node binary, different bin shim)
+- Edge cases: undefined / null / empty argv[1] → false
+- `realpath` throws (ENOENT, etc.) → caught, returns false (must not crash the CLI on broken installs)
+
+54 total (up from 53). Full suite green.
+
+### Apology
+
+This shipped because every layer of validation we have runs against `node dist/cli.js`, never against the installed bin shim. PR #137 added the guard with thorough unit tests; PRs #138–#142 layered features on top; v3.31.18 went out the door yesterday with `npm publish --provenance` perfectly intact, every test green, and a completely-broken end-user CLI. The post-merge "manual smoke test against the installed binary" step we always skipped because it was inconvenient is what would have caught it. Adding it to the release checklist.
+
+Sorry for the breakage on what was supposed to be a feature release. Anyone on v3.31.15 through v3.31.18 should `npm install -g @askalf/dario@latest` once this is published.
+
 ## [3.31.18] - 2026-04-25
 
 ### Added — `dario doctor --usage` surfaces per-model rate-limit buckets

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "3.31.18",
+  "version": "3.31.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "3.31.18",
+      "version": "3.31.19",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.31.18",
+  "version": "3.31.19",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@
 // other startup side effect.
 
 import { unlink } from 'node:fs/promises';
+import { realpathSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { pathToFileURL } from 'node:url';
@@ -1190,15 +1191,46 @@ const commands: Record<string, () => Promise<void>> = {
   '-V': version,
 };
 
-// Main-entry guard. Only run the Bun auto-relaunch and handler dispatch when
-// this module is the direct entry point — importing it (from tests or for
-// a library helper like `parsePositiveIntEnv`) must NOT start the proxy.
-// Before this guard, `import { parsePositiveIntEnv } from './cli.js'` would
-// fall through to `command = args[0] ?? 'proxy'` and fire `handler()`, which
-// tried to run `startProxy()` and failed the test with "Not authenticated".
-const isDirectEntry =
-  typeof process.argv[1] === 'string' &&
-  import.meta.url === pathToFileURL(process.argv[1]).href;
+/**
+ * Decide whether this module is being invoked as the CLI entry point or
+ * imported as a library. Pure, exported for tests; the file-bottom uses
+ * it with `process.argv[1]` + `import.meta.url` + `fs.realpathSync`.
+ *
+ * The pre-v3.31.19 implementation was a strict string compare —
+ *   import.meta.url === pathToFileURL(process.argv[1]).href
+ * — which silently failed on every npm-global install because the bin
+ * shim path (e.g. `/usr/local/bin/dario`) is a symlink to `dist/cli.js`.
+ * `argv[1]` arrived as the *symlink* path while `import.meta.url`
+ * resolved through the symlink to the real file. They never matched,
+ * the guard returned false, and the entire CLI body was gated out —
+ * `dario doctor`, `dario proxy`, every command produced zero output and
+ * exited 0. Reported as dario#143 by @tetsuco.
+ *
+ * The fix: also check the symlink-resolved path. `realpathSync`
+ * canonicalizes the argv[1] symlink into the same on-disk path that
+ * `import.meta.url` already represents, so a global-install bin-shim
+ * invocation matches. Direct invocation (`node dist/cli.js`) still
+ * matches via the first leg. Test-side imports of named exports still
+ * don't match either leg, which preserves the original purpose of the
+ * guard from #137 (v3.31.15).
+ */
+export function isMainEntry(
+  argv1: string | undefined | null,
+  moduleHref: string,
+  realpath: (p: string) => string = realpathSync,
+): boolean {
+  if (typeof argv1 !== 'string' || argv1.length === 0) return false;
+  if (moduleHref === pathToFileURL(argv1).href) return true;
+  try {
+    return moduleHref === pathToFileURL(realpath(argv1)).href;
+  } catch {
+    return false;
+  }
+}
+
+// Main-entry guard. Only run the Bun auto-relaunch and handler dispatch
+// when this module is the direct CLI entry point.
+const isDirectEntry = isMainEntry(process.argv[1], import.meta.url);
 
 if (isDirectEntry) {
   // Bun auto-relaunch for TLS fingerprint fidelity. Only meaningful when

--- a/test/main-entry-guard.mjs
+++ b/test/main-entry-guard.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+// Regression test for dario#143 — the v3.31.18 silent-CLI bug.
+//
+// The main-entry guard added in v3.31.15 (#137) was a strict string
+// compare between `import.meta.url` and `pathToFileURL(process.argv[1])`.
+// That works when you run `node dist/cli.js` directly but breaks the
+// moment npm installs dario globally and Node receives `argv[1]` as
+// a bin-shim symlink (e.g. `/usr/local/bin/dario`). The strings differ,
+// the guard returns false, and the entire CLI body is gated out —
+// `dario doctor` produces no output and exits 0.
+//
+// Three contracts to pin so this can't regress:
+//   1. Direct invocation (no symlink): argv[1] === module path → true.
+//   2. Symlink invocation (the bug): argv[1] is a symlink whose realpath
+//      equals the module path → true.
+//   3. Library import: argv[1] points somewhere else, not a symlink to
+//      the module → false.
+// Plus edge cases: undefined / null / empty argv[1] → false; realpath
+// throws (path doesn't exist) → false.
+
+import { isMainEntry } from '../dist/cli.js';
+import { pathToFileURL } from 'node:url';
+
+let pass = 0, fail = 0;
+function check(label, cond, ...rest) {
+  if (cond) { console.log(`  ✅ ${label}`); pass++; }
+  else { console.log(`  ❌ ${label}`, ...rest); fail++; }
+}
+function header(label) {
+  console.log(`\n======================================================================`);
+  console.log(`  ${label}`);
+  console.log(`======================================================================`);
+}
+
+// ----------------------------------------------------------------------
+//  1. Direct invocation — argv[1] is exactly the module path
+// ----------------------------------------------------------------------
+header('isMainEntry — direct invocation (node dist/cli.js)');
+{
+  const modulePath = '/usr/local/lib/node_modules/@askalf/dario/dist/cli.js';
+  const moduleHref = pathToFileURL(modulePath).href;
+  // realpath stub never gets called in this path
+  const result = isMainEntry(modulePath, moduleHref, p => p);
+  check('argv[1] === module path → true', result === true);
+}
+
+// ----------------------------------------------------------------------
+//  2. Symlink invocation — npm-global bin shim (the dario#143 case)
+// ----------------------------------------------------------------------
+header('isMainEntry — symlink invocation (npm-global bin shim)');
+{
+  const realModulePath = '/usr/local/lib/node_modules/@askalf/dario/dist/cli.js';
+  const symlinkPath = '/usr/local/bin/dario';
+  const moduleHref = pathToFileURL(realModulePath).href;
+  // Stub realpath: when given the symlink, return the real file
+  const realpathStub = (p) => (p === symlinkPath ? realModulePath : p);
+  const result = isMainEntry(symlinkPath, moduleHref, realpathStub);
+  check('argv[1]=symlink, realpath resolves to module → true', result === true);
+}
+
+header('isMainEntry — symlink invocation on macOS (homebrew style)');
+{
+  const realModulePath = '/opt/homebrew/lib/node_modules/@askalf/dario/dist/cli.js';
+  const symlinkPath = '/opt/homebrew/bin/dario';
+  const moduleHref = pathToFileURL(realModulePath).href;
+  const realpathStub = (p) => (p === symlinkPath ? realModulePath : p);
+  check('homebrew bin symlink → true',
+    isMainEntry(symlinkPath, moduleHref, realpathStub) === true);
+}
+
+header('isMainEntry — symlink invocation on Linux (~/.local/bin)');
+{
+  const realModulePath = '/home/user/.local/lib/node_modules/@askalf/dario/dist/cli.js';
+  const symlinkPath = '/home/user/.local/bin/dario';
+  const moduleHref = pathToFileURL(realModulePath).href;
+  const realpathStub = (p) => (p === symlinkPath ? realModulePath : p);
+  check('~/.local/bin symlink → true',
+    isMainEntry(symlinkPath, moduleHref, realpathStub) === true);
+}
+
+// ----------------------------------------------------------------------
+//  3. Library import — test or third-party importing a named export
+// ----------------------------------------------------------------------
+header('isMainEntry — library import returns false');
+{
+  const modulePath = '/usr/local/lib/node_modules/@askalf/dario/dist/cli.js';
+  const moduleHref = pathToFileURL(modulePath).href;
+
+  // Test runner running an unrelated test file
+  check('argv[1] is unrelated test file → false',
+    isMainEntry('/somewhere/test/request-queue.mjs', moduleHref, p => p) === false);
+
+  // node REPL (no real argv[1] script)
+  check('argv[1] is node binary itself → false',
+    isMainEntry('/usr/local/bin/node', moduleHref, p => p) === false);
+
+  // Importer where realpath also doesn't match (importer is a different package)
+  const realpathStub = (p) =>
+    p === '/usr/local/bin/some-other-tool' ? '/some/other/dist/cli.js' : p;
+  check('argv[1] is a different bin shim → false',
+    isMainEntry('/usr/local/bin/some-other-tool', moduleHref, realpathStub) === false);
+}
+
+// ----------------------------------------------------------------------
+//  4. Edge cases — undefined / null / empty / realpath throws
+// ----------------------------------------------------------------------
+header('isMainEntry — edge cases');
+{
+  const modulePath = '/usr/local/lib/node_modules/@askalf/dario/dist/cli.js';
+  const moduleHref = pathToFileURL(modulePath).href;
+
+  check('argv[1] undefined → false', isMainEntry(undefined, moduleHref, p => p) === false);
+  check('argv[1] null → false',      isMainEntry(null,      moduleHref, p => p) === false);
+  check('argv[1] empty string → false', isMainEntry('',     moduleHref, p => p) === false);
+
+  // Real-world failure mode: argv[1] doesn't exist on disk → realpath throws ENOENT.
+  // The guard must NOT propagate the error — it should return false.
+  const throwingRealpath = () => { throw new Error('ENOENT'); };
+  check('realpath throws → catches and returns false',
+    isMainEntry('/nonexistent/path', moduleHref, throwingRealpath) === false);
+}
+
+// ----------------------------------------------------------------------
+console.log(`\n======================================================================`);
+console.log(`  Results: ${pass} passed, ${fail} failed`);
+console.log(`======================================================================\n`);
+if (fail > 0) process.exit(1);


### PR DESCRIPTION
## Summary

**Critical regression fix** — every user who installed dario globally via \`npm install -g\` between v3.31.15 and v3.31.18 got a completely silent CLI: \`dario doctor\`, \`dario proxy\`, all commands produced **zero output and exited 0**. Reported by @tetsuco in #143.

## Root cause

v3.31.15 (PR #137) added a main-entry guard so that test files importing \`parsePositiveIntEnv\` from \`cli.js\` wouldn't accidentally start the proxy. The original implementation:

\`\`\`ts
const isDirectEntry =
  typeof process.argv[1] === 'string' &&
  import.meta.url === pathToFileURL(process.argv[1]).href;
\`\`\`

This works for \`node dist/cli.js\` (the dev loop) but breaks when \`npm install -g @askalf/dario\` creates a bin shim. The shim — \`/usr/local/bin/dario\`, \`~/.local/bin/dario\`, homebrew \`/opt/homebrew/bin/dario\` — is a **symlink** to \`dist/cli.js\`. When the user runs \`dario\`, Node receives:

- \`process.argv[1]\` = \`/usr/local/bin/dario\` (the symlink path)
- \`import.meta.url\` = \`file:///usr/local/lib/node_modules/@askalf/dario/dist/cli.js\` (Node already resolved the symlink before evaluating the module)

Strings didn't match → \`isDirectEntry\` false → entire CLI body gated out → silent exit.

## How this hid through 4 releases

Every test in \`npm test\` runs \`node test/*.mjs\` directly — never through the bin shim. The dev loop of \`node dist/cli.js doctor\` also bypasses the shim. CI's smoke step (\`dario --help\`) ran via the dev path, not the installed path. There was literally no validation gate that exercised the npm-global-install code path.

The lesson is "test the installed package, not the dev tree" — adding to the release checklist.

## Fix

When the strict string match fails, also resolve \`argv[1]\` through \`realpathSync\` and compare again. The symlink canonicalizes to the same on-disk path that \`import.meta.url\` represents.

\`\`\`ts
export function isMainEntry(argv1, moduleHref, realpath = realpathSync) {
  if (typeof argv1 !== 'string' || argv1.length === 0) return false;
  if (moduleHref === pathToFileURL(argv1).href) return true;
  try { return moduleHref === pathToFileURL(realpath(argv1)).href; }
  catch { return false; }
}
\`\`\`

- Direct invocation matches via first leg (regression-safe — same behavior as v3.31.15+)
- Symlinked global-install matches via second leg (the bug fix)
- Library imports of named exports still match neither leg (preserves the v3.31.15 guard purpose)
- \`realpath\` ENOENT and friends → catch → false (broken-install safe, never crashes the CLI)

\`isMainEntry\` extracted as a pure exported helper so the contract is testable without filesystem-dependent fixtures.

## Tests

11 new assertions in \`test/main-entry-guard.mjs\`:

- Direct invocation (no symlink) → true
- Symlink invocation across three install layouts: \`/usr/local/bin\`, \`/opt/homebrew/bin\`, \`~/.local/bin\` → true each
- Library import (unrelated argv[1]) → false in three shapes (test runner, node binary, different bin shim)
- Edge cases: undefined / null / empty argv[1] → false each
- realpath throws → caught, returns false (must not crash the CLI on broken installs)

**54 tests total** (up from 53). Full suite green.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 54/54 pass
- [x] \`node dist/cli.js doctor\` (dev loop) still works
- [x] Standalone \`node test/main-entry-guard.mjs\` — 11/11 pass
- [ ] Post-merge: validate end-user fix by \`npm install -g @askalf/dario@3.31.19\` and confirming output appears
- [ ] Add bin-shim smoke to release checklist so this can't reoccur

## Apology to users

Anyone on v3.31.15–v3.31.18 should run \`npm install -g @askalf/dario@latest\` once auto-release publishes 3.31.19 to npm. Sorry for the breakage on what was supposed to be a feature release.
