### PR TITLE
fix(test): resolve the two pre-existing failures (hybrid-tools, oauth-detector)

### DIFF
--- a/src/cc-oauth-detect.ts
+++ b/src/cc-oauth-detect.ts
@@ -135,6 +135,12 @@ function candidatePaths(): string[] {
   const home = homedir();
   if (platform() === 'win32') {
     return [
+      // CC v2.x ships a Bun-compiled standalone exe under bin/.
+      // Earlier (v1.x) layouts used cli.js / cli.mjs at the package
+      // root. Both are kept in the search list so we work across the
+      // upgrade without forcing every user onto a fresh capture.
+      join(home, 'AppData', 'Roaming', 'npm', 'node_modules', '@anthropic-ai', 'claude-code', 'bin', 'claude.exe'),
+      join(home, '.claude', 'local', 'node_modules', '@anthropic-ai', 'claude-code', 'bin', 'claude.exe'),
       join(home, '.local', 'bin', 'claude.exe'),
       join(home, 'AppData', 'Roaming', 'npm', 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js'),
       join(home, 'AppData', 'Roaming', 'npm', 'node_modules', '@anthropic-ai', 'claude-code', 'cli.mjs'),
@@ -143,6 +149,10 @@ function candidatePaths(): string[] {
     ];
   }
   return [
+    // v2.x bin/claude precompiled exe — checked before legacy cli.js/.mjs.
+    '/usr/local/lib/node_modules/@anthropic-ai/claude-code/bin/claude',
+    '/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/bin/claude',
+    join(home, '.claude', 'local', 'node_modules', '@anthropic-ai', 'claude-code', 'bin', 'claude'),
     join(home, '.local', 'bin', 'claude'),
     '/usr/local/bin/claude',
     '/opt/homebrew/bin/claude',

--- a/test/hybrid-tools.mjs
+++ b/test/hybrid-tools.mjs
@@ -435,6 +435,13 @@ header('dario#37 (Glob) — unmapped `image` cannot steal Glob reverse slot');
   // padding tools claiming Bash/Read/Grep, the fourth unmapped tool lands
   // on Glob. No legitimate Glob mapping is declared — this matches the
   // original OpenClaw repro.
+  //
+  // noAutoDetect is required: PR #158 added a structural fallback that
+  // catches "3+ tools, ≥80% unmapped" → 'unknown-non-cc' → auto-preserve,
+  // which would skip the round-robin path entirely. This test is *about*
+  // the round-robin reverse-mapper; opt out of the fallback so the path
+  // we want to exercise actually runs. The structural fallback has its
+  // own coverage in test/client-detection.mjs section 10/11.
   const body = {
     model: 'claude-sonnet-4-6',
     messages: [{ role: 'user', content: 'list /tmp' }],
@@ -450,7 +457,7 @@ header('dario#37 (Glob) — unmapped `image` cannot steal Glob reverse slot');
     'billing',
     { type: 'ephemeral' },
     { deviceId: 'd', accountUuid: 'a', sessionId: 's' },
-    {},
+    { noAutoDetect: true },
   );
   // Test premise: `image` actually landed on Glob via round-robin. If the
   // distribution algorithm ever changes, fail loud rather than silently.
@@ -514,6 +521,9 @@ header('dario#37 (Glob) — unmapped `image` cannot steal Glob reverse slot');
 // that could in principle diverge. Cover it explicitly.
 header('dario#37 (Glob) — streaming: real Glob passes through unchanged');
 {
+  // Same noAutoDetect note as the buffered case above — PR #158
+  // structural fallback would short-circuit the round-robin path
+  // we're trying to test here.
   const body = {
     model: 'claude-sonnet-4-6',
     messages: [{ role: 'user', content: 'list /tmp' }],
@@ -530,7 +540,7 @@ header('dario#37 (Glob) — streaming: real Glob passes through unchanged');
     'billing',
     { type: 'ephemeral' },
     { deviceId: 'd', accountUuid: 'a', sessionId: 's' },
-    {},
+    { noAutoDetect: true },
   );
   // Test premise check — if round-robin ever changes this will fail loud.
   check('stream premise: `image` is round-robin\'d onto Glob', built.toolMap.get('image')?.ccTool === 'Glob');


### PR DESCRIPTION
## Summary

The suite has been carrying two failing tests since at least the start of the PR-#158 work. Both fixed here; full suite now 56/56 (was 54/56).

## hybrid-tools.mjs — `test premise: image is round-robin'd onto Glob`

PR #158 added a structural fallback (`detectNonCCByTools`) that catches "3+ tools, ≥80% unmapped" and flips to auto-preserve. The test bodies have 4-of-4 unmapped tools (100%), so the fallback fires and skips the round-robin entirely. The `toolMap` is empty and `.get('image')` is undefined.

Fix: pass `noAutoDetect: true` to both `buildCCRequest` call sites. The test is about the round-robin reverse-mapper (dario#37 Glob path); opting out of the structural fallback lets the path under test actually run. The structural fallback has its own coverage in `test/client-detection.mjs` sections 10–11, so this opt-out doesn't reduce overall coverage.

## oauth-detector.mjs — `source is "detected" (not fallback)` + 2 dependent failures

`cc-oauth-detect.ts:candidatePaths()` looked for the v1.x layout (`cli.js` / `cli.mjs` at the package root) but CC v2.x ships a Bun-compiled standalone exe under `bin/claude.exe` (Win) or `bin/claude` (Unix). On a v2.x install the detector found nothing and fell back to `FALLBACK`, so `source` stayed `'fallback'` and the cache write never happened — chain of three failed assertions.

Fix: add `bin/claude.exe` and `bin/claude` variants to the candidate path list, ahead of the legacy `cli.js` / `cli.mjs` entries (so precompiled installs are preferred). Both layouts stay in the list to keep working across the v1 → v2 upgrade without forcing every user onto a fresh capture.

## Test plan

- [x] `npm run build` clean (no TS errors)
- [x] `npm test` — 56/56 pass, 0 fail. First clean suite run on this branch since PR work started.
- [x] Re-ran each affected test individually: `node test/hybrid-tools.mjs` (60 pass / 0 fail), `node test/oauth-detector.mjs` (23/23 pass).
- [ ] Reviewer to confirm the fixes work on a Linux / macOS host (the `bin/claude` Unix path additions weren't end-to-end tested locally, only the Windows `bin/claude.exe` path).