### PR TITLE
fix(open-browser + accounts): rundll32 dispatch on Windows + --manual wiring for accounts add

### DIFF
--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -22,9 +22,11 @@ import { homedir } from 'node:os';
 import { randomUUID, randomBytes, createHash } from 'node:crypto';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { detectCCOAuthConfig } from './cc-oauth-detect.js';
-import { loadCredentials } from './oauth.js';
+import { loadCredentials, buildManualAuthorizeUrl, parseManualPaste, readLineFromStdin } from './oauth.js';
 import { openBrowser } from './open-browser.js';
 import { redactSecrets } from './redact.js';
+
+const MANUAL_REDIRECT_URI = 'https://platform.claude.com/oauth/code/callback';
 
 const DARIO_DIR = join(homedir(), '.dario');
 const ACCOUNTS_DIR = join(DARIO_DIR, 'accounts');
@@ -354,6 +356,90 @@ export async function addAccountViaOAuth(alias: string): Promise<AccountCredenti
     }, 300_000);
     timeout.unref();
   });
+}
+
+/**
+ * Manual / headless flow for `dario accounts add` — the pool-mode counterpart
+ * to `startManualOAuthFlow` in oauth.ts. Prints the authorize URL, asks the
+ * user to paste back `code#state` from Anthropic's success page, exchanges
+ * for tokens, saves to `~/.dario/accounts/<alias>.json`.
+ *
+ * Used when a localhost-callback flow can't reach the dario process — SSH
+ * sessions, containers — and as the on-Windows escape hatch when the URL
+ * dispatch chain (rundll32 / explorer) can't be relied on to deliver the
+ * full URL to the browser.
+ */
+export async function addAccountViaManualOAuth(alias: string): Promise<AccountCredentials> {
+  const cfg = await detectCCOAuthConfig();
+  const { codeVerifier, codeChallenge } = generatePKCE();
+  // 32-byte state — same constraint as the auto flow. See dario#71.
+  const state = base64url(randomBytes(32));
+  const authUrl = buildManualAuthorizeUrl(cfg, codeChallenge, state);
+
+  console.log('');
+  console.log(`  Open this URL in any browser to add account "${alias}":`);
+  console.log('');
+  console.log(`    ${authUrl}`);
+  console.log('');
+  console.log('  Sign in with the Claude account you want to add. After you approve,');
+  console.log('  Anthropic will display an authorization code. Paste it below');
+  console.log('  (format: "code#state" or just the code).');
+  console.log('');
+
+  const pasted = await readLineFromStdin('  Code: ');
+  const { code, state: returnedState } = parseManualPaste(pasted);
+
+  if (!code) {
+    throw new Error(`No authorization code entered. Re-run \`dario accounts add ${alias} --manual\`.`);
+  }
+
+  if (returnedState && returnedState !== state) {
+    throw new Error(`State mismatch — the pasted code is from a different login attempt. Re-run \`dario accounts add ${alias} --manual\` and paste the most recent code.`);
+  }
+
+  const tokenRes = await fetch(cfg.tokenUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      grant_type: 'authorization_code',
+      client_id: cfg.clientId,
+      code,
+      redirect_uri: MANUAL_REDIRECT_URI,
+      code_verifier: codeVerifier,
+      state,
+    }),
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  if (!tokenRes.ok) {
+    const body = await tokenRes.text().catch(() => '');
+    throw new Error(`Token exchange failed (${tokenRes.status}): ${redactSecrets(body.slice(0, 200))}`);
+  }
+
+  const tokens = await tokenRes.json() as {
+    access_token: string;
+    refresh_token: string;
+    expires_in: number;
+    scope?: string;
+  };
+
+  const identity = (await detectClaudeIdentity()) ?? {
+    deviceId: randomUUID(),
+    accountUuid: randomUUID(),
+  };
+
+  const creds: AccountCredentials = {
+    alias,
+    accessToken: tokens.access_token,
+    refreshToken: tokens.refresh_token,
+    expiresAt: Date.now() + tokens.expires_in * 1000,
+    scopes: tokens.scope?.split(' ') ?? cfg.scopes.split(' '),
+    deviceId: identity.deviceId,
+    accountUuid: identity.accountUuid,
+  };
+
+  await saveAccount(creds);
+  return creds;
 }
 
 export function getAccountsDir(): string {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -650,6 +650,21 @@ async function accounts() {
     console.log('');
     console.log(`  Adding account "${alias}" to the pool${manualAccountFlag ? ' (manual / headless flow)' : ''}...`);
     console.log('');
+
+    // Mirror the heuristic that `dario login` uses: if the user didn't
+    // explicitly pick `--manual` AND we detect SSH / container / no-DISPLAY,
+    // print a hint before opening the browser. Doesn't auto-flip — false
+    // positives are more annoying than false negatives — but the hint keeps
+    // users from waiting for a browser redirect that can't land.
+    if (!manualAccountFlag) {
+      const reason = detectHeadlessEnvironment();
+      if (reason) {
+        console.log(`  Note: ${reason}. If the browser redirect doesn't land,`);
+        console.log(`  re-run with: dario accounts add ${alias} --manual`);
+        console.log('');
+      }
+    }
+
     try {
       const creds = manualAccountFlag
         ? await addAccountViaManualOAuth(alias)
@@ -669,8 +684,16 @@ async function accounts() {
       }
       console.log('');
     } catch (err) {
+      const msg = sanitizeError(err);
       console.error('');
-      console.error(`  Failed to add account: ${sanitizeError(err)}`);
+      console.error(`  Failed to add account: ${msg}`);
+      // Targeted hint for callback-server failures — same heuristic as
+      // `dario login`. Auto flow can fail on EADDRINUSE (port already
+      // bound), SSH-tunnel mismatch, or the browser timing out before
+      // the user signs in. `--manual` works in all of those cases.
+      if (!manualAccountFlag && /callback server|EADDRINUSE|bind|timed out|did not receive/i.test(msg)) {
+        console.error(`  Hint: try \`dario accounts add ${alias} --manual\` for headless / container setups.`);
+      }
       console.error('');
       process.exit(1);
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,7 +26,7 @@ import { pathToFileURL } from 'node:url';
 import { startAutoOAuthFlow, startManualOAuthFlow, detectHeadlessEnvironment, getStatus, refreshTokens, loadCredentials } from './oauth.js';
 import { startProxy, sanitizeError } from './proxy.js';
 import { VALID_EFFORT_VALUES, type EffortValue } from './cc-template.js';
-import { listAccountAliases, loadAllAccounts, addAccountViaOAuth, removeAccount, ensureLoginCredentialsInPool, MIGRATED_LOGIN_ALIAS } from './accounts.js';
+import { listAccountAliases, loadAllAccounts, addAccountViaOAuth, addAccountViaManualOAuth, removeAccount, ensureLoginCredentialsInPool, MIGRATED_LOGIN_ALIAS } from './accounts.js';
 import { listBackends, saveBackend, removeBackend, type BackendCredentials } from './openai-backend.js';
 import { parseOutboundProxy, installOutboundProxyWrapper, type OutboundProxyConfig } from './outbound-proxy.js';
 
@@ -645,11 +645,15 @@ async function accounts() {
       }
     }
 
+    const manualAccountFlag = args.includes('--manual') || args.includes('--headless');
+
     console.log('');
-    console.log(`  Adding account "${alias}" to the pool...`);
+    console.log(`  Adding account "${alias}" to the pool${manualAccountFlag ? ' (manual / headless flow)' : ''}...`);
     console.log('');
     try {
-      const creds = await addAccountViaOAuth(alias);
+      const creds = manualAccountFlag
+        ? await addAccountViaManualOAuth(alias)
+        : await addAccountViaOAuth(alias);
       const minutes = Math.round((creds.expiresAt - Date.now()) / 60000);
       console.log('');
       console.log(`  Account "${alias}" added.`);
@@ -810,7 +814,13 @@ async function help() {
     dario refresh            Force token refresh
     dario logout             Remove saved credentials
     dario accounts list      List accounts in the multi-account pool
-    dario accounts add NAME  Add a new account to the pool (runs OAuth flow)
+    dario accounts add NAME [--manual]
+                             Add a new account to the pool (runs OAuth flow).
+                             --manual (alias: --headless) prints an authorize
+                             URL and reads the code you paste back — for
+                             container / SSH / no-browser-on-this-machine
+                             setups, or as the on-Windows escape hatch when
+                             the URL dispatch chain truncates query params.
     dario accounts remove N  Remove an account from the pool
     dario backend list       List configured OpenAI-compat backends
     dario backend add NAME --key=sk-... [--base-url=...]

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -560,7 +560,7 @@ async function exchangeCodeManual(code: string, codeVerifier: string, state: str
   return tokens;
 }
 
-async function readLineFromStdin(prompt: string): Promise<string> {
+export async function readLineFromStdin(prompt: string): Promise<string> {
   const { createInterface } = await import('node:readline/promises');
   const rl = createInterface({ input: process.stdin, output: process.stdout });
   try {

--- a/src/open-browser.ts
+++ b/src/open-browser.ts
@@ -57,11 +57,23 @@ export function browserDispatchCommand(
   }
   const safe = parsed.toString();
   if (platform === 'win32') {
-    // explorer.exe accepts a URL as a single argv element and routes it
-    // through the registered URL handler. Avoids `cmd /c start "" "URL"`,
-    // which re-parses cmd metacharacters even when called via execFile
-    // because the cmd builtin runs *inside* cmd's parser, not Node's.
-    return { bin: 'explorer.exe', args: [safe] };
+    // rundll32 url.dll,FileProtocolHandler is Microsoft's documented "open
+    // URL with default handler" entry point — invokes the DLL function with
+    // the URL as a single in-process string, no command-line re-parsing.
+    //
+    // Was previously `explorer.exe URL`. Failed in the wild on URLs with
+    // multiple `&`-joined query params: explorer's URL-handler chain on
+    // some Windows configurations re-shells the URL through the registered
+    // browser's command line template, and any `&` after the *first* one
+    // gets interpreted as a cmd separator at substitution time. Symptom:
+    // browser opens with the URL truncated at an `&`, downstream OAuth
+    // endpoint reports a "missing required parameter" error because the
+    // truncated tail held the missing param (`state`, `code_challenge`, etc).
+    //
+    // rundll32 sidesteps the chain entirely. The function name token
+    // (`url.dll,FileProtocolHandler`) MUST be a single argv element with
+    // no space around the comma — System32's rundll32 parses it itself.
+    return { bin: 'rundll32.exe', args: ['url.dll,FileProtocolHandler', safe] };
   }
   if (platform === 'darwin') {
     return { bin: 'open', args: [safe] };

--- a/test/open-browser.mjs
+++ b/test/open-browser.mjs
@@ -90,12 +90,30 @@ header('browserDispatchCommand — shell metacharacters in URL stay in argv (not
 // ----------------------------------------------------------------------
 header('browserDispatchCommand — per-platform bin');
 {
-  check('win32 → explorer.exe', browserDispatchCommand('https://x.test', 'win32').bin === 'explorer.exe');
+  check('win32 → rundll32.exe', browserDispatchCommand('https://x.test', 'win32').bin === 'rundll32.exe');
   check('darwin → open',        browserDispatchCommand('https://x.test', 'darwin').bin === 'open');
   check('linux → xdg-open',     browserDispatchCommand('https://x.test', 'linux').bin === 'xdg-open');
   check('freebsd → xdg-open',   browserDispatchCommand('https://x.test', 'freebsd').bin === 'xdg-open');
   // Unknown platforms fall through to xdg-open as the most-common Unix default.
   check('unknown → xdg-open',   browserDispatchCommand('https://x.test', 'aix').bin === 'xdg-open');
+}
+
+// ----------------------------------------------------------------------
+//  Windows-specific argv shape — rundll32 url.dll,FileProtocolHandler URL
+// ----------------------------------------------------------------------
+header('browserDispatchCommand — Windows rundll32 argv shape');
+{
+  // Real OAuth URL — multiple `&`-joined params. The previous explorer.exe
+  // path truncated this at an `&` in some Windows configurations because
+  // the URL-handler chain re-shelled the URL through cmd. rundll32 must
+  // pass it through as a single in-process string.
+  const oauthUrl = 'https://claude.ai/oauth/authorize?code=true&client_id=abc&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A14995%2Fcallback&scope=org%3Acreate_api_key+user%3Aprofile&code_challenge=xyz&code_challenge_method=S256&state=43charstateparamatend';
+  const cmd = browserDispatchCommand(oauthUrl, 'win32');
+  check('bin is rundll32.exe (System32 binary)', cmd.bin === 'rundll32.exe');
+  check('first argv: url.dll,FileProtocolHandler entry point', cmd.args[0] === 'url.dll,FileProtocolHandler');
+  check('second argv: URL preserved verbatim, no truncation', cmd.args[1] === oauthUrl);
+  check('no space between dll name and function (rundll32 parses comma itself)', !cmd.args[0].includes(' '));
+  check('exactly two argv elements (entry point + URL)', cmd.args.length === 2);
 }
 
 // ----------------------------------------------------------------------
@@ -110,8 +128,14 @@ header('openBrowser — invokes execFile with argv (no shell)');
   };
   openBrowser('https://example.com/?x=1&y=2', { exec: stub });
   check('exec was called', called !== null);
-  check('exec received URL handler binary, not shell', called && (called.file === 'explorer.exe' || called.file === 'open' || called.file === 'xdg-open'));
-  check('URL passed as single argv element', called && called.args.length === 1 && called.args[0] === 'https://example.com/?x=1&y=2');
+  check('exec received URL handler binary, not shell', called && (called.file === 'rundll32.exe' || called.file === 'open' || called.file === 'xdg-open'));
+  // On win32 the URL is the second argv element (rundll32's entry-point
+  // token comes first); on darwin/linux it's the first and only.
+  if (called) {
+    const url = 'https://example.com/?x=1&y=2';
+    const urlIsLast = called.args[called.args.length - 1] === url;
+    check('URL preserved verbatim as last argv element', urlIsLast);
+  }
 }
 
 header('openBrowser — throws on unsafe protocol before spawning');


### PR DESCRIPTION
## Summary

Two related Windows-OAuth fixes folded together. Both surfaced today while wiring up live pool-mode testing.

## Fix 1 — `rundll32` URL dispatch on Windows

`dario accounts add` (and any other path that opens a URL) silently truncated long URLs on Windows: `explorer.exe URL` re-shells the URL through the registered browser's command-line template in some configurations, and `&` past the first one gets re-parsed as a cmd separator. Browser opens with the URL cut off at an `&`; downstream OAuth endpoint reports a "missing required parameter" error because the truncated tail held the missing param.

Repro that surfaced this:

```
$ dario accounts add personal
  Opening browser to add account "personal"...
  ...
```

→ Browser landed on a URL truncated before `&state=...` → `claude.ai` returned `Invalid OAuth Request — Missing state parameter`. The state was sent correctly by dario; explorer's URL-handler chain ate it.

Switch the win32 path from `explorer.exe URL` to `rundll32 url.dll,FileProtocolHandler URL` — Microsoft's documented Win32 entry point for "open URL with default handler". System32 binary, invokes the DLL function with the URL as a single in-process string, no re-parsing.

```diff
-  return { bin: 'explorer.exe', args: [safe] };
+  return { bin: 'rundll32.exe', args: ['url.dll,FileProtocolHandler', safe] };
```

The function-name token (`url.dll,FileProtocolHandler`) is one argv element with no space around the comma — System32's rundll32 parses the comma itself.

## Fix 2 — `--manual` / `--headless` wired through `dario accounts add`

`--manual` has been documented and working for `dario login` since v3.31.x, but `dario accounts add` silently ignored it. With the dispatch bug above, users on Windows had no escape hatch because there was no manual paste path for the pool flow. (Caught live today — the user tried `--manual` and the CLI just ran the auto-callback flow, opening explorer.exe, hitting the truncation bug.)

Adds `addAccountViaManualOAuth(alias)` to `accounts.ts` (mirrors `startManualOAuthFlow` from `oauth.ts` but writes to `~/.dario/accounts/<alias>.json` instead of `~/.dario/credentials.json`) and routes the `accounts add` CLI handler through it when `--manual` / `--headless` is present.

`readLineFromStdin` in `oauth.ts` is now `export`ed so `accounts.ts` can reuse the prompt without duplicating it. `parseManualPaste` and `buildManualAuthorizeUrl` were already exported.

Help text updated to document the flag on `accounts add`.

```
dario accounts add NAME [--manual]
                         Add a new account to the pool (runs OAuth flow).
                         --manual (alias: --headless) prints an authorize
                         URL and reads the code you paste back — for
                         container / SSH / no-browser-on-this-machine
                         setups, or as the on-Windows escape hatch when
                         the URL dispatch chain truncates query params.
```

## What's NOT changed

- macOS (`open URL`) and Linux/BSD (`xdg-open URL`) paths — unchanged. Those don't go through a re-shelling chain.
- URL validation (http/https only, malformed-URL rejection, javascript:/file:/data:/vbscript: blocking) — unchanged.
- Defense-in-depth `&`/`|`/backtick handling in the auto flow — preserved.
- The auto / localhost-callback `accounts add` path — unchanged. `--manual` is opt-in.

## Tests

- `test/open-browser.mjs` per-platform-bin assertion flipped: `win32 → rundll32.exe`.
- New `Windows rundll32 argv shape` block pins the win32 argv shape (entry point token + URL, exactly two argv elements, no space around the comma).
- End-to-end `openBrowser` stub test loosens "first arg" to "last arg" because the URL is no longer the only argv element on win32.
- 30/30 in `open-browser.mjs`, 60/60 in the full suite.

## Test plan

- [x] `npm run build` clean
- [x] `node test/open-browser.mjs` — 30/30 pass
- [x] `npm test` — 60/60 pass
- [ ] Live: `dario accounts add <alias>` on Windows (auto flow) opens the full OAuth URL with state intact
- [ ] Live: `dario accounts add <alias> --manual` prints the URL, reads `code#state` back, saves to pool

## Bundles

Closes the on-Windows blocker for live pool-mode testing — once this lands, `dario accounts add` works in both modes on Windows, no copy-paste-the-URL-from-stderr workaround needed.