### PR TITLE
fix(effort): add 'max' to --effort enum (CC v2.1.126 drift, dario#190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ checklist.
 
 ## [Unreleased]
 
+### Drift fix — `--effort=max` (CC v2.1.126 supported, dario didn't)
+
+CC's `--effort` flag accepts `low|medium|high|xhigh|max`; dario's enum stopped at `xhigh` so `dario proxy --effort=max` errored with *"Invalid --effort value"*. Surfaced from a real user request in dario#190 — they were comparing dario behavior to CC's max-thinking mode and couldn't pin it through the proxy.
+
+Verified by capture against the installed CC binary: `claude --effort=max --print -p hi` wires `output_config.effort: "max"` cleanly (same shape as the other levels, `effort-2025-11-24` beta gate already present). No other levels are missing — just `max`.
+
+### Added
+
+- `'max'` added to `EffortValue` type and `VALID_EFFORT_VALUES` constant.
+- `dario proxy --effort=max` and `DARIO_EFFORT=max` now valid; outbound `output_config.effort` becomes `"max"` on non-haiku requests.
+- Test coverage in `test/effort-flag.mjs`: `VALID_EFFORT_VALUES.includes('max')`, `length === 6`, `resolveEffort('max', {}) === 'max'`, client-passthrough of `"max"`, `buildCCRequest` integration, CLI parser.
+
+### Files
+
+- `src/cc-template.ts` — `EffortValue` union + `VALID_EFFORT_VALUES`, docstring.
+- `src/cli.ts` — `--effort=` help text.
+- `test/effort-flag.mjs` — added `max` cases, bumped length assertion, updated invalid-value stderr regex.
+
 ## [3.37.0] - 2026-05-02
 
 Adds `dario shim --priority=<level>` for setting the spawned child's scheduling priority. Cross-platform via Node's `os.setPriority` — `BELOW_NORMAL_PRIORITY_CLASS` on Windows / `nice +7` on POSIX for `below-normal`, `IDLE_PRIORITY_CLASS` / `nice +19` for `low`. Default remains `normal` (no behavior change for existing users).

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -955,15 +955,15 @@ export function resolveMaxTokens(flag: number | 'client' | undefined, clientBody
   return flag;
 }
 
-/** Valid values for the `--effort` flag. `'client'` passes through the client's own `output_config.effort` (falling back to `'high'` if the client didn't send one). dario#87. */
-export type EffortValue = 'low' | 'medium' | 'high' | 'xhigh' | 'client';
-export const VALID_EFFORT_VALUES: ReadonlyArray<EffortValue> = ['low', 'medium', 'high', 'xhigh', 'client'];
+/** Valid values for the `--effort` flag. Mirrors CC's `--effort` set as of v2.1.126 (`low|medium|high|xhigh|max`) plus dario's pseudo-value `'client'` for passthrough. `'client'` passes through the client's own `output_config.effort` (falling back to `'high'` if the client didn't send one). dario#87, `'max'` added in dario#190. */
+export type EffortValue = 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'client';
+export const VALID_EFFORT_VALUES: ReadonlyArray<EffortValue> = ['low', 'medium', 'high', 'xhigh', 'max', 'client'];
 
 /**
  * Resolve the outbound `output_config.effort` value.
  *
  *   undefined / 'high' → 'high' (current default, matches CC 2.1.116 wire value)
- *   'low' / 'medium' / 'xhigh' → pin to that value
+ *   'low' / 'medium' / 'xhigh' / 'max' → pin to that value
  *   'client' → extract from `clientBody.output_config.effort`; fall back
  *              to 'high' if the client didn't send one or sent a non-string
  *

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -986,12 +986,15 @@ async function help() {
                              dario returns 504 "queue-timeout"
                              (default: 60000).
                              Env: DARIO_QUEUE_TIMEOUT_MS. (dario#80)
-    --effort=<low|medium|high|xhigh|client>
+    --effort=<low|medium|high|xhigh|max|client>
                              Override the outbound output_config.effort
                              on non-haiku requests. Default (unset)
                              pins 'high' — matches CC 2.1.116's wire
-                             value. 'client' passes through what the
-                             client sent (falls back to 'high' if none).
+                             value. 'max' is CC's highest reasoning
+                             budget (added in CC v2.1.x; verified in
+                             v2.1.126). 'client' passes through what
+                             the client sent (falls back to 'high' if
+                             none).
                              WARNING: non-'high' values may cause
                              Anthropic's classifier to flip requests
                              to 'overage' billing; watch -v logs for

--- a/test/effort-flag.mjs
+++ b/test/effort-flag.mjs
@@ -21,8 +21,9 @@ header('VALID_EFFORT_VALUES — the allowed set');
   check('includes medium', VALID_EFFORT_VALUES.includes('medium'));
   check('includes high', VALID_EFFORT_VALUES.includes('high'));
   check('includes xhigh', VALID_EFFORT_VALUES.includes('xhigh'));
+  check('includes max', VALID_EFFORT_VALUES.includes('max'));
   check('includes client', VALID_EFFORT_VALUES.includes('client'));
-  check('length === 5', VALID_EFFORT_VALUES.length === 5);
+  check('length === 6', VALID_EFFORT_VALUES.length === 6);
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -33,6 +34,7 @@ header('resolveEffort — explicit values pin');
   check('medium → medium', resolveEffort('medium', {}) === 'medium');
   check('high → high', resolveEffort('high', {}) === 'high');
   check('xhigh → xhigh', resolveEffort('xhigh', {}) === 'xhigh');
+  check('max → max', resolveEffort('max', {}) === 'max');
 }
 
 header('resolveEffort — client passthrough');
@@ -45,6 +47,8 @@ header('resolveEffort — client passthrough');
     resolveEffort('client', { output_config: { effort: 'low' } }) === 'low');
   check('client, output_config.effort = "xhigh" → xhigh',
     resolveEffort('client', { output_config: { effort: 'xhigh' } }) === 'xhigh');
+  check('client, output_config.effort = "max" → max',
+    resolveEffort('client', { output_config: { effort: 'max' } }) === 'max');
   check('client, non-string effort ignored → high',
     resolveEffort('client', { output_config: { effort: 42 } }) === 'high');
   check('client, empty string effort ignored → high',
@@ -67,6 +71,9 @@ header('buildCCRequest — effort reaches outbound body');
 
   const xhighBuild = buildCCRequest(clientBody, billingTag, cacheControl, identity, { effort: 'xhigh' });
   check('effort=xhigh → outbound xhigh', xhighBuild.body.output_config?.effort === 'xhigh');
+
+  const maxBuild = buildCCRequest(clientBody, billingTag, cacheControl, identity, { effort: 'max' });
+  check('effort=max → outbound max', maxBuild.body.output_config?.effort === 'max');
 
   // client passthrough
   const clientBodyWithEffort = { ...clientBody, output_config: { effort: 'xhigh' } };
@@ -107,6 +114,8 @@ header('resolveEffortFlag — CLI parsing');
     resolveEffortFlag(['--effort=low'], undefined) === 'low');
   check('--effort=xhigh → "xhigh"',
     resolveEffortFlag(['--effort=xhigh'], undefined) === 'xhigh');
+  check('--effort=max → "max"',
+    resolveEffortFlag(['--effort=max'], undefined) === 'max');
   check('--effort=CLIENT (case) → "client"',
     resolveEffortFlag(['--effort=CLIENT'], undefined) === 'client');
   check('--effort= HIGH (whitespace) → "high"',
@@ -131,7 +140,7 @@ header('resolveEffortFlag — invalid value exits non-zero');
     `import('./dist/cli.js').then(({ resolveEffortFlag }) => { resolveEffortFlag(['--effort=ultra'], undefined); });`,
   ], { cwd: process.cwd(), encoding: 'utf-8', timeout: 5_000 });
   check('invalid value → non-zero exit', result.status !== 0);
-  check('stderr names valid values', /low, medium, high, xhigh, client/.test(result.stderr));
+  check('stderr names valid values', /low, medium, high, xhigh, max, client/.test(result.stderr));
 }
 
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `'max'` to `EffortValue` + `VALID_EFFORT_VALUES`. Closes a CC v2.1.126 drift gap surfaced by dario#190.
- `dario proxy --effort=max` and `DARIO_EFFORT=max` now valid; outbound `output_config.effort` becomes `"max"` on non-haiku requests.
- Test coverage: 42/42 in `effort-flag.mjs`, 59/59 in full suite.

## Why

CC's `--effort` flag has accepted `low|medium|high|xhigh|max` since at least v2.1.126 (and probably earlier — `effort-2025-11-24` beta gate has been live for months). Dario's enum stopped at `xhigh`, so passing `--effort=max` to dario errored with *"Invalid --effort value"* before reaching the wire. User in dario#190 hit this while testing — they wanted to compare dario behavior to CC's max-thinking mode and couldn't pin it through the proxy.

Verified by capture against the installed CC binary on the maintainer's machine:

```bash
claude --effort=max --print -p hi
# → output_config.effort: "max"
```

Same wire shape as the other levels, beta gate already present. Only `max` is missing — no other CC effort levels need adding.

## Test plan

- [x] `node test/effort-flag.mjs` — 42/42 pass (added 6 new `max` assertions across the existing six test groups)
- [x] `npm test` — 59/59 pass (full suite)
- [x] `npm run build` — clean tsc
- [ ] Manual: `dario proxy --effort=max` accepts the flag without error and forwards `output_config.effort: "max"` upstream
- [ ] Manual: invalid value (`--effort=ultra`) rejects with `"Must be one of: low, medium, high, xhigh, max, client"`

## Files

- `src/cc-template.ts:959-960` — type union + constant + docstring
- `src/cli.ts:989` — `--effort=` help text
- `test/effort-flag.mjs` — `max` cases added across all existing test groups; length assertion `5 → 6`; invalid-value stderr regex updated
- `CHANGELOG.md` — `[Unreleased]` entry under "Drift fix"
