### PR TITLE
ci(cc-drift): stage only patched files; auto-merge drift PRs

### DIFF
--- a/.github/workflows/cc-drift-watch.yml
+++ b/.github/workflows/cc-drift-watch.yml
@@ -169,9 +169,11 @@ jobs:
         # Only when the binary-scan drift check flagged an item. The
         # auto-drafter reads drift-report.json and, for known one-line
         # drift classes (v1: compat.range / SUPPORTED_CC_RANGE.maxTested
-        # bumps), applies the patch, pushes to a bot branch, and opens
-        # a DRAFT PR for maintainer review. Other drift classes still
-        # just open the plain issue via the next step.
+        # bumps), applies the patch, pushes to a bot branch, opens a PR,
+        # and turns on auto-merge. Once required CI checks pass, GitHub
+        # squash-merges the PR; cc-drift-auto-release.yml then tags the
+        # release and publish.yml ships to npm. Other drift classes still
+        # just open the plain issue via the earlier step.
         if: steps.drift.outputs.exit_code != '0'
         id: auto_draft
         env:
@@ -179,6 +181,11 @@ jobs:
         run: |
           set -eo pipefail
 
+          # The script writes its own artifact files (drift-report.json,
+          # drift-log.txt, auto-draft-result.json, pr-body.md, etc.) into
+          # the workdir. Stage ONLY the files it actually patched so CI
+          # artifacts don't end up in the commit — that requires the
+          # explicit `changedFiles` list emitted alongside `fixed: true`.
           DRAFT_RESULT=$(node scripts/auto-draft-drift-fix.mjs drift-report.json)
           echo "$DRAFT_RESULT" > auto-draft-result.json
 
@@ -206,16 +213,30 @@ jobs:
           git config user.email "actions@github.com"
           git config user.name "cc-drift-watch[bot]"
           git checkout -b "$BRANCH"
-          git add -A
+
+          # Stage only the files the auto-drafter patched. Using `git add
+          # -A` here would sweep in CI artifacts (drift-report.json,
+          # drift-log.txt, issue-body.md, pr-body.md, auto-draft-result.json).
+          echo "$DRAFT_RESULT" \
+            | node -pe "JSON.parse(require('fs').readFileSync(0,'utf8')).changedFiles.join('\n')" \
+            | xargs -I {} git add -- {}
           git commit -m "$TITLE"
           git push origin "$BRANCH"
 
-          gh pr create \
+          PR_URL=$(gh pr create \
             --head "$BRANCH" \
             --title "$TITLE" \
             --body-file pr-body.md \
-            --draft \
-            --label cc-drift
+            --label cc-drift)
+          echo "Opened $PR_URL"
+
+          # Enable auto-merge: GitHub will squash-merge the PR as soon as
+          # all required status checks pass (build × 3 node versions,
+          # validate-package-json, analyze, actionlint). Branch protection
+          # on master gates the actual merge; if a check fails the PR
+          # stays open with the failure visible and the bot branch
+          # preserved for inspection.
+          gh pr merge "$PR_URL" --auto --squash --delete-branch
 
       - name: Close resolved drift issues
         if: steps.drift.outputs.exit_code == '0'


### PR DESCRIPTION
## Summary

Two related fixes to `.github/workflows/cc-drift-watch.yml`:

1. **Stage only the files the auto-drafter actually patched.** The old `git add -A` swept in five CI artifacts the script writes to the workdir alongside the real fix (`drift-report.json`, `drift-log.txt`, `auto-draft-result.json`, `issue-body.md`, `pr-body.md`). The v2.1.121 bot commit (74db8c6 on `bot/cc-drift-v2.1.121`) includes all five — none belong in the repo. Now we read the explicit `changedFiles` array the script already emits and `git add` only that list.

2. **Drop `--draft`, enable auto-merge.** Master's branch protection requires `build (18)`, `build (20)`, `build (22)`, `validate-package-json`, `analyze`, and `actionlint` to pass — auto-merge respects all of those. The PR body the auto-drafter writes already promises "Auto-merge will ship it through CI"; the workflow now matches that intent.

End-to-end on a future CC release:
detect → patch → push branch → open PR → wait for required checks → squash-merge → `cc-drift-auto-release.yml` tags → `publish.yml` ships to npm.

Other drift classes (template re-capture, scope rotations, URL/clientId changes) still require human judgment and stay on the plain drift-issue path.

## Test plan

- [ ] actionlint passes in CI on this PR
- [ ] After merge, manually dispatch the workflow with `force=true` against the current CC version to confirm a clean run with no artifact pollution in the resulting bot branch