### PR TITLE
fix(health): reflect refresh-token state, return 503 when broken

### DIFF
--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -38,6 +38,13 @@ const REFRESH_BUFFER_MS = 30 * 60 * 1000;
 let lastRefreshFailure = 0;
 const REFRESH_COOLDOWN_MS = 60 * 1000;
 
+// Track consecutive refresh failures so /health can surface a dead refresh
+// token instead of cheerfully reporting `oauth: "expiring"` while every
+// upstream call returns 401.
+let consecutiveRefreshFailures = 0;
+let lastRefreshError: string | undefined;
+const REFRESH_BROKEN_THRESHOLD = 3;
+
 // In-memory credential cache — avoids disk reads on every request
 let credentialsCache: CredentialsFile | null = null;
 let credentialsCacheTime = 0;
@@ -645,6 +652,8 @@ async function doRefreshTokens(): Promise<OAuthTokens> {
     };
 
     await saveCredentials({ claudeAiOauth: tokens });
+    consecutiveRefreshFailures = 0;
+    lastRefreshError = undefined;
     return tokens;
   }
 
@@ -678,7 +687,9 @@ export async function getAccessToken(): Promise<string> {
     return refreshed.accessToken;
   } catch (err) {
     lastRefreshFailure = Date.now();
-    console.error(`[dario] Refresh failed: ${err instanceof Error ? err.message : err}. Will retry in 60s. Run \`dario login\` if this persists.`);
+    consecutiveRefreshFailures++;
+    lastRefreshError = err instanceof Error ? err.message : String(err);
+    console.error(`[dario] Refresh failed (${consecutiveRefreshFailures} consecutive): ${lastRefreshError}. Will retry in 60s. Run \`dario login\` if this persists.`);
     // Return current token — it might still work for a few more minutes
     return oauth.accessToken;
   }
@@ -686,13 +697,21 @@ export async function getAccessToken(): Promise<string> {
 
 /**
  * Get token status info.
+ *
+ * `status` returns 'broken' when refresh has failed REFRESH_BROKEN_THRESHOLD
+ * times in a row — this matters because the access token can still be ticking
+ * down (so naive "expiresIn" looks fine) while every actual upstream call
+ * returns 401. Operators relying on /health for a docker healthcheck or for
+ * `depends_on: service_healthy` need to see this state.
  */
 export async function getStatus(): Promise<{
   authenticated: boolean;
-  status: 'healthy' | 'expiring' | 'expired' | 'none';
+  status: 'healthy' | 'expiring' | 'expired' | 'broken' | 'none';
   expiresAt?: number;
   expiresIn?: string;
   canRefresh?: boolean;
+  refreshFailures?: number;
+  lastRefreshError?: string;
 }> {
   const creds = await loadCredentials();
   if (!creds?.claudeAiOauth?.accessToken) {
@@ -701,11 +720,19 @@ export async function getStatus(): Promise<{
 
   const { expiresAt } = creds.claudeAiOauth;
   const now = Date.now();
+  const broken = consecutiveRefreshFailures >= REFRESH_BROKEN_THRESHOLD;
 
   if (expiresAt < now) {
-    // Expired but has refresh token — can be refreshed
-    const canRefresh = !!creds.claudeAiOauth.refreshToken;
-    return { authenticated: false, status: 'expired', expiresAt, canRefresh };
+    // Expired but has refresh token — can be refreshed (unless refresh itself is dead)
+    const canRefresh = !!creds.claudeAiOauth.refreshToken && !broken;
+    return {
+      authenticated: false,
+      status: broken ? 'broken' : 'expired',
+      expiresAt,
+      canRefresh,
+      refreshFailures: consecutiveRefreshFailures,
+      lastRefreshError,
+    };
   }
 
   const ms = expiresAt - now;
@@ -714,9 +741,11 @@ export async function getStatus(): Promise<{
   const expiresIn = hours > 0 ? `${hours}h ${mins}m` : `${mins}m`;
 
   return {
-    authenticated: true,
-    status: ms < REFRESH_BUFFER_MS ? 'expiring' : 'healthy',
+    authenticated: !broken,
+    status: broken ? 'broken' : (ms < REFRESH_BUFFER_MS ? 'expiring' : 'healthy'),
     expiresAt,
     expiresIn,
+    refreshFailures: consecutiveRefreshFailures || undefined,
+    lastRefreshError,
   };
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -962,14 +962,25 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
     const urlPath = req.url?.split('?')[0] ?? '';
 
     // Health check
+    //
+    // Returns HTTP 503 when OAuth is in a state that will cause every upstream
+    // call to fail: refresh has failed N consecutive times ('broken'), or the
+    // access token is expired with no usable refresh path. Docker healthchecks
+    // and dependent services (`depends_on: service_healthy`) need this to
+    // react instead of cheerfully passing while every /v1/messages 401s.
     if (urlPath === '/health' || urlPath === '/') {
       const s = await getStatus();
-      res.writeHead(200, JSON_HEADERS);
+      const dead = s.status === 'broken' || s.status === 'none' ||
+                   (s.status === 'expired' && s.canRefresh === false);
+      const httpStatus = dead ? 503 : 200;
+      res.writeHead(httpStatus, JSON_HEADERS);
       res.end(JSON.stringify({
-        status: 'ok',
+        status: dead ? 'degraded' : 'ok',
         oauth: s.status,
         expiresIn: s.expiresIn,
         requests: requestCount,
+        ...(s.refreshFailures ? { refreshFailures: s.refreshFailures } : {}),
+        ...(s.lastRefreshError ? { lastRefreshError: s.lastRefreshError } : {}),
       }));
       return;
     }


### PR DESCRIPTION
## Summary
\`/health\` cheerfully returns \`{status:"ok",oauth:"expiring"}\` for hours while every upstream \`/v1/messages\` call returns 401, because the access token is still ticking down its \`expiresIn\` but the refresh token is dead. The refresh loop logs failures every 60s but nothing surfaces it to operators relying on the health endpoint.

## Concrete failure caught in the wild today
A self-hosted deploy had dario container healthy per docker-compose's healthcheck, brio's \`depends_on: dario service_healthy\` satisfied, but every Anthropic call returned:
\`\`\`json
{"type":"error","error":{"type":"authentication_error","message":"Invalid authentication credentials","request_id":"req_011Cau..."}}
\`\`\`
Operator only noticed hours later when an unrelated capability test surfaced the 401. \`/health\` was lying the whole time. Container logs showed the actual problem:
\`\`\`
[dario] Refresh attempt 3/3 failed: HTTP 400 — {"error": "invalid_grant"}
[dario] Refresh failed: ... Will retry in 60s. Run \`dario login\` if this persists.
\`\`\`

## Changes
* Track \`consecutiveRefreshFailures\` and \`lastRefreshError\` in oauth.ts. Reset on successful refresh; increment in the cooldown-catch path of \`getAccessToken\`.
* \`getStatus()\` returns new \`'broken'\` state when failures >= \`REFRESH_BROKEN_THRESHOLD\` (default 3). Includes \`refreshFailures\` and \`lastRefreshError\` in the payload when relevant.
* \`/health\` returns HTTP **503** (\`status: "degraded"\`) when:
  - oauth is \`'broken'\` (refresh dead), OR
  - oauth is \`'none'\` (no creds at all), OR
  - oauth is \`'expired'\` AND \`canRefresh=false\` (no refresh token).
  Healthy / expiring / expired-with-refresh still return 200 as before.
* Refresh-failure log line now shows the running counter:
\`\`\`
[dario] Refresh failed (3 consecutive): Refresh token rejected (400). ...
\`\`\`

## Behavior change
**Before**: \`/health\` always returned 200 \`{status:"ok"}\` regardless of refresh state. Docker healthchecks + dependent services couldn't react.

**After**: same shape when healthy/expiring; returns 503 + degraded payload when actually broken. Existing 200-only consumers still work; consumers that check status code now have signal.

## Test plan
- [ ] CI green
- [ ] Manual: trigger a refresh failure (revoke creds upstream, or hand-edit refreshToken), wait 3 attempts (~3 min), \`curl /health\` returns 503 with \`oauth: "broken"\` and \`refreshFailures: 3\`
- [ ] After successful \`dario login\` re-auth, counter resets and /health returns 200 again

🤖 Generated with [Claude Code](https://claude.com/claude-code)