### PR TITLE
v3.36.0 — fix Cursor BYOK Claude routing (dario#190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,40 @@ checklist.
 
 ## [Unreleased]
 
+## [3.36.0] - 2026-05-02
+
+Fix Cursor BYOK routing for Claude (dario#190) — apply `MODEL_ALIASES` at request time on the provider-prefix path, plus surface Cursor's built-in name collision in the docs so users don't lose hours debugging "looks fine, charges API costs anyway."
+
+### Why this is needed
+
+Cursor's "Override OpenAI Base URL" silently rewrites any model name it recognizes as built-in (`claude-opus-4-7`, `claude-sonnet-4-6`, etc.) to its own Anthropic gateway path. Requests never reach `localhost:3456`; the user's Cursor API credits get charged; `dario doctor --usage` stays at 0.0% used. There's no "Override Anthropic Base URL" in Cursor and no plans to ship one ([year-old open feature request](https://forum.cursor.com/t/missing-anthropic-base-url-override-in-cursor-byok/158805)).
+
+The only workaround is to use a model name Cursor doesn't recognize — naturally that means dario's `claude:`/`anthropic:` provider-prefix syntax. But the request-time path didn't resolve aliases, so `claude:opus` would forward `model: "opus"` upstream and Anthropic 400'd it. Users had to type the full `claude:claude-opus-4-7` to make it work. This release closes that gap.
+
+### Changed — `claude:opus` / `anthropic:opus` now resolve aliases upstream
+
+`MODEL_ALIASES` (`opus` → `claude-opus-4-6`, `sonnet` → `claude-sonnet-4-6`, `haiku` → `claude-haiku-4-5`, plus `opus1m`/`sonnet1m`) now applies at request time on the provider-prefix path, not just at CLI startup. So `model: "claude:opus"` arrives upstream as `claude-opus-4-6` exactly like `--model=opus` would have.
+
+```jsonc
+// Cursor sends:
+{ "model": "claude:opus", "messages": [...] }
+
+// dario forwards upstream:
+{ "model": "claude-opus-4-6", "messages": [...] }
+```
+
+OpenAI-side prefixes (`openai:`, `groq:`, `openrouter:`, `local:`) keep their pass-through behavior — they go to the configured backend with the stripped name unchanged, since those backends decide their own model namespace.
+
+### Docs
+
+- `docs/agent-compat.md` Cursor section rewritten with a prominent built-in-collision warning, the `claude:opus` / `claude:sonnet` / `claude:haiku` workaround, the "no Verify button in recent Cursor" note (UI removed it; the green toggle is sufficient), and a verification checklist that surfaces the `dario proxy --verbose` line you should see when the prefix path activates. Notes that there is no "Override Anthropic Base URL" in Cursor and links the open feature request.
+
+### Files
+
+- `src/proxy.ts` — extracted `resolveClaudeAlias(model)` helper from the existing `MODEL_ALIASES` table; called from the provider-prefix block when `forcedProvider === 'claude'`. Unknown / canonical names pass through unchanged. Verbose log now includes an `(alias: opus → claude-opus-4-6)` annotation when resolution fires.
+- `test/provider-prefix.mjs` — extended with 10 new assertions covering `resolveClaudeAlias` directly: short aliases (`opus`/`sonnet`/`haiku`/`opus1m`/`sonnet1m`), canonical pass-through (`claude-opus-4-7`/`claude-sonnet-4-6`/`claude-haiku-4-5`), unknown-name pass-through, empty string. Total 26/26 assertions in this file.
+- `docs/agent-compat.md` — Cursor section rewrite (see above).
+
 ## [3.35.0] - 2026-05-02
 
 Adds `--upstream-proxy=<url>` / `--via=<url>` / `DARIO_UPSTREAM_PROXY` for routing dario's outbound traffic (api.anthropic.com requests, OpenAI-compat backend forwarding, OAuth flows) through an HTTP/HTTPS proxy without putting the entire host on a system VPN. Pairs with the HTTP-proxy endpoint of common VPN providers (Mullvad, AirVPN), corporate proxies, privoxy-on-Tor, Cloudflare WARP's proxy mode, or self-hosted squid in a desired jurisdiction.

--- a/docs/agent-compat.md
+++ b/docs/agent-compat.md
@@ -27,20 +27,30 @@ The OpenAI-compat backend forwards tool definitions byte-for-byte and doesn't ne
 
 ### Cursor
 
+> **⚠️ Built-in name collision (read this before configuring)**
+>
+> Cursor recognizes any model name it ships natively (e.g., `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5`, `gpt-5`, `gpt-4o`). When you try to add one of those names as a custom OpenAI-compat model, Cursor pops a "this model is already available as Opus 4.7" toast and silently routes it through **its own** Anthropic gateway — billing your Cursor API credits, never reaching `localhost:3456`. The Override OpenAI Base URL only takes effect for model names Cursor does **not** recognize as built-ins. Confirmed via dario#190 + multiple [Cursor forum reports](https://forum.cursor.com/t/anthropic-models-break-when-override-openai-baseurl-is-set/144899).
+>
+> **Workaround:** prefix the name with `claude:` so it doesn't collide with Cursor's catalog. dario's [provider prefix](./usage.md#provider-prefix) parser strips the prefix and routes through your Claude subscription. Same trick works for `openai:`, `groq:`, etc. on the OpenAI-compat side.
+
 1. **Cmd/Ctrl + ,** to open Settings → **Models**
 2. Under the **OpenAI API Key** section:
    - Check **Override OpenAI Base URL**: `http://localhost:3456/v1` *(the checkbox must be enabled, not just the field populated)*
    - API key: `dario`
-   - Click **Verify** — should turn green
-3. Under the **Model Names** section (or the Add Model button), add the model names whose backends you've configured in dario:
-   - **Claude (always available)** — `claude-sonnet-4-6`, `claude-opus-4-7` (premium), `claude-haiku-4-5` (cheap)
-   - **OpenAI** *(if you've run `dario backend add openai --key=sk-...`)* — `gpt-4o`, `gpt-5`, `o1`, `o3`, etc.
-   - **Other OpenAI-compat backends** *(Groq, OpenRouter, local LiteLLM, Ollama, etc.)* — whichever model names that backend serves; force the route with a [provider prefix](./usage.md#provider-prefix) like `groq:llama-3.3-70b` or `openrouter:moonshotai/kimi-k2` if model names overlap.
+   - *(Recent Cursor versions removed the explicit "Verify" button — the green toggle on its own is sufficient.)*
+3. Under the **Model Names** section (or the Add Model button), add **prefixed** names so they don't collide with Cursor's built-in catalog:
+   - **Claude (always available)** — `claude:opus`, `claude:sonnet`, `claude:haiku` (or full IDs: `claude:claude-opus-4-7` / `claude:claude-sonnet-4-6` / `claude:claude-haiku-4-5`)
+   - **OpenAI** *(if you've run `dario backend add openai --key=sk-...`)* — `openai:gpt-4o`, `openai:gpt-5`, `openai:o1`, etc. The `openai:` prefix dodges Cursor's `gpt-*` collision the same way `claude:` dodges the Anthropic collision.
+   - **Other OpenAI-compat backends** *(Groq, OpenRouter, local LiteLLM, Ollama, etc.)* — `groq:llama-3.3-70b`, `openrouter:moonshotai/kimi-k2`, `local:qwen-coder-32b`, etc.
 4. Select one of the registered models in Cursor's chat input picker.
 
-With the Override OpenAI Base URL checked, **every OpenAI-protocol request from Cursor goes through dario** — the model name in the request decides which backend dario forwards it to. `claude-*` → your Claude subscription (Pro / Max 5x / Max 20x), `gpt-*` / `o*` → your configured OpenAI backend, anything matched by a [provider prefix](./usage.md#provider-prefix) → that prefix's backend.
+dario v3.36+ resolves `claude:opus`/`claude:sonnet`/`claude:haiku` shortcuts to canonical Anthropic model IDs at request time, so the natural shorthand routes to the right model upstream. Older dario versions (≤ v3.35) need the full canonical form: `claude:claude-opus-4-7` etc.
 
-**Cursor surfaces note:** Composer, Tab Apply, and Cmd-K each have their own model-selection UI in recent Cursor versions, separate from Chat. Adding a model to the registered list only routes through dario for the surfaces that let you pick that model. If a Cursor surface is using a default model (e.g., `cursor-small`, `cursor-fast`, or Cursor's bundled `claude-3.5-sonnet`), those go to Cursor's own infrastructure — they never reach localhost:3456 regardless of override settings.
+**Verification:** with `dario proxy --verbose` running, send a test message in Cursor's chat. You should see a `provider prefix: claude:opus → claude backend with model claude-opus-4-6` line in dario's logs and an incremented request count in `dario doctor --usage`. If dario's logs stay silent and `Usage 5h (all)` stays at 0.0%, Cursor is still routing the model through its own gateway — double-check the model name has a prefix and isn't one of Cursor's built-in aliases (e.g. "Opus 4.7" without a prefix).
+
+**Why no "Override Anthropic Base URL"?** Cursor doesn't have one. There's a [year-old open feature request](https://forum.cursor.com/t/missing-anthropic-base-url-override-in-cursor-byok/158805) and no plans to ship it. Routing Claude through dario is only possible via the OpenAI-compat path with a prefixed model name as above.
+
+**Cursor surfaces note:** Composer, Tab Apply, and Cmd-K each have their own model-selection UI, separate from Chat. Adding a prefixed model to the registered list only routes through dario for the surfaces that let you pick that model. Cursor-proprietary defaults (`cursor-small`, `cursor-fast`, etc.) and any built-in name without a prefix go to Cursor's own infra regardless of override settings — they never reach localhost:3456.
 
 ### Continue.dev
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.35.0",
+  "version": "3.36.0",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -136,6 +136,21 @@ const MODEL_ALIASES: Record<string, string> = {
   'haiku': 'claude-haiku-4-5',
 };
 
+/**
+ * Resolve a Claude-side model name through MODEL_ALIASES if it's a short
+ * alias (`opus`/`sonnet`/`haiku`/etc.), otherwise pass through unchanged.
+ *
+ * Used at request time on the provider-prefix path so `claude:opus` arrives
+ * upstream as `claude-opus-4-6` rather than the bare `opus` (which Anthropic
+ * 400's). Critical for Cursor BYOK setups (dario#190) where users have to
+ * pick a colon-prefixed model name to dodge Cursor's built-in `claude-*`
+ * name collision — which means the natural shorthand is `claude:opus`, and
+ * that needs to Just Work.
+ */
+export function resolveClaudeAlias(model: string): string {
+  return MODEL_ALIASES[model] ?? model;
+}
+
 // Provider prefix in the `model` field — `<provider>:<model>`. Forces
 // routing regardless of model-name regex. Only recognized prefixes are
 // parsed, so ollama-style `llama3:8b` (without a recognized prefix)
@@ -1122,6 +1137,16 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
       // regex. CLI-level `--model=<provider>:<name>` applies the same override
       // server-wide. Rewrites the body in place once so both code paths below
       // see the stripped model name.
+      //
+      // MODEL_ALIASES resolution (v3.36): on the claude/anthropic prefix path,
+      // resolve short names (`opus`/`sonnet`/`haiku`) to canonical Anthropic
+      // model IDs at request time. Without this, `claude:opus` would forward
+      // `model: "opus"` upstream and Anthropic 400's it. The CLI parser
+      // (--model=opus) already does this at startup; the request-time path
+      // didn't until now. Important for the Cursor BYOK workaround in
+      // dario#190 where users have to use a colon-prefix to dodge Cursor's
+      // built-in `claude-*` name collision (Cursor reroutes any name it
+      // recognizes through its own Anthropic gateway, bypassing localhost).
       let forcedProvider: 'openai' | 'claude' | null = cliProviderOverride;
       if (body.length > 0) {
         try {
@@ -1130,10 +1155,14 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           const prefix = parseProviderPrefix(rawModel);
           if (prefix) {
             forcedProvider = prefix.provider;
-            parsed.model = prefix.model;
+            const resolvedModel = prefix.provider === 'claude'
+              ? resolveClaudeAlias(prefix.model)
+              : prefix.model;
+            parsed.model = resolvedModel;
             body = Buffer.from(JSON.stringify(parsed));
             if (verbose) {
-              console.log(`[dario] provider prefix: ${rawModel} → ${prefix.provider} backend with model ${prefix.model}`);
+              const aliasNote = resolvedModel !== prefix.model ? ` (alias: ${prefix.model} → ${resolvedModel})` : '';
+              console.log(`[dario] provider prefix: ${rawModel} → ${prefix.provider} backend with model ${resolvedModel}${aliasNote}`);
             }
           } else if (cliProviderOverride === 'openai' && cliModelRaw) {
             // --model=openai:<name> forces the openai backend and replaces

--- a/test/provider-prefix.mjs
+++ b/test/provider-prefix.mjs
@@ -2,8 +2,14 @@
 // body model fields. `<provider>:<model>` with a recognized prefix
 // forces routing; unrecognized prefixes and bare names pass through
 // unchanged (crucial for ollama-style `llama3:8b` names).
+//
+// Also covers resolveClaudeAlias — request-time alias resolution on the
+// claude/anthropic prefix path. Critical for the Cursor BYOK workaround
+// in dario#190: users must pick `claude:opus` (or similar colon-prefixed
+// names) to dodge Cursor's built-in `claude-*` name collision, and that
+// shorthand has to map to the canonical Anthropic model id at request time.
 
-import { parseProviderPrefix } from '../dist/proxy.js';
+import { parseProviderPrefix, resolveClaudeAlias } from '../dist/proxy.js';
 
 let pass = 0;
 let fail = 0;
@@ -53,6 +59,26 @@ assert(parseProviderPrefix('unknown:something') === null, 'unknown provider → 
 // Case-insensitive prefix match
 const upper = parseProviderPrefix('OPENAI:gpt-4o');
 assert(upper?.provider === 'openai' && upper.model === 'gpt-4o', 'OPENAI: (uppercase) → openai');
+
+console.log('\n======================================================================');
+console.log('  resolveClaudeAlias — request-time alias resolution (dario#190)');
+console.log('======================================================================');
+
+assert(resolveClaudeAlias('opus') === 'claude-opus-4-6', 'opus → claude-opus-4-6');
+assert(resolveClaudeAlias('sonnet') === 'claude-sonnet-4-6', 'sonnet → claude-sonnet-4-6');
+assert(resolveClaudeAlias('haiku') === 'claude-haiku-4-5', 'haiku → claude-haiku-4-5');
+assert(resolveClaudeAlias('opus1m') === 'claude-opus-4-6[1m]', 'opus1m → claude-opus-4-6[1m]');
+assert(resolveClaudeAlias('sonnet1m') === 'claude-sonnet-4-6[1m]', 'sonnet1m → claude-sonnet-4-6[1m]');
+
+// Already-canonical names pass through unchanged
+assert(resolveClaudeAlias('claude-opus-4-7') === 'claude-opus-4-7', 'canonical claude-opus-4-7 → unchanged');
+assert(resolveClaudeAlias('claude-sonnet-4-6') === 'claude-sonnet-4-6', 'canonical claude-sonnet-4-6 → unchanged');
+assert(resolveClaudeAlias('claude-haiku-4-5') === 'claude-haiku-4-5', 'canonical claude-haiku-4-5 → unchanged');
+
+// Unknown / non-aliased names pass through (caller decides what to do — Anthropic
+// upstream will 400 if invalid, which is the right error for the user to see)
+assert(resolveClaudeAlias('unknown-model') === 'unknown-model', 'unknown-model → unchanged');
+assert(resolveClaudeAlias('') === '', 'empty string → unchanged');
 
 console.log(`\n${pass} pass, ${fail} fail`);
 process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

- **Diagnosis (dario#190):** Cursor's "Override OpenAI Base URL" silently reroutes any model name it recognizes as built-in (`claude-opus-4-7`, `claude-sonnet-4-6`, etc.) through Cursor's own Anthropic gateway — billing the user's Cursor API credits, never reaching `localhost:3456`. This is a known Cursor design ([forum thread](https://forum.cursor.com/t/anthropic-models-break-when-override-openai-baseurl-is-set/144899) + [year-old open feature request](https://forum.cursor.com/t/missing-anthropic-base-url-override-in-cursor-byok/158805)) with no fix from Cursor in sight. The only practical workaround is a model name Cursor doesn't recognize — naturally that's dario's `claude:`/`anthropic:` provider-prefix syntax.
- **Code fix:** `MODEL_ALIASES` (`opus` → `claude-opus-4-6`, etc.) now applies at request time on the provider-prefix path, not just at CLI startup. So `claude:opus` arrives upstream as `claude-opus-4-6` exactly like `--model=opus` would have. Without this, `claude:opus` would forward `model: "opus"` and Anthropic 400's it; users had to type the full `claude:claude-opus-4-7`.
- **Docs fix:** `docs/agent-compat.md` Cursor section rewritten with the built-in-collision warning at the top, the prefixed-name workaround, "no Verify button in recent Cursor" note, verification checklist, and a link to the open Anthropic-base-url feature request so users know not to wait for it.

Resolves dario#190.

## Test plan

- [x] `npm test` — 59/59 green (was 59 before; 10 new assertions extend `provider-prefix.mjs` from 16 → 26)
- [x] `node test/provider-prefix.mjs` direct — covers `resolveClaudeAlias` short aliases, canonical pass-through, unknown-name pass-through, empty string
- [x] `npm run build` — clean
- [x] Manual: `dario proxy --verbose` logs `provider prefix: claude:opus → claude backend with model claude-opus-4-6 (alias: opus → claude-opus-4-6)` when fired