### PR TITLE
fix(test): stealth #4 — effort ratio is now diagnostic-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ checklist.
 
 ## [Unreleased]
 
+### Fixed — stealth test #4 false-fails on default-config installs (dario#87 follow-up)
+
+`test/stealth-test.mjs`'s "Effort medium vs high" test asserted a hard `high.output_tokens / medium.output_tokens > 1.3x` ratio against a single complex-prompt sample. The assertion only makes sense when dario is started with `--effort=client` — in the default `--effort=high` mode (per dario#87) both client requests are rewritten to `effort: 'high'` before they leave dario, so the ratio is just stochastic variance between two identical-effort runs and the test false-fails on every vanilla install. Caught during a full e2e sweep against master.
+
+Effort-flag plumbing is already verified at the unit level by `test/effort-flag.mjs` (resolveEffort + buildCCRequest integration, all five valid values, client-passthrough, haiku carve-out, runs as part of `npm test`). What remained in stealth #4 was a live diagnostic — "given whatever proxy mode is running, how does the model respond to medium vs high?" — useful to eyeball when tuning effort behavior, not useful as a regression gate against stochastic single-sample model output.
+
+Replaced the hard assertion with a diagnostic-only block that prints the same comparison numbers (medium/high output tokens, thinking chars, ratio) but never fails the suite. The diagnostic doesn't pretend to interpret the ratio — the test can't observe the proxy's effort mode from black-box probing, so we just remind the reader that the ratio is meaningful only when dario is run with `--effort=client`. Test count drops from 11 to 10 in the stealth suite; nothing else changed.
+
 ### CI — spam-watch auto-flags drive-by spam issues / PRs
 
 New `.github/workflows/spam-watch.yml`. Triggers on `issues.opened/reopened` and `pull_request_target.opened/reopened` — the `_target` variant gives fork PRs a write-capable token; safe here because we never check out PR code, only read the event payload + call the REST API.

--- a/test/stealth-test.mjs
+++ b/test/stealth-test.mjs
@@ -165,9 +165,24 @@ async function testSystemNormalization() {
   if (r3) check('No system: five_hour', r3.headers['anthropic-ratelimit-unified-representative-claim'] === 'five_hour');
 }
 
-// ── Test 4: Effort comparison with complex prompt ──
+// ── Test 4: Effort comparison (diagnostic; not pass/fail) ──
+//
+// This used to assert a hard `high.output_tokens / medium.output_tokens > 1.3x`,
+// but that assertion only makes sense when dario is started with
+// `--effort=client` (passes the client's `output_config.effort` through to
+// upstream). In the default `--effort=high` mode (per dario#87) BOTH requests
+// are rewritten to `effort: 'high'` before they leave dario, so the ratio is
+// just stochastic variance between two identical-effort runs and the test
+// false-fails on every default-config install.
+//
+// Effort-flag plumbing is already verified at the unit level by
+// `test/effort-flag.mjs` (resolveEffort + buildCCRequest integration, all
+// five valid values, client-passthrough, haiku carve-out). What remains
+// here is a live diagnostic — "given whatever proxy mode is running, how
+// does the model respond to medium vs high?" — useful to eyeball when
+// tuning effort behavior, not useful as a regression gate.
 async function testEffortComplex() {
-  header('4. Effort medium vs high (complex prompt)');
+  header('4. Effort medium vs high (diagnostic)');
 
   const complexPrompt = `Analyze the following code and identify all potential security vulnerabilities,
 race conditions, and performance bottlenecks. For each issue found, provide the severity,
@@ -222,7 +237,14 @@ class TokenBucket {
     console.log(`\n  Medium: ${mOut} output tokens, ${mThink} thinking chars`);
     console.log(`  High:   ${hOut} output tokens, ${hThink} thinking chars`);
     console.log(`  Ratio:  ${ratio.toFixed(2)}x`);
-    check(`High/medium ratio > 1.3x (got ${ratio.toFixed(2)}x)`, ratio > 1.3);
+
+    // Diagnostic only — never fails the suite. The ratio is meaningful
+    // only when dario was started with `--effort=client`; otherwise both
+    // requests are clamped to `effort: 'high'` upstream (per dario#87)
+    // and the ratio is just model-variance noise. We can't tell from
+    // black-box probing which mode produced the number, so we don't
+    // pretend to. Plumbing is verified by `test/effort-flag.mjs`.
+    console.log(`  ↳ to interpret meaningfully, run dario with --effort=client; otherwise both efforts clamp to 'high' upstream and the ratio is just model variance.`);
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to dario#87. `test/stealth-test.mjs`'s "Effort medium vs high" test asserted a hard `high.output_tokens / medium.output_tokens > 1.3x` ratio against a single complex-prompt sample. The assertion only makes sense when dario is started with `--effort=client` — in the default `--effort=high` mode both client requests are rewritten to `effort: 'high'` before they leave dario (`src/cc-template.ts:1138`), so the ratio is just stochastic variance between two identical-effort runs.

Caught during a full e2e sweep against master after #146:
- Run 1: ratio = 1.08x → false-fail
- Run 2: ratio = 1.71x → false-pass
- Both runs sent identical `effort: 'high'` requests upstream (proxy was in default mode).

Effort-flag plumbing is already covered at the unit level by `test/effort-flag.mjs` (resolveEffort + buildCCRequest integration, all five valid values, client-passthrough, haiku carve-out — runs as part of `npm test`, all green). What remained in stealth #4 was a live diagnostic, useful to eyeball when tuning effort behavior, not useful as a regression gate against stochastic single-sample model output.

## What changed

- `test/stealth-test.mjs` — testEffortComplex now prints the comparison numbers (medium/high output tokens, thinking chars, ratio) and a one-line note about how to interpret the ratio (only meaningful with `--effort=client`). The `check(...)` call is gone, so the test no longer contributes to pass/fail counts. Stealth suite test count drops 11 → 10.
- `CHANGELOG.md` — `### Fixed` entry under `[Unreleased]` documenting the change and the dario#87 link.
- No runtime code change. No third-party-action change. No new files.

## Test plan

- [x] `node --check test/stealth-test.mjs` — syntax clean.
- [x] Re-ran `node test/stealth-test.mjs` after the change — test #4 prints the diagnostic and does not fail.
- [ ] `actionlint`, `analyze`, `validate-package-json`, `build (18/20/22)` required checks pass on this PR (no source-code change, expected green).
- [ ] After merge, run the full stealth suite once against a vanilla `dario proxy` install to confirm the suite reports 10/10 (or 9/10 if test #1 also flakes — see note below) instead of 10/11.

## Out of scope (separate finding)

During the e2e sweep, stealth test #1 (thinking-strip token-diff) also flaked on one of the two runs because turn 1 happened to produce zero thinking blocks, breaking the comparison logic (`dario stripped: 26, pre-stripped: 3`). Same class of single-sample-stochastic-behavior issue but a different root cause; left for a follow-up since the right fix (skip when turn 1 generates no thinking) is conceptually distinct from this one.