### PR TITLE
docs(returning): tier-1 prep for the CC return wave

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <h1 align="center">dario</h1>
-  <p align="center"><strong>Use your Claude Pro/Max subscription with Cursor, Aider, Cline, Zed, the Claude Agent SDK — any tool that speaks Anthropic or OpenAI.</strong></p>
+  <p align="center"><strong>Use your Claude Pro/Max subscription with Cursor, Aider, Cline, Zed, Codex CLI, the Claude Agent SDK — any tool that speaks Anthropic or OpenAI.</strong></p>
   <p align="center">A local LLM router. One endpoint, every provider. Your Claude subscription — Pro ($20), Max 5x ($100), or Max 20x ($200) — stops sitting idle in Claude Code while you pay per-token everywhere else. Speaks both the Anthropic Messages API and the OpenAI Chat Completions API at <code>http://localhost:3456</code>.</p>
 </p>
 
@@ -40,7 +40,9 @@ export ANTHROPIC_BASE_URL=http://localhost:3456
 export ANTHROPIC_API_KEY=dario
 ```
 
-Done. Every tool that honors those env vars — Claude Code, Cursor, Aider, Cline, Roo Code, Continue.dev, Zed, Windsurf, OpenHands, OpenClaw, Hermes, the [Claude Agent SDK](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk), your own scripts — now routes through your **Claude subscription** (Pro / Max 5x / Max 20x) instead of per-token API pricing. Dario sends the same request shape Claude Code itself sends, which is the shape the subscription-billing path recognizes.
+Done. Every tool that honors those env vars — Claude Code, Cursor, Aider, Cline, Roo Code, Continue.dev, Zed, Windsurf, OpenHands, OpenClaw, Hermes, Codex CLI, the [Claude Agent SDK](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk), your own scripts — now routes through your **Claude subscription** (Pro / Max 5x / Max 20x) instead of per-token API pricing. Dario sends the same request shape Claude Code itself sends, which is the shape the subscription-billing path recognizes.
+
+Prefer Docker? `ghcr.io/askalf/dario:latest` is a multi-arch (`linux/amd64` + `linux/arm64`) image published on every release — homelab, k8s, NAS. Full guide: [`docs/docker.md`](./docs/docker.md).
 
 For OpenAI / Groq / OpenRouter / Ollama / LiteLLM / vLLM, add one backend line and reuse the same proxy:
 
@@ -277,6 +279,9 @@ Yes. Skip `dario login`, `dario backend add openai --key=...` and you have a loc
 
 **Something's wrong. Where do I start?**
 `dario doctor`. One command, paste-ready report. If you're inside CC, `dario subagent install` once and ask CC to "use the dario sub-agent to run doctor."
+
+**I used dario before, drifted to another tool, now coming back — anything to redo?**
+No reinstall. `dario login` re-uses any existing Claude Code credentials on your machine. If you also picked up Codex CLI / OpenAI in the gap, `dario backend add openai --key=$OPENAI_API_KEY` puts both your subscription path and your OpenAI fallback on the same `localhost:3456`. Full returner walkthrough: [`docs/returning.md`](./docs/returning.md).
 
 **I'm seeing `representative-claim: seven_day` in my rate-limit headers — am I being downgraded?**
 **No.** Both `five_hour` and `seven_day` are subscription billing — different accounting buckets inside the same subscription mode. `overage` is the one that flips you to per-token. See [Discussion #1](https://github.com/askalf/dario/discussions/1) for the full rate-limit-header breakdown.

--- a/docs/returning.md
+++ b/docs/returning.md
@@ -1,0 +1,94 @@
+# Returning to dario
+
+If you used dario before — set it up, hit a drift / capacity / tool-compat wall during the v3.30s, drifted to Codex or Cursor's BYOK or pure API keys — this page is the 5-minute path back.
+
+## What changed while you were gone
+
+- **Multi-arch Docker image** — `ghcr.io/askalf/dario:latest` (and `:vX.Y.Z`, `:vX.Y`, `:vX`). Pull and run, no npm install needed. See [`docs/docker.md`](./docker.md).
+- **GHCR publish wired into the release pipeline** — every dario release ships an image. Renovate / Argo Image Updater / Keel can track `:vX.Y.Z` automatically.
+- **Hourly CC drift detection** — `cc-drift-watch.yml` runs every hour, auto-drafts a maxTested bump PR within 60 minutes of a Claude Code release. The "dario broke because CC drifted" gap that bit returners is closed.
+- **Headless OAuth flow** — `dario login --manual` skips the localhost callback for SSH / container / k8s installs. Browser anywhere, paste the code back.
+- **Multi-account pool** — `dario accounts add work` / `dario accounts add personal`. Pool mode kicks in at 2+ accounts; sticky-session routing keeps prompt cache alive across multi-turn agent runs.
+- **System-prompt stripping** — `dario proxy --system-prompt=partial` removes CC's behavioral constraints, recovers ~1.2–2.8× output capability on open-ended work without flipping subscription billing. See [`docs/system-prompt.md`](./system-prompt.md).
+- **MCP server + CC sub-agent** — `dario mcp` exposes dario as a read-only MCP server; `dario subagent install` registers it inside CC for in-session diagnostics.
+
+## I have an existing dario install
+
+```sh
+dario upgrade           # pulls the latest npm release
+dario doctor            # reports config, OAuth health, drift status, pool state
+```
+
+Read the doctor output. If it's all OK / WARN, nothing to do. If anything is RED, the line tells you the fix.
+
+## I uninstalled dario; have my Claude Code creds; want to come back
+
+```sh
+npm install -g @askalf/dario
+dario login             # detects existing CC credentials, no re-OAuth needed
+dario proxy
+```
+
+Or via Docker:
+
+```sh
+docker volume create dario-config
+docker run --rm -it -v dario-config:/home/dario/.dario \
+  ghcr.io/askalf/dario:latest login --manual
+
+docker run -d -p 3456:3456 -v dario-config:/home/dario/.dario \
+  -e DARIO_API_KEY="$(openssl rand -hex 32)" \
+  ghcr.io/askalf/dario:latest
+```
+
+Point your tools at `http://localhost:3456` (Anthropic) or `http://localhost:3456/v1` (OpenAI) with the same `DARIO_API_KEY`.
+
+## I picked up Codex CLI / Cursor BYOK / OpenAI direct in the gap — keep them?
+
+Yes. dario routes both protocols through one endpoint:
+
+```sh
+dario backend add openai --key=sk-proj-...
+```
+
+Now Codex CLI hits dario at `OPENAI_BASE_URL=http://localhost:3456/v1` and gets routed to OpenAI (your existing OpenAI cost path stays as-is), while Claude Code / Cursor / Aider hit dario at `ANTHROPIC_BASE_URL=http://localhost:3456` and get routed to your Claude subscription. Same proxy. Same restart.
+
+Force a specific backend with a model prefix when the default routing isn't what you want:
+
+- `openai:gpt-4o` — always goes to OpenAI, even from a tool that defaults to Claude
+- `anthropic:opus` — always goes to your Claude subscription, even from an OpenAI-shape tool
+- `groq:llama-3.3-70b` / `local:qwen-coder` — same pattern for any backend you've added
+
+## I'm hitting the 5h subscription cap immediately on agent runs
+
+Add a second account.
+
+```sh
+dario accounts add work
+dario accounts add personal
+dario proxy
+```
+
+Pool mode activates automatically at 2+ accounts. Each request picks the account with the most headroom. Multi-turn agent sessions stick to one account so the Anthropic prompt cache survives. In-flight 429s retry on a different account before your tool sees the error. Tier mixing is fine — Pro + Max 5x + Max 20x all pool together; dario only cares about headroom percentage, not plan name.
+
+Full headroom math, sticky-key implementation, inspection endpoints: [`docs/multi-account-pool.md`](./multi-account-pool.md).
+
+## I'm running this in k8s now, not on my laptop
+
+The Docker image is k8s-ready: non-root user, healthcheck on `/health`, volume on `/home/dario/.dario`, mandatory `DARIO_API_KEY` when binding non-loopback. A complete Deployment + Service + Secret manifest is in [`docs/docker.md#kubernetes-example`](./docker.md#kubernetes-example).
+
+Pre-seed credentials by running `dario login --manual` on a workstation, then ship `~/.dario/credentials.json` into the k8s Secret via SOPS / sealed-secrets / `kubectl create secret generic --from-file`. Refresh tokens auto-rotate inside the pod.
+
+Replicas should stay at `1`. dario's OAuth refresh races on a single credentials file. For HA, run multiple dario instances each with their own account in a multi-account pool — separate Deployments, separate Secrets, separate Services, fronted by your usual ingress.
+
+## I had `--passthrough` set; do I still need it?
+
+`--passthrough` is only useful when the upstream tool already builds Claude-Code-shaped requests on its own. Most tools don't; without `--passthrough` dario rebuilds the request to match CC's wire shape, which is what keeps the request on the subscription-billing path.
+
+If you weren't sure what `--passthrough` did before and just had it set, drop it. `dario doctor` will tell you whether your installed CC binary is being used as the template source.
+
+## Something specific is broken
+
+`dario doctor` prints a paste-ready report. Open an issue with that report attached.
+
+If you're inside Claude Code, `dario subagent install` registers a CC sub-agent — ask CC to "use the dario sub-agent to run doctor" and it'll attach the report to your conversation directly.


### PR DESCRIPTION
## Summary

Tier-1 prep for the CC return wave (per the SpaceX/Colossus deal news cycle and the broader "users drifted to Codex during the v3.30s and may come back" demographic).

Surgical edits to README + a new `docs/returning.md`. No structural rewrite — the existing framing reads well; what was missing was **Docker visibility** and an explicit **"used this before, here's how to come back"** landing surface.

## What changed

**README.md** (3 small edits):
- Hero one-liner adds **Codex CLI** alongside Cursor / Aider / Cline / Zed — the OpenAI-compat path already routes Codex requests, but the README never named it, which leaves returners who picked up Codex during the gap unaware that dario covers their fallback too.
- 30-seconds quickstart adds a one-line **Docker pointer** (`ghcr.io/askalf/dario:latest`, multi-arch). Image landed in #208; quickstart was npm-only.
- New **FAQ entry** for the returner case, pointing at the new doc.

**`docs/returning.md`** (new, ~95 lines):

Five-minute path back, covering:
- What changed during the v3.30s (cc-drift-watch hourly, GHCR image, `login --manual`, pool mode, `--system-prompt=partial`, MCP / sub-agent).
- Upgrade path for existing installs (`dario upgrade && dario doctor`).
- Fresh install via npm or Docker (with the manual-OAuth flow for containers).
- Keeping Codex CLI / Cursor BYOK / OpenAI direct on the same `localhost:3456` via `dario backend add openai`.
- Multi-account pool when the 5h cap bites on long agent runs.
- k8s walkthrough (links to `docs/docker.md` + manifest example).
- `--passthrough` deprecation note for users who had it set without knowing why.

## Why this isn't a wholesale README rewrite

The current README is dense but information-rich, and the framing largely works (router pitch up top, cost comparison, "why you'll install this" bullets, independent reviews, trust table). Rewriting wholesale risks losing what's working. The two gaps were Docker visibility (one line, fixed) and a returner landing page (new file, additive).

## Open questions before merge

1. **Codex CLI naming** — added to the hero and the "every tool" sentence. If Codex CLI compat hasn't been explicitly smoke-tested through dario's OpenAI-compat backend, the claim is technically promissory. Tier-2 in the prep list flags a smoke test as a follow-up.
2. **Returner FAQ tone** — "drifted to another tool" is soft. Could be sharpened to "if you used Codex / Cursor BYOK / pure API in the gap" if you want to be more direct.

## Test plan

- [x] `npm run build` clean
- [ ] Render README.md on GitHub and confirm the hero, 30-seconds, and new FAQ sections read correctly
- [ ] Render `docs/returning.md` on GitHub and confirm internal links resolve (`./docker.md`, `./multi-account-pool.md`, `./system-prompt.md`)
- [ ] Once a real release publishes (next merge of #214 or any tagged release), pull `ghcr.io/askalf/dario:latest` per the new quickstart line and confirm the documented flow works end-to-end
