### PR TITLE
fix(login): clean failure modes for containerised re-auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,12 @@ RUN addgroup -S dario \
 WORKDIR /app
 COPY --from=build --chown=dario:dario /app/dist ./dist
 
+# Expose `dario` on PATH so `docker exec <container> dario login --manual`
+# works without falling back to `node /app/dist/cli.js`. The shebang in
+# cli.ts (`#!/usr/bin/env node`) handles the rest.
+RUN chmod +x /app/dist/cli.js \
+ && ln -s /app/dist/cli.js /usr/local/bin/dario
+
 USER dario
 
 ENV DARIO_HOST=0.0.0.0 \

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,10 +43,25 @@ async function login() {
   console.log('');
 
   const manualFlag = args.includes('--manual') || args.includes('--headless');
+  // --force-reauth skips the existing-credentials short-circuit entirely.
+  // Use when the refresh token is dead and you need a clean OAuth re-auth
+  // without manually deleting credentials.json first.
+  const forceReauth = args.includes('--force-reauth') || args.includes('--force');
+  // --no-proxy keeps `dario login` to its name — it just does auth, doesn't
+  // try to start the proxy as a side effect. Useful in containerised deploys
+  // where the proxy is the container's CMD and is already running. Implicitly
+  // set by --manual since manual flow is for headless / scripted contexts
+  // where proxy lifecycle is managed externally.
+  const noProxy = args.includes('--no-proxy') || manualFlag;
 
   // Check for existing credentials (Claude Code or dario's own)
-  const creds = await loadCredentials();
+  const creds = forceReauth ? null : await loadCredentials();
   if (creds?.claudeAiOauth?.accessToken && creds.claudeAiOauth.expiresAt > Date.now()) {
+    if (noProxy) {
+      console.log('  Found valid credentials. (--no-proxy / --manual: not starting proxy.)');
+      console.log('');
+      return;
+    }
     console.log('  Found credentials. Starting proxy...');
     console.log('');
     await proxy();
@@ -72,6 +87,9 @@ async function login() {
       console.log(`  Refresh failed (${sanitizeError(err)}). Starting fresh OAuth flow...`);
       console.log('');
     }
+  } else if (forceReauth) {
+    console.log('  --force-reauth: skipping credential detection, starting fresh OAuth flow...');
+    console.log('');
   } else {
     console.log('  No Claude Code credentials found. Starting OAuth flow...');
     console.log('');
@@ -98,7 +116,11 @@ async function login() {
     console.log('  Login successful!');
     console.log(`  Token expires in ${expiresIn} minutes (auto-refreshes).`);
     console.log('');
-    console.log('  Run `dario proxy` to start the API proxy.');
+    if (noProxy) {
+      console.log('  (--no-proxy / --manual: credentials saved, proxy not started.)');
+    } else {
+      console.log('  Run `dario proxy` to start the API proxy.');
+    }
     console.log('');
   } catch (err) {
     const msg = sanitizeError(err);
@@ -156,8 +178,18 @@ async function logout() {
   try {
     await unlink(path);
     console.log('[dario] Credentials removed.');
-  } catch {
-    console.log('[dario] No credentials found.');
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === 'ENOENT') {
+      console.log('[dario] No credentials found.');
+    } else {
+      // Permission denied, EISDIR, EBUSY, etc — surface the real error so the
+      // operator can fix it. Previous catch-all silently lied with "No
+      // credentials found" even when the file was clearly there but unreadable
+      // (e.g. ownership got mangled by a `docker run --user 0` recovery op).
+      console.error(`[dario] Could not remove ${path}: ${(err as Error).message}`);
+      process.exit(1);
+    }
   }
 }
 
@@ -828,10 +860,19 @@ async function help() {
   dario — Use your Claude subscription as an API.
 
   Usage:
-    dario login [--manual]   Detect credentials + start proxy (or run OAuth)
+    dario login [--manual] [--no-proxy] [--force-reauth]
+                             Detect credentials + start proxy (or run OAuth).
                              --manual (alias: --headless) for container / SSH
                              setups — prints an authorize URL and reads the
-                             code you paste back instead of a local redirect
+                             code you paste back instead of a local redirect.
+                             --no-proxy stops after auth — do not start the
+                             proxy (implied by --manual). Use this when the
+                             proxy is already running in a separate process /
+                             container so login doesn't collide on the port.
+                             --force-reauth (alias: --force) ignores any
+                             existing credentials and runs a fresh OAuth
+                             flow — for when the refresh token is dead and
+                             /health still reports access-token countdown.
     dario proxy [options]    Start the API proxy server
     dario status             Check authentication status
     dario refresh            Force token refresh

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -7,7 +7,7 @@
 
 import { randomBytes, createHash } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
-import { readFile, writeFile, mkdir, rename } from 'node:fs/promises';
+import { readFile, writeFile, mkdir, rename, unlink } from 'node:fs/promises';
 import { execFile } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { homedir, platform } from 'node:os';
@@ -93,6 +93,36 @@ function getDarioCredentialsPath(): string {
 
 function getClaudeCodeCredentialsPath(): string {
   return join(homedir(), '.claude', '.credentials.json');
+}
+
+/**
+ * Verify the credentials directory is writable BEFORE we open the OAuth URL.
+ *
+ * Why: an unwritable ~/.dario (e.g. EACCES from a `--user 0` docker op that
+ * left the volume owned by root) is a silent killer — the OAuth round-trip
+ * succeeds, the user pastes the code, and saveCredentials() crashes with
+ * EACCES on the .tmp file. The auth code is now consumed and unrecoverable;
+ * the user has to start over and re-paste a fresh code, only to hit the same
+ * EACCES. Probing first surfaces the permission problem cleanly while the
+ * user still holds an un-burned auth code.
+ */
+async function probeWritability(): Promise<void> {
+  const dir = dirname(getDarioCredentialsPath());
+  await mkdir(dir, { recursive: true });
+  const probe = join(dir, `.write-probe.${process.pid}`);
+  try {
+    await writeFile(probe, '', { mode: 0o600 });
+    await unlink(probe);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    throw new Error(
+      `Credentials directory is not writable: ${dir} (${code || 'unknown'}). ` +
+      `Fix permissions before running 'dario login' so the OAuth code isn't ` +
+      `consumed by a flow that can't persist the result. ` +
+      `On Docker volumes left root-owned by a '--user 0' op, run: ` +
+      `chown -R dario:dario ${dir}`
+    );
+  }
 }
 
 /**
@@ -289,6 +319,8 @@ async function saveCredentials(creds: CredentialsFile): Promise<void> {
  * Opens browser, captures the authorization code automatically.
  */
 export async function startAutoOAuthFlow(): Promise<OAuthTokens> {
+  // Fail fast on unwritable credentials dir BEFORE the auth code is issued.
+  await probeWritability();
   const { createServer } = await import('node:http');
   const { codeVerifier, codeChallenge } = generatePKCE();
   // 32 random bytes → 43-char base64url state. See dario#71 — Anthropic's
@@ -510,6 +542,8 @@ export function detectHeadlessEnvironment(): string | null {
  * (it's CSRF protection for a redirect we don't have here).
  */
 export async function startManualOAuthFlow(): Promise<OAuthTokens> {
+  // Fail fast on unwritable credentials dir BEFORE the auth code is issued.
+  await probeWritability();
   const { codeVerifier, codeChallenge } = generatePKCE();
   // 32 bytes — same reason as startAutoOAuthFlow. See dario#71.
   const state = base64url(randomBytes(32));


### PR DESCRIPTION
## Summary

Five small fixes that all collide on the same workflow: **re-authenticating dario inside a Docker container after the refresh token dies**. Hit every one of them during a platform rollout last week — bundling because they share one path.

### `src/cli.ts` — `login` command
- **`--no-proxy`** flag (and imply it from `--manual`). Containerised deploys run the proxy as the container's `CMD`; the login command's auto-proxy-start collides on port 3456 and aborts. Login is now pure-auth when asked.
- **`--force-reauth`** (alias `--force`). Currently the only way to re-auth when the refresh token is dead but `credentials.json` still parses is to manually `rm` the file. New flag skips the existing-creds short-circuit and runs a fresh OAuth flow.
- Updated success message + `dario --help` to document the new flags.

### `src/cli.ts` — `logout` command
- Catch-all hid `EACCES` / `EISDIR` / `EBUSY` behind a cheerful `"No credentials found."` message even when the file was clearly there but unreadable (e.g. ownership mangled by a `docker run --user 0` recovery op). Now differentiates `ENOENT` from real errors and exits non-zero on real errors.

### `src/oauth.ts` — both OAuth flows
- New `probeWritability()` helper writes/unlinks a sentinel file in the credentials dir at the **start** of `startAutoOAuthFlow` and `startManualOAuthFlow`, **before** the authorize URL is opened. Without this, an unwritable `~/.dario` silently consumes the auth code: OAuth round-trip succeeds, user pastes code, `saveCredentials()` `EACCES` on the `.tmp` file, code is now burned and unrecoverable. Failing fast surfaces the permission issue while the user still holds an un-burned auth code.

### `Dockerfile`
- Symlink `/usr/local/bin/dario -> /app/dist/cli.js` so `docker exec <container> dario login --manual` actually works. Currently operators have to fall back to `node /app/dist/cli.js` because the binary isn't on `PATH`.

## Test plan

- [ ] `npm run build` — confirm no TS errors (verified locally with `tsc --noEmit`)
- [ ] `dario logout` on a non-existent creds file → still prints `[dario] No credentials found.`
- [ ] `chmod 000 ~/.dario/credentials.json && dario logout` → exits 1 with clear EACCES message (instead of lying)
- [ ] `dario login --no-proxy` on a host where proxy is already on :3456 → completes auth, doesn't try to bind
- [ ] `dario login --force-reauth` with valid creds on disk → ignores them, opens fresh OAuth flow
- [ ] `chown root:root ~/.dario && dario login --manual` → fails immediately with the probeWritability error, never opens the URL
- [ ] `docker build` + `docker exec <container> dario --help` → resolves binary on PATH

## Related

Companion to #241 (which made `/health` reflect refresh-token failures). Together these close the "refresh token died inside a container" recovery loop end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)