### PR TITLE
fix(oauth): pick freshest credentials, don't shadow CC fallback with stale dario file

### DIFF
--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -194,28 +194,62 @@ export async function loadCredentials(): Promise<CredentialsFile | null> {
     return credentialsCache;
   }
 
-  // Try dario's own credentials first, then fall back to Claude Code's file
+  // Read every available source (dario file, CC file, OS keychain) and
+  // pick the freshest. Previously this returned the first source that
+  // had both tokens regardless of expiry — which means a stale
+  // ~/.dario/credentials.json (left over from a prior `dario login`
+  // whose refresh_token has since been invalidated by Anthropic) would
+  // shadow CC's still-fresh ~/.claude/.credentials.json forever, with
+  // no automatic recovery. Picking the freshest makes auto-detection
+  // work the way it did before any `dario login` had ever run, while
+  // still preferring dario's own file when both sources are equivalent
+  // (dario file wins ties on expiresAt by being checked first).
+  const candidates: CredentialsFile[] = [];
+
   for (const path of [getDarioCredentialsPath(), getClaudeCodeCredentialsPath()]) {
     try {
       const raw = await readFile(path, 'utf-8');
       const parsed = JSON.parse(raw);
       if (parsed?.claudeAiOauth?.accessToken && parsed?.claudeAiOauth?.refreshToken) {
-        credentialsCache = parsed as CredentialsFile;
-        credentialsCacheTime = Date.now();
-        return credentialsCache;
+        candidates.push(parsed as CredentialsFile);
       }
     } catch { /* try next */ }
   }
 
-  // Fall back to OS keychain (modern CC stores credentials here, not on disk)
+  // OS keychain (modern CC stores credentials here, not on disk).
   const keychainCreds = await loadKeychainCredentials();
-  if (keychainCreds) {
-    credentialsCache = keychainCreds;
-    credentialsCacheTime = Date.now();
-    return credentialsCache;
+  if (keychainCreds?.claudeAiOauth?.accessToken && keychainCreds?.claudeAiOauth?.refreshToken) {
+    candidates.push(keychainCreds);
   }
 
-  return null;
+  const best = pickFreshestCredentials(candidates);
+  if (!best) return null;
+
+  credentialsCache = best;
+  credentialsCacheTime = Date.now();
+  return credentialsCache;
+}
+
+/**
+ * Pick the freshest of a set of `CredentialsFile` candidates by
+ * `expiresAt` (unix-ms timestamp; missing/zero sorts last). Stable on
+ * ties — the first-pushed candidate wins when expiresAt is equal,
+ * which means the canonical call order
+ * `[darioFile, ccFile, keychain]` keeps the dario-file source as the
+ * tiebreaker preference. Exported for direct testing.
+ */
+export function pickFreshestCredentials(candidates: CredentialsFile[]): CredentialsFile | null {
+  if (candidates.length === 0) return null;
+  let best = candidates[0]!;
+  let bestExp = best.claudeAiOauth.expiresAt ?? 0;
+  for (let i = 1; i < candidates.length; i++) {
+    const exp = candidates[i]!.claudeAiOauth.expiresAt ?? 0;
+    if (exp > bestExp) {
+      best = candidates[i]!;
+      bestExp = exp;
+    }
+  }
+  return best;
 }
 
 async function saveCredentials(creds: CredentialsFile): Promise<void> {

--- a/test/credential-freshness.mjs
+++ b/test/credential-freshness.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * loadCredentials freshness fall-through.
+ *
+ * Regression guard: a stale `~/.dario/credentials.json` whose
+ * `refresh_token` has been invalidated by Anthropic must NOT shadow
+ * a fresh `~/.claude/.credentials.json` indefinitely. Before this
+ * fix, loadCredentials returned the first source with the right
+ * shape regardless of expiry, so dario lost its auto-detection
+ * fall-through once any prior `dario login` had created a file
+ * that subsequently went stale.
+ *
+ * pickFreshestCredentials is the helper that contains the new
+ * "pick freshest by expiresAt, tie goes to first" logic; tests
+ * exercise it with synthetic candidates so we don't need real
+ * credentials on disk.
+ */
+
+import { pickFreshestCredentials } from '../dist/oauth.js';
+
+let pass = 0, fail = 0;
+function check(label, cond) {
+  if (cond) { pass++; console.log(`  ✅ ${label}`); }
+  else { fail++; console.log(`  ❌ ${label}`); }
+}
+function header(name) {
+  console.log(`\n${'='.repeat(70)}\n  ${name}\n${'='.repeat(70)}`);
+}
+
+const cred = (label, expiresAt, accessToken = `ak-${label}`, refreshToken = `rt-${label}`) => ({
+  claudeAiOauth: { accessToken, refreshToken, expiresAt, scopes: [] },
+});
+
+const NOW = Date.now();
+const HOUR = 3_600_000;
+
+// ────────────────────────────────────────────────────────────────────
+header('1. empty / null cases');
+
+check('empty array → null', pickFreshestCredentials([]) === null);
+
+// ────────────────────────────────────────────────────────────────────
+header('2. single candidate always wins');
+
+const onlyOne = cred('a', NOW + HOUR);
+check('single fresh → that one', pickFreshestCredentials([onlyOne]) === onlyOne);
+
+const onlyOneStale = cred('b', NOW - 7 * 24 * HOUR);
+check('single stale → that one (caller decides if usable)', pickFreshestCredentials([onlyOneStale]) === onlyOneStale);
+
+// ────────────────────────────────────────────────────────────────────
+header('3. freshness wins across multiple candidates');
+
+// The real-world bug: dario-file is stale, CC-file is fresh. Stale
+// must NOT win.
+const darioStale = cred('dario-stale', NOW - 3 * 24 * HOUR);
+const ccFresh = cred('cc-fresh', NOW + 8 * HOUR);
+const result1 = pickFreshestCredentials([darioStale, ccFresh]);
+check('stale dario + fresh CC → CC wins', result1 === ccFresh);
+check('stale dario + fresh CC → access token from CC source', result1?.claudeAiOauth.accessToken === 'ak-cc-fresh');
+
+// And the inverse: dario fresh, CC older. Dario should win.
+const darioFresh = cred('dario-fresh', NOW + 8 * HOUR);
+const ccStale = cred('cc-stale', NOW - HOUR);
+const result2 = pickFreshestCredentials([darioFresh, ccStale]);
+check('fresh dario + stale CC → dario wins', result2 === darioFresh);
+
+// All three sources, freshest wins regardless of position.
+const keychainNewest = cred('keychain-newest', NOW + 24 * HOUR);
+const result3 = pickFreshestCredentials([darioStale, ccFresh, keychainNewest]);
+check('three sources, last is freshest → last wins', result3 === keychainNewest);
+
+// ────────────────────────────────────────────────────────────────────
+header('4. tie-breaking — first wins on equal expiresAt');
+
+// When dario-file and CC-file have the same expiresAt (e.g. both refer
+// to the same OAuth session — they often do), the first-pushed
+// candidate wins. Canonical call order is [darioFile, ccFile,
+// keychain], so this keeps dario-file as the preferred source on
+// ties — preserves prior behavior for the equal-freshness case.
+const tied1 = cred('first', NOW + HOUR);
+const tied2 = cred('second', NOW + HOUR);
+check('equal expiresAt → first one wins', pickFreshestCredentials([tied1, tied2]) === tied1);
+
+// ────────────────────────────────────────────────────────────────────
+header('5. missing / malformed expiresAt sorts last');
+
+const fresh = cred('fresh', NOW + HOUR);
+const noExpiresAt = { claudeAiOauth: { accessToken: 'ak', refreshToken: 'rt', scopes: [] } };
+const result4 = pickFreshestCredentials([noExpiresAt, fresh]);
+check('candidate with no expiresAt loses to a fresh one', result4 === fresh);
+
+const onlyNoExpires = pickFreshestCredentials([noExpiresAt]);
+check('only candidate has no expiresAt → still returned (caller decides)', onlyNoExpires === noExpiresAt);
+
+// ────────────────────────────────────────────────────────────────────
+
+console.log(`\n${pass} pass, ${fail} fail`);
+if (fail > 0) process.exit(1);


### PR DESCRIPTION
## Summary

dario's auto-detection of CC credentials stopped working after any prior `dario login` had created `~/.dario/credentials.json` and that file subsequently went stale (token expired + refresh_token invalidated by Anthropic). `dario proxy` started failing with "Not authenticated. Run \`dario login\` first." even when CC was authenticated and OAuth worked end-to-end.

## Root cause

`loadCredentials` (`src/oauth.ts:191-208`) iterated `[~/.dario/credentials.json, ~/.claude/.credentials.json]` and returned the **first source with the right shape** (both `accessToken` + `refreshToken` keys present) — **regardless of expiry**. Stale dario file → first match → returned. CC fallback never reached.

## Fix

Read every available source (dario file, CC file, OS keychain) and pick the freshest by `expiresAt`. Stable on ties — first-pushed candidate wins when expiresAt is equal — so the dario file remains the preferred source on ties for callers who explicitly logged in via `dario login`.

```diff
-  for (const path of [getDarioCredentialsPath(), getClaudeCodeCredentialsPath()]) {
-    try {
-      const raw = await readFile(path, 'utf-8');
-      const parsed = JSON.parse(raw);
-      if (parsed?.claudeAiOauth?.accessToken && parsed?.claudeAiOauth?.refreshToken) {
-        credentialsCache = parsed as CredentialsFile;
-        credentialsCacheTime = Date.now();
-        return credentialsCache;
-      }
-    } catch { /* try next */ }
-  }
+  const candidates: CredentialsFile[] = [];
+  for (const path of [getDarioCredentialsPath(), getClaudeCodeCredentialsPath()]) {
+    try {
+      const raw = await readFile(path, 'utf-8');
+      const parsed = JSON.parse(raw);
+      if (parsed?.claudeAiOauth?.accessToken && parsed?.claudeAiOauth?.refreshToken) {
+        candidates.push(parsed as CredentialsFile);
+      }
+    } catch { /* try next */ }
+  }
+  // ... keychain candidate added the same way ...
+  const best = pickFreshestCredentials(candidates);
```

Refactor: `pickFreshestCredentials` extracted as an exported helper so the rule is testable directly with synthetic candidates.

## What this changes vs. doesn't

- ✅ When dario file is stale and CC file is fresh → CC wins (the bug case)
- ✅ When dario file is fresh and CC file is older → dario wins (unchanged for active dario-login users)
- ✅ When both files have equal expiresAt (e.g. they're cached copies of the same session) → dario wins on tie (preserves prior behavior)
- ✅ Empty array → null (unchanged)
- ✅ OS keychain still consulted as third source

## Test plan

- [x] New: `test/credential-freshness.mjs` — 10 assertions across empty / single / multi-source / tie-breaking / malformed-expiresAt cases
- [x] Local: full suite passes 57/57 (was 56/56; +1 test file)
- [x] Manually verified: `getStatus()` against the affected machine returned `{ authenticated: false, status: 'expired' }` before; `{ authenticated: true, status: 'healthy', expiresIn: '5h 56m' }` after.
- [ ] CI: actionlint, validate-package-json, build × Node 18/20/22, CodeQL

## Notes

- Standalone fix. No coupling with PR #174 (hands client detection) — both can land in either order.
- This unblocks `dario proxy` startup against any user whose `~/.dario/credentials.json` has gone stale, which is the common case for anyone who ran `dario login` more than a few weeks ago and hasn't used dario actively since.