### PR TITLE
v3.37.1 — fix(effort): add 'max' to --effort enum (CC v2.1.126 drift, dario#190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ checklist.
 
 ## [Unreleased]
 
+## [3.37.1] - 2026-05-03
+
 ### Drift fix — `--effort=max` (CC v2.1.126 supported, dario didn't)
 
 CC's `--effort` flag accepts `low|medium|high|xhigh|max`; dario's enum stopped at `xhigh` so `dario proxy --effort=max` errored with *"Invalid --effort value"*. Surfaced from a real user request in dario#190 — they were comparing dario behavior to CC's max-thinking mode and couldn't pin it through the proxy.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.37.0",
+  "version": "3.37.1",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Bump `package.json` 3.37.0 → 3.37.1
- Rename CHANGELOG `[Unreleased]` section to `[3.37.1] - 2026-05-03`

## Why

Cuts the release for the `--effort=max` drift fix (#201, commit `c8663e9`). Auto-release pipeline picks up the version bump on merge → tags v3.37.1 → publishes to npm. User in #190 is currently install-from-git'd; this gets him onto the regular npm path.

## Test plan

- [x] Same shape as v3.37.0's release-bump: only package.json + CHANGELOG header.
- [ ] Verify on green CI that auto-release pipeline picks up the bump and tags + publishes (per cc-drift-auto-release.yml fast path on pull_request: closed + merged).