### PR TITLE
release: v3.32.0 — backlog clear-out (5 features + test cleanup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ checklist.
 
 ## [Unreleased]
 
+## [3.32.0] - 2026-04-28
+
+Backlog clear-out — five new operator-facing features (one per merged PR) plus a test-suite cleanup. Net: dario gets a structural fallback that catches in-house non-CC clients without per-client maintenance, an append-only request log for backgrounded proxies, four `dario doctor` improvements, an operator-pinned beta allow-list, a user-facing `dario usage` summary, and an experimental `--merge-tools` mode. Wire shape unchanged on the default path; every new behavior is opt-in via flag, env var, or detector heuristic. Test suite goes from 54/56 to 56/56 — both long-running failures fixed alongside the feature work.
+
+PRs in this release: #158 (auto-detect + `--log-file`), #159 (doctor improvements), #160 (`--passthrough-betas`), #161 (`dario usage`), #162 (`--merge-tools`), #163 (test-suite cleanup).
+
 ### Added — `--merge-tools` (EXPERIMENTAL) — append client tools after CC's canonical set
 
 Third tool-routing mode, sitting alongside `--preserve-tools` (forward client tools verbatim) and `--hybrid-tools` (remap to CC + inject request-context). Merge mode sends CC's canonical tool array first, then appends the client's custom tools deduped by name (case-insensitive). The model sees the union and may call either side; tool calls flow back unchanged because no reverse-mapping runs in this branch.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "3.31.21",
+  "version": "3.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "3.31.21",
+      "version": "3.32.0",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.31.21",
+  "version": "3.32.0",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Bumps `package.json.version` to **3.32.0** and dates the `## [3.32.0]` heading in CHANGELOG. Auto-release fires on merge: tag, GitHub Release, `npm publish --provenance` in one job.

This is a minor bump from 3.31.21. Five new opt-in features (no breaking changes), one test-suite cleanup. Every PR in this release was already individually CI-green and merged separately.

## What's in this release

- **#158** — `arnie` identity + structural non-CC fallback (auto preserve-tools) + `--log-file` / `DARIO_LOG_FILE` (append-only JSON-ND request log).
- **#159** — `dario doctor` improvements: per-request overhead row, pool-rotation visibility, tool-substitution warn, `--bun-bootstrap` one-shot installer.
- **#160** — `--passthrough-betas` / `DARIO_PASSTHROUGH_BETAS` — operator-pinned beta allow-list.
- **#161** — `dario usage` CLI + MCP `usage` tool — proxy burn-rate summary.
- **#162** — `--merge-tools` (EXPERIMENTAL) — append client tools after CC's canonical set.
- **#163** — fix(test): clean up the two long-running pre-existing failures (`hybrid-tools.mjs`, `oauth-detector.mjs`) — suite is 56/56 for the first time in months.

Wire shape unchanged on the default path. Every new behavior is opt-in via flag, env var, or detector heuristic.

## Pre-merge checklist (per RELEASING.md)

- [x] `npm run build` clean
- [x] `npm test` — 56/56 pass, 0 fail
- [x] `package.json.version` bumped: `3.31.21` → `3.32.0`
- [x] `CHANGELOG.md` has `## [3.32.0] - 2026-04-28` heading above a fresh `## [Unreleased]`, with the per-PR breakdown plus a one-paragraph rollup
- [x] No `Co-Authored-By:` trailers
- [x] `package-lock.json` re-synced (`npm install --package-lock-only`)
- [x] `node dist/cli.js --version` reports `3.32.0`

## Post-publish smoke (RELEASING.md §3 — dario#143 lesson)

Reviewer to run within ~10 min of `npm publish` completing:

```bash
npm install -g @askalf/dario@latest
which dario
dario --version            # expect 3.32.0
dario --help               # non-empty output
dario doctor               # full health table; new "Overhead" + "Pool routing" rows visible
dario doctor --usage       # per-model probe path; new bin/claude.exe detection should hit
DARIO_NO_BUN=1 dario proxy &
sleep 2
curl -s http://127.0.0.1:3456/health
kill %1
```

If `dario doctor` is silent or any command exits 0 with no output: the `dario#143`-class regression is back, hotfix immediately.