### PR TITLE
v3.37.3 — feat(docker): wire GHCR publish, both inline + manual paths (#199 follow-up)

### DIFF
--- a/.github/workflows/cc-drift-auto-release.yml
+++ b/.github/workflows/cc-drift-auto-release.yml
@@ -76,6 +76,12 @@ permissions:
   # merged PR's head ref via `gh pr view` when the workflow is
   # triggered by schedule (no `github.event.pull_request` payload).
   pull-requests: read
+  # packages: write is required for the inline docker build/push to
+  # ghcr.io/askalf/dario at the end of the release pipeline. Same loop-
+  # protection reasoning as the inline npm publish — `gh release create`
+  # via GITHUB_TOKEN doesn't fire `release: published`, so we can't
+  # delegate to docker-publish.yml from this path.
+  packages: write
 
 jobs:
   release:
@@ -286,6 +292,51 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public --provenance
+
+      # ─── Inline Docker publish to GHCR ─────────────────────────────
+      # Same loop-protection reason as the inline npm publish above:
+      # `gh release create` via GITHUB_TOKEN doesn't fire
+      # `release: published`, so docker-publish.yml never gets the chance
+      # to run from this path. Mirror its build/push steps inline.
+      - name: Set up QEMU
+        if: steps.gate.outputs.proceed == 'true'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        if: steps.gate.outputs.proceed == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: steps.gate.outputs.proceed == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Docker tag matrix
+        if: steps.gate.outputs.proceed == 'true'
+        id: docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/askalf/dario
+          tags: |
+            type=raw,value=v${{ steps.ver.outputs.version }}
+            type=raw,value=latest
+            type=match,pattern=v(\d+\.\d+),group=1,value=v${{ steps.ver.outputs.version }}
+            type=match,pattern=v(\d+),group=1,value=v${{ steps.ver.outputs.version }}
+
+      - name: Build and push (multi-arch)
+        if: steps.gate.outputs.proceed == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Close matching cc-drift issues
         if: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,66 @@
+name: Publish Docker image to GHCR
+
+# Manual-release fallback for the Docker image publish path.
+#
+# Why two publish paths exist:
+# - `cc-drift-auto-release.yml` does an *inline* docker build/push as
+#   part of its release pipeline, because `gh release create` invoked
+#   from a workflow uses GITHUB_TOKEN attribution and GitHub deliberately
+#   suppresses downstream `release: published` events from those.
+# - This workflow handles the rare maintainer case: a real user running
+#   `gh release create vX.Y.Z` locally, which DOES fire
+#   `release: published` and lets this workflow do the docker build+push.
+#
+# Mirrors the publish.yml + cc-drift-auto-release.yml pattern, same
+# reasoning. Both paths build the same image from the same Dockerfile;
+# Docker tags overwrite, so a duplicate run is a no-op rather than an
+# error.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate tag matrix
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/askalf/dario
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ !contains(github.event.release.tag_name, '-') }}
+
+      - name: Build and push (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ checklist.
 
 ## [Unreleased]
 
+## [3.37.3] - 2026-05-05
+
+### Added — official Docker image at `ghcr.io/askalf/dario`
+
+The Dockerfile + docs landed in dario#207, but the publish wiring didn't — `ghcr.io/askalf/dario:latest` was 404'ing because no workflow ever pushed an image. This release closes that gap.
+
+- **`docker-publish.yml`** — new workflow on `release: published` for the manual-release fallback path. Multi-arch buildx for `linux/amd64` + `linux/arm64`, GHCR auth via `GITHUB_TOKEN`, semver-derived tag matrix (`vX.Y.Z`, `vX.Y`, `vX`, `latest`).
+- **`cc-drift-auto-release.yml`** — added inline docker build/push steps after the inline npm publish. Same loop-protection reasoning that forced inline npm publish: `gh release create` invoked from a workflow uses GITHUB_TOKEN attribution, which suppresses downstream `release: published` triggers, so docker-publish.yml never fires from this path.
+- **`packages: write`** added to the cc-drift-auto-release.yml permissions block for the inline GHCR push.
+
+Both publish paths build the same Dockerfile and tag with the same matrix; Docker tags overwrite, so a duplicate run for the same release is a safe no-op.
+
 ## [3.37.2] - 2026-05-04
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.126` → `2.1.128` for CC v2.1.128. Auto-drafted by `cc-drift-watch.yml`; maintainer confirm the bundled template doesn't also need a re-capture (run `node scripts/capture-and-bake.mjs` locally, amend this PR).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.37.2",
+  "version": "3.37.3",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Closes the GHCR publish gap surfaced after v3.37.2. The Dockerfile + docs landed in #207 but `ghcr.io/askalf/dario:latest` is 404 because no workflow ever pushed an image. This PR wires both publish paths so the next release (v3.37.3 itself, on this PR's merge) is the first one with a real GHCR image.

## What changed

- **`docker-publish.yml`** (new) — manual-release fallback. Triggered by `release: published`, fires when a maintainer runs `gh release create` locally as a real user. Multi-arch buildx + GHCR push.
- **`cc-drift-auto-release.yml`** — added inline docker build/push steps after the inline npm publish. Same loop-protection rationale as the inline npm publish: `gh release create` from a workflow uses `GITHUB_TOKEN` attribution which suppresses downstream `release: published` events, so `docker-publish.yml` would never fire from the auto-release path. Inline is the only way to keep the ship-on-merge cadence.
- **`packages: write`** added to `cc-drift-auto-release.yml` permissions block for the GHCR push.
- **`package.json`** bumped 3.37.2 → 3.37.3.
- **`CHANGELOG.md`** entry under `[3.37.3]`.

Both paths use the same Dockerfile, same tag matrix (`vX.Y.Z`, `vX.Y`, `vX`, `latest`), same auth (`GITHUB_TOKEN` against `ghcr.io`). Docker tags overwrite, so a duplicate run for the same release is a safe no-op.

## Test plan

- [x] CI green on PR (actionlint catches workflow syntax issues — no local actionlint available)
- [ ] On merge: `cc-drift-auto-release.yml` fires → builds + npm-publishes v3.37.3 → docker buildx + pushes `ghcr.io/askalf/dario:v3.37.3`, `:v3.37`, `:v3`, `:latest`
- [ ] Verify `gh api orgs/askalf/packages/container/dario` returns 200 (currently 404)
- [ ] Verify `ghcr.io/askalf/dario:latest` is pullable on a Docker host
- [ ] Follow up on #199 with @daimonbot to take up the ARM64 + k8s manifest offer

## Risk

Low. Only touches CI workflows + version metadata; no source code changes. The new docker-publish path is idempotent against the existing npm-publish path (different secret, different registry, separate steps in the same job). Rollback if needed: revert this commit and the next release skips GHCR while keeping npm publishing intact.