### PR TITLE
v3.31.20 — template re-bake against CC v2.1.120 + stealth #4 + spam-watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ checklist.
 
 ## [Unreleased]
 
+## [3.31.20] - 2026-04-26
+
+Three landed PRs since v3.31.19, two of which (the template re-bake and the spam-watch workflow) carry user-visible changes — bundling as a patch release. The stealth #4 fix is a test-only change but rides along since it's already on master.
+
+- **#148** — bundled template re-captured against CC v2.1.120; `SUPPORTED_CC_RANGE.maxTested` 2.1.119 → 2.1.120. Pre-emptive: 2.1.120 is published to npm but not yet `@latest`-tagged. Anthropic tightened the `Agent` tool description in 2.1.120 (Explore now explicitly *not* for code review / cross-file consistency / open-ended analysis); shipping the new template ahead of the @latest promotion keeps users on the bundled fallback from drifting.
+- **#147** — stealth test #4 effort ratio softened to a diagnostic-only print. The hard `1.3x` assertion false-failed on every default-config install (proxy clamps `output_config.effort` to 'high' in default `--effort=high` mode, so both client values become identical upstream — the ratio is just stochastic noise). Plumbing already verified at the unit level by `test/effort-flag.mjs`.
+- **#146** — `.github/workflows/spam-watch.yml` auto-flags drive-by spam issues / PRs from external accounts on open. Five-signal scoring with threshold 2; members / collaborators / contributors short-circuit before scoring; flagged items get the `spam` label, an appeal comment, and a close (no auto-lock — keeps the appeal pathway open for false positives).
+
 ### Changed — bundled template re-captured against CC v2.1.120; SUPPORTED_CC_RANGE.maxTested 2.1.119 → 2.1.120
 
 Pre-emptive bake against the next CC version. CC v2.1.120 has been published to npm (visible in the `versions[]` list) but is **not** tagged `latest` / `stable` / `next` — Anthropic is staging the rollout. The drift watcher tracks `@latest` and is correctly clean against 2.1.119. This re-bake gets the bundled fallback ahead of the eventual `@latest` promotion so users who upgrade past 2.1.119 don't sit on a stale template through the watcher's hourly window.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "3.31.19",
+  "version": "3.31.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "3.31.19",
+      "version": "3.31.20",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.31.19",
+  "version": "3.31.20",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

v3.31.20 release — bundles three landed PRs since v3.31.19. Patch bump matches the dario#129 / v3.31.5 precedent (template re-bake gets a patch).

| PR | Theme | User-visible? |
|---|---|---|
| **#148** | Template re-bake against CC v2.1.120 + maxTested bump | Yes — bundled fallback template changes |
| **#147** | Stealth test #4 effort ratio → diagnostic-only | No — test-only change |
| **#146** | spam-watch GitHub Actions workflow | No — repo-side housekeeping |

The template re-bake is the load-bearing change: 2.1.120 is published to npm (but not yet `@latest`-tagged); Anthropic tightened the `Agent` tool description so `Explore` is explicitly not for code review / cross-file consistency / open-ended analysis. Shipping the new template ahead of the @latest promotion keeps users on the bundled fallback from drifting through the hourly-watcher window.

## What changed in this release PR

- `package.json` — version 3.31.19 → 3.31.20
- `package-lock.json` — re-synced, 0 vulns
- `CHANGELOG.md` — `[Unreleased]` renamed to `[3.31.20] - 2026-04-26` with a concise three-bullet summary referencing each contributor PR; original per-PR sections preserved in place underneath; fresh empty `[Unreleased]` left at the top

## Test plan

- [x] `npm install --package-lock-only` — clean, 0 vulns.
- [x] `npm run build` — clean.
- [x] `npm test` — 54/54 pass.
- [x] `node dist/cli.js --version` → `3.31.20`.
- [ ] Required CI checks (`actionlint`, `analyze`, `validate-package-json`, `build (18/20/22)`) on this PR.
- [ ] **On merge:** `auto-release.yml` fires → tag `v3.31.20` → `npm publish --access public --provenance`.
- [ ] **Post-publish bin-shim smoke** within ~10 min: `npm install -g @askalf/dario@3.31.20` → `dario --version` → `dario doctor`. Catches the dario#143-class regression — same lesson now also applies to hands.