### PR TITLE
fix(ci): pin docker actions to full SHAs (#208 follow-up)

### DIFF
--- a/.github/workflows/cc-drift-auto-release.yml
+++ b/.github/workflows/cc-drift-auto-release.yml
@@ -300,15 +300,15 @@ jobs:
       # to run from this path. Mirror its build/push steps inline.
       - name: Set up QEMU
         if: steps.gate.outputs.proceed == 'true'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
         if: steps.gate.outputs.proceed == 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to GHCR
         if: steps.gate.outputs.proceed == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -317,7 +317,7 @@ jobs:
       - name: Generate Docker tag matrix
         if: steps.gate.outputs.proceed == 'true'
         id: docker_meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ghcr.io/askalf/dario
           tags: |
@@ -328,7 +328,7 @@ jobs:
 
       - name: Build and push (multi-arch)
         if: steps.gate.outputs.proceed == 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,13 +31,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -45,7 +45,7 @@ jobs:
 
       - name: Generate tag matrix
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ghcr.io/askalf/dario
           tags: |
@@ -55,7 +55,7 @@ jobs:
             type=raw,value=latest,enable=${{ !contains(github.event.release.tag_name, '-') }}
 
       - name: Build and push (multi-arch)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary

Fixes the auto-release failure on master after #208 merged. Workflow's docker/* actions used major-version tags (`@v3`, `@v5`, `@v6`); the org requires full-length SHA pins.

## What

Pinned both `docker-publish.yml` and `cc-drift-auto-release.yml` to:

- `docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a` — v4.0.0
- `docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd` — v4.0.0
- `docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121` — v4.1.0
- `docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf` — v6.0.0
- `docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f` — v7.1.0

Resolved via `gh api repos/docker/<action>/releases/latest` + `gh api repos/docker/<action>/git/refs/tags/<tag>`.

## Why no version bump

`package.json` is already at `3.37.3` (from #208), but no `v3.37.3` tag was created because the previous auto-release run aborted at "Set up job" before tagging. The auto-release gate on this PR's merge will see "package.json says 3.37.3, no v3.37.3 tag exists" → proceed with the same release that was supposed to ship from #208.

## Test plan

- [x] CI green (actionlint validates SHA-pinned uses)
- [ ] On merge: auto-release retries → builds → npm publishes v3.37.3 → docker buildx → pushes `ghcr.io/askalf/dario:v3.37.3` + `:v3.37` + `:v3` + `:latest`
- [ ] Verify `gh api orgs/askalf/packages/container/dario` returns 200