### PR TITLE
research(system-prompt): recipes vs constraint-strip matrix — emoji axis + replacement > stripping

### DIFF
--- a/docs/research/system-prompt.md
+++ b/docs/research/system-prompt.md
@@ -166,6 +166,67 @@ If you find a variant that flips the classifier, file an issue with the request-
 
 The user-facing how-to with four ready-to-use custom prompts (terse engineer / verbose explainer / code reviewer / research assistant) plus the empirical mapping of *which CC section controls which behavior* lives in [`docs/system-prompt.md`](../system-prompt.md). Each recipe is short (200–500 chars), self-contained, and can be saved to a file and loaded via `dario proxy --system-prompt=<filepath>`.
 
+## Test 3 — recipes vs constraint-strip (the bigger limit-test, 2026-04-30)
+
+We expanded the matrix in `scripts/test-prompt-matrix.mjs` to test the recipes empirically against the constraint-strip baselines. 4 user prompts × 3 variants = 12 trials, all routed `five_hour`. The headline finding: **replacement (a 390-char recipe) beats stripping (24,085-char aggressive) on output recovery, decisive starts, and emoji-tone unlock — three different behavioral axes.**
+
+| User prompt | Variant | Sys size | Output tokens | Δ vs control | md | tbl | emoji | decisive |
+|---|---|---|---|---|---|---|---|---|
+| redis-vs-postgres | control | 27,260 | 239 | — | — | — | — | ✓ |
+| | aggressive | 24,085 | 448 | +87% | ✓ | — | — | — |
+| | terse-engineer | 390 | 449 | +88% | — | — | — | ✓ |
+| http-fun-explanation | control | 27,260 | 824 | — | ✓ | ✓ | — | — |
+| | aggressive | 24,085 | 728 | −12% | ✓ | ✓ | — | ✓ |
+| | terse-engineer | 390 | 828 | +0.5% | ✓ | ✓ | **✓** | — |
+| async-error-guide | control | 27,260 | 4,297 | — | ✓ | ✓ | — | ✓ |
+| | aggressive | 24,085 | 4,749 | +11% | ✓ | ✓ | — | ✓ |
+| | terse-engineer | 390 | **6,088** | **+42%** | ✓ | ✓ | **✓** | — |
+| productivity-tips-listing | control | 27,260 | 744 | — | — | — | — | — |
+| | aggressive | 24,085 | 786 | +6% | — | — | — | — |
+| | terse-engineer | 390 | **923** | **+24%** | ✓ | — | — | — |
+
+**Average output recovery vs control across all 4 prompts: aggressive +23%, terse-engineer +39%.** Terse-engineer is 70× shorter than CC's full prompt yet recovers more capability.
+
+### Finding 1 — CC's no-emoji policy is layered, not purely prompt-level
+
+The user prompt explicitly asked to *"Explain HTTP methods... in a fun, conversational way for a junior developer."* That's a textbook cue for emoji use.
+
+- **control** (27,260 chars of CC prompt): zero emojis. Opens with `# HTTP Methods: A Restaurant Analogy`.
+- **aggressive** (24,085 chars, behavioral constraints stripped + RLHF-restatement removed): **still zero emojis.** Opens with the same `# HTTP Methods: A Restaurant Analogy` — structurally near-identical to control.
+- **terse-engineer** (390-char custom recipe with no emoji guidance either way): **🍽️ in the heading.** Opens with `# HTTP Methods: A Restaurant Analogy 🍽️`.
+
+The constraint-strip variant doesn't unlock emoji behavior. That points to something beyond `# Tone and style` enforcing the no-emoji policy — possibly RLHF training around "professional tone," possibly cache_control structure, possibly an instruction we haven't isolated. **A clean replacement prompt frees the model; subtractive strips don't.** This is the cleanest "limit reached" we've documented in the system-prompt slot.
+
+### Finding 2 — Recipe replacement outperforms strip on every axis
+
+Stripping has an inherent ceiling: you can only remove what's there. Replacement lets you choose what's there. Empirically:
+
+- **Output token recovery**: terse-engineer averages +39%, aggressive averages +23%. The recipe's positive-direction prose ("answer questions directly and ship code") motivates output more than removing CC's verbosity caps.
+- **Decisive lead**: terse-engineer led with `"**Use Redis.**"` (imperative period). Control led with `"Redis, unless..."` (immediately hedged). Aggressive led with `"**Redis** is the better default..."` (mildly hedged). The recipe's *"recommend — don't enumerate every option unless asked"* line did exactly what it said it would.
+- **Format flexibility**: terse-engineer added markdown headers to the productivity-tips listing (control + aggressive both produced flat numbered lists). The recipe doesn't say "use markdown," but its short instructional surface gives the model latitude its 27kB-prompt counterpart didn't have.
+
+### Finding 3 — Long-form generation is where recipes pay off most
+
+The async-error-guide prompt (*"Write a comprehensive technical guide on error handling in async JavaScript..."*) produced the largest delta:
+
+- control: 4,297 tokens (the model wanted to write thoroughly but was capped)
+- aggressive: 4,749 tokens (+11%)
+- **terse-engineer: 6,088 tokens (+42%)**
+
+For a 6kB-token output, the difference between control and terse-engineer is roughly **1,800 tokens of additional content** — about 1,500 words. On a long-form workload (technical writing, deep research, comprehensive guides), the choice between control and terse-engineer is the difference between a partial answer and a complete one.
+
+### Finding 4 — Hard constraints survive replacement
+
+The listing prompt asked for *"15 underrated developer productivity tips."* All three variants produced **exactly 15 numbered items**. CC's "be terse" defaults didn't cap the model below 15 on control either — the explicit count instruction overrode the prompt-level guidance regardless of variant.
+
+This is reassuring: replacing CC's prompt with a 390-char recipe doesn't break instruction-following on hard constraints. The model still does what the user asks for. Only the *style* and *expansiveness* of the answer change.
+
+### What this means
+
+For most agentic workloads, **start with `--system-prompt=partial` for safety, A/B against a custom recipe, keep what works.** The recipes in [`docs/system-prompt.md`](../system-prompt.md) are starting points; the empirical lift is real and measurable, but the right recipe for your workload is the one you tested against your workload.
+
+The matrix script (`scripts/test-prompt-matrix.mjs`) is committed and reproducible. Pass `--variants=` and `--prompts=` to subset the run when you want a focused probe rather than the full matrix.
+
 ---
 
 *Independent, unofficial, third-party. See [DISCLAIMER.md](../../DISCLAIMER.md). Use of these techniques is between you and Anthropic — consult their terms and your subscription agreement.*

--- a/scripts/test-prompt-matrix.mjs
+++ b/scripts/test-prompt-matrix.mjs
@@ -1,0 +1,308 @@
+#!/usr/bin/env node
+// Extended A/B matrix probe — push the limits of behavioral variation
+// surfaceable via system-prompt modification. Builds on the smaller
+// test-constraint-removal.mjs by adding:
+//
+//   - Custom-prompt recipes from docs/system-prompt.md as variants
+//     (terse-engineer / verbose-explainer / code-reviewer /
+//     research-assistant) alongside the constraint-strip levels.
+//   - Wider behavioral measurements: emoji presence, markdown headers,
+//     tables, "decisive start" pattern matching, in addition to the
+//     chars / tokens / comments / question measurements from the
+//     earlier matrix.
+//   - Configurable matrix dimensions — pass --variants and --prompts
+//     to subset the run when you want a focused probe rather than
+//     full N×M.
+//
+// Empirical premise (from test-system-prompt-mods.mjs): the billing
+// classifier doesn't read system prompt content. Therefore every
+// variant in this matrix should route `five_hour`. Behavior delta is
+// the dependent variable.
+//
+// Real upstream cost on the maintainer's Max plan; negligible
+// (single-digit cents per run for a 12-trial focused matrix).
+
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const CC_BIN = process.env.DARIO_CLAUDE_BIN
+  || 'C:/Users/masterm1nd.DOCK/.local/bin/claude.exe';
+const CAPTURE_TIMEOUT_MS = 25_000;
+const PACE_MS = 3_000;
+
+// ──────────────────────────────────────────────────────────────────────
+// Constraint stripping — ported byte-for-byte from
+// test-constraint-removal.mjs:stripConstraints. Same regex list.
+// ──────────────────────────────────────────────────────────────────────
+
+function stripConstraints(sys, level = 'partial') {
+  let s = sys;
+  s = s.replace(/# Tone and style[\s\S]*?(?=\n# |\n$|$)/m, '');
+  s = s.replace(/# Text output[^\n]*\n[\s\S]*?(?=\n# |\n$|$)/m, '');
+  const doingTasksConstraints = [
+    /^ - Don't add features, refactor, or introduce abstractions[^\n]*\n[^\n]*\n[^\n]*\n[^\n]*\n[^\n]*\n/m,
+    /^ - Don't add error handling, fallbacks, or validation[^\n]*\n[^\n]*\n/m,
+    /^ - Default to writing no comments\.[^\n]*\n[^\n]*\n[^\n]*\n[^\n]*\n/m,
+    /^ - Don't explain WHAT the code does[^\n]*\n[^\n]*\n/m,
+    /^ - For exploratory questions[^\n]*\n[^\n]*\n/m,
+    /^ - Avoid backwards-compatibility hacks[^\n]*\n[^\n]*\n/m,
+  ];
+  for (const re of doingTasksConstraints) s = s.replace(re, '');
+  s = s.replace(
+    /^# Doing tasks\n/m,
+    '# Doing tasks\n\nBe thorough. Show your reasoning. Provide the context and explanations the user is likely to find useful. Use as many tokens as the task warrants.\n\n',
+  );
+  if (level === 'aggressive') {
+    s = s.replace(/^IMPORTANT: Assist with authorized security testing[^\n]*\n/m, '');
+    s = s.replace(/^IMPORTANT: You must NEVER generate or guess URLs[^\n]*\n/m, '');
+    s = s.replace(/# Executing actions with care[\s\S]*?(?=\n# |\n$|$)/m, '');
+  }
+  return s;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Recipe library — same text that ships in docs/system-prompt.md
+// ──────────────────────────────────────────────────────────────────────
+
+const RECIPES = {
+  'terse-engineer':
+    "You are a senior engineer. Answer questions directly and ship code. Prefer working code over prose. Skip pleasantries, hedging, and apologies. When asked for a recommendation, recommend — don't enumerate every option unless asked. Match output length to question complexity. If the question is ambiguous, pick the most likely interpretation and proceed; flag the assumption in one sentence.",
+
+  'verbose-explainer':
+    "You are an engineer-mentor. Your job is to teach by example. For every code answer, explain the reasoning, alternative approaches, and tradeoffs you considered. For every concept, give the intuition first, then the technical detail, then a concrete example. Include comments in code that explain WHY decisions were made, not just WHAT the code does. Aim for outputs that build the user's mental model, not just answer the question.",
+
+  'code-reviewer':
+    "You are reviewing code. Your job is to surface issues — bugs, security risks, performance traps, edge cases not handled, style and maintainability concerns, missing tests, ambiguous APIs. Order findings by severity. Suggest specific fixes with code snippets, but don't rewrite the entire file unless asked. If the code is correct, say \"no issues found\" and stop — don't invent problems. Honest is more valuable than thorough.",
+
+  'research-assistant':
+    "You are a research assistant. Answer questions with structured analysis: summary first (2-4 sentences), then claim-by-claim breakdown with supporting reasoning, then unresolved questions or limitations. Distinguish between observed facts, reasonable inferences, and speculation — never blur the boundaries. Use markdown tables for comparisons across more than two items. When citing online sources, prefer primary documentation, papers, or official spec text over secondary blog posts. Flag uncertainty explicitly.",
+};
+
+function resolveVariant(name, ccVerbatim) {
+  if (name === 'control') return ccVerbatim;
+  if (name === 'partial') return stripConstraints(ccVerbatim, 'partial');
+  if (name === 'aggressive') return stripConstraints(ccVerbatim, 'aggressive');
+  if (RECIPES[name]) return RECIPES[name];
+  throw new Error(`Unknown variant: ${name}`);
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Behavioral measurements
+// ──────────────────────────────────────────────────────────────────────
+
+function measure(text) {
+  if (!text) return null;
+  const lines = text.split('\n');
+  return {
+    chars: text.length,
+    lines: lines.length,
+    comment_lines: lines.filter((l) => /^\s*(\/\/|#|\/\*|\*\s)/.test(l)).length,
+    has_code_block: /```/.test(text),
+    has_markdown_headers: /^#{2,}\s/m.test(text),
+    has_table: /^\|.*\|/m.test(text),
+    // Emoji range covers common pictographic emoji.
+    has_emoji: /[\u{1F300}-\u{1FAFF}]|[\u{2600}-\u{27BF}]/u.test(text),
+    ends_with_question: /\?\s*$/.test(text.trim()),
+    // Heuristic for "decisive start" — answers that lead with a
+    // recommendation rather than reciting the question or hedging.
+    starts_decisive: /^[A-Z][a-z]+(?:\.|,| is | wins | first | over )/m.test(text.trim()),
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Test prompts — chosen to surface different behavioral axes
+// ──────────────────────────────────────────────────────────────────────
+
+const TEST_PROMPTS = [
+  {
+    label: 'redis-vs-postgres',
+    prompt: 'Should I use Redis or Postgres for session storage in a Node.js web app?',
+    note: 'Recommendation under ambiguity. Cross-reference to prior matrix.',
+  },
+  {
+    label: 'http-fun-explanation',
+    prompt: 'Explain HTTP methods (GET, POST, PUT, DELETE, PATCH) in a fun, conversational way for a junior developer.',
+    note: '"Fun" tone request. Tests CC\'s no-emoji bias + tone constraint directly.',
+  },
+  {
+    label: 'async-error-guide',
+    prompt: 'Write a comprehensive technical guide on error handling in async JavaScript. Cover Promise rejection handling, try/catch with async/await, error propagation through async stacks, and observability patterns.',
+    note: 'Long-form generation. Tests verbosity caps under explicit "comprehensive" instruction.',
+  },
+  {
+    label: 'productivity-tips-listing',
+    prompt: 'List 15 underrated developer productivity tips. Be specific and actionable.',
+    note: 'Listing task with explicit count. Tests verbosity bias on enumeration.',
+  },
+];
+
+// ──────────────────────────────────────────────────────────────────────
+// Capture (mirrors test-constraint-removal.mjs)
+// ──────────────────────────────────────────────────────────────────────
+
+async function captureFromCC() {
+  return new Promise((resolve, reject) => {
+    let captured = null;
+    const server = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', (c) => { body += c; });
+      req.on('end', () => {
+        if (req.url.startsWith('/v1/messages') && req.method === 'POST' && !captured) {
+          try { captured = { url: req.url, headers: req.headers, body: JSON.parse(body) }; }
+          catch (e) { captured = { url: req.url, headers: req.headers, err: e.message }; }
+        }
+        res.writeHead(200, { 'content-type': 'text/event-stream' });
+        res.end('event: error\ndata: {"type":"error","error":{"type":"capture_only"}}\n\n');
+      });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const port = server.address().port;
+      console.error(`[capture] MITM on http://127.0.0.1:${port}, spawning CC...`);
+      const cc = spawn(CC_BIN, ['--print', '-p', 'hi'], {
+        env: {
+          ...process.env,
+          ANTHROPIC_BASE_URL: `http://127.0.0.1:${port}`,
+          ANTHROPIC_API_KEY: 'sk-capture-stub',
+          CLAUDE_NONINTERACTIVE: '1',
+        },
+        stdio: ['ignore', 'ignore', 'ignore'],
+        windowsHide: true,
+      });
+      const finish = () => {
+        server.close();
+        if (captured?.body) resolve(captured);
+        else reject(new Error('no /v1/messages body captured'));
+      };
+      cc.on('exit', () => setTimeout(finish, 200));
+      cc.on('error', (err) => reject(err));
+      setTimeout(() => { cc.kill(); finish(); }, CAPTURE_TIMEOUT_MS);
+    });
+  });
+}
+
+async function sendUpstream(body, bearer, captureHeaders, urlPath) {
+  let beta = captureHeaders['anthropic-beta'] || '';
+  if (!beta.split(',').includes('oauth-2025-04-20')) {
+    beta = beta ? `oauth-2025-04-20,${beta}` : 'oauth-2025-04-20';
+  }
+  const headers = {
+    'accept': 'application/json',
+    'content-type': 'application/json',
+    'anthropic-beta': beta,
+    'anthropic-version': captureHeaders['anthropic-version'] || '2023-06-01',
+    'authorization': `Bearer ${bearer}`,
+    'user-agent': captureHeaders['user-agent'],
+    'x-app': captureHeaders['x-app'] || 'cli',
+    'anthropic-dangerous-direct-browser-access': 'true',
+  };
+  body.stream = false;
+
+  const res = await fetch('https://api.anthropic.com' + urlPath, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+  const claim = res.headers.get('anthropic-ratelimit-unified-representative-claim') || '(unset)';
+  const respText = await res.text();
+  let respJson = null;
+  try { respJson = JSON.parse(respText); } catch {}
+  const text = respJson?.content?.find((b) => b.type === 'text')?.text || '';
+  return {
+    status: res.status,
+    claim,
+    requestId: res.headers.get('request-id'),
+    text,
+    output_tokens: respJson?.usage?.output_tokens,
+    input_tokens: respJson?.usage?.input_tokens,
+    errorType: respJson?.error?.type,
+    errorMessage: respJson?.error?.message?.slice(0, 200),
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// CLI args — pick subsets of the matrix
+// ──────────────────────────────────────────────────────────────────────
+
+const argv = process.argv.slice(2);
+function getArg(flag) {
+  const a = argv.find((x) => x.startsWith(flag + '='));
+  return a ? a.slice(flag.length + 1).split(',') : null;
+}
+const variantsToRun = getArg('--variants') || ['control', 'aggressive', 'terse-engineer'];
+const promptLabelsToRun = getArg('--prompts') || TEST_PROMPTS.map((p) => p.label);
+const promptsToRun = TEST_PROMPTS.filter((p) => promptLabelsToRun.includes(p.label));
+
+console.error(`[matrix] variants: ${variantsToRun.join(', ')}`);
+console.error(`[matrix] prompts:  ${promptsToRun.map((p) => p.label).join(', ')}`);
+console.error(`[matrix] total trials: ${variantsToRun.length * promptsToRun.length}`);
+console.error('');
+
+// ──────────────────────────────────────────────────────────────────────
+// Main
+// ──────────────────────────────────────────────────────────────────────
+
+const captured = await captureFromCC();
+console.error(`[capture] system blocks: ${captured.body.system.length}`);
+console.error(`[capture] system[2] (CC verbatim) length: ${captured.body.system[2].text.length}`);
+console.error('');
+
+const ccVerbatim = captured.body.system[2].text;
+const variantTexts = Object.fromEntries(
+  variantsToRun.map((name) => [name, resolveVariant(name, ccVerbatim)])
+);
+console.error('[variants] resolved sizes:');
+for (const [name, sys] of Object.entries(variantTexts)) {
+  console.error(`  ${name.padEnd(22)} ${sys.length.toLocaleString()} chars`);
+}
+console.error('');
+
+const home = process.env.USERPROFILE || process.env.HOME;
+const oa = JSON.parse(fs.readFileSync(path.join(home, '.claude', '.credentials.json'), 'utf-8')).claudeAiOauth;
+const bearer = oa.accessToken;
+if (!bearer) { console.error('FATAL: no CC accessToken'); process.exit(1); }
+const minsLeft = Math.round((oa.expiresAt - Date.now()) / 60000);
+console.error(`[auth] resolved CC token (${minsLeft} min remaining)`);
+console.error('');
+
+const results = [];
+
+for (const p of promptsToRun) {
+  console.error(`=== prompt: ${p.label} ===`);
+  for (const variantName of variantsToRun) {
+    const body = structuredClone(captured.body);
+    body.system[2].text = variantTexts[variantName];
+    body.messages = [{ role: 'user', content: p.prompt }];
+
+    process.stderr.write(`  ${variantName.padEnd(22)} ... `);
+    try {
+      const r = await sendUpstream(body, bearer, captured.headers, captured.url);
+      const m = measure(r.text);
+      const compactSummary = m
+        ? `chars=${m.chars} tok=${r.output_tokens} md=${m.has_markdown_headers ? '1' : '0'} tbl=${m.has_table ? '1' : '0'} emoji=${m.has_emoji ? '1' : '0'} q?=${m.ends_with_question ? '1' : '0'} dec=${m.starts_decisive ? '1' : '0'}`
+        : `error: ${r.errorType || r.status}`;
+      process.stderr.write(`status=${r.status} claim=${r.claim} ${compactSummary}\n`);
+      results.push({
+        prompt: p.label,
+        variant: variantName,
+        status: r.status,
+        claim: r.claim,
+        request_id: r.requestId,
+        output_tokens: r.output_tokens,
+        input_tokens: r.input_tokens,
+        ...(m || {}),
+        text_full: r.text,
+      });
+    } catch (e) {
+      process.stderr.write(`ERROR: ${e.message}\n`);
+      results.push({ prompt: p.label, variant: variantName, error: e.message });
+    }
+    await sleep(PACE_MS);
+  }
+}
+
+console.error('');
+console.error('=== JSON ===');
+console.log(JSON.stringify(results, null, 2));


### PR DESCRIPTION
## Summary

Pushes the system-prompt research further with a 12-trial matrix comparing the docs/system-prompt.md recipes (terse-engineer specifically) against the existing constraint-strip baselines (control, aggressive). All 12 routed \`five_hour\`. Three findings worth shipping.

## Findings

### 1. CC's no-emoji policy is layered, not purely prompt-level

The user prompt explicitly asks for *"a fun, conversational way for a junior developer."* That's a textbook emoji cue.

- **control** (27,260 chars): zero emojis. Opens \`# HTTP Methods: A Restaurant Analogy\`.
- **aggressive** (24,085 chars, behavioral constraints + RLHF restatements stripped): **still zero emojis.** Opens with the same \`# HTTP Methods: A Restaurant Analogy\` — structurally near-identical to control.
- **terse-engineer** (390-char custom recipe): **🍽️ in the heading.** Opens \`# HTTP Methods: A Restaurant Analogy 🍽️\`.

Stripping doesn't unlock emoji output. Something beyond \`# Tone and style\` is enforcing the no-emoji bias. Replacement frees it. **This is the cleanest "limit reached" we've documented in the system-prompt slot.**

### 2. Replacement > stripping on every axis

Average output recovery vs control across 4 prompts: aggressive +23%, **terse-engineer +39%**. The 390-char recipe is 70× shorter than CC's full prompt yet recovers more capability AND produces cleaner decisive starts ("Use Redis." vs "Redis, unless you have a specific reason not to.").

### 3. Long-form generation is where the gap is largest

| Variant | async-error-guide tokens | Δ |
|---|---|---|
| control | 4,297 | — |
| aggressive | 4,749 | +11% |
| **terse-engineer** | **6,088** | **+42%** |

On a 6k-token output, ~1,800 tokens of additional content unlocked by the recipe. CC's 27kB of guidance was costing real output capability on long-form tasks.

### What survived

All three variants produced **exactly 15 numbered items** on the listing task. Instruction-following on hard constraints isn't broken by replacement. Only style and expansiveness change.

## Files

- **\`docs/research/system-prompt.md\`** — adds "Test 3" section with the per-trial table, the three findings prose, and the practical recommendation. Will be pushed as the updated Discussion #183 body via \`gh api graphql updateDiscussion\` after merge.
- **\`scripts/test-prompt-matrix.mjs\`** — new flexible matrix runner. \`--variants=\` and \`--prompts=\` for subsetting. Recipe library embedded inline (synced with docs/system-prompt.md). Constraint-strip helper ported byte-for-byte from \`test-constraint-removal.mjs\`. Extended measurements: emoji, markdown headers, tables, decisive-start heuristic.

## Test plan

- [x] All 12 trials completed with valid request IDs preserved
- [x] All 12 routed \`five_hour\`
- [x] Cross-checked findings against actual response text (emoji presence verified by reading the strings, decisive starts verified by reading first sentences)
- [x] Existing \`test-system-prompt-mods.mjs\` and \`test-constraint-removal.mjs\` remain unmodified — this is additive
- [ ] CI: actionlint, validate-package-json, build × Node 18/20/22, CodeQL