### PR TITLE
ci: spam-watch auto-flags drive-by spam issues / PRs

### DIFF
--- a/.github/workflows/spam-watch.yml
+++ b/.github/workflows/spam-watch.yml
@@ -1,0 +1,193 @@
+name: Spam removal
+
+# Auto-flags and closes spam issues / PRs from external accounts on open.
+#
+# Detection is signal-based with a conservative threshold: multiple
+# independent indicators must fire before we act, which keeps brusque
+# but legitimate first-time contributions out of the dragnet. Members,
+# collaborators, and prior contributors are exempt regardless of
+# content (author_association short-circuit, before any scoring).
+#
+# When flagged: add `spam` label, post an appeal comment, then close.
+# We deliberately do NOT auto-lock — locking silences a real person
+# caught in a false positive and removes their appeal pathway. The
+# `spam` label gives maintainers a clean audit lane to manually lock
+# the genuine ones if drive-by follow-up comments accumulate.
+#
+# Why pull_request_target instead of pull_request: fork-originated PRs
+# run pull_request with a read-only token, which can't label/close.
+# pull_request_target gives write perms + secrets — normally a footgun,
+# but only dangerous when you check out PR code. We don't check out
+# anything and only read event payload + call the REST API, so the
+# usual untrusted-code-with-write-token vector doesn't apply.
+#
+# Threshold tuning: scoring rules and the threshold live at the top of
+# the inline scorer so adjustments are a small PR, not a rewrite.
+# Start at 2 and revisit after 30 days of operation against actual
+# hits — same dial-in approach used for stale.yml's day counts.
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request_target:
+    types: [opened, reopened]
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Issue or PR number to re-score (dry-run; no action taken)'
+        required: true
+        type: string
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Score
+        id: score
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_TARGET: ${{ inputs.target }}
+        run: |
+          set -euo pipefail
+
+          # workflow_dispatch hits the REST API for current state — a
+          # dry-run pathway for verifying rule changes against a real
+          # past item without waiting for organic spam.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            ITEM=$(gh api "repos/${REPO}/issues/${DISPATCH_TARGET}")
+          else
+            ITEM=$(node -e "const e = require(process.env.GITHUB_EVENT_PATH); console.log(JSON.stringify(e.issue || e.pull_request));")
+          fi
+          export ITEM_JSON="$ITEM"
+
+          node - <<'NODE'
+          // Signal-based scoring. Each rule that fires adds 1 to the
+          // score; default threshold is 2. Tuned conservatively because
+          // any single rule has plausible legit overlap (a real issue
+          // can mention "airdrop" if the project is in that space).
+          // Two independent signals together is the pattern that has
+          // actually correlated with spam in adjacent repos
+          // (claude-bridge, deepdive) since 2026-01.
+          const fs = require('fs');
+          const item = JSON.parse(process.env.ITEM_JSON);
+
+          const exempt = new Set(['OWNER', 'MEMBER', 'COLLABORATOR', 'CONTRIBUTOR']);
+          if (exempt.has(item.author_association)) {
+            console.log(`#${item.number}: exempt (author_association=${item.author_association})`);
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, 'flagged=false\n');
+            process.exit(0);
+          }
+
+          const title = String(item.title || '');
+          const body = String(item.body || '');
+          const hay = `${title}\n${body}`.toLowerCase();
+
+          // Multi-word phrases only — single-token matches are too
+          // broad and false-positive on real engineering content.
+          const SPAM_PHRASES = [
+            'airdrop', 'giveaway', 'free money', 'earn $', 'earn from home',
+            'click here to claim', 'subscribe to my channel', 'visit my channel',
+            'guaranteed profit', '1000x return', 'pump and dump',
+            'limited time offer', 'whatsapp me', 'dm me on telegram',
+            'crypto signal', 'investment opportunity', 'work from home and earn',
+          ];
+          const phraseHits = SPAM_PHRASES.filter(p => hay.includes(p));
+
+          // Shortener + chat-invite link patterns. Legit issues
+          // overwhelmingly link to docs/code on the project's own
+          // hosting; these domains are nearly exclusive to drive-by
+          // spam in this corner of GitHub.
+          const SUSPICIOUS_LINK_RE = /\b(?:t\.me|telegram\.me|discord\.gg|bit\.ly|tinyurl\.com|goo\.gl|cutt\.ly|is\.gd|rebrand\.ly)\/\S+/gi;
+          const linkHits = hay.match(SUSPICIOUS_LINK_RE) || [];
+
+          // Title with almost no alphabetic content — emoji-only or
+          // pure punctuation/numerics. Real issue titles always have
+          // letters describing the problem.
+          const titleAlpha = title.replace(/[^a-z]/gi, '').length;
+          const titleEmojiHeavy = title.length >= 8 && (titleAlpha / title.length) < 0.2;
+
+          // Empty body is suspicious only when paired with another
+          // signal — many real bug reports are 1-line title-only.
+          const emptyBody = body.trim().length === 0;
+
+          let score = 0;
+          const reasons = [];
+          if (phraseHits.length >= 1) {
+            score++;
+            const more = phraseHits.length > 1 ? ` (+${phraseHits.length - 1} more)` : '';
+            reasons.push(`spam phrase: "${phraseHits[0]}"${more}`);
+          }
+          if (phraseHits.length >= 3) {
+            score++;
+            reasons.push('high spam-phrase density (3+)');
+          }
+          if (linkHits.length >= 1) {
+            score++;
+            reasons.push(`suspicious link domain: ${linkHits[0]}`);
+          }
+          if (titleEmojiHeavy) {
+            score++;
+            reasons.push('title has < 20% alphabetic characters');
+          }
+          if (emptyBody && (linkHits.length >= 1 || phraseHits.length >= 1)) {
+            score++;
+            reasons.push('empty body paired with suspicious title');
+          }
+
+          const THRESHOLD = 2;
+          const flagged = score >= THRESHOLD;
+
+          console.log(`#${item.number}: score=${score} (threshold=${THRESHOLD}) flagged=${flagged}`);
+          for (const r of reasons) console.log(`  - ${r}`);
+
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `flagged=${flagged}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `number=${item.number}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `kind=${item.pull_request ? 'pr' : 'issue'}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `score=${score}\n`);
+          fs.writeFileSync('reasons.md', reasons.map(r => `- ${r}`).join('\n'));
+          NODE
+
+      - name: Label, comment, close
+        if: steps.score.outputs.flagged == 'true' && github.event_name != 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUMBER: ${{ steps.score.outputs.number }}
+          KIND: ${{ steps.score.outputs.kind }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Idempotent label create. --force updates color/description
+          # if the label already exists; harmless on first run.
+          gh label create spam \
+            --color B60205 \
+            --description 'Auto-flagged by spam-watch' \
+            --force \
+            --repo "$REPO"
+
+          gh issue edit "$NUMBER" --add-label spam --repo "$REPO"
+
+          {
+            echo "Auto-closed by [\`.github/workflows/spam-watch.yml\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) after matching:"
+            echo ""
+            cat reasons.md
+            echo ""
+            echo "If this is a false positive, reply with what you actually intended to report and a maintainer will reopen."
+          } > comment.md
+
+          gh issue comment "$NUMBER" --repo "$REPO" --body-file comment.md
+
+          # Dispatch by kind: gh issue close refuses PR numbers, and
+          # gh pr close lacks a --reason flag. Both routes end with the
+          # item closed; the comment is already posted.
+          if [ "$KIND" = "pr" ]; then
+            gh pr close "$NUMBER" --repo "$REPO"
+          else
+            gh issue close "$NUMBER" --reason 'not planned' --repo "$REPO"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ checklist.
 
 ## [Unreleased]
 
+### CI — spam-watch auto-flags drive-by spam issues / PRs
+
+New `.github/workflows/spam-watch.yml`. Triggers on `issues.opened/reopened` and `pull_request_target.opened/reopened` — the `_target` variant gives fork PRs a write-capable token; safe here because we never check out PR code, only read the event payload + call the REST API.
+
+Members / collaborators / contributors short-circuit before any scoring (`author_association` exempt list). External accounts go through five signals: spam phrases (multi-word only — single tokens false-positive too often), suspicious link domains (`t.me`, `discord.gg`, `bit.ly`, …), emoji-heavy titles (< 20% alphabetic content), high spam-phrase density (3+), and empty body paired with another signal. Default threshold is 2 — a single hit is not enough, since each rule on its own has plausible legit overlap (a real issue can mention "airdrop" if the project is in that space).
+
+When flagged: adds `spam` label, posts an appeal comment linking back to the workflow run, then closes (issues with reason `not planned`, PRs via `gh pr close`). Does **not** auto-lock — locking removes a real person's appeal pathway in a false positive. The `spam` label gives maintainers a clean audit lane to manually lock genuine ones if drive-by follow-up comments accumulate.
+
+`workflow_dispatch` with a target number is a dry-run path for tuning rules against past items without waiting for organic spam. Same gh-CLI + inline-node shape as `cc-drift-watch.yml` — no new third-party actions to SHA-pin or dependabot-track. Threshold and rule list live at the top of the inline scorer so adjustments are a small PR, not a rewrite.
+
 ## [3.31.19] - 2026-04-25
 
 ### Fixed — silent CLI on every npm-global install (dario#143)


### PR DESCRIPTION
## Summary

- New `.github/workflows/spam-watch.yml` that auto-flags drive-by spam issues / PRs from external accounts on open. Same `gh`-CLI + inline-node shape as `cc-drift-watch.yml` — no new third-party actions to SHA-pin or dependabot-track.
- Five-signal scoring (multi-word spam phrases, suspicious link domains like `t.me`/`discord.gg`/`bit.ly`, emoji-heavy titles, phrase density, empty body + suspicious title) with threshold 2. Members / collaborators / contributors short-circuit before scoring via the `author_association` exempt list.
- When flagged: adds `spam` label, posts an appeal comment linking back to the workflow run, closes (issues with reason `not planned`, PRs via `gh pr close`). Deliberately does **not** auto-lock — locking removes a real person's appeal pathway in a false positive; the `spam` label gives maintainers a clean audit lane to manually lock genuine ones if drive-by follow-up comments accumulate.
- `workflow_dispatch` with a target number is a dry-run path for tuning rules against past items without waiting for organic spam.
- CHANGELOG entry under `[Unreleased]` documents the addition (matches the precedent set by `stale.yml` / `actionlint.yml` / `cc-drift-watch` cadence changes — `### CI —` heading, no version bump needed since this is repo housekeeping not a runtime change).

## Test plan

- [ ] `actionlint` required check passes (workflow YAML, shell-quoting, `needs:` refs, etc.).
- [ ] After merge, manually `workflow_dispatch` with a `target` of a past closed item to confirm the scoring path works without mutating state — output goes to the workflow run logs only.
- [ ] First organic flagged issue reviewed end-to-end before relying on it: label + appeal comment + close all land cleanly, with reasons rendered correctly in the comment.
- [ ] First fork PR that triggers `pull_request_target` reviewed to confirm the write-capable token reaches the label/close steps as expected.
- [ ] Watch for false-positive reports during the first 30 days of operation. Threshold and rule list live at the top of the inline scorer for small follow-up adjustments.