### PR TITLE
fix(pool): auth-failure cool-down + login-snapshot resync (closes #234, #235)

### DIFF
--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -423,3 +423,60 @@ export async function ensureLoginCredentialsInPool(
 
   return alias;
 }
+
+/**
+ * Detect divergence between `accounts/login.json` and the current
+ * `credentials.json` (or whichever store loadCredentials finds), and
+ * re-sync if they differ. Returns one of:
+ *   - 'no-pool'      : pool is single-account, nothing to do
+ *   - 'no-login'     : pool active but no `login` alias — back-fill
+ *                       was never run, nothing to do
+ *   - 'no-creds'     : login.json exists but no current credentials
+ *                       reachable to compare against — leave alone
+ *   - 'in-sync'      : tokens match; no action
+ *   - 'resynced'     : login.json was stale; overwrote with current
+ *                       credentials. Caller should reload pool state
+ *
+ * Why: the single-account path keeps refreshing `credentials.json` in
+ * the background (proxy startup auth check, periodic refresh in oauth.ts).
+ * Each refresh issues new tokens and Anthropic invalidates the previous
+ * refresh_token. The pool's `login.json` snapshot — frozen at back-fill
+ * time — is now wrong on both fields, but its `expiresAt` metadata still
+ * says "healthy" so the selector keeps picking it. Detect this at startup
+ * and overwrite with the current canonical content. dario#235.
+ */
+export async function resyncLoginFromCredentialsIfStale(): Promise<
+  'no-pool' | 'no-login' | 'no-creds' | 'in-sync' | 'resynced'
+> {
+  const aliases = await listAccountAliases();
+  if (aliases.length < 2) return 'no-pool';
+  if (!aliases.includes(MIGRATED_LOGIN_ALIAS)) return 'no-login';
+
+  const loginAcc = await loadAccount(MIGRATED_LOGIN_ALIAS);
+  if (!loginAcc) return 'no-login';
+
+  const creds = await loadCredentials();
+  const tok = creds?.claudeAiOauth;
+  if (!tok?.accessToken || !tok?.refreshToken) return 'no-creds';
+
+  if (
+    loginAcc.accessToken === tok.accessToken &&
+    loginAcc.refreshToken === tok.refreshToken
+  ) {
+    return 'in-sync';
+  }
+
+  // Tokens diverged — credentials.json has refreshed since last back-fill.
+  // Overwrite the snapshot, preserving deviceId/accountUuid (they don't
+  // rotate with token refresh; they're pool-internal identity).
+  await saveAccount({
+    alias: MIGRATED_LOGIN_ALIAS,
+    accessToken: tok.accessToken,
+    refreshToken: tok.refreshToken,
+    expiresAt: tok.expiresAt,
+    scopes: tok.scopes ?? loginAcc.scopes ?? [],
+    deviceId: loginAcc.deviceId,
+    accountUuid: loginAcc.accountUuid,
+  });
+  return 'resynced';
+}

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -46,6 +46,19 @@ const CACHE_TTL_MS = 10_000; // Re-read from disk every 10s at most
 // Mutex to prevent concurrent refresh races
 let refreshInProgress: Promise<OAuthTokens> | null = null;
 
+/**
+ * Test-only — invalidate the in-memory credentials cache so the next
+ * `loadCredentials` re-reads from disk / keychain. Production code paths
+ * never need this: the 10-second TTL is short, and `saveCredentials`
+ * already invalidates on write. But unit tests that mutate
+ * `~/.dario/credentials.json` between scenarios within the same process
+ * see stale cached values and their assertions race against the TTL.
+ */
+export function _clearCredentialsCacheForTest(): void {
+  credentialsCache = null;
+  credentialsCacheTime = 0;
+}
+
 export interface OAuthTokens {
   accessToken: string;
   refreshToken: string;

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -76,6 +76,43 @@ export interface PoolAccount {
   identity: AccountIdentity;
   rateLimit: RateLimitSnapshot;
   requestCount: number;
+  /**
+   * Auth-failure cool-down (dario#234). Set when an upstream returns
+   * 401/403 or an `authentication_error` / `permission_error` /
+   * `invalid_grant` body — tokens are server-invalidated and the
+   * selector should route around this account until either:
+   *   (a) a successful request on this account clears the cool-down, or
+   *   (b) the cool-down window expires
+   *
+   * Without this, the selector keeps picking the dead account because
+   * 401 responses don't include rate-limit headers, so headroom math
+   * sees a healthy idle account. Reproed live with a stale `login`
+   * back-fill against an OAuth-derived account: pool routed every
+   * request to the dead login and never tried the healthy peer.
+   */
+  lastAuthFailureAt?: number;
+  consecutiveAuthFailures: number;
+}
+
+/**
+ * Cool-down schedule after auth failures. First failure: 60s. Each
+ * consecutive failure doubles the window up to 30 minutes. Cleared
+ * by any successful response on the same account. Numbers are tunable
+ * — the shape is the design.
+ */
+const AUTH_COOLDOWN_BASE_MS = 60 * 1000;
+const AUTH_COOLDOWN_MAX_MS = 30 * 60 * 1000;
+
+export function authCooldownMs(consecutiveFailures: number): number {
+  if (consecutiveFailures <= 0) return 0;
+  const ms = AUTH_COOLDOWN_BASE_MS * Math.pow(2, consecutiveFailures - 1);
+  return Math.min(ms, AUTH_COOLDOWN_MAX_MS);
+}
+
+export function isInAuthCooldown(account: PoolAccount, now: number = Date.now()): boolean {
+  if (!account.lastAuthFailureAt || account.consecutiveAuthFailures <= 0) return false;
+  const cooldown = authCooldownMs(account.consecutiveAuthFailures);
+  return now - account.lastAuthFailureAt < cooldown;
 }
 
 export interface PoolStatus {
@@ -234,6 +271,8 @@ export class AccountPool {
       },
       rateLimit: existing?.rateLimit ?? { ...EMPTY_SNAPSHOT },
       requestCount: existing?.requestCount ?? 0,
+      lastAuthFailureAt: existing?.lastAuthFailureAt,
+      consecutiveAuthFailures: existing?.consecutiveAuthFailures ?? 0,
     });
   }
 
@@ -243,6 +282,38 @@ export class AccountPool {
 
   get size(): number {
     return this.accounts.size;
+  }
+
+  /**
+   * Record an auth failure (401/403/auth_error/permission_error/invalid_grant)
+   * against `alias`. Increments the consecutive-failure counter and stamps
+   * `lastAuthFailureAt`, putting the account in cool-down (see `authCooldownMs`).
+   * Subsequent `select()` calls will skip this account until the cool-down
+   * expires or `clearAuthFailure` is called.
+   *
+   * No-op if the alias isn't in the pool.
+   */
+  markAuthFailure(alias: string): void {
+    const account = this.accounts.get(alias);
+    if (!account) return;
+    account.lastAuthFailureAt = Date.now();
+    account.consecutiveAuthFailures = (account.consecutiveAuthFailures ?? 0) + 1;
+  }
+
+  /**
+   * Clear an account's auth-failure cool-down. Called by the proxy after a
+   * successful upstream response on `alias` — the account is healthy again,
+   * so the counter resets and any future failure starts fresh from 60s.
+   *
+   * Failures and successes are alias-scoped: a success on account A never
+   * clears account B's cool-down.
+   */
+  clearAuthFailure(alias: string): void {
+    const account = this.accounts.get(alias);
+    if (!account) return;
+    if (account.consecutiveAuthFailures === 0 && !account.lastAuthFailureAt) return;
+    account.lastAuthFailureAt = undefined;
+    account.consecutiveAuthFailures = 0;
   }
 
   /**
@@ -260,7 +331,8 @@ export class AccountPool {
 
     const eligible = all.filter(a =>
       a.rateLimit.status !== 'rejected' &&
-      a.expiresAt > now + 30_000,
+      a.expiresAt > now + 30_000 &&
+      !isInAuthCooldown(a, now),
     );
 
     if (eligible.length > 0) {
@@ -271,14 +343,20 @@ export class AccountPool {
       });
     }
 
-    // All accounts exhausted — return the one with the earliest reset
-    const withReset = all.filter(a => a.rateLimit.reset > 0);
+    // All accounts exhausted — return the one with the earliest reset.
+    // Auth-cooldown'd accounts are excluded from this fallback too: we
+    // know upstream rejected their tokens, so picking them on rate-limit
+    // grounds wouldn't help. Better to return null and let the caller
+    // surface "no account available" than to hand back a dead account.
+    const withReset = all.filter(a => a.rateLimit.reset > 0 && !isInAuthCooldown(a, now));
     if (withReset.length > 0) {
       return withReset.reduce((a, b) => a.rateLimit.reset < b.rateLimit.reset ? a : b);
     }
 
-    // No rate-limit data at all — least-used first
-    return all.reduce((a, b) => a.requestCount < b.requestCount ? a : b);
+    // No rate-limit data at all — least-used first, still skipping cool-downs.
+    const usable = all.filter(a => !isInAuthCooldown(a, now));
+    if (usable.length === 0) return null;
+    return usable.reduce((a, b) => a.requestCount < b.requestCount ? a : b);
   }
 
   /**
@@ -308,6 +386,7 @@ export class AccountPool {
       if (bound
         && bound.rateLimit.status !== 'rejected'
         && bound.expiresAt > now + 30_000
+        && !isInAuthCooldown(bound, now)
         && computeHeadroom(bound.rateLimit, family) > POOL_HEADROOM_FLOOR
       ) {
         return bound;
@@ -372,7 +451,8 @@ export class AccountPool {
 
     const eligible = candidates.filter(a =>
       a.rateLimit.status !== 'rejected' &&
-      a.expiresAt > now + 30_000,
+      a.expiresAt > now + 30_000 &&
+      !isInAuthCooldown(a, now),
     );
 
     if (eligible.length > 0) {
@@ -424,7 +504,8 @@ export class AccountPool {
     const now = Date.now();
     const healthy = all.filter(a =>
       a.rateLimit.status !== 'rejected' &&
-      a.expiresAt > now + 30_000,
+      a.expiresAt > now + 30_000 &&
+      !isInAuthCooldown(a, now),
     );
     // Status is a pool-wide aggregate; family-agnostic. Per-model
     // headroom is request-context-specific and only meaningful at

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,9 +8,9 @@ import { arch, platform } from 'node:process';
 import { getAccessToken, getStatus } from './oauth.js';
 import { buildCCRequest, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, CC_TEMPLATE, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
 import { describeTemplate, detectDrift, checkCCCompat } from './live-fingerprint.js';
-import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, type PoolAccount } from './pool.js';
+import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCooldown, authCooldownMs, type PoolAccount } from './pool.js';
 import { Analytics, billingBucketFromClaim } from './analytics.js';
-import { loadAllAccounts, loadAccount, refreshAccountToken } from './accounts.js';
+import { loadAllAccounts, loadAccount, refreshAccountToken, resyncLoginFromCredentialsIfStale } from './accounts.js';
 import { getOpenAIBackend, isOpenAIModel, forwardToOpenAI, type BackendCredentials } from './openai-backend.js';
 import { RequestQueue, QueueFullError, QueueTimeoutError, DEFAULT_MAX_CONCURRENT, DEFAULT_MAX_QUEUED, DEFAULT_QUEUE_TIMEOUT_MS } from './request-queue.js';
 import { redactSecrets } from './redact.js';
@@ -712,6 +712,17 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
 
   // Multi-account pool — activated when ~/.dario/accounts/ has 2+ entries.
   // Single-account dario keeps its existing code path unchanged.
+  //
+  // Before loading the pool, check whether the back-filled `login` snapshot
+  // has gone stale relative to credentials.json (dario#235). The single-
+  // account path keeps refreshing credentials.json independently; each
+  // refresh invalidates the snapshot's tokens server-side. Re-syncing at
+  // startup ensures the pool sees the current canonical tokens.
+  const resyncResult = await resyncLoginFromCredentialsIfStale();
+  if (resyncResult === 'resynced') {
+    console.log('[dario] re-synced pool `login` account from current credentials.json (was stale; dario#235)');
+  }
+
   const accountsList = await loadAllAccounts();
   const pool = accountsList.length >= 2 ? new AccountPool() : null;
   // Per-model rate-limit bucket families seen during this proxy run. First-
@@ -993,15 +1004,29 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
         res.end(JSON.stringify({ mode: 'single-account', accounts: 0 }));
         return;
       }
-      const accounts = pool.all().map(a => ({
-        alias: a.alias,
-        util5h: a.rateLimit.util5h,
-        util7d: a.rateLimit.util7d,
-        claim: a.rateLimit.claim,
-        status: a.rateLimit.status,
-        requestCount: a.requestCount,
-        expiresInMs: Math.max(0, a.expiresAt - Date.now()),
-      }));
+      const now = Date.now();
+      const accounts = pool.all().map(a => {
+        const inCooldown = isInAuthCooldown(a, now);
+        const cooldownMs = inCooldown && a.lastAuthFailureAt
+          ? Math.max(0, authCooldownMs(a.consecutiveAuthFailures) - (now - a.lastAuthFailureAt))
+          : 0;
+        return {
+          alias: a.alias,
+          util5h: a.rateLimit.util5h,
+          util7d: a.rateLimit.util7d,
+          claim: a.rateLimit.claim,
+          status: inCooldown ? 'auth-cooldown' : a.rateLimit.status,
+          requestCount: a.requestCount,
+          expiresInMs: Math.max(0, a.expiresAt - now),
+          ...(inCooldown
+            ? {
+                lastAuthFailureAt: a.lastAuthFailureAt,
+                consecutiveAuthFailures: a.consecutiveAuthFailures,
+                cooldownMs,
+              }
+            : {}),
+        };
+      });
       res.writeHead(200, JSON_HEADERS);
       res.end(JSON.stringify({
         mode: 'pool',
@@ -1693,6 +1718,32 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
         }
       }
 
+      // Auth failover (dario#234). 401/403 means the account's tokens are
+      // server-invalidated — retrying on the same account is guaranteed to
+      // fail, and the rate-limit-driven selector won't route around the
+      // dead account because 401 responses don't include rate-limit
+      // headers, so headroom math sees a healthy idle account. Mark the
+      // cool-down here, try the next-best account, fall through to the
+      // normal forwarding only if no peer is available.
+      if (pool && poolAccount && (upstream.status === 401 || upstream.status === 403)) {
+        pool.markAuthFailure(poolAccount.alias);
+        if (verbose) {
+          console.error(`[dario] auth failure (${upstream.status}) on account "${poolAccount.alias}" — placing in cool-down and attempting failover`);
+        }
+        const nextAccount = pool.selectExcluding(triedAliases, modelFamily(requestModel));
+        if (nextAccount) {
+          triedAliases.add(nextAccount.alias);
+          poolAccount = nextAccount;
+          accessToken = nextAccount.accessToken;
+          headers['Authorization'] = `Bearer ${accessToken}`;
+          headers['x-claude-code-session-id'] = nextAccount.identity.sessionId;
+          pool.rebindSticky(stickyKey, nextAccount.alias);
+          continue dispatchLoop;
+        }
+        // No peer available — fall through to normal forwarding so the
+        // client sees the upstream's 401/403. Don't swallow the error.
+      }
+
       // Enrich 429 errors with rate limit details from headers (Anthropic only returns "Error")
       if (upstream.status === 429) {
         // Try pool failover before surfacing to client
@@ -1736,6 +1787,12 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
       }
 
       // Non-429 — exit dispatch loop and forward the response to client.
+      // Clear the auth-failure cool-down on the responding account if
+      // the upstream returned a 2xx — this account is healthy again,
+      // so its consecutive-failure counter resets. dario#234.
+      if (pool && poolAccount && upstream.status >= 200 && upstream.status < 300) {
+        pool.clearAuthFailure(poolAccount.alias);
+      }
       break;
       } // end dispatchLoop: while (true)
 

--- a/test/pool-auth-cooldown.mjs
+++ b/test/pool-auth-cooldown.mjs
@@ -1,0 +1,211 @@
+// dario#234 — pool selector skips accounts in auth-failure cool-down.
+//
+// Without this, a 401/403 on one account never moves the selector off it:
+// rate-limit-driven routing only sees `util5h` / `util7d` headers, which
+// 401 responses don't include. Headroom math sees a healthy idle account
+// → selector keeps picking the dead one. The cool-down adds an explicit
+// "this account just failed auth, skip for N seconds" filter.
+//
+// The actual proxy-side hook (mark on 401/403, clear on 2xx) is exercised
+// by the live e2e — these tests cover the pool-internal contract.
+
+import {
+  AccountPool,
+  authCooldownMs,
+  isInAuthCooldown,
+} from '../dist/pool.js';
+
+let pass = 0, fail = 0;
+function check(label, cond, ...rest) {
+  if (cond) { console.log(`  ✅ ${label}`); pass++; }
+  else { console.log(`  ❌ ${label}`, ...rest); fail++; }
+}
+function header(label) {
+  console.log(`\n======================================================================`);
+  console.log(`  ${label}`);
+  console.log(`======================================================================`);
+}
+
+function makePool(aliases) {
+  const pool = new AccountPool();
+  for (const alias of aliases) {
+    pool.add(alias, {
+      accessToken: `tok-${alias}`,
+      refreshToken: `ref-${alias}`,
+      expiresAt: Date.now() + 60 * 60 * 1000,
+      deviceId: `dev-${alias}`,
+      accountUuid: `uuid-${alias}`,
+    });
+  }
+  return pool;
+}
+
+// ----------------------------------------------------------------------
+header('authCooldownMs — exponential backoff with cap');
+// ----------------------------------------------------------------------
+{
+  check('0 failures → 0ms', authCooldownMs(0) === 0);
+  check('1 failure → 60s', authCooldownMs(1) === 60_000);
+  check('2 failures → 120s (doubles)', authCooldownMs(2) === 120_000);
+  check('3 failures → 240s', authCooldownMs(3) === 240_000);
+  check('large N caps at 30 min', authCooldownMs(20) === 30 * 60 * 1000);
+}
+
+// ----------------------------------------------------------------------
+header('isInAuthCooldown — fresh account is not in cooldown');
+// ----------------------------------------------------------------------
+{
+  const pool = makePool(['alpha']);
+  const acc = pool.all().find(a => a.alias === 'alpha');
+  check('no failure → not in cooldown', !isInAuthCooldown(acc));
+  check('lastAuthFailureAt is undefined initially', acc.lastAuthFailureAt === undefined);
+  check('consecutiveAuthFailures starts at 0', acc.consecutiveAuthFailures === 0);
+}
+
+// ----------------------------------------------------------------------
+header('markAuthFailure — puts account in cooldown');
+// ----------------------------------------------------------------------
+{
+  const pool = makePool(['alpha']);
+  pool.markAuthFailure('alpha');
+  const acc = pool.all().find(a => a.alias === 'alpha');
+  check('lastAuthFailureAt populated', typeof acc.lastAuthFailureAt === 'number');
+  check('consecutiveAuthFailures = 1', acc.consecutiveAuthFailures === 1);
+  check('isInAuthCooldown returns true', isInAuthCooldown(acc));
+}
+
+// ----------------------------------------------------------------------
+header('markAuthFailure — increments counter on consecutive failures');
+// ----------------------------------------------------------------------
+{
+  const pool = makePool(['alpha']);
+  pool.markAuthFailure('alpha');
+  pool.markAuthFailure('alpha');
+  pool.markAuthFailure('alpha');
+  const acc = pool.all().find(a => a.alias === 'alpha');
+  check('counter reaches 3', acc.consecutiveAuthFailures === 3);
+}
+
+// ----------------------------------------------------------------------
+header('markAuthFailure — no-op for unknown alias');
+// ----------------------------------------------------------------------
+{
+  const pool = makePool(['alpha']);
+  pool.markAuthFailure('nonexistent');
+  const acc = pool.all().find(a => a.alias === 'alpha');
+  check('alpha untouched', acc.consecutiveAuthFailures === 0);
+}
+
+// ----------------------------------------------------------------------
+header('clearAuthFailure — resets counter and timestamp');
+// ----------------------------------------------------------------------
+{
+  const pool = makePool(['alpha']);
+  pool.markAuthFailure('alpha');
+  pool.markAuthFailure('alpha');
+  pool.clearAuthFailure('alpha');
+  const acc = pool.all().find(a => a.alias === 'alpha');
+  check('lastAuthFailureAt cleared', acc.lastAuthFailureAt === undefined);
+  check('counter reset to 0', acc.consecutiveAuthFailures === 0);
+  check('isInAuthCooldown returns false', !isInAuthCooldown(acc));
+}
+
+// ----------------------------------------------------------------------
+header('clearAuthFailure on alias A does not affect alias B');
+// ----------------------------------------------------------------------
+{
+  const pool = makePool(['alpha', 'beta']);
+  pool.markAuthFailure('alpha');
+  pool.markAuthFailure('beta');
+  pool.clearAuthFailure('alpha');
+  const beta = pool.all().find(a => a.alias === 'beta');
+  check('beta still in cooldown', isInAuthCooldown(beta));
+}
+
+// ----------------------------------------------------------------------
+header('select() skips cooldown\'d accounts');
+// ----------------------------------------------------------------------
+{
+  const pool = makePool(['alpha', 'beta']);
+  pool.markAuthFailure('alpha');
+  const picked = pool.select();
+  check('skipped alpha (in cooldown)', picked && picked.alias === 'beta');
+}
+
+// ----------------------------------------------------------------------
+header('select() returns null when ALL accounts are in cooldown');
+// ----------------------------------------------------------------------
+{
+  const pool = makePool(['alpha', 'beta']);
+  pool.markAuthFailure('alpha');
+  pool.markAuthFailure('beta');
+  const picked = pool.select();
+  check('returns null (no eligible account)', picked === null);
+}
+
+// ----------------------------------------------------------------------
+header('selectExcluding() skips cooldown\'d accounts on 429 failover');
+// ----------------------------------------------------------------------
+{
+  const pool = makePool(['alpha', 'beta', 'gamma']);
+  // Simulate 429 on alpha → tried alpha, then auth-failure on beta
+  // → now selectExcluding({alpha}) should return gamma, not beta
+  pool.markAuthFailure('beta');
+  const picked = pool.selectExcluding(new Set(['alpha']));
+  check('skipped both alpha (excluded) and beta (cooldown)', picked && picked.alias === 'gamma');
+}
+
+// ----------------------------------------------------------------------
+header('selectSticky() breaks binding when bound account is in cooldown');
+// ----------------------------------------------------------------------
+{
+  const pool = makePool(['alpha', 'beta']);
+  // First call binds key to whichever is bestAccount (alphabetical tied).
+  const first = pool.selectSticky('conv-key-1');
+  check('first call binds and picks an account', first !== null);
+  const firstAlias = first.alias;
+
+  // Mark the bound account in cooldown — next selectSticky should rebind
+  // to the other account.
+  pool.markAuthFailure(firstAlias);
+  const second = pool.selectSticky('conv-key-1');
+  check('second call rebinds to peer (not the cooldown\'d account)', second && second.alias !== firstAlias);
+  check('peer received the binding', pool.stickyAliasFor('conv-key-1') === second.alias);
+}
+
+// ----------------------------------------------------------------------
+header('cooldown expires after the configured window');
+// ----------------------------------------------------------------------
+{
+  const pool = makePool(['alpha']);
+  pool.markAuthFailure('alpha');
+  const acc = pool.all().find(a => a.alias === 'alpha');
+
+  // Tamper with the timestamp to simulate the cooldown having passed.
+  // Real code wouldn't do this — wallclock advances naturally — but
+  // we can't sleep 60s in a unit test. The contract we're pinning is
+  // "isInAuthCooldown returns false once now > lastAuthFailureAt + cooldownMs".
+  acc.lastAuthFailureAt = Date.now() - 61_000; // 61s ago, past 60s cooldown
+  check('past the cooldown window → no longer in cooldown', !isInAuthCooldown(acc));
+
+  // And select() can pick it again.
+  const picked = pool.select();
+  check('select() returns the now-eligible account', picked && picked.alias === 'alpha');
+}
+
+// ----------------------------------------------------------------------
+header('status() counts cooldown\'d accounts as unhealthy');
+// ----------------------------------------------------------------------
+{
+  const pool = makePool(['alpha', 'beta']);
+  pool.markAuthFailure('alpha');
+  const status = pool.status();
+  check('healthy count excludes cooldown\'d alpha', status.healthy === 1);
+  check('exhausted count includes alpha', status.exhausted === 1);
+}
+
+// ----------------------------------------------------------------------
+console.log(`\n======================================================================`);
+console.log(`  Results: ${pass} passed, ${fail} failed`);
+console.log(`======================================================================\n`);
+if (fail > 0) process.exit(1);

--- a/test/resync-login-stale.mjs
+++ b/test/resync-login-stale.mjs
@@ -1,0 +1,272 @@
+// dario#235 — pool's back-filled `login` snapshot goes stale on
+// credentials.json refresh-token rotation.
+//
+// Setup: the back-fill (ensureLoginCredentialsInPool) copies credentials.json
+// into accounts/login.json on the user's first `dario accounts add`. After
+// that, the single-account path keeps refreshing credentials.json
+// independently. Each refresh issues new tokens and Anthropic invalidates
+// the snapshot's refresh_token. login.json now has tokens that 401 on
+// every request and 400 invalid_grant on every refresh.
+//
+// resyncLoginFromCredentialsIfStale fixes this at proxy startup by
+// detecting divergence and overwriting the snapshot with the current
+// canonical credentials.json content. These tests cover the contract.
+
+import { mkdtemp, writeFile, mkdir, rm, readdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let pass = 0, fail = 0;
+function check(label, cond) {
+  if (cond) { console.log(`  ✅ ${label}`); pass++; }
+  else { console.log(`  ❌ ${label}`); fail++; }
+}
+function header(label) {
+  console.log(`\n======================================================================`);
+  console.log(`  ${label}`);
+  console.log(`======================================================================`);
+}
+
+// Temp home + env override must happen BEFORE importing accounts.
+const tmpHome = await mkdtemp(join(tmpdir(), 'dario-resync-test-'));
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+const dariDir = join(tmpHome, '.dario');
+const accountsDir = join(dariDir, 'accounts');
+const credentialsPath = join(dariDir, 'credentials.json');
+await mkdir(dariDir, { recursive: true });
+
+const {
+  resyncLoginFromCredentialsIfStale,
+  saveAccount,
+  loadAccount,
+  removeAccount,
+  listAccountAliases,
+  MIGRATED_LOGIN_ALIAS,
+} = await import('../dist/accounts.js');
+
+const { _clearCredentialsCacheForTest } = await import('../dist/oauth.js');
+
+async function resetAccounts() {
+  try {
+    const entries = await readdir(accountsDir);
+    for (const f of entries) {
+      await removeAccount(f.replace(/\.json$/, ''));
+    }
+  } catch { /* dir may not exist yet */ }
+  // Invalidate the in-memory credentials cache between tests — the cache
+  // TTL is 10s and the tests run in ms, so without this invalidation each
+  // scenario sees the previous scenario's cached creds and misses the
+  // updated credentials.json content on disk.
+  _clearCredentialsCacheForTest();
+}
+
+async function writeCredentials(tokens) {
+  await writeFile(credentialsPath, JSON.stringify({ claudeAiOauth: tokens }, null, 2));
+}
+
+async function deleteCredentials() {
+  try { await rm(credentialsPath); } catch { /* not there */ }
+}
+
+// ----------------------------------------------------------------------
+header('returns no-pool when fewer than 2 accounts');
+// ----------------------------------------------------------------------
+{
+  await resetAccounts();
+  const result = await resyncLoginFromCredentialsIfStale();
+  check('empty accounts/ → no-pool', result === 'no-pool');
+
+  await saveAccount({
+    alias: 'login',
+    accessToken: 'at-1',
+    refreshToken: 'rt-1',
+    expiresAt: Date.now() + 3600_000,
+    scopes: ['user:inference'],
+    deviceId: 'dev', accountUuid: 'uuid',
+  });
+  const result2 = await resyncLoginFromCredentialsIfStale();
+  check('1 account → no-pool', result2 === 'no-pool');
+}
+
+// ----------------------------------------------------------------------
+header('returns no-login when pool has 2+ but no login alias');
+// ----------------------------------------------------------------------
+{
+  await resetAccounts();
+  await saveAccount({
+    alias: 'work', accessToken: 'at', refreshToken: 'rt',
+    expiresAt: Date.now() + 3600_000, scopes: [],
+    deviceId: 'd', accountUuid: 'u',
+  });
+  await saveAccount({
+    alias: 'personal', accessToken: 'at2', refreshToken: 'rt2',
+    expiresAt: Date.now() + 3600_000, scopes: [],
+    deviceId: 'd2', accountUuid: 'u2',
+  });
+  const result = await resyncLoginFromCredentialsIfStale();
+  check('no `login` alias → no-login', result === 'no-login');
+}
+
+// ----------------------------------------------------------------------
+header('returns no-creds when login.json present but credentials.json missing');
+// ----------------------------------------------------------------------
+{
+  await resetAccounts();
+  await deleteCredentials();
+  await saveAccount({
+    alias: 'login', accessToken: 'at', refreshToken: 'rt',
+    expiresAt: Date.now() + 3600_000, scopes: [],
+    deviceId: 'd', accountUuid: 'u',
+  });
+  await saveAccount({
+    alias: 'personal', accessToken: 'at2', refreshToken: 'rt2',
+    expiresAt: Date.now() + 3600_000, scopes: [],
+    deviceId: 'd2', accountUuid: 'u2',
+  });
+  const result = await resyncLoginFromCredentialsIfStale();
+  check('no credentials reachable → no-creds (leave login alone)', result === 'no-creds');
+  // Confirm we didn't touch login.json
+  const after = await loadAccount('login');
+  check('login.json unmodified', after.accessToken === 'at' && after.refreshToken === 'rt');
+}
+
+// ----------------------------------------------------------------------
+header('returns in-sync when tokens match');
+// ----------------------------------------------------------------------
+{
+  await resetAccounts();
+  const matchingAccess = 'access-token-shared-AAAA';
+  const matchingRefresh = 'refresh-token-shared-BBBB';
+  // Far-future expiresAt so the synthetic test creds beat any real keychain
+  // entry on the freshest-wins ordering inside loadCredentials.
+  const expiresAt = Date.now() + 365 * 24 * 3600_000;
+
+  await writeCredentials({
+    accessToken: matchingAccess,
+    refreshToken: matchingRefresh,
+    expiresAt,
+    scopes: ['user:inference'],
+  });
+  await saveAccount({
+    alias: 'login',
+    accessToken: matchingAccess,
+    refreshToken: matchingRefresh,
+    expiresAt,
+    scopes: ['user:inference'],
+    deviceId: 'preserved-device-id',
+    accountUuid: 'preserved-uuid',
+  });
+  await saveAccount({
+    alias: 'personal', accessToken: 'at2', refreshToken: 'rt2',
+    expiresAt: Date.now() + 3600_000, scopes: [],
+    deviceId: 'd2', accountUuid: 'u2',
+  });
+
+  const result = await resyncLoginFromCredentialsIfStale();
+  check('matching tokens → in-sync', result === 'in-sync');
+  const after = await loadAccount('login');
+  check('login.json unchanged', after.accessToken === matchingAccess);
+}
+
+// ----------------------------------------------------------------------
+header('returns resynced + overwrites when tokens differ');
+// ----------------------------------------------------------------------
+{
+  await resetAccounts();
+  const staleAccess = 'old-access-CCCC';
+  const staleRefresh = 'old-refresh-DDDD';
+  const freshAccess = 'new-access-EEEE';
+  const freshRefresh = 'new-refresh-FFFF';
+  // 1 year ahead — must beat any real keychain entry's expiresAt because
+  // loadCredentials picks the freshest across (dario file, CC file, keychain).
+  const newExpires = Date.now() + 365 * 24 * 3600_000;
+
+  await writeCredentials({
+    accessToken: freshAccess,
+    refreshToken: freshRefresh,
+    expiresAt: newExpires,
+    scopes: ['user:inference', 'org:create_api_key'],
+  });
+  await saveAccount({
+    alias: 'login',
+    accessToken: staleAccess,
+    refreshToken: staleRefresh,
+    expiresAt: Date.now() + 3600_000,
+    scopes: ['user:inference'],
+    deviceId: 'preserved-device-id',
+    accountUuid: 'preserved-uuid',
+  });
+  await saveAccount({
+    alias: 'personal', accessToken: 'at2', refreshToken: 'rt2',
+    expiresAt: Date.now() + 3600_000, scopes: [],
+    deviceId: 'd2', accountUuid: 'u2',
+  });
+
+  const result = await resyncLoginFromCredentialsIfStale();
+  check('mismatched tokens → resynced', result === 'resynced');
+
+  const after = await loadAccount('login');
+  check('accessToken overwritten with fresh value', after.accessToken === freshAccess);
+  check('refreshToken overwritten with fresh value', after.refreshToken === freshRefresh);
+  check('expiresAt updated', after.expiresAt === newExpires);
+  check('scopes updated from credentials.json', after.scopes.length === 2 && after.scopes.includes('org:create_api_key'));
+  check('deviceId preserved (pool-internal identity)', after.deviceId === 'preserved-device-id');
+  check('accountUuid preserved (pool-internal identity)', after.accountUuid === 'preserved-uuid');
+}
+
+// ----------------------------------------------------------------------
+header('idempotent — second call after resync returns in-sync');
+// ----------------------------------------------------------------------
+{
+  // State from previous test: login.json now matches credentials.json.
+  const result = await resyncLoginFromCredentialsIfStale();
+  check('immediately after resync → in-sync', result === 'in-sync');
+}
+
+// ----------------------------------------------------------------------
+header('only access-token diverges → still resyncs');
+// ----------------------------------------------------------------------
+{
+  await resetAccounts();
+  const sharedRefresh = 'shared-refresh-token';
+  const oldAccess = 'access-old';
+  const newAccess = 'access-new-after-refresh';
+  // 1 year ahead so keychain doesn't outrank our synthetic credentials.
+  const expiresAt = Date.now() + 365 * 24 * 3600_000;
+
+  await writeCredentials({
+    accessToken: newAccess,
+    refreshToken: sharedRefresh,
+    expiresAt,
+    scopes: [],
+  });
+  await saveAccount({
+    alias: 'login',
+    accessToken: oldAccess,
+    refreshToken: sharedRefresh,
+    expiresAt,
+    scopes: [],
+    deviceId: 'd', accountUuid: 'u',
+  });
+  await saveAccount({
+    alias: 'personal', accessToken: 'at2', refreshToken: 'rt2',
+    expiresAt: Date.now() + 3600_000, scopes: [],
+    deviceId: 'd2', accountUuid: 'u2',
+  });
+
+  const result = await resyncLoginFromCredentialsIfStale();
+  check('access-only divergence triggers resync', result === 'resynced');
+  const after = await loadAccount('login');
+  check('access-token updated', after.accessToken === newAccess);
+}
+
+// ----------------------------------------------------------------------
+//  Cleanup
+// ----------------------------------------------------------------------
+await rm(tmpHome, { recursive: true, force: true });
+
+console.log(`\n======================================================================`);
+console.log(`  Results: ${pass} passed, ${fail} failed`);
+console.log(`======================================================================\n`);
+if (fail > 0) process.exit(1);


### PR DESCRIPTION
## Summary

Two related pool reliability bugs surfaced during live Max+Pro pool-mode e2e today. Both fixed in this PR with unit tests.

## #234 — pool selector skips accounts in auth-failure cool-down

**Repro:** 2-account pool, one account's tokens server-invalidated (the back-fill snapshot from #235). Sent 3 requests through the proxy. All 3 routed to the dead account; never tried the healthy peer. `/accounts` showed `requestCount: 3` on the dead account, `0` on the peer.

**Root cause:** `AccountPool.select()` routes by headroom (computed from rate-limit response headers). 401/403 responses don't include rate-limit headers, so headroom math sees a healthy idle account → selector keeps picking the dead one indefinitely.

**Fix:** per-account auth-failure cool-down on `PoolAccount`. New fields (`lastAuthFailureAt`, `consecutiveAuthFailures`), new methods (`markAuthFailure` / `clearAuthFailure`), new helpers (`authCooldownMs` with 60s base + exponential backoff capped at 30 min, `isInAuthCooldown`). `select()` / `selectExcluding()` / `selectSticky()` / `status()` all skip accounts in active cool-down.

The proxy's response-handling path now:
- Calls `markAuthFailure` on 401/403
- Attempts in-request failover (mirroring the existing 429 path)
- Calls `clearAuthFailure` on 2xx success

Surfaces in `/accounts` as `status: "auth-cooldown"` with `cooldownMs` and `consecutiveAuthFailures`.

```diff
+ if (pool && poolAccount && (upstream.status === 401 || upstream.status === 403)) {
+   pool.markAuthFailure(poolAccount.alias);
+   const nextAccount = pool.selectExcluding(triedAliases, modelFamily(requestModel));
+   if (nextAccount) {
+     // ... rebind, retry on the peer
+     continue dispatchLoop;
+   }
+ }
```

## #235 — pool's back-filled `login` snapshot goes stale on credentials.json refresh-token rotation

**Repro:** user runs `dario login` (single-account, OAuth → `credentials.json`), then `dario accounts add personal`. Back-fill copies `credentials.json` into `accounts/login.json`. Single-account path keeps refreshing `credentials.json` independently (proxy startup auth check, periodic refresh in `oauth.ts`). Each refresh issues new tokens; Anthropic invalidates the previous refresh_token. The pool's `login.json` snapshot now has tokens that 401 on every request and 400 `invalid_grant` on every refresh, but its `expiresAt` metadata still says "healthy" so the selector keeps picking it.

(With #234's fix in place that's already mostly contained — auth cool-down would route around the dead account. But the snapshot itself can be repaired cheaply at startup, eliminating the cool-down entirely.)

**Fix:** at proxy startup, before loading the pool, call `resyncLoginFromCredentialsIfStale()`. Reads `accounts/login.json`, compares to current `credentials.json`, and overwrites the snapshot when they diverge — preserving the pool-internal `deviceId` / `accountUuid` (those don't rotate with token refresh), rotating just the OAuth tokens. Returns `'no-pool'` / `'no-login'` / `'no-creds'` / `'in-sync'` / `'resynced'` so the proxy can log appropriately. Idempotent on repeated invocation.

```diff
+ const resyncResult = await resyncLoginFromCredentialsIfStale();
+ if (resyncResult === 'resynced') {
+   console.log('[dario] re-synced pool `login` account from current credentials.json (was stale; dario#235)');
+ }
```

## Test coverage

| File | New tests | Coverage |
|---|---|---|
| `test/pool-auth-cooldown.mjs` | 27 | cooldown math, mark/clear semantics, select-path filtering across all 3 selector variants, sticky-binding break-on-cooldown, status() accounting, alias-scoped failure isolation |
| `test/resync-login-stale.mjs` | 17 | five return cases (no-pool, no-login, no-creds, in-sync, resynced), token replacement invariants, deviceId/accountUuid preservation, idempotency, access-only divergence detection |

Total tests: **60 → 62** (the new files contribute 2 suite entries; the 27 and 17 are intra-file assertions).

Required a new test-only export `_clearCredentialsCacheForTest()` from `oauth.ts` because `resyncLoginFromCredentialsIfStale` calls `loadCredentials()` which caches at module scope for 10 seconds — multi-scenario tests in a single process see stale cached values without explicit invalidation.

## What's NOT changed

- Existing 429 failover path — same code, same behavior.
- Rate-limit-driven headroom routing — unchanged. The cool-down is an additional filter, not a replacement.
- The `dario accounts add` back-fill behavior — only its recovery story changes.
- credentials.json single-account refresh path — untouched. The collision is now self-healing on next proxy start.

## Why it matters more with mixed plans (Max + Pro)

Just hit live with a Max + Pro pool. Max-tier per-model 7d buckets (`7d_sonnet`) can exhaust mid-week while the Pro account is still fresh — the right behavior is to fail over to Pro silently. Today, if Max returns a `permission_error` or `authentication_error` mid-day (revoked scope, account-state change, etc.), the pool keeps routing at the dead Max account until rate-limit data eventually flips. With this PR, pool fails over within the same request and the next client request goes to Pro automatically.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 62/62 pass
- [x] `node test/pool-auth-cooldown.mjs` — 27/27
- [x] `node test/resync-login-stale.mjs` — 17/17
- [ ] Live: simulate a 401 by tampering with one account's `accessToken` → next request fails over to peer, `/accounts` shows `auth-cooldown` status
- [ ] Live: mutate `credentials.json` (force a refresh), restart proxy → `[dario] re-synced pool \`login\`` log line, `login.json` reflects current creds