### PR TITLE
ci(docker): provenance + sbom + release concurrency group

### DIFF
--- a/.github/workflows/cc-drift-auto-release.yml
+++ b/.github/workflows/cc-drift-auto-release.yml
@@ -90,6 +90,16 @@ jobs:
     # the gate step short-circuits when there's nothing to ship.
     if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    # Serializes overlapping triggers so a pull_request:closed and a
+    # schedule tick that fire within seconds of each other don't both
+    # race past the `gate` step (TOCTOU on `gh release view`) and end
+    # up with one run failing on `gh release create` because the other
+    # already created the tag. cancel-in-progress=false because the
+    # in-flight run is doing real work (build/test/publish); we want
+    # the second to wait, not abort the first.
+    concurrency:
+      group: cc-drift-auto-release-master
+      cancel-in-progress: false
     steps:
       - name: Checkout master (post-merge state)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -333,6 +343,8 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: true
+          sbom: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -60,6 +60,8 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: true
+          sbom: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
## Summary

Two changes from the docker-pipeline code review (in-session, no separate write-up):

1. **`provenance: true` + `sbom: true`** on `docker/build-push-action` in both `docker-publish.yml` and `cc-drift-auto-release.yml`. Closes the supply-chain consistency gap: the npm publish path is SLSA-attested (`npm publish --provenance`), the GHCR publish path wasn't. README's trust table claim "every release is SLSA-attested" is now true for both artifact types. SBOM is the cheap companion — image dependency graph attached as a separate manifest, viewable via `docker buildx imagetools inspect ghcr.io/askalf/dario:vX.Y.Z`.

2. **`concurrency: group cc-drift-auto-release-master, cancel-in-progress: false`** on the release job. Serializes overlapping triggers so a `pull_request: closed` event and the `:15-past-the-hour` cron tick that fire seconds apart can't both pass the gate step (TOCTOU on `gh release view`) and race on `gh release create`. `cancel-in-progress: false` because the in-flight run is doing real work (build / test / npm publish / docker push) — the second trigger should wait, not abort the first.

## What this doesn't change

- Dockerfile is untouched.
- Tag matrix is untouched (no `:vX.Y.Z` / `:vX.Y` / `:vX` / `:latest` shape changes).
- Release cadence and triggers are untouched.

## Verifying after release

```sh
docker buildx imagetools inspect ghcr.io/askalf/dario:vX.Y.Z --raw | jq '.manifests[].annotations'
# expect to see in-toto SLSA attestation + SBOM manifests in the index
```

## Test plan

- [x] actionlint clean on both workflow files
- [ ] On next release: confirm GHCR shows attestation + sbom manifests in the index inspector
- [ ] On next release: confirm `cosign verify-attestation` (if cosign is added later) can read the provenance

## What was deliberately deferred from the review

Five other items from the review (SHA-pin base images, native ARM runners, reusable docker-publish workflow, defensive `.dockerignore` adds, body-validating healthcheck) — all "nice to have", none worth shipping in the same PR. Will be revisited if/when the docker pipeline gets touched again.
