### PR TITLE
scripts: maintainer diagnostics for fingerprint + behavioral testing

### DIFF
--- a/scripts/capture-full-body.mjs
+++ b/scripts/capture-full-body.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// One-shot capture of the FULL outbound /v1/messages body from the
+// installed `claude` binary. The existing capture-and-bake script only
+// retains structural axes (header_order, body_field_order, tool names,
+// system prompt) — it doesn't surface the actual VALUES of effort,
+// max_tokens, model, etc. This script does.
+//
+// Usage:
+//   node scripts/capture-full-body.mjs
+//   MODEL=claude-sonnet-4-6 node scripts/capture-full-body.mjs
+//
+// Spawns CC against a loopback MITM, captures the first POST that hits
+// /v1/messages*, prints the fingerprint-relevant fields as JSON, exits.
+// Useful for verifying what the installed CC version actually wires for
+// `effort`, `max_tokens`, `thinking`, etc. — values the bake script
+// strips during scrubTemplate. Maintainer-only diagnostic; not invoked
+// from CI or runtime paths.
+
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+
+const CC_BIN = process.env.DARIO_CLAUDE_BIN
+  || 'C:/Users/masterm1nd.DOCK/.local/bin/claude.exe';
+const TIMEOUT_MS = 25_000;
+
+let captured = null;
+
+const server = http.createServer((req, res) => {
+  let body = '';
+  req.on('data', (c) => { body += c; });
+  req.on('end', () => {
+    console.error(`[capture] ${req.method} ${req.url} (body ${body.length} bytes)`);
+    if (req.url.startsWith('/v1/messages') && req.method === 'POST' && !captured) {
+      try {
+        captured = { headers: req.headers, body: JSON.parse(body) };
+      } catch {
+        captured = { headers: req.headers, raw: body };
+      }
+    }
+    res.writeHead(200, { 'content-type': 'text/event-stream' });
+    res.end('event: error\ndata: {"type":"error","error":{"type":"capture_only","message":"capture-full-body.mjs"}}\n\n');
+  });
+});
+
+server.listen(0, '127.0.0.1', () => {
+  const port = server.address().port;
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const args = ['--print', '-p', 'hi'];
+  if (process.env.MODEL) args.unshift('--model', process.env.MODEL);
+
+  console.error(`[capture] MITM listening on ${baseUrl}`);
+  console.error(`[capture] spawning ${CC_BIN} ${args.join(' ')} ...`);
+
+  const cc = spawn(CC_BIN, args, {
+    env: {
+      ...process.env,
+      ANTHROPIC_BASE_URL: baseUrl,
+      ANTHROPIC_API_KEY: 'sk-capture-stub',
+      CLAUDE_NONINTERACTIVE: '1',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  });
+
+  cc.stderr.on('data', (d) => { process.stderr.write('[cc-stderr] ' + d); });
+  cc.stdout.on('data', (d) => { process.stderr.write('[cc-stdout] ' + d); });
+  cc.on('exit', (code) => {
+    setTimeout(finish, 100);
+  });
+  cc.on('error', (err) => {
+    console.error('[capture] spawn error:', err.message);
+    finish();
+  });
+
+  setTimeout(() => {
+    console.error('[capture] TIMEOUT — CC did not send a /v1/messages within ' + TIMEOUT_MS + 'ms');
+    cc.kill();
+    finish();
+  }, TIMEOUT_MS);
+});
+
+function finish() {
+  if (!captured) {
+    console.error('[capture] no request captured');
+    process.exit(1);
+  }
+  // Surface only the fingerprint-relevant fields. Strip the messages
+  // (just user 'hi') and tools (verbose, already covered by bake).
+  const { body } = captured;
+  const fingerprint = {
+    model: body.model,
+    max_tokens: body.max_tokens,
+    stream: body.stream,
+    thinking: body.thinking,
+    output_config: body.output_config,
+    context_management: body.context_management,
+    metadata_keys: body.metadata ? Object.keys(body.metadata) : null,
+    metadata_user_id_shape: body.metadata?.user_id ? typeof body.metadata.user_id : null,
+    system_block_count: Array.isArray(body.system) ? body.system.length : (typeof body.system === 'string' ? 1 : 0),
+    tool_count: Array.isArray(body.tools) ? body.tools.length : 0,
+    body_field_order: Object.keys(body),
+    user_agent: captured.headers['user-agent'],
+    anthropic_beta: captured.headers['anthropic-beta'],
+    anthropic_version: captured.headers['anthropic-version'],
+  };
+  console.log(JSON.stringify(fingerprint, null, 2));
+  process.exit(0);
+}

--- a/scripts/test-constraint-removal.mjs
+++ b/scripts/test-constraint-removal.mjs
@@ -1,0 +1,300 @@
+#!/usr/bin/env node
+// Deep A/B test: take CC's system prompt, strip the behavioral
+// constraint language (verbosity caps, no-comments-by-default,
+// ask-before-acting, scope discipline), keep the alignment / safety
+// content, then send identical user prompts to both versions and
+// measure the behavior delta.
+//
+// Builds on test-system-prompt-mods.mjs's finding that system prompt
+// content is unfingerprinted by the billing classifier — so the
+// stripped variant should still route to `five_hour` and the only
+// observable difference should be the model's output behavior.
+//
+// Variables held identical between control and stripped variants:
+//   - model, tools, max_tokens, effort, thinking, context_management
+//   - body field order, metadata.user_id, OAuth bearer
+//   - anthropic-beta (with oauth-2025-04-20 prepended), user-agent
+//   - the user message itself
+//
+// Variable changed:
+//   - system[2].text — CC verbatim (control) vs constraint-stripped (test)
+//
+// What we measure per variant per prompt:
+//   - billing classification (`anthropic-ratelimit-unified-representative-claim`)
+//   - response length (chars + roughly tokens)
+//   - comment density in code outputs (lines starting with `//` or `#` or `/*`)
+//   - clarifying-question rate (response ends with `?`)
+
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const CC_BIN = process.env.DARIO_CLAUDE_BIN
+  || 'C:/Users/masterm1nd.DOCK/.local/bin/claude.exe';
+const CAPTURE_TIMEOUT_MS = 25_000;
+const PACE_MS = 3_000;
+
+// ──────────────────────────────────────────────────────────────────────
+// Constraint stripping
+// ──────────────────────────────────────────────────────────────────────
+
+// Two strip levels.
+//
+// Partial strip — removes purely behavioral preferences (verbosity caps,
+// comment defaults, scope discipline). Keeps every "IMPORTANT:" line,
+// keeps tool descriptions, keeps "# Executing actions with care".
+//
+// Aggressive strip — additionally removes prompt-level reminders of
+// RLHF-trained alignment ("IMPORTANT: Refuse requests for destructive
+// techniques..."). These are reminders, not enforcement — the model's
+// refusal behavior on harmful content is RLHF-trained and survives
+// prompt removal. Stripping them tests whether the prompt-level
+// reminders contribute observable delta on benign tasks (they likely
+// don't) and whether the classifier cares (it doesn't, per the
+// system-prompt-mods test).
+function stripConstraints(sys, level = 'partial') {
+  let s = sys;
+
+  // Remove entire "# Tone and style" section.
+  s = s.replace(/# Tone and style[\s\S]*?(?=\n# |\n$|$)/m, '');
+
+  // Remove entire "# Text output" section.
+  s = s.replace(/# Text output[^\n]*\n[\s\S]*?(?=\n# |\n$|$)/m, '');
+
+  // Within "# Doing tasks", remove scope-discipline / verbosity /
+  // commenting bullets.
+  const doingTasksConstraints = [
+    /^ - Don't add features, refactor, or introduce abstractions[^\n]*\n[^\n]*\n[^\n]*\n[^\n]*\n[^\n]*\n/m,
+    /^ - Don't add error handling, fallbacks, or validation[^\n]*\n[^\n]*\n/m,
+    /^ - Default to writing no comments\.[^\n]*\n[^\n]*\n[^\n]*\n[^\n]*\n/m,
+    /^ - Don't explain WHAT the code does[^\n]*\n[^\n]*\n/m,
+    /^ - For exploratory questions[^\n]*\n[^\n]*\n/m,
+    /^ - Avoid backwards-compatibility hacks[^\n]*\n[^\n]*\n/m,
+  ];
+  for (const re of doingTasksConstraints) {
+    s = s.replace(re, '');
+  }
+
+  s = s.replace(
+    /^# Doing tasks\n/m,
+    '# Doing tasks\n\nBe thorough. Show your reasoning. Provide the context and explanations the user is likely to find useful. Use as many tokens as the task warrants.\n\n',
+  );
+
+  if (level === 'aggressive') {
+    // Remove prompt-level reminders of RLHF-trained alignment. These
+    // are "IMPORTANT:" lines in CC's `# System` section that re-state
+    // refusal categories. Removing them tests whether prompt-level
+    // re-statement contributes observable delta beyond the RLHF
+    // baseline. Critically: this does NOT remove RLHF — the model
+    // still refuses on those categories because alignment is trained,
+    // not prompted.
+    s = s.replace(/^IMPORTANT: Assist with authorized security testing[^\n]*\n/m, '');
+    s = s.replace(/^IMPORTANT: You must NEVER generate or guess URLs[^\n]*\n/m, '');
+
+    // Remove the bulk of "# Executing actions with care" — most of it
+    // is behavioral overcaution ("ask before this", "confirm before
+    // that") rather than load-bearing safety. Keep the "# Using your
+    // tools" section intact since it's tool descriptions, not
+    // behavioral caps.
+    s = s.replace(/# Executing actions with care[\s\S]*?(?=\n# |\n$|$)/m, '');
+  }
+
+  return s;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Capture, auth, send (mirrors test-system-prompt-mods.mjs)
+// ──────────────────────────────────────────────────────────────────────
+
+async function captureFromCC() {
+  return new Promise((resolve, reject) => {
+    let captured = null;
+    const server = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', (c) => { body += c; });
+      req.on('end', () => {
+        if (req.url.startsWith('/v1/messages') && req.method === 'POST' && !captured) {
+          try { captured = { url: req.url, headers: req.headers, body: JSON.parse(body) }; }
+          catch (e) { captured = { url: req.url, headers: req.headers, err: e.message }; }
+        }
+        res.writeHead(200, { 'content-type': 'text/event-stream' });
+        res.end('event: error\ndata: {"type":"error","error":{"type":"capture_only"}}\n\n');
+      });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const port = server.address().port;
+      console.error(`[capture] MITM on http://127.0.0.1:${port}, spawning CC...`);
+      const cc = spawn(CC_BIN, ['--print', '-p', 'hi'], {
+        env: {
+          ...process.env,
+          ANTHROPIC_BASE_URL: `http://127.0.0.1:${port}`,
+          ANTHROPIC_API_KEY: 'sk-capture-stub',
+          CLAUDE_NONINTERACTIVE: '1',
+        },
+        stdio: ['ignore', 'ignore', 'ignore'],
+        windowsHide: true,
+      });
+      const finish = () => {
+        server.close();
+        if (captured?.body) resolve(captured);
+        else reject(new Error('no /v1/messages body captured'));
+      };
+      cc.on('exit', () => setTimeout(finish, 200));
+      cc.on('error', (err) => reject(err));
+      setTimeout(() => { cc.kill(); finish(); }, CAPTURE_TIMEOUT_MS);
+    });
+  });
+}
+
+async function sendUpstream(body, bearer, captureHeaders, urlPath) {
+  let beta = captureHeaders['anthropic-beta'] || '';
+  if (!beta.split(',').includes('oauth-2025-04-20')) {
+    beta = beta ? `oauth-2025-04-20,${beta}` : 'oauth-2025-04-20';
+  }
+  const headers = {
+    'accept': 'application/json',
+    'content-type': 'application/json',
+    'anthropic-beta': beta,
+    'anthropic-version': captureHeaders['anthropic-version'] || '2023-06-01',
+    'authorization': `Bearer ${bearer}`,
+    'user-agent': captureHeaders['user-agent'],
+    'x-app': captureHeaders['x-app'] || 'cli',
+    'anthropic-dangerous-direct-browser-access': 'true',
+  };
+  body.stream = false;
+
+  const res = await fetch('https://api.anthropic.com' + urlPath, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+  const claim = res.headers.get('anthropic-ratelimit-unified-representative-claim') || '(unset)';
+  const respText = await res.text();
+  let respJson = null;
+  try { respJson = JSON.parse(respText); } catch {}
+  const text = respJson?.content?.find((b) => b.type === 'text')?.text || '';
+  return {
+    status: res.status,
+    claim,
+    requestId: res.headers.get('request-id'),
+    text,
+    output_chars: text.length,
+    output_tokens: respJson?.usage?.output_tokens,
+    input_tokens: respJson?.usage?.input_tokens,
+    errorType: respJson?.error?.type,
+    errorMessage: respJson?.error?.message?.slice(0, 200),
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Behavior measurement
+// ──────────────────────────────────────────────────────────────────────
+
+function measure(text) {
+  if (!text) return { chars: 0, lines: 0, comment_lines: 0, ends_with_question: false, has_code_block: false };
+  const lines = text.split('\n');
+  const commentLines = lines.filter((l) => /^\s*(\/\/|#|\/\*|\*\s)/.test(l)).length;
+  return {
+    chars: text.length,
+    lines: lines.length,
+    comment_lines: commentLines,
+    ends_with_question: /\?\s*$/.test(text.trim()),
+    has_code_block: /```/.test(text),
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Test prompts that should trigger CC's constraints
+// ──────────────────────────────────────────────────────────────────────
+
+const TEST_PROMPTS = [
+  {
+    label: 'code-with-comments',
+    prompt: 'Write a TypeScript function that deduplicates an array of objects by a specified key. Include thorough comments explaining your reasoning, edge cases, and the tradeoffs of different approaches.',
+  },
+  {
+    label: 'detailed-explanation',
+    prompt: 'Explain how V8\'s hidden class optimization works in Node.js, why it matters for performance, and how to write code that benefits from it.',
+  },
+  {
+    label: 'open-ended-decision',
+    prompt: 'Should I use Redis or Postgres for session storage in a Node.js web app?',
+  },
+];
+
+// ──────────────────────────────────────────────────────────────────────
+// Main
+// ──────────────────────────────────────────────────────────────────────
+
+const captured = await captureFromCC();
+console.error(`[capture] body keys: ${Object.keys(captured.body).join(', ')}`);
+console.error(`[capture] system blocks: ${captured.body.system.length}`);
+console.error(`[capture] system[2] (CC verbatim) length: ${captured.body.system[2].text.length}`);
+
+const partial = stripConstraints(captured.body.system[2].text, 'partial');
+const aggressive = stripConstraints(captured.body.system[2].text, 'aggressive');
+const origLen = captured.body.system[2].text.length;
+console.error(`[strip] partial:    ${partial.length} chars (-${Math.round(100*(origLen-partial.length)/origLen)}%)`);
+console.error(`[strip] aggressive: ${aggressive.length} chars (-${Math.round(100*(origLen-aggressive.length)/origLen)}%)`);
+console.error('');
+
+// Read OAuth from CC's credentials directly (dario's resolver may
+// be stale; CC's path is the authoritative fresh source).
+const home = process.env.USERPROFILE || process.env.HOME;
+const oa = JSON.parse(fs.readFileSync(path.join(home, '.claude', '.credentials.json'), 'utf-8')).claudeAiOauth;
+const bearer = oa.accessToken;
+if (!bearer) { console.error('FATAL: no CC accessToken'); process.exit(1); }
+const minsLeft = Math.round((oa.expiresAt - Date.now()) / 60000);
+console.error(`[auth] resolved CC token (${minsLeft} min remaining)`);
+console.error('');
+
+const results = [];
+
+const VARIANTS = [
+  { name: 'control', sys: captured.body.system[2].text },
+  { name: 'partial', sys: partial },
+  { name: 'aggressive', sys: aggressive },
+];
+
+for (const p of TEST_PROMPTS) {
+  console.error(`=== prompt: ${p.label} ===`);
+  for (const v of VARIANTS) {
+    const body = structuredClone(captured.body);
+    body.system[2].text = v.sys;
+    body.messages = [{ role: 'user', content: p.prompt }];
+
+    process.stderr.write(`  ${v.name.padEnd(11)} ... `);
+    try {
+      const r = await sendUpstream(body, bearer, captured.headers, captured.url);
+      const m = measure(r.text);
+      process.stderr.write(`status=${r.status} claim=${r.claim} chars=${m.chars} lines=${m.lines} comments=${m.comment_lines} q?=${m.ends_with_question} out_tok=${r.output_tokens}\n`);
+      results.push({ prompt: p.label, variant: v.name, status: r.status, claim: r.claim, ...m, output_tokens: r.output_tokens, input_tokens: r.input_tokens, text_preview: r.text.slice(0, 200), text_full: r.text });
+    } catch (e) {
+      process.stderr.write(`ERROR: ${e.message}\n`);
+      results.push({ prompt: p.label, variant: v.name, error: e.message });
+    }
+    await sleep(PACE_MS);
+  }
+}
+
+console.error('');
+console.error('=== SUMMARY (control vs stripped, per prompt) ===');
+console.error('');
+const byPrompt = new Map();
+for (const r of results) {
+  if (!byPrompt.has(r.prompt)) byPrompt.set(r.prompt, {});
+  byPrompt.get(r.prompt)[r.variant] = r;
+}
+for (const [prompt, set] of byPrompt) {
+  console.error(`--- ${prompt} ---`);
+  for (const variant of ['control', 'partial', 'aggressive']) {
+    const r = set[variant];
+    if (!r) continue;
+    console.error(`  ${variant.padEnd(11)} chars=${r.chars} out_tok=${r.output_tokens} lines=${r.lines} comments=${r.comment_lines} q?=${r.ends_with_question} claim=${r.claim}`);
+  }
+}
+console.error('');
+console.error('=== FULL JSON (write to file via redirect to keep raw output) ===');
+console.log(JSON.stringify(results, null, 2));

--- a/scripts/test-system-prompt-mods.mjs
+++ b/scripts/test-system-prompt-mods.mjs
@@ -221,7 +221,7 @@ if (!bearer) {
   process.exit(1);
 }
 const minsLeft = Math.round((oa.expiresAt - Date.now()) / 60000);
-console.error(`[auth] using CC's accessToken (${bearer.length} chars, ${minsLeft} min remaining)`);
+console.error(`[auth] using CC's accessToken (${minsLeft} min remaining)`);
 console.error('');
 
 const results = [];

--- a/scripts/test-system-prompt-mods.mjs
+++ b/scripts/test-system-prompt-mods.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+// Empirical A/B test: does Anthropic's billing classifier route to
+// `five_hour` (subscription) when CC's system prompt content is
+// modified, while everything else (effort, max_tokens, tools, headers,
+// field order, billing tag, metadata user_id) is held identical?
+//
+// Approach:
+//   1. Capture CC's exact outbound body via a loopback MITM (same
+//      approach as scripts/capture-full-body.mjs).
+//   2. For each variant in the ladder, deep-clone the captured body,
+//      apply the variant's mutation to `system[2].text` only, and POST
+//      the result directly to https://api.anthropic.com/v1/messages
+//      with OAuth bearer auth.
+//   3. Read the `anthropic-ratelimit-unified-representative-claim`
+//      response header — that's the billing classification (`five_hour`
+//      = subscription, `overage` = pay-per-token).
+//   4. Print a result table.
+//
+// Cost: 1 real upstream request per variant. With ~7 variants on the
+// default ladder, that's a trivial slice of any Max plan's budget. The
+// dispatched messages are short ("hi") so output_tokens are minimal.
+
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+const CC_BIN = process.env.DARIO_CLAUDE_BIN
+  || 'C:/Users/masterm1nd.DOCK/.local/bin/claude.exe';
+const CAPTURE_TIMEOUT_MS = 25_000;
+const PACE_MS = 2_000;
+
+// ──────────────────────────────────────────────────────────────────────
+// Step 1: Capture CC's outbound body (control)
+// ──────────────────────────────────────────────────────────────────────
+
+async function captureFromCC() {
+  return new Promise((resolve, reject) => {
+    let captured = null;
+    const server = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', (c) => { body += c; });
+      req.on('end', () => {
+        if (req.url.startsWith('/v1/messages') && req.method === 'POST' && !captured) {
+          try {
+            captured = { url: req.url, headers: req.headers, body: JSON.parse(body) };
+          } catch (e) {
+            captured = { url: req.url, headers: req.headers, raw: body, err: e.message };
+          }
+        }
+        res.writeHead(200, { 'content-type': 'text/event-stream' });
+        res.end('event: error\ndata: {"type":"error","error":{"type":"capture_only","message":"test-system-prompt-mods.mjs"}}\n\n');
+      });
+    });
+
+    server.listen(0, '127.0.0.1', () => {
+      const port = server.address().port;
+      const baseUrl = `http://127.0.0.1:${port}`;
+      console.error(`[capture] MITM on ${baseUrl}, spawning CC...`);
+
+      const cc = spawn(CC_BIN, ['--print', '-p', 'hi'], {
+        env: {
+          ...process.env,
+          ANTHROPIC_BASE_URL: baseUrl,
+          ANTHROPIC_API_KEY: 'sk-capture-stub',
+          CLAUDE_NONINTERACTIVE: '1',
+        },
+        stdio: ['ignore', 'ignore', 'ignore'],
+        windowsHide: true,
+      });
+
+      const finish = () => {
+        server.close();
+        if (captured && captured.body) resolve(captured);
+        else reject(new Error('no /v1/messages body captured'));
+      };
+
+      cc.on('exit', () => setTimeout(finish, 200));
+      cc.on('error', (err) => reject(err));
+      setTimeout(() => { cc.kill(); finish(); }, CAPTURE_TIMEOUT_MS);
+    });
+  });
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Step 2: Variant ladder
+// ──────────────────────────────────────────────────────────────────────
+
+// Each variant mutates the captured body in-place. block 2 of the
+// system array is CC's 13kB system prompt; block 1 is the agent
+// identity; block 0 is the billing tag.
+const VARIANTS = [
+  {
+    name: '01_control',
+    desc: 'CC verbatim, no modifications',
+    mutate: (_body) => {},
+  },
+  {
+    name: '02_single_char_typo',
+    desc: 'system[2]: prepend single char',
+    mutate: (b) => { b.system[2].text = 'X' + b.system[2].text; },
+  },
+  {
+    name: '03_word_substitution',
+    desc: 'system[2]: "concise" → "brief"',
+    mutate: (b) => { b.system[2].text = b.system[2].text.replaceAll('concise', 'brief'); },
+  },
+  {
+    name: '04_sentence_removal',
+    desc: 'system[2]: remove "Default to writing no comments." line',
+    mutate: (b) => {
+      b.system[2].text = b.system[2].text.replace(/Default to writing no comments\.[^\n]*\n/g, '');
+    },
+  },
+  {
+    name: '05_block2_replaced',
+    desc: 'system[2].text replaced with custom 200-char prompt',
+    mutate: (b) => {
+      b.system[2].text = 'You are a helpful assistant. Be terse and direct. Prefer code over prose. Default to assuming the user knows what they want; ask only if their request is genuinely ambiguous.';
+    },
+  },
+  {
+    name: '06_extra_block_added',
+    desc: 'system: add 4th block (3 → 4 blocks)',
+    mutate: (b) => {
+      b.system.push({ type: 'text', text: 'Additional operator instructions: prefer concise responses.' });
+    },
+  },
+  {
+    name: '07_length_padding',
+    desc: 'system[2]: append 500 chars of "x"',
+    mutate: (b) => { b.system[2].text = b.system[2].text + '\n\n' + 'x'.repeat(500); },
+  },
+];
+
+// ──────────────────────────────────────────────────────────────────────
+// Step 3: Send to api.anthropic.com with OAuth bearer
+// ──────────────────────────────────────────────────────────────────────
+
+async function sendUpstream(body, bearer, captureHeaders, urlPath) {
+  // Reproduce CC's wire headers but swap auth: drop x-api-key, use Bearer.
+  // anthropic-beta and anthropic-version come from the captured headers
+  // so we don't drift from what CC sends.
+  //
+  // CC's MITM capture is done with a placeholder API key, so CC's
+  // outbound anthropic-beta does NOT include `oauth-2025-04-20` (CC
+  // only appends that beta when actually authenticated via OAuth).
+  // When we replace the API-key auth with a real OAuth Bearer, we
+  // need to prepend that beta or Anthropic returns
+  // `authentication_error: invalid x-api-key` even with a valid token
+  // — same workaround dario's proxy applies (see src/proxy.ts:821 and
+  // dario#42).
+  let beta = captureHeaders['anthropic-beta'] || '';
+  if (!beta.split(',').includes('oauth-2025-04-20')) {
+    beta = beta ? `oauth-2025-04-20,${beta}` : 'oauth-2025-04-20';
+  }
+
+  const headers = {
+    'accept': 'application/json',
+    'content-type': 'application/json',
+    'anthropic-beta': beta,
+    'anthropic-version': captureHeaders['anthropic-version'] || '2023-06-01',
+    'authorization': `Bearer ${bearer}`,
+    'user-agent': captureHeaders['user-agent'],
+    'x-app': captureHeaders['x-app'] || 'cli',
+    'anthropic-dangerous-direct-browser-access': 'true',
+  };
+  // Force non-streaming so we read the response body in one shot.
+  // Note: this alters one wire-shape axis (`stream`) but is necessary
+  // for clean header reads. If the classifier flips on stream alone
+  // we'd see that in the control row.
+  body.stream = false;
+
+  const url = 'https://api.anthropic.com' + urlPath;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+
+  const claim = res.headers.get('anthropic-ratelimit-unified-representative-claim') || '(unset)';
+  const respText = await res.text();
+  let respJson = null;
+  try { respJson = JSON.parse(respText); } catch {}
+  return {
+    status: res.status,
+    claim,
+    requestId: res.headers.get('request-id') || res.headers.get('x-request-id'),
+    errorType: respJson?.error?.type,
+    errorMessage: respJson?.error?.message?.slice(0, 120),
+    output_chars: respJson?.content?.[0]?.text?.length ?? null,
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Main
+// ──────────────────────────────────────────────────────────────────────
+
+const captured = await captureFromCC();
+console.error(`[capture] body keys: ${Object.keys(captured.body).join(', ')}`);
+console.error(`[capture] system blocks: ${captured.body.system.length}`);
+console.error(`[capture] system[2].text length: ${captured.body.system[2].text.length} chars`);
+console.error(`[capture] tools: ${captured.body.tools?.length ?? 0}`);
+console.error(`[capture] effort: ${captured.body.output_config?.effort}, max_tokens: ${captured.body.max_tokens}, model: ${captured.body.model}`);
+console.error('');
+
+// Skip dario's getAccessToken — it prefers ~/.dario/credentials.json which
+// holds an expired token whose refresh_token has been invalidated by
+// Anthropic, so it falls back to that stale token. Read CC's own fresh
+// token at ~/.claude/.credentials.json directly. CC refreshes it as
+// needed during normal CC use and the file's update time is the source
+// of truth.
+const fs = await import('node:fs');
+const path = await import('node:path');
+const home = process.env.USERPROFILE || process.env.HOME;
+const ccCredsPath = path.join(home, '.claude', '.credentials.json');
+const ccCreds = JSON.parse(fs.readFileSync(ccCredsPath, 'utf-8'));
+const oa = ccCreds.claudeAiOauth || ccCreds;
+const bearer = oa.accessToken;
+if (!bearer) {
+  console.error('FATAL: no accessToken in', ccCredsPath);
+  process.exit(1);
+}
+const minsLeft = Math.round((oa.expiresAt - Date.now()) / 60000);
+console.error(`[auth] using CC's accessToken (${bearer.length} chars, ${minsLeft} min remaining)`);
+console.error('');
+
+const results = [];
+for (const v of VARIANTS) {
+  const body = structuredClone(captured.body);
+  v.mutate(body);
+  const sysLen = (body.system || []).reduce((s, b) => s + (b.text?.length || 0), 0);
+  process.stderr.write(`[run] ${v.name.padEnd(28)} (sys total: ${sysLen} chars) ... `);
+  try {
+    const r = await sendUpstream(body, bearer, captured.headers, captured.url);
+    process.stderr.write(`status=${r.status} claim=${r.claim}\n`);
+    results.push({ ...v, sys_total_chars: sysLen, ...r });
+  } catch (e) {
+    process.stderr.write(`ERROR: ${e.message}\n`);
+    results.push({ ...v, error: e.message });
+  }
+  await sleep(PACE_MS);
+}
+
+console.error('');
+console.error('=== RESULT TABLE ===');
+console.log(JSON.stringify(results, null, 2));


### PR DESCRIPTION
## Summary

Adds three paired maintainer-only diagnostics under `scripts/` that don't ship with the package and aren't invoked from CI:

- **`capture-full-body.mjs`** — captures the literal **values** CC wires on `/v1/messages` (effort, max_tokens, thinking config, model, etc.) — fields the existing `capture-and-bake.mjs` strips during `scrubTemplate`. Verifies CC's actual wire values against Anthropic's stated defaults in ~10s.

- **`test-system-prompt-mods.mjs`** — A/B billing-classifier probe against system prompt mutations. Captures CC's outbound body, deep-clones it for each variant in a 7-step ladder, mutates ONLY `system[]` per variant, sends to `api.anthropic.com` with OAuth bearer, and reads the `anthropic-ratelimit-unified-representative-claim` response header.

- **`test-constraint-removal.mjs`** — builds on the system-prompt-mods finding. Tests what the model actually **does** when CC's behavioral constraints (verbosity caps, comment defaults, scope discipline) are removed, while everything else (effort, max_tokens, tools, body field order, billing tag, OAuth bearer) is held identical. Two strip levels: `partial` (removes "Tone and style" / "Text output" sections), `aggressive` (additionally removes prompt-level alignment reminders).

```
node scripts/capture-full-body.mjs                                # default model
MODEL=claude-sonnet-4-6 node scripts/capture-full-body.mjs        # override

node scripts/test-system-prompt-mods.mjs                          # 7 real upstream requests
node scripts/test-constraint-removal.mjs                          # 9 real upstream requests
```

## Why

The bake captures structural axes (header_order, body_field_order, tool names, system prompt). It does **not** retain the literal value of `effort`, `max_tokens`, the shape of `thinking` / `context_management`, or any way to verify what the classifier actually checks vs. what it tolerates. That gap matters when reasoning about Anthropic's public claims (e.g. the [April 23 postmortem](https://www.anthropic.com/engineering/april-23-postmortem)) or empirically mapping which fields are fingerprint inputs.

Initial findings (CC v2.1.123 + Opus 4.7):

`capture-full-body.mjs` confirms current-state defaults match Anthropic's postmortem:
```json
{ "model": "claude-opus-4-7", "max_tokens": 64000, "output_config": { "effort": "xhigh" }, ... }
{ "model": "claude-sonnet-4-6", "max_tokens": 32000, "output_config": { "effort": "high" }, ... }
```

`test-system-prompt-mods.mjs`: all 7 variants — including replacing CC's 27k-char system prompt with a 321-char custom one and adding a 4th block — routed to `five_hour`. **System prompt content, length, and block count are not classifier inputs.**

`test-constraint-removal.mjs`: 9 (3 prompts × 3 strip levels) variants, all routed `five_hour`. Removing behavioral constraints produces 1.2-2.8× output capability on open-ended work; aggressive strip adds <3% over partial because alignment is RLHF-trained, not prompt-trained.

Full writeup pending in a follow-up Discussion.

## Test plan

- [x] `capture-full-body` works for default model (Opus 4.7) and `MODEL=` override (Sonnet 4.6)
- [x] `test-system-prompt-mods` runs the full 7-variant ladder, parses billing header
- [x] `test-constraint-removal` runs 3 prompts × 3 variants with measurable output
- [x] All three handle `/v1/messages?beta=true` (CC's actual URL)
- [x] All three return SSE-shaped 200 so CC closes its socket promptly (no 5-min hang)
- [ ] CI: actionlint, validate-package-json, build × Node 18/20/22, CodeQL

## Notes

- All three are maintainer-only. Not added to `package.json` scripts, not invoked from CI, not part of any runtime path.
- Both A/B test scripts read OAuth directly from `~/.claude/.credentials.json` rather than going through dario's `getAccessToken()`. dario's resolver prefers `~/.dario/credentials.json`, which gets stale when refresh tokens are invalidated by Anthropic over weeks of disuse, and falls back to the stale token rather than to CC's fresh path. Direct read is more robust for these maintainer use cases.
- `test-constraint-removal.mjs` dispatches 9 real upstream requests with non-trivial output token counts (~10-15k aggregate per run). Negligible on a Max plan; worth knowing before running.