### PR TITLE
feat: wildcard CORS Allow-Headers, add claude-opus-4-7

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -939,7 +939,9 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
   const CORS_HEADERS = {
     'Access-Control-Allow-Origin': corsOrigin,
     'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-    'Access-Control-Allow-Headers': '*',
+    // *-wildcard covers custom headers in non-credentialed mode, except
+    // Authorization, which is a CORS non-wildcard request-header name.
+    'Access-Control-Allow-Headers': '*, Authorization',
     'Access-Control-Max-Age': '86400',
     ...SECURITY_HEADERS,
   };

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -129,8 +129,9 @@ function loadClaudeIdentity(): { deviceId: string; accountUuid: string } {
 
 // Model shortcuts — users can pass short names
 const MODEL_ALIASES: Record<string, string> = {
-  'opus': 'claude-opus-4-6',
-  'opus1m': 'claude-opus-4-6[1m]',
+  'opus': 'claude-opus-4-7',
+  'opus46': 'claude-opus-4-6',
+  'opus1m': 'claude-opus-4-7[1m]',
   'sonnet': 'claude-sonnet-4-6',
   'sonnet1m': 'claude-sonnet-4-6[1m]',
   'haiku': 'claude-haiku-4-5',
@@ -368,7 +369,7 @@ function translateStreamChunk(line: string): string | null {
   return null;
 }
 
-const OPENAI_MODELS_LIST = { object: 'list', data: ['claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5'].map(id => ({ id, object: 'model', created: 1700000000, owned_by: 'anthropic' })) };
+const OPENAI_MODELS_LIST = { object: 'list', data: ['claude-opus-4-7', 'claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5'].map(id => ({ id, object: 'model', created: 1700000000, owned_by: 'anthropic' })) };
 
 interface ProxyOptions {
   port?: number;
@@ -938,7 +939,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
   const CORS_HEADERS = {
     'Access-Control-Allow-Origin': corsOrigin,
     'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-api-key, anthropic-version, anthropic-beta',
+    'Access-Control-Allow-Headers': '*',
     'Access-Control-Max-Age': '86400',
     ...SECURITY_HEADERS,
   };

--- a/test/provider-prefix.mjs
+++ b/test/provider-prefix.mjs
@@ -64,10 +64,11 @@ console.log('\n=================================================================
 console.log('  resolveClaudeAlias — request-time alias resolution (dario#190)');
 console.log('======================================================================');
 
-assert(resolveClaudeAlias('opus') === 'claude-opus-4-6', 'opus → claude-opus-4-6');
+assert(resolveClaudeAlias('opus') === 'claude-opus-4-7', 'opus → claude-opus-4-7');
+assert(resolveClaudeAlias('opus46') === 'claude-opus-4-6', 'opus46 → claude-opus-4-6 (legacy-pin alias)');
 assert(resolveClaudeAlias('sonnet') === 'claude-sonnet-4-6', 'sonnet → claude-sonnet-4-6');
 assert(resolveClaudeAlias('haiku') === 'claude-haiku-4-5', 'haiku → claude-haiku-4-5');
-assert(resolveClaudeAlias('opus1m') === 'claude-opus-4-6[1m]', 'opus1m → claude-opus-4-6[1m]');
+assert(resolveClaudeAlias('opus1m') === 'claude-opus-4-7[1m]', 'opus1m → claude-opus-4-7[1m]');
 assert(resolveClaudeAlias('sonnet1m') === 'claude-sonnet-4-6[1m]', 'sonnet1m → claude-sonnet-4-6[1m]');
 
 // Already-canonical names pass through unchanged


### PR DESCRIPTION
## Changes

1. **CORS Allow-Headers wildcard** (`*` instead of explicit list)
   When `DARIO_CORS_ORIGIN=*` is set (non-credentialed CORS), modern browsers accept `Access-Control-Allow-Headers: *`. This avoids whack-a-mole with every header that OpenAI's stainless SDK (`x-stainless-*`) or Anthropic's browser client (`anthropic-dangerous-direct-browser-access`) may send.

2. **Add claude-opus-4-7 to `/v1/models`** — same approach as the existing 4-6/4-5 entries.

3. **Update MODEL_ALIASES**
   - `opus` → `claude-opus-4-7` (latest)
   - `opus46` → `claude-opus-4-6` (new alias for pinning old)
   - `opus1m` → `claude-opus-4-7[1m]`

## Trade-offs

- `Access-Control-Allow-Headers: *` is broadly permissive, but since dario already allows the user to set `DARIO_CORS_ORIGIN=*`, there's no meaningful security boundary being weakened here. The alternative (maintaining an ever-growing header whitelist) is brittle and blocks real-world use cases.