### PR TITLE
chore(release): v3.37.11 + redact lastRefreshError

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.37.10",
+  "version": "3.37.11",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -722,7 +722,12 @@ export async function getAccessToken(): Promise<string> {
   } catch (err) {
     lastRefreshFailure = Date.now();
     consecutiveRefreshFailures++;
-    lastRefreshError = err instanceof Error ? err.message : String(err);
+    // Redact tokens/JWTs/Bearer values and truncate before storing — this
+    // string surfaces on /status and /health (CodeQL js/stack-trace-exposure
+    // dario#17). The raw err.message can include URLs, partial response
+    // bodies, and stack-derived paths from fetch/JSON-parse errors.
+    const raw = err instanceof Error ? err.message : String(err);
+    lastRefreshError = redactSecrets(raw.slice(0, 200));
     console.error(`[dario] Refresh failed (${consecutiveRefreshFailures} consecutive): ${lastRefreshError}. Will retry in 60s. Run \`dario login\` if this persists.`);
     // Return current token — it might still work for a few more minutes
     return oauth.accessToken;


### PR DESCRIPTION
## Summary

Cuts v3.37.11 to ship the cumulative fixes since v3.37.10:
- **#241** — \`/health\` reflects refresh-token state (returns 503 when broken)
- **#242** — login-flow cleanup for containerised re-auth (\`--no-proxy\`, \`--force-reauth\`, write-perm probe, dario-on-PATH symlink, logout EACCES surfacing)

Plus a small CodeQL fix bundled into the release commit:

### CodeQL: js/stack-trace-exposure (dario#17)

PR #241 added \`lastRefreshError = err.message\` and surfaces it on \`/status\` and \`/health\`. The raw \`err.message\` from \`fetch\` / token-exchange / JSON-parse can include URLs, partial response bodies, and stack-derived paths. Run through the existing \`redactSecrets()\` pattern set (which already handles tokens / JWTs / Bearer values) and truncate to 200 chars before storing.

\`\`\`ts
const raw = err instanceof Error ? err.message : String(err);
lastRefreshError = redactSecrets(raw.slice(0, 200));
\`\`\`

## Pipeline

- Merge → \`cc-drift-auto-release.yml\` sees the version bump, tags \`v3.37.11\`, creates a release
- Release \`published\` → \`docker-publish.yml\` builds + pushes \`ghcr.io/askalf/dario:latest\` and \`:3.37.11\`
- \`docker compose pull dario && up -d\` on consumers picks up the new image

## Test plan

- [ ] CI green (build + actionlint + CodeQL)
- [ ] After merge: v3.37.11 tag exists on GitHub
- [ ] After merge: \`docker pull ghcr.io/askalf/dario:3.37.11\` resolves
- [ ] CodeQL alert dario#17 closes on next scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)