### PR TITLE
research: openclaw classifier-trigger findings (4 diagnostic scripts)

### DIFF
--- a/scripts/test-cc-binary-openclaw.mjs
+++ b/scripts/test-cc-binary-openclaw.mjs
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+// Test 3 in the @theo OpenClaw triage: spawn CC's actual binary
+// from two test directories — one clean, one with "OpenClaw" in
+// the commit history — and observe BOTH:
+//
+//   (a) what CC actually puts on the wire (does CC pre-filter,
+//       transform, redact, or otherwise behave differently when
+//       OpenClaw appears in its environment context?)
+//
+//   (b) what api.anthropic.com responds with given CC's exact
+//       unmodified body, including billing-claim header and any
+//       refusal indicators.
+//
+// Methodology:
+//   - Spin up a transparent forwarding proxy on a random localhost
+//     port. Proxy logs CC's request, swaps x-api-key → OAuth
+//     bearer, prepends oauth-2025-04-20 to anthropic-beta, then
+//     forwards to api.anthropic.com unchanged. Logs the response.
+//   - Create two ephemeral git directories. `clean/` has a single
+//     "initial commit". `openclaw/` has the same plus an additional
+//     commit "feat: OpenClaw integration baseline" + a JSON file
+//     with "OpenClaw" content (matching Theo's setup).
+//   - From each directory, spawn `claude --print -p "<prompt>"`
+//     pointed at our proxy. Capture the full transaction.
+//   - Diff the two transactions. Report.
+//
+// The script is read-only against api.anthropic.com — it just
+// proxies CC's request. Cost is two real upstream requests (~$0
+// on a Max plan).
+
+import http from 'node:http';
+import https from 'node:https';
+import { spawn, spawnSync } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const CC_BIN = process.env.DARIO_CLAUDE_BIN || 'C:/Users/masterm1nd.DOCK/.local/bin/claude.exe';
+// Hardcoded — env-var fallback was getting shadowed by Windows shell PROMPT.
+const PROMPT = 'say hello in 5 words';
+
+// ──────────────────────────────────────────────────────────────────────
+// Auth
+// ──────────────────────────────────────────────────────────────────────
+
+const home = process.env.USERPROFILE || process.env.HOME;
+const oa = JSON.parse(fs.readFileSync(path.join(home, '.claude', '.credentials.json'), 'utf-8')).claudeAiOauth;
+const bearer = oa.accessToken;
+if (!bearer) { console.error('FATAL: no CC accessToken'); process.exit(1); }
+console.error(`[auth] resolved CC token (${Math.round((oa.expiresAt - Date.now()) / 60000)} min remaining)`);
+
+// ──────────────────────────────────────────────────────────────────────
+// Forwarding proxy: log CC's request, swap auth, forward, log response
+// ──────────────────────────────────────────────────────────────────────
+
+function startProxy() {
+  return new Promise((resolve) => {
+    const server = http.createServer(async (clientReq, clientRes) => {
+      let bodyChunks = [];
+      clientReq.on('data', (c) => bodyChunks.push(c));
+      clientReq.on('end', async () => {
+        const reqBody = Buffer.concat(bodyChunks).toString();
+        const txn = {
+          ts: Date.now(),
+          req: {
+            method: clientReq.method,
+            url: clientReq.url,
+            headers: { ...clientReq.headers },
+            body: reqBody,
+          },
+        };
+
+        // Build outbound to api.anthropic.com: swap auth, prepend beta
+        const outHeaders = { ...clientReq.headers };
+        delete outHeaders['x-api-key'];
+        delete outHeaders['host'];
+        delete outHeaders['content-length'];
+        outHeaders['authorization'] = `Bearer ${bearer}`;
+        let beta = outHeaders['anthropic-beta'] || '';
+        if (!beta.split(',').includes('oauth-2025-04-20')) {
+          beta = beta ? `oauth-2025-04-20,${beta}` : 'oauth-2025-04-20';
+          outHeaders['anthropic-beta'] = beta;
+        }
+        outHeaders['anthropic-dangerous-direct-browser-access'] = 'true';
+
+        const upstream = https.request({
+          hostname: 'api.anthropic.com',
+          path: clientReq.url,
+          method: clientReq.method,
+          headers: outHeaders,
+        }, (upRes) => {
+          const respChunks = [];
+          upRes.on('data', (c) => respChunks.push(c));
+          upRes.on('end', () => {
+            const respBody = Buffer.concat(respChunks);
+            txn.resp = {
+              status: upRes.statusCode,
+              headers: { ...upRes.headers },
+              billingClaim: upRes.headers['anthropic-ratelimit-unified-representative-claim'] || '(unset)',
+              body: respBody.toString(),
+            };
+            // Forward to CC client
+            clientRes.writeHead(upRes.statusCode, upRes.headers);
+            clientRes.end(respBody);
+            transactions.push(txn);
+          });
+        });
+        upstream.on('error', (err) => {
+          txn.resp = { error: err.message };
+          clientRes.writeHead(502);
+          clientRes.end('proxy error');
+          transactions.push(txn);
+        });
+        upstream.write(reqBody);
+        upstream.end();
+      });
+    });
+
+    server.listen(0, '127.0.0.1', () => {
+      const port = server.address().port;
+      console.error(`[proxy] listening on http://127.0.0.1:${port}`);
+      resolve({ server, port });
+    });
+  });
+}
+
+const transactions = [];
+
+// ──────────────────────────────────────────────────────────────────────
+// Test fixture: ephemeral git directories
+// ──────────────────────────────────────────────────────────────────────
+
+function gitInit(dir, label) {
+  fs.mkdirSync(dir, { recursive: true });
+  const opts = { cwd: dir, stdio: 'ignore', shell: false };
+  spawnSync('git', ['init', '-q'], opts);
+  spawnSync('git', ['config', 'user.email', 'test@local'], opts);
+  spawnSync('git', ['config', 'user.name', 'test'], opts);
+  // Default branch name varies (master vs main); force 'main' for reproducibility.
+  spawnSync('git', ['symbolic-ref', 'HEAD', 'refs/heads/main'], opts);
+
+  fs.writeFileSync(path.join(dir, 'README.md'), `# ${label} test repo\n`);
+  spawnSync('git', ['add', '.'], opts);
+  spawnSync('git', ['commit', '-m', 'initial commit', '-q'], opts);
+  return dir;
+}
+
+function addOpenClawCommit(dir) {
+  const opts = { cwd: dir, stdio: 'ignore', shell: false };
+  // JSON file matching Theo's "OpenClaw in a json blob" claim.
+  fs.writeFileSync(path.join(dir, 'config.json'), JSON.stringify({
+    integrations: ['OpenClaw'],
+    description: 'OpenClaw integration config',
+  }, null, 2));
+  spawnSync('git', ['add', '.'], opts);
+  spawnSync('git', ['commit', '-m', 'feat: OpenClaw integration baseline', '-q'], opts);
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// CC spawn helper
+// ──────────────────────────────────────────────────────────────────────
+
+function runCC(cwd, port) {
+  return new Promise((resolve) => {
+    const cc = spawn(CC_BIN, ['--print', '-p', PROMPT], {
+      cwd,
+      env: {
+        ...process.env,
+        ANTHROPIC_BASE_URL: `http://127.0.0.1:${port}`,
+        ANTHROPIC_API_KEY: 'sk-cc-binary-test-stub',
+        CLAUDE_NONINTERACTIVE: '1',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    let stdout = '', stderr = '';
+    cc.stdout.on('data', (c) => { stdout += c; });
+    cc.stderr.on('data', (c) => { stderr += c; });
+    cc.on('exit', (code) => resolve({ code, stdout, stderr }));
+    cc.on('error', (err) => resolve({ code: -1, stdout, stderr, error: err.message }));
+    setTimeout(() => { cc.kill(); resolve({ code: -2, stdout, stderr, timeout: true }); }, 60_000);
+  });
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Main
+// ──────────────────────────────────────────────────────────────────────
+
+const { server, port } = await startProxy();
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-binary-test-'));
+const cleanDir = gitInit(path.join(tmpRoot, 'clean'), 'clean');
+const openclawDir = gitInit(path.join(tmpRoot, 'openclaw'), 'openclaw');
+addOpenClawCommit(openclawDir);
+
+console.error(`[fixture] clean dir:    ${cleanDir}`);
+console.error(`[fixture] openclaw dir: ${openclawDir}`);
+console.error('');
+
+// Run twice from each, so we have N=2 trials per condition. Pace
+// between to avoid concentrated burst.
+const runs = [];
+for (const trial of [1, 2]) {
+  for (const variant of [
+    { name: `clean_t${trial}`, dir: cleanDir },
+    { name: `openclaw_t${trial}`, dir: openclawDir },
+  ]) {
+    process.stderr.write(`  running ${variant.name.padEnd(15)} ... `);
+    const txnIndexBefore = transactions.length;
+    const cc = await runCC(variant.dir, port);
+    const myTxns = transactions.slice(txnIndexBefore);
+    const lastTxn = myTxns[myTxns.length - 1];
+    const claim = lastTxn?.resp?.billingClaim ?? '(no txn)';
+    const status = lastTxn?.resp?.status ?? '-';
+    process.stderr.write(`exit=${cc.code} requests=${myTxns.length} status=${status} claim=${claim}\n`);
+    runs.push({
+      ...variant,
+      trial,
+      ccExit: cc.code,
+      ccStdout: cc.stdout.slice(0, 1000),
+      ccStderr: cc.stderr.slice(0, 1000),
+      requestCount: myTxns.length,
+      transactions: myTxns,
+    });
+    await sleep(2000);
+  }
+}
+
+server.close();
+
+// ──────────────────────────────────────────────────────────────────────
+// Analysis
+// ──────────────────────────────────────────────────────────────────────
+
+console.error('');
+console.error('=== SUMMARY ===');
+console.error('variant              exit  reqs  status  claim');
+console.error('─'.repeat(75));
+for (const r of runs) {
+  const last = r.transactions[r.transactions.length - 1];
+  console.error(
+    `${r.name.padEnd(20)} ${String(r.ccExit).padEnd(5)} ${String(r.requestCount).padEnd(5)} ${String(last?.resp?.status ?? '-').padEnd(7)} ${last?.resp?.billingClaim ?? '(no resp)'}`,
+  );
+}
+
+console.error('');
+console.error('=== CC stdout per variant (what the user would see) ===');
+for (const r of runs) {
+  console.error(`--- ${r.name} ---`);
+  console.error(`  ${r.ccStdout.replace(/\n/g, ' | ').slice(0, 200)}`);
+}
+
+// JSON dump FIRST so we always have the data even if analysis below crashes.
+console.log(JSON.stringify({ runs, totalTransactions: transactions.length }, null, 2));
+
+// Find the /v1/messages POST in a run (the first transaction is sometimes a
+// HEAD probe or an OAuth-detection request that isn't the /v1/messages call).
+function findMessagesTxn(run) {
+  return run.transactions.find((t) => t.req.method === 'POST' && t.req.url.startsWith('/v1/messages'));
+}
+
+console.error('');
+console.error('=== CC outbound body diff: clean_t1 vs openclaw_t1 ===');
+try {
+  const clean1 = runs.find((r) => r.name === 'clean_t1');
+  const oc1 = runs.find((r) => r.name === 'openclaw_t1');
+  const cTxn = clean1 ? findMessagesTxn(clean1) : null;
+  const oTxn = oc1 ? findMessagesTxn(oc1) : null;
+
+  if (!cTxn) console.error('  WARNING: no POST /v1/messages found in clean_t1');
+  if (!oTxn) console.error('  WARNING: no POST /v1/messages found in openclaw_t1');
+
+  if (cTxn && oTxn) {
+    let cBody, oBody;
+    try { cBody = JSON.parse(cTxn.req.body); } catch (e) { console.error('  clean body parse:', e.message); }
+    try { oBody = JSON.parse(oTxn.req.body); } catch (e) { console.error('  openclaw body parse:', e.message); }
+
+    console.error(`  clean    body bytes: ${cTxn.req.body.length}, system[2] chars: ${cBody?.system?.[2]?.text?.length ?? 0}`);
+    console.error(`  openclaw body bytes: ${oTxn.req.body.length}, system[2] chars: ${oBody?.system?.[2]?.text?.length ?? 0}`);
+
+    const cleanHasOC = cTxn.req.body.toLowerCase().includes('openclaw');
+    const openclawHasOC = oTxn.req.body.toLowerCase().includes('openclaw');
+    console.error(`  clean    has "openclaw" in outbound body: ${cleanHasOC}`);
+    console.error(`  openclaw has "openclaw" in outbound body: ${openclawHasOC}`);
+
+    if (openclawHasOC) {
+      const text = oTxn.req.body;
+      let idx = 0;
+      const occurrences = [];
+      while ((idx = text.toLowerCase().indexOf('openclaw', idx)) !== -1) {
+        occurrences.push({
+          offset: idx,
+          context: text.slice(Math.max(0, idx - 60), idx + 60).replace(/\n/g, '\\n'),
+        });
+        idx++;
+      }
+      console.error(`  openclaw occurrences in CC's outbound body: ${occurrences.length}`);
+      occurrences.slice(0, 5).forEach((o) => console.error(`    [${o.offset}] ...${o.context}...`));
+    }
+  }
+} catch (err) {
+  console.error('  analysis error:', err.message);
+}
+
+// Cleanup
+try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch {}

--- a/scripts/test-dario-protects-openclaw.mjs
+++ b/scripts/test-dario-protects-openclaw.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// Verify that dario's default template-replay mode protects users
+// from Anthropic's `openclaw.inbound_meta.v1` billing-classifier
+// filter (verified by test-openclaw-schema-trigger.mjs as flipping
+// requests to extra-usage when the string appears in CC's git
+// environment block).
+//
+// dario's template-replay architecture (since v3.0.0; see Discussion
+// #14) replaces CC's outbound body with dario's bundled CC template.
+// The user's git context — including any commit messages referencing
+// openclaw protocol namespaces — gets discarded at the proxy
+// boundary. Only dario's captured generic system prompt reaches
+// Anthropic.
+//
+// Test: from a directory whose git history contains
+// `{"schema": "openclaw.inbound_meta.v1"}`, run
+// `claude --print -p "say hello in 5 words"` with
+// ANTHROPIC_BASE_URL pointed at dario (localhost:3456). Expect:
+// status 200, claim five_hour, no 400 — because the offending
+// commit message never leaves the local machine.
+//
+// Compares against the same directory routed direct-to-API (which
+// we already know returns 400).
+
+import { spawn, spawnSync } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const CC_BIN = process.env.DARIO_CLAUDE_BIN || 'C:/Users/masterm1nd.DOCK/.local/bin/claude.exe';
+const DARIO_URL = 'http://localhost:3456';
+const PROMPT = 'say hello in 5 words';
+
+function gitInit(dir, commitMsg) {
+  fs.mkdirSync(dir, { recursive: true });
+  const opts = { cwd: dir, stdio: 'ignore', shell: false };
+  spawnSync('git', ['init', '-q'], opts);
+  spawnSync('git', ['config', 'user.email', 'test@local'], opts);
+  spawnSync('git', ['config', 'user.name', 'test'], opts);
+  spawnSync('git', ['symbolic-ref', 'HEAD', 'refs/heads/main'], opts);
+  fs.writeFileSync(path.join(dir, 'test.md'), '# test\n');
+  spawnSync('git', ['add', '.'], opts);
+  spawnSync('git', ['commit', '-m', commitMsg, '-q'], opts);
+  return dir;
+}
+
+function runCC(cwd, baseUrl) {
+  return new Promise((resolve) => {
+    const cc = spawn(CC_BIN, ['--print', '-p', PROMPT], {
+      cwd,
+      env: {
+        ...process.env,
+        ANTHROPIC_BASE_URL: baseUrl,
+        ANTHROPIC_API_KEY: 'sk-stub-for-dario-test',
+        CLAUDE_NONINTERACTIVE: '1',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    let stdout = '', stderr = '';
+    cc.stdout.on('data', (c) => { stdout += c; });
+    cc.stderr.on('data', (c) => { stderr += c; });
+    cc.on('exit', (code) => resolve({ code, stdout, stderr }));
+    cc.on('error', (err) => resolve({ code: -1, stdout, stderr, error: err.message }));
+    setTimeout(() => { cc.kill(); resolve({ code: -2, stdout, stderr, timeout: true }); }, 60_000);
+  });
+}
+
+async function checkDarioRunning() {
+  try {
+    const res = await fetch(`${DARIO_URL}/health`, { signal: AbortSignal.timeout(3000) });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+const ok = await checkDarioRunning();
+if (!ok) {
+  console.error(`FATAL: dario not reachable at ${DARIO_URL}/health. Start it with \`node dist/cli.js proxy --verbose\` first.`);
+  process.exit(1);
+}
+console.error(`[ok] dario reachable at ${DARIO_URL}`);
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dario-protects-'));
+const dirOpenclaw = gitInit(path.join(tmpRoot, 'openclaw'), '{"schema": "openclaw.inbound_meta.v1"}');
+console.error(`[fixture] openclaw dir: ${dirOpenclaw}`);
+console.error('');
+
+const trials = [];
+for (const trial of [1, 2]) {
+  process.stderr.write(`  trial ${trial} — claude --print through dario ... `);
+  const r = await runCC(dirOpenclaw, DARIO_URL);
+  // Parse stdout for refusal/success
+  const looksOk = r.stdout.length > 0 && !r.stdout.includes('API Error');
+  const looks400 = r.stdout.includes('You\'re out of extra usage') || r.stdout.includes('400');
+  process.stderr.write(`exit=${r.code} | ok=${looksOk} | hit-400=${looks400}\n`);
+  process.stderr.write(`    stdout: ${r.stdout.slice(0, 150).replace(/\n/g, ' | ')}\n`);
+  trials.push({ trial, ...r, looksOk, looks400 });
+  await sleep(2000);
+}
+
+console.error('');
+console.error('=== SUMMARY ===');
+for (const t of trials) {
+  console.error(`  trial ${t.trial}: exit=${t.code} ok=${t.looksOk} 400=${t.looks400}`);
+}
+
+console.log(JSON.stringify({ trials, dirOpenclaw }, null, 2));
+
+try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch {}

--- a/scripts/test-openclaw-schema-trigger.mjs
+++ b/scripts/test-openclaw-schema-trigger.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+// Refined test of @theo's claim — using his EXACT commit message
+// format. His test used `{"schema": "openclaw.inbound_meta.v1"}`
+// as the commit message — a JSON blob that looks like an internal
+// openclaw schema reference. Earlier tests used a friendly
+// "feat: OpenClaw integration" message and didn't reproduce; the
+// hypothesis is that the classifier pattern-matches on the
+// schema-shape, not the bare "openclaw" string.
+//
+// Variants (one ephemeral git directory per variant; CC spawned
+// from each via the same forwarding-proxy infra as
+// test-cc-binary-openclaw.mjs):
+//
+//   01_control_clean              initial commit only, nothing openclaw
+//   02_theo_exact                 {"schema": "openclaw.inbound_meta.v1"}  (Theo's exact)
+//   03_friendly_openclaw          feat: OpenClaw integration baseline       (the earlier-test format that didn't reproduce)
+//   04_plain_openclaw             openclaw                                  (just the word)
+//   05_schema_name_only           openclaw.inbound_meta.v1                  (schema name, no JSON shape)
+//   06_claude_schema_blob         {"schema": "claude.inbound_meta.v1"}      (same JSON shape, claude name — control)
+//   07_competitor_schema_blob     {"schema": "competitor.foo.v1"}           (same JSON shape, generic — control)
+//
+// Account-state nuance: Theo got HTTP 400 ("You're out of extra
+// usage") because the classifier flipped his request to
+// extra-usage billing AND he was out of credit. On an account WITH
+// extra-usage capacity, the same flip would surface as
+// `claim: extra_usage` (or similar) in the response header,
+// request would succeed silently. So we read the BILLING CLAIM
+// HEADER for ground truth, not the status code.
+
+import http from 'node:http';
+import https from 'node:https';
+import { spawn, spawnSync } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const CC_BIN = process.env.DARIO_CLAUDE_BIN || 'C:/Users/masterm1nd.DOCK/.local/bin/claude.exe';
+const PROMPT = 'say hello in 5 words';
+
+const home = process.env.USERPROFILE || process.env.HOME;
+const oa = JSON.parse(fs.readFileSync(path.join(home, '.claude', '.credentials.json'), 'utf-8')).claudeAiOauth;
+const bearer = oa.accessToken;
+if (!bearer) { console.error('FATAL: no CC accessToken'); process.exit(1); }
+console.error(`[auth] resolved CC token (${Math.round((oa.expiresAt - Date.now()) / 60000)} min remaining)`);
+
+const transactions = [];
+
+function startProxy() {
+  return new Promise((resolve) => {
+    const server = http.createServer(async (clientReq, clientRes) => {
+      let bodyChunks = [];
+      clientReq.on('data', (c) => bodyChunks.push(c));
+      clientReq.on('end', async () => {
+        const reqBody = Buffer.concat(bodyChunks).toString();
+        const txn = {
+          ts: Date.now(),
+          req: { method: clientReq.method, url: clientReq.url, headers: { ...clientReq.headers }, body: reqBody },
+        };
+        const outHeaders = { ...clientReq.headers };
+        delete outHeaders['x-api-key'];
+        delete outHeaders['host'];
+        delete outHeaders['content-length'];
+        outHeaders['authorization'] = `Bearer ${bearer}`;
+        let beta = outHeaders['anthropic-beta'] || '';
+        if (!beta.split(',').includes('oauth-2025-04-20')) {
+          beta = beta ? `oauth-2025-04-20,${beta}` : 'oauth-2025-04-20';
+          outHeaders['anthropic-beta'] = beta;
+        }
+        outHeaders['anthropic-dangerous-direct-browser-access'] = 'true';
+
+        const upstream = https.request({
+          hostname: 'api.anthropic.com',
+          path: clientReq.url,
+          method: clientReq.method,
+          headers: outHeaders,
+        }, (upRes) => {
+          const respChunks = [];
+          upRes.on('data', (c) => respChunks.push(c));
+          upRes.on('end', () => {
+            const respBody = Buffer.concat(respChunks);
+            txn.resp = {
+              status: upRes.statusCode,
+              headers: { ...upRes.headers },
+              billingClaim: upRes.headers['anthropic-ratelimit-unified-representative-claim'] || '(unset)',
+              body: respBody.toString(),
+            };
+            clientRes.writeHead(upRes.statusCode, upRes.headers);
+            clientRes.end(respBody);
+            transactions.push(txn);
+          });
+        });
+        upstream.on('error', (err) => {
+          txn.resp = { error: err.message };
+          clientRes.writeHead(502);
+          clientRes.end('proxy error');
+          transactions.push(txn);
+        });
+        upstream.write(reqBody);
+        upstream.end();
+      });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const port = server.address().port;
+      console.error(`[proxy] listening on http://127.0.0.1:${port}`);
+      resolve({ server, port });
+    });
+  });
+}
+
+function gitInit(dir, commitMsg) {
+  fs.mkdirSync(dir, { recursive: true });
+  const opts = { cwd: dir, stdio: 'ignore', shell: false };
+  spawnSync('git', ['init', '-q'], opts);
+  spawnSync('git', ['config', 'user.email', 'test@local'], opts);
+  spawnSync('git', ['config', 'user.name', 'test'], opts);
+  spawnSync('git', ['symbolic-ref', 'HEAD', 'refs/heads/main'], opts);
+
+  fs.writeFileSync(path.join(dir, 'test.md'), '# test\n');
+  spawnSync('git', ['add', '.'], opts);
+  spawnSync('git', ['commit', '-m', commitMsg, '-q'], opts);
+  return dir;
+}
+
+function runCC(cwd, port) {
+  return new Promise((resolve) => {
+    const cc = spawn(CC_BIN, ['--print', '-p', PROMPT], {
+      cwd,
+      env: {
+        ...process.env,
+        ANTHROPIC_BASE_URL: `http://127.0.0.1:${port}`,
+        ANTHROPIC_API_KEY: 'sk-cc-binary-test-stub',
+        CLAUDE_NONINTERACTIVE: '1',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    let stdout = '', stderr = '';
+    cc.stdout.on('data', (c) => { stdout += c; });
+    cc.stderr.on('data', (c) => { stderr += c; });
+    cc.on('exit', (code) => resolve({ code, stdout, stderr }));
+    cc.on('error', (err) => resolve({ code: -1, stdout, stderr, error: err.message }));
+    setTimeout(() => { cc.kill(); resolve({ code: -2, stdout, stderr, timeout: true }); }, 60_000);
+  });
+}
+
+const VARIANTS = [
+  { name: '01_control_clean',          commitMsg: 'initial commit' },
+  { name: '02_theo_exact',             commitMsg: '{"schema": "openclaw.inbound_meta.v1"}' },
+  { name: '03_friendly_openclaw',      commitMsg: 'feat: OpenClaw integration baseline' },
+  { name: '04_plain_openclaw',         commitMsg: 'openclaw' },
+  { name: '05_schema_name_only',       commitMsg: 'openclaw.inbound_meta.v1' },
+  { name: '06_claude_schema_blob',     commitMsg: '{"schema": "claude.inbound_meta.v1"}' },
+  { name: '07_competitor_schema_blob', commitMsg: '{"schema": "competitor.foo.v1"}' },
+];
+
+const { server, port } = await startProxy();
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-schema-test-'));
+
+const runs = [];
+for (const v of VARIANTS) {
+  const dir = path.join(tmpRoot, v.name);
+  gitInit(dir, v.commitMsg);
+  const txnIndexBefore = transactions.length;
+  process.stderr.write(`  ${v.name.padEnd(32)} ... `);
+  const cc = await runCC(dir, port);
+  const myTxns = transactions.slice(txnIndexBefore);
+
+  // Pick the conversation transaction (largest /v1/messages POST)
+  const conv = myTxns
+    .filter((t) => t.req.method === 'POST' && t.req.url.startsWith('/v1/messages'))
+    .sort((a, b) => b.req.body.length - a.req.body.length)[0];
+
+  const claim = conv?.resp?.billingClaim ?? '(no resp)';
+  const status = conv?.resp?.status ?? '-';
+  process.stderr.write(`status=${status} claim=${claim.padEnd(15)} exit=${cc.code}\n`);
+
+  runs.push({
+    ...v,
+    dir,
+    ccExit: cc.code,
+    ccStdout: cc.stdout.slice(0, 500),
+    transactions: myTxns,
+    convTxnExists: !!conv,
+    convStatus: status,
+    convClaim: claim,
+    convBodyBytes: conv?.req.body.length ?? 0,
+    convRespBody: conv?.resp?.body?.slice(0, 500) ?? null,
+  });
+  await sleep(2000);
+}
+
+server.close();
+
+console.error('');
+console.error('=== SUMMARY ===');
+console.error('variant                          status  claim          body bytes');
+console.error('─'.repeat(80));
+for (const r of runs) {
+  console.error(
+    `${r.name.padEnd(32)} ${String(r.convStatus).padEnd(7)} ${r.convClaim.padEnd(14)} ${r.convBodyBytes}`,
+  );
+}
+console.error('');
+
+console.error('=== CC stdout per variant ===');
+for (const r of runs) {
+  console.error(`--- ${r.name} ---`);
+  console.error(`  ${r.ccStdout.replace(/\n/g, ' | ').slice(0, 200)}`);
+}
+
+// JSON dump
+console.log(JSON.stringify({ runs, totalTransactions: transactions.length }, null, 2));
+
+try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch {}

--- a/scripts/test-openclaw-trigger.mjs
+++ b/scripts/test-openclaw-trigger.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+// A/B test of the @theo claim (2026-04-29):
+//
+//   "if you have a recent commit that mentions OpenClaw in a json
+//    blob, Claude Code will either refuse your request or bill you
+//    extra money."
+//
+// We disambiguate two distinct mechanisms his claim could be from:
+//
+//   - REFUSAL (content filter, RLHF or server-side classifier on
+//     content): manifests as the model refusing to comply with a
+//     benign prompt. Status code may stay 200 with a refusal body,
+//     or it may become a 4xx.
+//
+//   - OVERAGE (billing classifier): manifests as the
+//     `anthropic-ratelimit-unified-representative-claim` response
+//     header flipping from `five_hour` (subscription) to a
+//     pay-per-token classification.
+//
+// Methodology mirrors test-system-prompt-mods.mjs: capture CC's
+// outbound body, deep-clone for each variant, mutate ONLY the
+// commit-messages substring inside system[2].text, hold everything
+// else identical (model, tools, effort, max_tokens, body field
+// order, OAuth bearer, anthropic-beta with `oauth-2025-04-20`
+// prepended). Send to api.anthropic.com directly. Read both the
+// billing-claim header AND the response body for refusal text.
+//
+// Variants:
+//   01  control_clean             — openclaw stripped from the captured baseline
+//   02  openclaw_lower            — "openclaw" injected into a commit line
+//   03  openclaw_caps             — "OpenClaw" (Theo's exact casing)
+//   04  openclaw_upper            — "OPENCLAW"
+//   05  hermes                    — another #13-listed tool name (control)
+//   06  cline                     — another text-tool client (control)
+//   07  neutral_rebar3            — random non-Anthropic-related token (noise control)
+//   08  openclaw_in_user_message  — same content but in user prompt, not system
+
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const CC_BIN = process.env.DARIO_CLAUDE_BIN || 'C:/Users/masterm1nd.DOCK/.local/bin/claude.exe';
+const CAPTURE_TIMEOUT_MS = 25_000;
+const PACE_MS = 2_000;
+
+// ──────────────────────────────────────────────────────────────────────
+// Capture (mirrors test-system-prompt-mods.mjs)
+// ──────────────────────────────────────────────────────────────────────
+
+async function captureFromCC() {
+  return new Promise((resolve, reject) => {
+    let captured = null;
+    const server = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', (c) => { body += c; });
+      req.on('end', () => {
+        if (req.url.startsWith('/v1/messages') && req.method === 'POST' && !captured) {
+          try { captured = { url: req.url, headers: req.headers, body: JSON.parse(body) }; }
+          catch (e) { captured = { url: req.url, headers: req.headers, err: e.message }; }
+        }
+        res.writeHead(200, { 'content-type': 'text/event-stream' });
+        res.end('event: error\ndata: {"type":"error","error":{"type":"capture_only"}}\n\n');
+      });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const port = server.address().port;
+      console.error(`[capture] MITM on http://127.0.0.1:${port}`);
+      const cc = spawn(CC_BIN, ['--print', '-p', 'hi'], {
+        env: {
+          ...process.env,
+          ANTHROPIC_BASE_URL: `http://127.0.0.1:${port}`,
+          ANTHROPIC_API_KEY: 'sk-capture-stub',
+          CLAUDE_NONINTERACTIVE: '1',
+        },
+        stdio: ['ignore', 'ignore', 'ignore'],
+        windowsHide: true,
+      });
+      const finish = () => {
+        server.close();
+        if (captured?.body) resolve(captured);
+        else reject(new Error('no /v1/messages body captured'));
+      };
+      cc.on('exit', () => setTimeout(finish, 200));
+      cc.on('error', (err) => reject(err));
+      setTimeout(() => { cc.kill(); finish(); }, CAPTURE_TIMEOUT_MS);
+    });
+  });
+}
+
+async function sendUpstream(body, bearer, captureHeaders, urlPath) {
+  let beta = captureHeaders['anthropic-beta'] || '';
+  if (!beta.split(',').includes('oauth-2025-04-20')) {
+    beta = beta ? `oauth-2025-04-20,${beta}` : 'oauth-2025-04-20';
+  }
+  const headers = {
+    'accept': 'application/json',
+    'content-type': 'application/json',
+    'anthropic-beta': beta,
+    'anthropic-version': captureHeaders['anthropic-version'] || '2023-06-01',
+    'authorization': `Bearer ${bearer}`,
+    'user-agent': captureHeaders['user-agent'],
+    'x-app': captureHeaders['x-app'] || 'cli',
+    'anthropic-dangerous-direct-browser-access': 'true',
+  };
+  body.stream = false;
+
+  const res = await fetch('https://api.anthropic.com' + urlPath, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+  const claim = res.headers.get('anthropic-ratelimit-unified-representative-claim') || '(unset)';
+  const respText = await res.text();
+  let respJson = null;
+  try { respJson = JSON.parse(respText); } catch {}
+  const text = respJson?.content?.find((b) => b.type === 'text')?.text || '';
+
+  // Look for refusal indicators in the response body. RLHF refusals
+  // typically use a small set of phrases; we flag any of them.
+  const refusalIndicators = [
+    /^I (can'?t|cannot|won'?t)/i,
+    /^I'?m not (able|going|comfortable)/i,
+    /\bagainst (my|our) (policies|guidelines)/i,
+    /\bI (apologize|cannot help)/i,
+    /\bunable to (assist|help|comply)/i,
+  ];
+  const refusalDetected = refusalIndicators.some((re) => re.test(text.slice(0, 500)));
+
+  return {
+    status: res.status,
+    claim,
+    requestId: res.headers.get('request-id'),
+    text,
+    output_chars: text.length,
+    output_tokens: respJson?.usage?.output_tokens,
+    input_tokens: respJson?.usage?.input_tokens,
+    errorType: respJson?.error?.type,
+    errorMessage: respJson?.error?.message?.slice(0, 200),
+    refusalDetected,
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Variant construction
+// ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Strip openclaw mentions from a captured baseline so the control
+ * variant is genuinely "clean." The dario repo's git history /
+ * status may surface openclaw via commit messages or branch names,
+ * so we redact them to NOTACLAW.
+ */
+function stripOpenClawMentions(s) {
+  return s.replace(/openclaw/gi, 'NOTACLAW');
+}
+
+/**
+ * Inject a synthetic commit line near the top of the "Recent
+ * commits:" section, so the token sits where Theo claims it
+ * triggers (a recent commit message that CC reports to the model
+ * via its environment block).
+ */
+function injectCommitLine(s, token) {
+  const synthetic = `f00dface chore: ${token} integration test for billing classifier verification\n`;
+  return s.replace(/Recent commits:\n/, `Recent commits:\n${synthetic}`);
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Main
+// ──────────────────────────────────────────────────────────────────────
+
+const captured = await captureFromCC();
+console.error(`[capture] body keys: ${Object.keys(captured.body).join(', ')}`);
+console.error(`[capture] system[2].text length: ${captured.body.system[2].text.length}`);
+
+const cleanBase = stripOpenClawMentions(captured.body.system[2].text);
+console.error(`[strip] after openclaw redaction: ${cleanBase.length} chars (was ${captured.body.system[2].text.length})`);
+console.error(`[strip] redactions: ${(captured.body.system[2].text.match(/openclaw/gi) || []).length}`);
+
+const VARIANTS = [
+  { name: '01_control_clean', sys: cleanBase, userPrompt: 'hi' },
+  { name: '02_openclaw_lower', sys: injectCommitLine(cleanBase, 'openclaw'), userPrompt: 'hi' },
+  { name: '03_openclaw_caps', sys: injectCommitLine(cleanBase, 'OpenClaw'), userPrompt: 'hi' },
+  { name: '04_openclaw_upper', sys: injectCommitLine(cleanBase, 'OPENCLAW'), userPrompt: 'hi' },
+  { name: '05_hermes', sys: injectCommitLine(cleanBase, 'hermes'), userPrompt: 'hi' },
+  { name: '06_cline', sys: injectCommitLine(cleanBase, 'cline'), userPrompt: 'hi' },
+  { name: '07_neutral_rebar3', sys: injectCommitLine(cleanBase, 'rebar3'), userPrompt: 'hi' },
+  { name: '08_openclaw_in_user', sys: cleanBase, userPrompt: 'I am working with openclaw integration code, please say hello in 5 words' },
+];
+
+const home = process.env.USERPROFILE || process.env.HOME;
+const oa = JSON.parse(fs.readFileSync(path.join(home, '.claude', '.credentials.json'), 'utf-8')).claudeAiOauth;
+const bearer = oa.accessToken;
+if (!bearer) { console.error('FATAL: no CC accessToken'); process.exit(1); }
+const minsLeft = Math.round((oa.expiresAt - Date.now()) / 60000);
+console.error(`[auth] resolved CC token (${minsLeft} min remaining)`);
+console.error('');
+
+const results = [];
+for (const v of VARIANTS) {
+  const body = structuredClone(captured.body);
+  body.system[2].text = v.sys;
+  body.messages = [{ role: 'user', content: v.userPrompt }];
+
+  process.stderr.write(`  ${v.name.padEnd(28)} ... `);
+  try {
+    const r = await sendUpstream(body, bearer, captured.headers, captured.url);
+    const refusalMark = r.refusalDetected ? 'REFUSAL' : '       ';
+    process.stderr.write(`status=${r.status} claim=${r.claim.padEnd(12)} ${refusalMark} chars=${r.output_chars} tok=${r.output_tokens}\n`);
+    results.push({
+      ...v,
+      sys: undefined,  // don't store 27kB of system per variant in JSON output
+      sys_chars: v.sys.length,
+      status: r.status,
+      claim: r.claim,
+      requestId: r.requestId,
+      output_chars: r.output_chars,
+      output_tokens: r.output_tokens,
+      input_tokens: r.input_tokens,
+      errorType: r.errorType,
+      errorMessage: r.errorMessage,
+      refusalDetected: r.refusalDetected,
+      response_preview: r.text.slice(0, 300),
+      response_full: r.text,
+    });
+  } catch (e) {
+    process.stderr.write(`ERROR: ${e.message}\n`);
+    results.push({ ...v, sys: undefined, error: e.message });
+  }
+  await sleep(PACE_MS);
+}
+
+console.error('');
+console.error('=== SUMMARY ===');
+console.error('variant                       status claim         refusal? chars  tokens');
+console.error('─'.repeat(85));
+for (const r of results) {
+  const claim = (r.claim || '?').padEnd(13);
+  const refusal = r.refusalDetected ? 'REFUSAL ' : '        ';
+  console.error(`${r.name.padEnd(28)} ${r.status || '?'}    ${claim} ${refusal} ${r.output_chars || 0}     ${r.output_tokens || 0}`);
+}
+console.error('');
+console.error('=== response previews ===');
+for (const r of results) {
+  console.error(`--- ${r.name} ---`);
+  console.error(`  ${(r.response_preview || r.error || '').replace(/\n/g, ' | ').slice(0, 150)}`);
+}
+
+console.log(JSON.stringify(results, null, 2));


### PR DESCRIPTION
## Summary

Four paired diagnostic scripts under \`scripts/\` that triaged [@theo's claim](https://x.com/theo/status/...) (2026-04-29):

> Fun fact - if you have a recent commit that mentions OpenClaw in a json blob, Claude Code will either refuse your request or bill you extra money.

Findings published in [Discussion #173](https://github.com/askalf/dario/discussions/173) (forthcoming, parallel work).

## What we tested

| # | Script | Methodology | Verdict |
|---|---|---|---|
| 1 | \`test-openclaw-trigger.mjs\` | Direct-API body injection, 8 variants, "openclaw" in various positions | All \`five_hour\` — bare string doesn't trigger |
| 2 | \`test-cc-binary-openclaw.mjs\` | Spawn CC binary from a real openclaw-tagged repo, 4 trials | All \`five_hour\` — CC doesn't pre-filter, friendly commit messages don't trigger |
| 3 | \`test-openclaw-schema-trigger.mjs\` | Theo's exact format \`{"schema": "openclaw.inbound_meta.v1"}\` + 6 control variants | **2 of 7 triggered: only the variants containing the literal openclaw protocol-namespace string \`openclaw.inbound_meta.v1\`** |
| 4 | \`test-dario-protects-openclaw.mjs\` | Same openclaw-tagged directory routed through dario at localhost:3456 | **2/2 trials \`five_hour\`** — dario template-replay drops user git context at the proxy boundary |

## Verified findings

- **Anthropic's billing classifier specifically pattern-matches on openclaw's protocol namespace** (\`openclaw.inbound_meta.v1\`). Bare "openclaw" doesn't trigger. \`{"schema": "claude.inbound_meta.v1"}\` (identical JSON shape) doesn't trigger. \`{"schema": "competitor.foo.v1"}\` doesn't trigger. Only the openclaw-namespace pattern.
- **CC sends the offending commit message verbatim** to api.anthropic.com — no client-side pre-filter.
- **dario's default template-replay mode protects users** by replacing CC's outbound body with dario's bundled template; the user's git context never leaves their machine.

## Test plan

- [x] All 4 scripts run end-to-end against api.anthropic.com (real upstream).
- [x] Reproduced @theo's 400 \`"You're out of extra usage"\` error on variants 02 and 05 of test-openclaw-schema-trigger.mjs.
- [x] Confirmed dario protection: same directory → 200 / \`five_hour\` through dario, 400 / extra-usage direct-to-API.
- [ ] Standard CI checks.

## Notes

- Maintainer-only scripts. Not added to \`package.json\` scripts, not invoked from CI, not part of any runtime path.
- Each script reads OAuth from \`~/.claude/.credentials.json\` directly — robust against stale dario state.
- Dispatches real upstream requests on the maintainer's Max plan; cost is negligible but worth knowing before running.
- Discussion #173 is the public-facing writeup with the full receipts table; this PR commits the reproducible methodology so the discussion's "scripts in repo" link works.