### PR TITLE
docs(system-prompt): expand Discussion #183 + recipes with fresh per-variant data

### DIFF
--- a/docs/research/system-prompt.md
+++ b/docs/research/system-prompt.md
@@ -91,18 +91,80 @@ Mirrored as `DARIO_SYSTEM_PROMPT=<mode>`. Surfaced in `dario doctor`. Default un
 - **Not detected as misuse by the classifier.** The empirical 7/7 result above is the documentation. If Anthropic later starts fingerprinting system-prompt content, we'll see it in the rate-limit-classifier headers and document the change. Until then, the classifier doesn't read this channel.
 - **Not specific to dario.** Any client that builds its own request body can already do this — dario just makes it a one-flag operation that preserves CC's other wire-shape axes (header order, body field order, billing tag, beta flags) so the rest of the subscription routing path keeps working.
 
+## Per-variant results (controlled re-run, 2026-04-30)
+
+Re-ran both scripts on 2026-04-30 against **CC v2.1.123 + Claude Sonnet 4.6** to capture the exact per-variant numbers behind the summary findings above. Real upstream requests, OAuth bearer read directly from `~/.claude/.credentials.json`, classifier readout per response. Request IDs preserved for verifiability.
+
+### Test 1 — system-prompt mutations (7/7 → `five_hour`)
+
+| # | Variant | `system[2]` size | Claim | Request ID |
+|---|---|---|---|---|
+| 01 | CC verbatim | 27,251 chars | `five_hour` | `req_011Caak88QqKs9JuFu4Af4HH` |
+| 02 | Single-char prepend | 27,252 chars | `five_hour` | `req_011Caak8Q3vy71zjVozp8j7j` |
+| 03 | Word substitution (`concise → brief`) | 27,247 chars | `five_hour` | `req_011Caak8gBJ3MUQCDDMpeSfb` |
+| 04 | Sentence removal (`"Default to writing no comments."`) | 26,990 chars | `five_hour` | `req_011Caak8uvmyGPaxHTEnuoqU` |
+| 05 | Block fully replaced (321-char custom prompt) | 174 chars | `five_hour` | `req_011Caak9B85WeeVkj7s72Xkk` |
+| 06 | Extra block added (3 → 4 system blocks) | 27,251 chars | `five_hour` | `req_011Caak9S41MMpAAnnZ6LDX8` |
+| 07 | Length padding (+500 chars of `'x'`) | 27,751 chars | `five_hour` | `req_011Caak9gbNaudiueuBzNudM` |
+
+Reducing `system[2]` from 27,251 chars to 174 chars (variant 05 — replacing CC's entire prompt with a single-paragraph custom one) didn't flip routing. Adding a fourth block to a system array CC always sends as 3 blocks didn't flip routing. The slot is not a fingerprint axis.
+
+### Test 2 — constraint removal × 3 user prompts (9/9 → `five_hour`)
+
+System prompts compared:
+- **control** = CC verbatim (27,341 chars)
+- **partial** = behavioral constraints stripped (24,871 chars, −9% length)
+- **aggressive** = partial + RLHF restatements + `# Executing actions with care` stripped (24,166 chars, −12% length)
+
+| User prompt | Variant | Chars | Output tokens | Lines | Comments | Claim |
+|---|---|---|---|---|---|---|
+| code-with-comments | control | 6,379 | 2,048 | 159 | 66 | `five_hour` |
+| | partial | 5,657 | **1,821** (−11%) | 136 | 63 | `five_hour` |
+| | aggressive | 7,208 | **2,301** (+12%) | 150 | 64 | `five_hour` |
+| detailed-explanation | control | 5,668 | 1,708 | 192 | 23 | `five_hour` |
+| | partial | 5,768 | 1,912 (+12%) | 226 | 25 | `five_hour` |
+| | aggressive | 5,704 | 1,843 (+8%) | 197 | 23 | `five_hour` |
+| open-ended-decision | control | 903 | 224 | 13 | 0 | `five_hour` |
+| | partial | 1,587 | **428** (+91%) | 29 | 3 | `five_hour` |
+| | aggressive | 1,889 | **558** (+149%) | 41 | 4 | `five_hour` |
+
+## Various results: the multiplier depends on how much CC's defaults are fighting your prompt
+
+The headline "1.2–2.8× output capability" framing in the original [PR #171 summary](https://github.com/askalf/dario/pull/171) is real but uneven across user-prompt shapes. The 2026-04-30 re-run lets us see exactly where the gain comes from:
+
+**Open-ended decision questions (the biggest gain — +149% output_tokens with aggressive).**
+The user asked *"Should I use Redis or Postgres for session storage?"* Under CC's verbatim defaults, the model produced 224 output tokens — a tight 13-line answer ending with *"Redis with `connect-redis` is the standard."* Under aggressive strip, the same prompt produced 558 output tokens — 41 lines with markdown sectioning, a comparison table, and explicit "when X / when Y" rules. The user's question hadn't changed; CC's `# Doing tasks` bullets ("be terse," "don't add features," "exploratory questions get 2-3 sentences") were doing exactly what they say they're doing — capping output regardless of how much information would actually be useful. Stripping them lets the model answer the question its capability allows.
+
+**Detailed technical explanations (small monotonic gain — ~8–12%).**
+The user asked *"Explain how V8's hidden class optimization works in Node.js."* All three variants produced ~5,500 chars and ~1,700–1,900 tokens. The model already wanted to explain thoroughly here, and CC's defaults didn't suppress it much. The constraints aren't doing observable work on this kind of prompt.
+
+**Code with explicit "thorough comments" request (non-monotonic — partial decreased, aggressive increased).**
+The user explicitly asked for *"thorough comments explaining your reasoning, edge cases, and the tradeoffs."* The result splits oddly: partial dropped output 11% (1,821 vs 2,048 tokens); aggressive raised it 12% (2,301). All three variants honored the comment request (63–66 comment lines). The non-monotonic pattern here reflects the interaction between the user's explicit instruction and the section-by-section content of what got stripped — partial removes the "Default to writing no comments" line (the model is now free to comply with the user) but also removes the "Don't explain WHAT the code does" guard that justified the heavily-narrated control output. Aggressive removes more, and the model commits more fully to the user's explicit "thorough" framing.
+
+**Translation to a tunable knob.**
+This is exactly what `--system-prompt=partial|aggressive` is for. The right strip level depends on the workload:
+
+- For **agentic workloads** that ask open-ended questions or do exploratory work, `partial` recovers most of the suppressed capability with no behavioral risk.
+- For **decisive recommendation tasks**, `aggressive` produces the largest measurable gain.
+- For **detailed-explanation prompts** that already align with the model's natural verbosity, the gain is small — `verbatim` (default) is fine.
+- For **code generation with specific stylistic requirements**, the effect is non-monotonic; A/B both modes against your actual workload before settling.
+
 ## Reproduce it yourself
 
-Both scripts are committed in `scripts/` and were [merged in PR #171](https://github.com/askalf/dario/pull/171). They cost real upstream tokens on your Max plan:
+Both scripts are committed in `scripts/` and were [merged in PR #171](https://github.com/askalf/dario/pull/171). They cost real upstream tokens on your Max plan (negligible — single-digit cents per run):
 
 ```bash
 node scripts/test-system-prompt-mods.mjs           # 7 upstream requests, ~30s, classifier readout per variant
 node scripts/test-constraint-removal.mjs            # 9 upstream requests, ~3 min, behavior delta per variant
 ```
 
-Both read OAuth from `~/.claude/.credentials.json` directly. CC v2.1.120+ recommended; Opus 4.7 / Sonnet 4.6 in scope.
+Both read OAuth from `~/.claude/.credentials.json` directly. CC v2.1.120+ recommended; Sonnet 4.6 / Opus 4.7 in scope.
 
 If you find a variant that flips the classifier, file an issue with the request-id and the variant — that's a billing-fingerprint axis we don't know about yet, and that's the kind of finding worth knowing about.
+
+## Drop-in custom prompts (recipes)
+
+The user-facing how-to with four ready-to-use custom prompts (terse engineer / verbose explainer / code reviewer / research assistant) plus the empirical mapping of *which CC section controls which behavior* lives in [`docs/system-prompt.md`](../system-prompt.md). Each recipe is short (200–500 chars), self-contained, and can be saved to a file and loaded via `dario proxy --system-prompt=<filepath>`.
 
 ---
 

--- a/docs/system-prompt.md
+++ b/docs/system-prompt.md
@@ -47,6 +47,54 @@ CLI flag wins over env var. Both are read at proxy startup; mid-run changes requ
 - **Not detected as misuse by the classifier.** 7/7 variants routed to `five_hour` in the empirical test. If Anthropic later starts fingerprinting system-prompt content, you'll see it in the rate-limit-classifier headers; we'll document the change and update this page.
 - **Not specific to dario.** Any client building its own request body could already do this. Dario makes it a one-flag operation that preserves CC's other wire-shape axes (header order, body field order, billing tag, beta flags) so the rest of the subscription routing path keeps working.
 
+## Drop-in custom-prompt recipes
+
+Four starting points you can save to a file and use with `--system-prompt=<filepath>`. Each is a complete `system[2].text` replacement — short by design (CC's stock prompt is ~27,000 characters; these are 200–500). Copy, modify, A/B against your actual workload, keep what works.
+
+### Recipe 1 — Terse engineer (~280 chars)
+
+```
+You are a senior engineer. Answer questions directly and ship code. Prefer working code over prose. Skip pleasantries, hedging, and apologies. When asked for a recommendation, recommend — don't enumerate every option unless asked. Match output length to question complexity. If the question is ambiguous, pick the most likely interpretation and proceed; flag the assumption in one sentence.
+```
+
+Day-to-day coding work, agent-driven sessions, anything where you want minimum friction. Optimizes signal-to-noise.
+
+### Recipe 2 — Verbose explainer (~500 chars)
+
+```
+You are an engineer-mentor. Your job is to teach by example. For every code answer, explain the reasoning, alternative approaches, and tradeoffs you considered. For every concept, give the intuition first, then the technical detail, then a concrete example. Include comments in code that explain WHY decisions were made, not just WHAT the code does. Aim for outputs that build the user's mental model, not just answer the question.
+```
+
+Learning a new codebase, onboarding, contexts where pedagogical depth matters more than turn-around. The opposite axis from Recipe 1.
+
+### Recipe 3 — Code reviewer (~440 chars)
+
+```
+You are reviewing code. Your job is to surface issues — bugs, security risks, performance traps, edge cases not handled, style and maintainability concerns, missing tests, ambiguous APIs. Order findings by severity. Suggest specific fixes with code snippets, but don't rewrite the entire file unless asked. If the code is correct, say "no issues found" and stop — don't invent problems. Honest is more valuable than thorough.
+```
+
+Review-only sessions, gating PRs through an LLM check, pairing review with another tool. The "honest > thorough" line is load-bearing — without it, models manufacture concerns to justify their output.
+
+### Recipe 4 — Research assistant (~520 chars)
+
+```
+You are a research assistant. Answer questions with structured analysis: summary first (2-4 sentences), then claim-by-claim breakdown with supporting reasoning, then unresolved questions or limitations. Distinguish between observed facts, reasonable inferences, and speculation — never blur the boundaries. Use markdown tables for comparisons across more than two items. When citing online sources, prefer primary documentation, papers, or official spec text over secondary blog posts. Flag uncertainty explicitly.
+```
+
+Investigation work, technical due diligence, evaluating libraries / frameworks / services. Optimizes for analysis quality over speed.
+
+### Empirical mapping — what each section of CC's prompt actually controls
+
+| CC Section | Constrains | Effect when removed |
+|---|---|---|
+| `# Tone and style` | Verbosity bias toward terse, no-emoji, apology patterns | Output length grows; conversational tone returns |
+| `# Text output` | Final-answer format, "summary at end" patterns | Less rigid output structure |
+| `# Doing tasks` bullets ("Don't add features", "Default to writing no comments", "Don't explain WHAT", scope discipline) | Code stays minimal; comments suppressed; refuses to expand scope past literal request | Code includes comments where useful; explanations included; scope inferred more broadly |
+| `# Executing actions with care` | Confirmation-before-action bias | More autonomous action; fewer clarifying questions for ambiguous-but-low-risk work |
+| `IMPORTANT:` lines reminding of refusal categories | Nothing measurable — restate RLHF-trained behavior | <3% practical delta. Alignment is in the weights, not the prompt. |
+
+Behavioral knobs (top three rows) are real — flipping them changes output. Alignment knobs (bottom two) are decorative — removing them doesn't change refusal behavior because refusal is trained into the weights.
+
 ## Reproducibility
 
 The strip rules in `src/cc-template.ts:resolveSystemPrompt` are ported byte-for-byte from `scripts/test-constraint-removal.mjs`, which is committed in this repo. The empirical billing-classifier validation script is `scripts/test-system-prompt-mods.mjs`. Both run real upstream requests against your own subscription.
@@ -56,4 +104,4 @@ node scripts/test-system-prompt-mods.mjs            # 7 upstream requests, class
 node scripts/test-constraint-removal.mjs             # 9 upstream requests, behavior delta per variant
 ```
 
-If you find a mutation that flips the classifier, file an issue with the request-id and the variant — that's a fingerprint axis we don't know about, and that's worth knowing.
+To A/B test your own custom prompt: hold everything constant (model, max_tokens, effort, tools, body field order, billing tag, OAuth bearer, headers) except `system[2].text`. Send identical user prompts under your variants. Measure the `representative-claim` header per response (should stay `five_hour`), output character count + `usage.output_tokens`, and whatever behavior axis you care about. Repeat at least 3× to rule out sampling variance. If your prompt routes to anything other than `five_hour`, something else changed besides the prompt — open an issue with the request-id; that's how a new fingerprint axis would be found.


### PR DESCRIPTION
## Summary

Expands the v3.34.0 system-prompt research with fresh per-variant data from a controlled re-run on **2026-04-30** against CC v2.1.123 + Sonnet 4.6. All 16 variants (7 mutation + 9 constraint-removal) routed `five_hour`. Adds per-variant data tables with full request IDs to `docs/research/system-prompt.md` (the Discussion #183 source) and a recipes + empirical-mapping section to `docs/system-prompt.md` (user-facing how-to).

## Headline finding

The 1.2–2.8× output-capability multiplier varies sharply by user-prompt shape:

- **Open-ended decision question** (Redis vs Postgres for sessions): aggressive strip recovered **+149% output_tokens** (224 → 558). CC's "be terse / ask back" bullets were directly suppressing useful output.
- **Detailed-explanation prompt** (V8 hidden classes): only ~8–12% delta. Model already wanted to explain; constraints didn't suppress it.
- **Code-with-explicit-thoroughness** prompt: non-monotonic. Partial −11%, aggressive +12%. Section-by-section interaction with the user's explicit instruction.

The output-recovery gain is biggest where CC's defaults most aggressively oppose the user's prompt. This is exactly what makes `--system-prompt=partial|aggressive` a tunable knob worth exposing rather than a single override.

## Files

- **`docs/research/system-prompt.md`** — added per-variant data tables (request IDs preserved), per-prompt-shape breakdown, and the "various results" interpretation. Will be pushed as the updated Discussion #183 body via `gh api graphql updateDiscussion` after merge.
- **`docs/system-prompt.md`** — added 4 drop-in custom-prompt recipes (terse engineer / verbose explainer / code reviewer / research assistant), an empirical mapping of CC's prompt sections → behaviors, and an A/B-your-own-prompt methodology.

## Test plan

- [x] Both result scripts re-ran successfully (7/7 + 9/9 → `five_hour`)
- [x] Request IDs captured in the data tables
- [x] No code changes — docs only, no behavior touched
- [ ] CI: actionlint, validate-package-json, build × Node 18/20/22, CodeQL