### PR TITLE
v3.37.4 — fix(docker): preserve 'v' prefix on rolling :vX.Y and :vX tags

### DIFF
--- a/.github/workflows/cc-drift-auto-release.yml
+++ b/.github/workflows/cc-drift-auto-release.yml
@@ -323,8 +323,8 @@ jobs:
           tags: |
             type=raw,value=v${{ steps.ver.outputs.version }}
             type=raw,value=latest
-            type=match,pattern=v(\d+\.\d+),group=1,value=v${{ steps.ver.outputs.version }}
-            type=match,pattern=v(\d+),group=1,value=v${{ steps.ver.outputs.version }}
+            type=match,pattern=v\d+\.\d+,value=v${{ steps.ver.outputs.version }}
+            type=match,pattern=v\d+,value=v${{ steps.ver.outputs.version }}
 
       - name: Build and push (multi-arch)
         if: steps.gate.outputs.proceed == 'true'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,9 +49,9 @@ jobs:
         with:
           images: ghcr.io/askalf/dario
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern={{raw}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
             type=raw,value=latest,enable=${{ !contains(github.event.release.tag_name, '-') }}
 
       - name: Build and push (multi-arch)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ checklist.
 
 ## [Unreleased]
 
+## [3.37.4] - 2026-05-05
+
+### Fixed — `vX.Y` and `vX` Docker tags lost their `v` prefix
+
+The first GHCR publish in v3.37.3 produced rolling tags `:3.37` and `:3` instead of the documented `:v3.37` and `:v3` because the metadata-action match pattern used `pattern=v(\d+\.\d+),group=1` — extracting capture group 1 strips the `v` prefix from the output. Pinned tags `:v3.37.3` and `:latest` were unaffected.
+
+This release fixes both publish paths:
+
+- **`cc-drift-auto-release.yml`** — dropped `group=1` and the parens; pattern is now `v\d+\.\d+` (no capture group), so the metadata-action outputs the full match including the `v` prefix.
+- **`docker-publish.yml`** — switched from `type=semver,pattern={{major}}.{{minor}}` (which strips `v`) to `pattern=v{{major}}.{{minor}}` (literal `v` in the template). Same idea, semver-flavor syntax.
+
+After v3.37.4 ships, `:v3.37` and `:v3` resolve as documented, and the orphan `:3.37` and `:3` from v3.37.3 stay frozen at the v3.37.3 image until the next release that would normally have advanced them.
+
 ## [3.37.3] - 2026-05-05
 
 ### Added — official Docker image at `ghcr.io/askalf/dario`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.37.3",
+  "version": "3.37.4",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Patch release for the cosmetic tag-prefix issue noted in the v3.37.3 release notes. Rolling `:vX.Y` and `:vX` tags landed without the `v` prefix (`:3.37`, `:3`) because the metadata-action pattern used capture-group extraction.

## What changed

- **`cc-drift-auto-release.yml`** — pattern `v(\d+\.\d+),group=1` → `v\d+\.\d+` (no group). The metadata-action outputs the full match including `v` instead of just the captured digits.
- **`docker-publish.yml`** — semver pattern `{{major}}.{{minor}}` → `v{{major}}.{{minor}}` (literal `v` in Handlebars template; semver-mode strips the `v` from `{{version}}` style outputs).
- `package.json` 3.37.3 → 3.37.4.
- `CHANGELOG.md` `[3.37.4]` entry.

## Test plan

- [x] CI green
- [ ] On merge: auto-release fires → publishes v3.37.4 → tags include `:v3.37.4`, `:v3.37`, `:v3`, `:latest` (all four with proper `v` prefix this time)
- [ ] Verify tag list via `curl -s 'https://ghcr.io/v2/askalf/dario/tags/list'`

## What about the orphan `:3.37` and `:3` tags from v3.37.3?

They stay frozen at the v3.37.3 image bytes. Not an active confusion risk because:
- Documented usage is to pin `vX.Y.Z` for production or use `latest` for tracking — neither is affected.
- Anyone who happened to pull `:3.37` (no `v`) gets a working v3.37.3 image; the tag just stops getting pushed updates.

If we want to actively delete them, can do that as a separate cleanup task with the GHCR delete-version API.