### PR TITLE
fix(release): idempotency gate uses gh release view (was: git rev-parse against unfetched tags)

### DIFF
--- a/.github/workflows/cc-drift-auto-release.yml
+++ b/.github/workflows/cc-drift-auto-release.yml
@@ -128,21 +128,31 @@ jobs:
           echo "version=$CURRENT" >> "$GITHUB_OUTPUT"
           echo "needs_release=true" >> "$GITHUB_OUTPUT"
 
-      - name: Idempotency gate (tag-exists check)
+      - name: Idempotency gate (release-exists check)
         id: gate
         if: steps.ver.outputs.needs_release == 'true'
-        # When the tag for the current version already exists, the
-        # release has already shipped — skip cleanly. This is the
-        # expected steady state for the hourly schedule trigger; we
-        # do NOT exit non-zero, because that would generate an hourly
+        # When a release for the current version already exists, the
+        # ship has already happened — skip cleanly. This is the
+        # expected steady state for the hourly schedule trigger; we do
+        # NOT exit non-zero, because that would generate an hourly
         # failure email forever.
+        #
+        # Queries the GitHub API directly (`gh release view`) rather
+        # than `git rev-parse` against the local checkout. The checkout
+        # uses `fetch-depth: 2` for the HEAD^1 version-diff and does
+        # not fetch tags, so a local `git rev-parse v3.32.2` returns
+        # false for an existing remote tag and the gate would
+        # incorrectly set proceed=true. The `gh release view` query
+        # hits the GitHub API and is decoupled from local fetch state.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="v${{ steps.ver.outputs.version }}"
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists — release already shipped (idempotent skip)."
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — already shipped (idempotent skip)."
             echo "proceed=false" >> "$GITHUB_OUTPUT"
           else
-            echo "Tag $TAG does not exist — proceeding with release."
+            echo "Release $TAG does not exist — proceeding."
             echo "proceed=true" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## Summary

The scheduled fallback added in PR #170 has been **failing every hourly cron tick since v3.32.2 shipped**. Two scheduled runs (17:47Z, 19:52Z on 2026-04-29) both failed at the "Create GitHub release" step — `gh release create v3.32.2` rejecting the duplicate tag.

## Root cause

The idempotency gate checks tag existence via `git rev-parse "$TAG"` against the local checkout. The job uses `actions/checkout@... with fetch-depth: 2` to get HEAD^1 for the version-diff fast-exit, but `fetch-depth: 2` **does not fetch tags**.

On every scheduled run:
1. `package.json` shows v3.32.2
2. HEAD^1 also shows v3.32.2 (post-merge state — no version bump in PR #171 either)
3. Schedule trigger skips the HEAD^1 fast-exit by design (line 99–104)
4. Gate runs `git rev-parse v3.32.2` against the local checkout
5. **Local tags weren't fetched → "tag not found" → `proceed=true`**
6. Workflow tries to cut a duplicate release, fails on collision, exit 1

## Fix

Switch the gate to `gh release view "$TAG"` — hits the GitHub API directly, decoupled from local fetch state. Same idempotent-skip behavior, but actually correct against remote state.

```diff
-      - name: Idempotency gate (tag-exists check)
+      - name: Idempotency gate (release-exists check)
         id: gate
         if: steps.ver.outputs.needs_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="v${{ steps.ver.outputs.version }}"
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
+          if gh release view "$TAG" >/dev/null 2>&1; then
```

## Test plan

- [x] Workflow YAML syntactically valid (no actionlint flags)
- [ ] CI green
- [ ] Post-merge: next hourly cron tick (`schedule: '15 * * * *'`) hits the gate, finds release v3.32.2 already published, exits cleanly without failure email
- [ ] When the next CC drift PR ships and bumps the version: gate finds no release for the new version, proceeds, ships to npm

## Notes

- This is the second iteration of the auto-release workflow fix. PR #170 added the schedule trigger; this PR makes the schedule path actually idempotent.
- After this lands, the next CC patch's bot-auto-merge cycle is the real end-to-end verification of the original fix's intent.