### PR TITLE
docs: add git-providers row to 'Also by askalf' table

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ MIT — see [LICENSE](LICENSE) and [DISCLAIMER.md](DISCLAIMER.md).
 | [browser-bridge](https://github.com/askalf/browser-bridge) | Stealth headless Chromium in a container. CDP on 9222 — Playwright/Puppeteer/MCP-compatible. |
 | [claude-bridge](https://github.com/askalf/claude-bridge) | Bridge Claude Code sessions to Discord. |
 | [deepdive](https://github.com/askalf/deepdive) | Local research agent. Plan → search → fetch → extract → synthesize. Cited answers. |
+| [git-providers](https://github.com/askalf/git-providers) | Unified GitHub + GitLab + Bitbucket Cloud REST clients behind one GitProvider interface. Plus a 44-entry api-key-provider taxonomy. |
 | [hands](https://github.com/askalf/hands) | Cross-platform computer-use agent. Mouse, keyboard, screen. |
 | [install-kit](https://github.com/askalf/install-kit) | curl-pipe-bash template for self-hosted Docker apps. |
 | [pgflex](https://github.com/askalf/pgflex) | One Postgres API. Two modes (real PG ↔ PGlite WASM). |


### PR DESCRIPTION
Adds the new `git-providers` cross-reference row, propagating the latest extraction to this repo's table. Same alphabetical sort + canonical row text as the others.

The 4 newer repos (pgflex, redisflex, browser-bridge, install-kit) had abbreviated tables left over from when they were first scaffolded; this PR also brings them up to the full canonical 10-row format that the older repos already use.