### PR TITLE
docs: add 'Also by askalf' cross-reference table at the bottom of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,3 +344,19 @@ npm run e2e   # live proxy + OAuth (requires a working Claude backend)
 ## License
 
 MIT — see [LICENSE](LICENSE) and [DISCLAIMER.md](DISCLAIMER.md).
+
+---
+
+## Also by askalf
+
+| Project | What it does |
+|---------|-------------|
+| [arnie](https://github.com/askalf/arnie) | Portable IT troubleshooting companion. Networking, AD, Windows Update, package managers, log triage, hardware checks. |
+| [brio](https://github.com/askalf/brio) | Capability layer for AI workloads — semantic cache, cost tiering, policy. Sits in front of any Anthropic-compat endpoint. |
+| [browser-bridge](https://github.com/askalf/browser-bridge) | Stealth headless Chromium in a container. CDP on 9222 — Playwright/Puppeteer/MCP-compatible. |
+| [claude-bridge](https://github.com/askalf/claude-bridge) | Bridge Claude Code sessions to Discord. |
+| [deepdive](https://github.com/askalf/deepdive) | Local research agent. Plan → search → fetch → extract → synthesize. Cited answers. |
+| [hands](https://github.com/askalf/hands) | Cross-platform computer-use agent. Mouse, keyboard, screen. |
+| [install-kit](https://github.com/askalf/install-kit) | curl-pipe-bash template for self-hosted Docker apps. |
+| [pgflex](https://github.com/askalf/pgflex) | One Postgres API. Two modes (real PG ↔ PGlite WASM). |
+| [redisflex](https://github.com/askalf/redisflex) | One Redis API. Two modes (ioredis ↔ in-process). |


### PR DESCRIPTION
## Summary

Adds the canonical "Also by askalf" cross-reference table at the bottom of the README. Pattern matches the new repos shipped today (pgflex, redisflex, browser-bridge, install-kit) — each repo's README ends with the same table, with that repo's own row excluded.

## What's NOT in this PR

- No code changes. README-only.
- Brio's previous "Relationship to other askalf projects" section (the prose narrative about which projects route through brio) is replaced by the canonical table for cross-repo consistency. The "brio is the upstream" detail is preserved as an inline note in dario's row.
- Hands's previous "Links" section keeps file/external links (npm, CHANGELOG, SECURITY, DISCLAIMER, X/Twitter) and moves the project cross-refs into the new table.

## Test plan

- [ ] CI green
- [ ] Render check: GitHub README preview shows the table correctly (no broken links)