### PR TITLE
feat(detection): hands identity match — unblock OAuth subscription routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ checklist.
 
 ## [Unreleased]
 
+### Added — `hands` identity detection (auto preserve-tools)
+
+New entry in `detectTextToolClient`: `/\bYou are a computer control agent\b/` → `'hands'`. Matches both of [hands](https://github.com/askalf/hands)'s system prompt variants — CLI mode (`"You are a computer control agent with FULL access to this <os> machine ..."`) and SDK mode (`"You are a computer control agent on <os> ..."`).
+
+Why identity match is the right routing: hands SDK mode sends Anthropic's beta computer-use tools — `computer` (`type: 'computer_20251124'`), `bash` (`type: 'bash_20250124'`), `str_replace_based_edit_tool` (`type: 'text_editor_20250728'`). Tool *name* `bash` overlaps with `TOOL_MAP` and would normally route to CC's `Bash` schema, but the wire shape is Anthropic's beta tool with no `description` field and no `command`/`cmd` rename — default round-robin would corrupt the calls. The other two tools aren't in `TOOL_MAP` at all and would round-robin onto CC's first-available slots and lose their semantics. 67% unmapped is below `detectNonCCByTools`'s 80% threshold so structural fallback won't catch hands either; identity match → auto preserve-tools is the only correct path. Same shape as the existing `arnie` entry from v3.30.
+
+End-to-end use case unblocked: hands SDK mode + `ANTHROPIC_BASE_URL=http://localhost:3456` now routes through dario for OAuth subscription billing instead of paying per-token via API key. dario detects hands' identity, preserves the beta tool array, OAuth-swaps the auth, forwards to api.anthropic.com.
+
+Test coverage: `test/client-detection.mjs` section 1 — both identity strings; integration test confirms `detectedClient === 'hands'` and tool array passed through unchanged. 63 → 63 unchanged before this PR; 65 after (5 new assertions).
+
 ## [3.32.2] - 2026-04-29
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.122` → `2.1.123` for CC v2.1.123. Auto-drafted by `cc-drift-watch.yml`; maintainer confirm the bundled template doesn't also need a re-capture (run `node scripts/capture-and-bake.mjs` locally, amend this PR).

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -265,6 +265,20 @@ export function detectTextToolClient(systemText: string): string | null {
   // round-robin remap silently corrupts the calls. Identity match → auto
   // preserve-tools is the only correct routing.
   if (/\bYou are Arnie\b/.test(systemText)) return 'arnie';
+  // hands (askalf) — cross-platform computer-use agent built on the
+  // Anthropic SDK with computer-use beta tools (computer_20251124,
+  // bash_20250124, text_editor_20250728). Identity line is stable
+  // across CLI mode ("You are a computer control agent with FULL
+  // access to this <os> machine ...") and SDK mode ("You are a
+  // computer control agent on <os> ..."). Tool name `bash` overlaps
+  // with TOOL_MAP, but the wire shape is Anthropic's beta computer-
+  // use tool (`type: 'bash_20250124'`, no `command`/`description`
+  // schema) — default round-robin remap would corrupt those calls
+  // and lose the `computer` / `text_editor` tools entirely (neither
+  // is in TOOL_MAP, structural fallback won't catch them at the
+  // 80% threshold either). Identity match → auto preserve-tools,
+  // like arnie.
+  if (/\bYou are a computer control agent\b/.test(systemText)) return 'hands';
   // Protocol-signature fallback — unique to the Cline family and its
   // forks; survives a forked system prompt that edited the identity
   // string out but kept the tool protocol intact.

--- a/test/client-detection.mjs
+++ b/test/client-detection.mjs
@@ -46,6 +46,14 @@ check(
   'You are Arnie → arnie',
   detectTextToolClient('You are Arnie, a portable IT tech troubleshooting assistant running as a CLI.') === 'arnie',
 );
+check(
+  'hands CLI mode → hands',
+  detectTextToolClient('You are a computer control agent with FULL access to this Windows machine. You can do ANYTHING — not just coding.') === 'hands',
+);
+check(
+  'hands SDK mode → hands',
+  detectTextToolClient('You are a computer control agent on macOS. CRITICAL: Use the bash tool with shell commands instead of screenshot-click loops whenever possible.') === 'hands',
+);
 
 // ────────────────────────────────────────────────────────────────────
 header('2. detectTextToolClient — protocol-signature fallback');
@@ -311,6 +319,29 @@ const arnieIdentityBody = {
 const arnieIdentityBuilt = buildCCRequest(arnieIdentityBody, billingTag, cache1h, identity);
 check('arnie identity match → detectedClient === "arnie"', arnieIdentityBuilt.detectedClient === 'arnie');
 check('arnie identity → tools preserved (schemas left alone)', arnieIdentityBuilt.body.tools === arnieRealisticTools);
+
+// Same shape for hands. Tool surface uses Anthropic's beta computer-use
+// types: `bash` is in TOOL_MAP, `computer` and `text_editor` (str_replace
+// _based_edit_tool) are not. 67% unmapped → below structural fallback's
+// 80% threshold. Identity match is the only correct routing.
+const handsRealisticTools = [
+  { name: 'computer', type: 'computer_20251124', display_width_px: 1920, display_height_px: 1080, display_number: 1 },
+  { name: 'bash', type: 'bash_20250124' },
+  { name: 'str_replace_based_edit_tool', type: 'text_editor_20250728' },
+];
+check(
+  'hands-realistic surface (mostly unmapped) → structural fallback does NOT fire (below threshold)',
+  detectNonCCByTools(handsRealisticTools) === null,
+);
+const handsIdentityBody = {
+  model: 'claude-opus-4-7',
+  system: 'You are a computer control agent with FULL access to this Windows machine. You can do ANYTHING — not just coding.',
+  messages: [{ role: 'user', content: 'hi' }],
+  tools: handsRealisticTools,
+};
+const handsIdentityBuilt = buildCCRequest(handsIdentityBody, billingTag, cache1h, identity);
+check('hands identity match → detectedClient === "hands"', handsIdentityBuilt.detectedClient === 'hands');
+check('hands identity → tools preserved (beta types left alone)', handsIdentityBuilt.body.tools === handsRealisticTools);
 
 // noAutoDetect disables structural fallback too
 const customNoDetect = buildCCRequest(customClientBody, billingTag, cache1h, identity, { noAutoDetect: true });


### PR DESCRIPTION
## Summary

Adds [hands](https://github.com/askalf/hands) to dario's client-identity detector so that when hands' SDK mode routes through dario, dario auto-flips to preserve-tools and leaves hands' beta computer-use tools alone instead of round-robin-mapping them onto CC's tool slots and corrupting the calls.

```ts
// src/cc-template.ts:268
if (/\bYou are a computer control agent\b/.test(systemText)) return 'hands';
```

The regex catches both of hands' system prompt variants — CLI mode (`"You are a computer control agent with FULL access to this <os> machine ..."`) and SDK mode (`"You are a computer control agent on <os> ..."`).

## Why

Hands SDK mode sends Anthropic's beta computer-use tools:

| Tool | Type | TOOL_MAP? |
|---|---|---|
| `computer` | `computer_20251124` | not mapped |
| `bash` | `bash_20250124` | mapped to `Bash` |
| `str_replace_based_edit_tool` | `text_editor_20250728` | not mapped |

Tool name `bash` overlaps with TOOL_MAP — but the *wire shape* is Anthropic's beta tool with no `description` field and no `command`/`cmd` rename. Default round-robin remap would corrupt those calls and lose `computer` / `text_editor` entirely. 67% unmapped is below `detectNonCCByTools`'s 80% threshold so structural fallback won't catch hands either; identity match → auto preserve-tools is the only correct routing.

Same shape as the existing `arnie` entry from v3.30 (`src/cc-template.ts:259-267`).

## Use case unblocked

Hands today either runs in CLI mode (spawning CC, OAuth via Claude Login) or SDK mode (paying per-token with an API key). With this change:

```bash
export ANTHROPIC_BASE_URL=http://localhost:3456
hands "open a terminal and show me /etc/hosts"   # SDK mode, OAuth subscription billing via dario
```

The SDK request goes to dario, dario detects `'hands'` identity, preserves the beta tool array, OAuth-swaps the auth, forwards to api.anthropic.com. Subscription billing instead of per-token, no API key required.

## Test plan

- [x] `test/client-detection.mjs` section 1 — CLI mode identity → `'hands'`, SDK mode identity → `'hands'`
- [x] `test/client-detection.mjs` section 10 — `detectNonCCByTools` does NOT fire on hands' tool surface (below threshold), confirming identity match is the load-bearing detection
- [x] Integration: `buildCCRequest` with hands identity + hands tool array → `detectedClient === 'hands'` AND `body.tools` is the same reference as the input array (preserved unchanged)
- [x] Local: `npm test` passes 56/56
- [ ] CI: actionlint, validate-package-json, build × Node 18/20/22, CodeQL
- [ ] Post-merge: end-to-end test with real hands SDK invocation through dario; verify `anthropic-ratelimit-unified-representative-claim: five_hour` on the upstream response

## Notes

- Pure additive change — three files, +55 lines, no runtime path modifications outside the new identity check.
- Mirrors the arnie precedent exactly. No new abstraction.
- This is the dario-side prerequisite for the broader "hands → dario for OAuth" wire-up. End-to-end verification happens after this lands.