### PR TITLE
feat(accounts): --from-keychain skips OAuth and imports CC keychain entries (#237)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.37.11",
+  "version": "3.37.12",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -22,7 +22,7 @@ import { homedir } from 'node:os';
 import { randomUUID, randomBytes, createHash } from 'node:crypto';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { detectCCOAuthConfig } from './cc-oauth-detect.js';
-import { loadCredentials, buildManualAuthorizeUrl, parseManualPaste, readLineFromStdin } from './oauth.js';
+import { loadCredentials, buildManualAuthorizeUrl, parseManualPaste, readLineFromStdin, enumerateKeychainCredentials, type KeychainEntry } from './oauth.js';
 import { openBrowser } from './open-browser.js';
 import { redactSecrets } from './redact.js';
 
@@ -444,6 +444,91 @@ export async function addAccountViaManualOAuth(alias: string): Promise<AccountCr
 
 export function getAccountsDir(): string {
   return ACCOUNTS_DIR;
+}
+
+/**
+ * Error subclass for the keychain-import path so the CLI can render
+ * actionable guidance (list of candidates) without parsing message strings.
+ */
+export class KeychainImportError extends Error {
+  constructor(message: string, public readonly kind: 'empty' | 'ambiguous' | 'no-match', public readonly candidates: string[] = []) {
+    super(message);
+    this.name = 'KeychainImportError';
+  }
+}
+
+/**
+ * Import a Claude Code keychain entry into the pool under `alias`. Skips
+ * the OAuth flow entirely — reuses tokens the user already authorised
+ * through Claude Code itself. See askalf/dario#237 for design rationale.
+ *
+ * Resolution rules:
+ *  - 0 entries on this host → throws KeychainImportError(kind: 'empty')
+ *  - 1 entry total → imports it; `target` argument ignored if supplied
+ *  - 2+ entries + no target → throws KeychainImportError(kind: 'ambiguous',
+ *    candidates: [<target1>, <target2>, ...]) so the CLI can list them
+ *  - 2+ entries + target → imports the matching one, throws
+ *    KeychainImportError(kind: 'no-match', candidates) if none match
+ *
+ * macOS currently only ever surfaces a single entry (see the comment in
+ * enumerateKeychainCredentials in oauth.ts). Linux + Windows enumerate
+ * all matching entries.
+ */
+export async function addAccountFromKeychain(alias: string, target?: string): Promise<AccountCredentials> {
+  const entries = await enumerateKeychainCredentials();
+  if (entries.length === 0) {
+    throw new KeychainImportError(
+      'No Claude Code keychain entries found on this host. Run `claude` (login flow) first, or use `dario accounts add ' + alias + '` to start a fresh OAuth.',
+      'empty',
+    );
+  }
+  let chosen: KeychainEntry | undefined;
+  if (target) {
+    chosen = entries.find(e => e.target === target);
+    if (!chosen) {
+      throw new KeychainImportError(
+        `No keychain entry matches target "${target}".`,
+        'no-match',
+        entries.map(e => e.target),
+      );
+    }
+  } else if (entries.length === 1) {
+    chosen = entries[0];
+  } else {
+    throw new KeychainImportError(
+      `Found ${entries.length} keychain entries — pick one with --from-keychain=<target>.`,
+      'ambiguous',
+      entries.map(e => e.target),
+    );
+  }
+
+  const oauth = chosen.credentials.claudeAiOauth;
+  if (!oauth?.accessToken || !oauth?.refreshToken) {
+    throw new KeychainImportError(
+      `Keychain entry "${chosen.target}" is missing accessToken/refreshToken — re-authenticate Claude Code.`,
+      'empty',
+    );
+  }
+
+  // Same identity preference as addAccountViaOAuth — prefer CC identity if
+  // installed; otherwise generate fresh IDs.
+  const identity = (await detectClaudeIdentity()) ?? {
+    deviceId: randomUUID(),
+    accountUuid: randomUUID(),
+  };
+
+  const creds: AccountCredentials = {
+    alias,
+    accessToken: oauth.accessToken,
+    refreshToken: oauth.refreshToken,
+    expiresAt: oauth.expiresAt,
+    scopes: oauth.scopes ?? ['user:inference'],
+    deviceId: identity.deviceId,
+    accountUuid: identity.accountUuid,
+  };
+
+  await saveAccount(creds);
+  return creds;
 }
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,7 +26,7 @@ import { pathToFileURL } from 'node:url';
 import { startAutoOAuthFlow, startManualOAuthFlow, detectHeadlessEnvironment, getStatus, refreshTokens, loadCredentials } from './oauth.js';
 import { startProxy, sanitizeError } from './proxy.js';
 import { VALID_EFFORT_VALUES, type EffortValue } from './cc-template.js';
-import { listAccountAliases, loadAllAccounts, addAccountViaOAuth, addAccountViaManualOAuth, removeAccount, ensureLoginCredentialsInPool, MIGRATED_LOGIN_ALIAS } from './accounts.js';
+import { listAccountAliases, loadAllAccounts, addAccountViaOAuth, addAccountViaManualOAuth, addAccountFromKeychain, KeychainImportError, removeAccount, ensureLoginCredentialsInPool, MIGRATED_LOGIN_ALIAS } from './accounts.js';
 import { listBackends, saveBackend, removeBackend, type BackendCredentials } from './openai-backend.js';
 import { parseOutboundProxy, installOutboundProxyWrapper, type OutboundProxyConfig } from './outbound-proxy.js';
 
@@ -678,17 +678,32 @@ async function accounts() {
     }
 
     const manualAccountFlag = args.includes('--manual') || args.includes('--headless');
+    // --from-keychain[=<target>] imports an existing Claude Code keychain
+    // entry instead of running OAuth. Bare flag uses the only/first match;
+    // --from-keychain=<target> picks a specific entry by its platform-
+    // specific identifier (Linux account, Windows TargetName). See
+    // askalf/dario#237.
+    const keychainArg = args.find(a => a === '--from-keychain' || a === '--from-cc' || a.startsWith('--from-keychain=') || a.startsWith('--from-cc='));
+    const fromKeychain = keychainArg !== undefined;
+    const keychainTarget = keychainArg && keychainArg.includes('=') ? keychainArg.split('=', 2)[1] : undefined;
+    if (fromKeychain && manualAccountFlag) {
+      console.error('');
+      console.error('  --from-keychain and --manual are mutually exclusive (one skips OAuth, the other does it manually).');
+      console.error('');
+      process.exit(1);
+    }
 
     console.log('');
-    console.log(`  Adding account "${alias}" to the pool${manualAccountFlag ? ' (manual / headless flow)' : ''}...`);
+    console.log(`  Adding account "${alias}" to the pool${manualAccountFlag ? ' (manual / headless flow)' : fromKeychain ? ' (importing from OS keychain)' : ''}...`);
     console.log('');
 
     // Mirror the heuristic that `dario login` uses: if the user didn't
     // explicitly pick `--manual` AND we detect SSH / container / no-DISPLAY,
     // print a hint before opening the browser. Doesn't auto-flip — false
     // positives are more annoying than false negatives — but the hint keeps
-    // users from waiting for a browser redirect that can't land.
-    if (!manualAccountFlag) {
+    // users from waiting for a browser redirect that can't land. Skip the
+    // hint entirely when --from-keychain is set since no browser is opened.
+    if (!manualAccountFlag && !fromKeychain) {
       const reason = detectHeadlessEnvironment();
       if (reason) {
         console.log(`  Note: ${reason}. If the browser redirect doesn't land,`);
@@ -698,9 +713,11 @@ async function accounts() {
     }
 
     try {
-      const creds = manualAccountFlag
-        ? await addAccountViaManualOAuth(alias)
-        : await addAccountViaOAuth(alias);
+      const creds = fromKeychain
+        ? await addAccountFromKeychain(alias, keychainTarget)
+        : manualAccountFlag
+          ? await addAccountViaManualOAuth(alias)
+          : await addAccountViaOAuth(alias);
       const minutes = Math.round((creds.expiresAt - Date.now()) / 60000);
       console.log('');
       console.log(`  Account "${alias}" added.`);
@@ -716,6 +733,23 @@ async function accounts() {
       }
       console.log('');
     } catch (err) {
+      // KeychainImportError carries structured kind+candidates so we can
+      // render a targeted next step without parsing the message.
+      if (err instanceof KeychainImportError) {
+        console.error('');
+        console.error(`  Failed to add account: ${err.message}`);
+        if (err.kind === 'ambiguous' && err.candidates.length > 0) {
+          console.error('');
+          console.error('  Available keychain entries:');
+          for (const t of err.candidates) console.error(`    --from-keychain="${t}"`);
+        } else if (err.kind === 'no-match' && err.candidates.length > 0) {
+          console.error('');
+          console.error('  Available keychain entries:');
+          for (const t of err.candidates) console.error(`    --from-keychain="${t}"`);
+        }
+        console.error('');
+        process.exit(1);
+      }
       const msg = sanitizeError(err);
       console.error('');
       console.error(`  Failed to add account: ${msg}`);
@@ -723,7 +757,7 @@ async function accounts() {
       // `dario login`. Auto flow can fail on EADDRINUSE (port already
       // bound), SSH-tunnel mismatch, or the browser timing out before
       // the user signs in. `--manual` works in all of those cases.
-      if (!manualAccountFlag && /callback server|EADDRINUSE|bind|timed out|did not receive/i.test(msg)) {
+      if (!manualAccountFlag && !fromKeychain && /callback server|EADDRINUSE|bind|timed out|did not receive/i.test(msg)) {
         console.error(`  Hint: try \`dario accounts add ${alias} --manual\` for headless / container setups.`);
       }
       console.error('');
@@ -878,13 +912,20 @@ async function help() {
     dario refresh            Force token refresh
     dario logout             Remove saved credentials
     dario accounts list      List accounts in the multi-account pool
-    dario accounts add NAME [--manual]
+    dario accounts add NAME [--manual] [--from-keychain[=<target>]]
                              Add a new account to the pool (runs OAuth flow).
                              --manual (alias: --headless) prints an authorize
                              URL and reads the code you paste back — for
                              container / SSH / no-browser-on-this-machine
                              setups, or as the on-Windows escape hatch when
                              the URL dispatch chain truncates query params.
+                             --from-keychain skips OAuth and imports an
+                             existing Claude Code keychain entry on this
+                             host. With no value: uses the only/first match
+                             (errors with the candidate list if multiple
+                             entries exist). With =<target>: picks a specific
+                             entry by its platform identifier (Linux account
+                             attribute, Windows TargetName).
     dario accounts remove N  Remove an account from the pool
     dario backend list       List configured OpenAI-compat backends
     dario backend add NAME --key=sk-... [--base-url=...]

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -174,6 +174,162 @@ if ([CM]::CredEnumerate('Claude Code-credentials*', 0, [ref]$count, [ref]$ptr)) 
 }
 `;
 
+// Enumeration variant of WIN_CRED_SCRIPT — emits one line per credential
+// formatted as `<TargetName>\t<JSON>` so the importer can label entries
+// for the operator to disambiguate between accounts.
+const WIN_CRED_ENUMERATE_SCRIPT = `
+$ErrorActionPreference = 'Stop'
+$sig = @"
+using System;
+using System.Runtime.InteropServices;
+public class CM2 {
+  [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Unicode)]
+  public struct CRED {
+    public uint Flags; public uint Type; public string TargetName;
+    public string Comment; public System.Runtime.InteropServices.ComTypes.FILETIME LW;
+    public uint BlobSize; public IntPtr Blob;
+    public uint Persist; public uint AC; public IntPtr Attrs;
+    public string Alias; public string UN;
+  }
+  [DllImport("advapi32.dll", EntryPoint="CredEnumerateW", CharSet=CharSet.Unicode, SetLastError=true)]
+  public static extern bool CredEnumerate(string filter, uint flag, out uint count, out IntPtr pCredentials);
+  [DllImport("advapi32.dll", EntryPoint="CredFree")]
+  public static extern void CredFree(IntPtr cred);
+}
+"@
+Add-Type -TypeDefinition $sig
+$count = 0
+$ptr = [IntPtr]::Zero
+if ([CM2]::CredEnumerate('Claude Code-credentials*', 0, [ref]$count, [ref]$ptr)) {
+  try {
+    for ($i = 0; $i -lt $count; $i++) {
+      $credPtr = [System.Runtime.InteropServices.Marshal]::ReadIntPtr($ptr, $i * [IntPtr]::Size)
+      $cred = [System.Runtime.InteropServices.Marshal]::PtrToStructure($credPtr, [type][CM2+CRED])
+      if ($cred.BlobSize -gt 0) {
+        $bytes = New-Object byte[] $cred.BlobSize
+        [System.Runtime.InteropServices.Marshal]::Copy($cred.Blob, $bytes, 0, $cred.BlobSize)
+        $blob = [System.Text.Encoding]::Unicode.GetString($bytes)
+        Write-Output ($cred.TargetName + "\`t" + $blob)
+      }
+    }
+  } finally {
+    [CM2]::CredFree($ptr)
+  }
+}
+`;
+
+/**
+ * Information about a keychain entry surfaced for operator disambiguation
+ * during `dario accounts add --from-keychain`.
+ */
+export interface KeychainEntry {
+  /**
+   * Implementation-defined identifier the operator uses to pick a specific
+   * entry. Stable per-platform but not equal across platforms:
+   *  - Linux: the libsecret `account` attribute (or value when absent)
+   *  - Windows: the Credential Manager TargetName (e.g.
+   *    "Claude Code-credentials" or "Claude Code-credentials@<account-uuid>")
+   *  - macOS: always "Claude Code-credentials" until macOS-side multi-entry
+   *    enumeration is implemented (see comment in enumerateKeychainCredentials)
+   */
+  target: string;
+  credentials: CredentialsFile;
+}
+
+/**
+ * Enumerate every Claude Code keychain entry on this host. Pool-mode
+ * counterpart to `loadKeychainCredentials` (which returns the first hit
+ * for the single-account login flow). Used by `dario accounts add
+ * --from-keychain` to import without rerunning OAuth.
+ *
+ * Per-platform coverage:
+ *  - **Linux**: `secret-tool search --all service "Claude Code-credentials"`
+ *    enumerates every matching attribute set. Account name comes from the
+ *    `account` attribute when set, otherwise the secret hash truncated.
+ *  - **Windows**: PowerShell + CredEnumerate already iterates every
+ *    matching credential (existing pattern just wasn't exposing the
+ *    TargetName). New script variant emits target + JSON blob per line.
+ *  - **macOS**: returns at most one entry. The `security` CLI doesn't
+ *    expose a clean enumeration for `find-generic-password` results; full
+ *    macOS multi-account support would need either `dump-keychain` parsing
+ *    or a Swift/native helper. Filed as a follow-up; the common case (one
+ *    CC account in keychain) still works.
+ *
+ * Returns an empty array on any failure (keychain unavailable, no entries
+ * matching, parse errors). Callers are expected to handle empty as
+ * "nothing to import."
+ */
+export async function enumerateKeychainCredentials(): Promise<KeychainEntry[]> {
+  const out: KeychainEntry[] = [];
+  try {
+    if (platform() === 'darwin') {
+      // Single-entry path; multi-entry on macOS is a known limitation.
+      const single = await loadKeychainCredentials();
+      if (single) out.push({ target: 'Claude Code-credentials', credentials: single });
+    } else if (platform() === 'linux') {
+      const raw = await new Promise<string>((resolve, reject) => {
+        execFile(
+          'secret-tool',
+          ['search', '--all', 'service', 'Claude Code-credentials'],
+          { timeout: 5000 },
+          (err, stdout) => (err ? reject(err) : resolve(stdout)),
+        );
+      });
+      // secret-tool emits blocks separated by blank lines, with lines like:
+      //   [/secret/Claude Code-credentials/0]
+      //   label = ...
+      //   secret = <json blob>
+      //   attribute.account = <account name>
+      //   attribute.service = Claude Code-credentials
+      let currentSecret: string | undefined;
+      let currentAccount: string | undefined;
+      const flush = () => {
+        if (!currentSecret) return;
+        try {
+          const parsed = JSON.parse(currentSecret);
+          if (parsed?.claudeAiOauth?.accessToken && parsed?.claudeAiOauth?.refreshToken) {
+            out.push({
+              target: currentAccount || 'Claude Code-credentials',
+              credentials: parsed as CredentialsFile,
+            });
+          }
+        } catch { /* not a CC creds blob — skip */ }
+        currentSecret = undefined;
+        currentAccount = undefined;
+      };
+      for (const line of raw.split(/\r?\n/)) {
+        if (line.startsWith('[/')) { flush(); continue; }
+        if (line.startsWith('secret = ')) currentSecret = line.slice('secret = '.length);
+        else if (line.startsWith('attribute.account = ')) currentAccount = line.slice('attribute.account = '.length);
+      }
+      flush();
+    } else if (platform() === 'win32') {
+      const raw = await new Promise<string>((resolve, reject) => {
+        execFile(
+          'powershell.exe',
+          ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-Command', WIN_CRED_ENUMERATE_SCRIPT],
+          { timeout: 5000, windowsHide: true },
+          (err, stdout) => (err ? reject(err) : resolve(stdout)),
+        );
+      });
+      for (const line of raw.split(/\r?\n/)) {
+        const tab = line.indexOf('\t');
+        if (tab < 0) continue;
+        const target = line.slice(0, tab).trim();
+        const blob = line.slice(tab + 1).trim();
+        if (!target || !blob) continue;
+        try {
+          const parsed = JSON.parse(blob);
+          if (parsed?.claudeAiOauth?.accessToken && parsed?.claudeAiOauth?.refreshToken) {
+            out.push({ target, credentials: parsed as CredentialsFile });
+          }
+        } catch { /* skip non-credential entries */ }
+      }
+    }
+  } catch { /* keychain unavailable / empty */ }
+  return out;
+}
+
 async function loadKeychainCredentials(): Promise<CredentialsFile | null> {
   try {
     if (platform() === 'darwin') {


### PR DESCRIPTION
Closes #237.

## Background
`dario login` (single-account) reuses Claude Code keychain tokens via `loadKeychainCredentials` — operators are in the proxy in seconds. `dario accounts add` (multi-account pool) didn't have the matching path: every new pool entry forced a fresh OAuth round-trip even when the same account was already in the keychain.

## New surface

```
dario accounts add work --from-keychain
dario accounts add work --from-keychain="<target>"
```

Resolution:
- **0 keychain entries** → error with "run `claude` first" hint
- **1 entry total** → import it (target ignored if supplied)
- **2+ entries + no target** → list candidates, exit non-zero
- **2+ entries + target** → import match; list candidates if no match
- **--from-keychain + --manual** → reject (mutually exclusive)

## Per-platform coverage
| Platform | Enumeration | Notes |
|---|---|---|
| **Linux** | `secret-tool search --all service "Claude Code-credentials"` | Account attr → target identifier |
| **Windows** | New PowerShell + `CredEnumerate` variant emitting `<TargetName>\t<JSON>` per line | TargetName → target identifier |
| **macOS** | Single best match via existing `find-generic-password` | Multi-entry on macOS needs `dump-keychain` parsing or a native helper — filed as follow-up; the common case (one CC account) still works |

## Implementation
- `oauth.ts`: new `enumerateKeychainCredentials()`, new `WIN_CRED_ENUMERATE_SCRIPT`. Existing `loadKeychainCredentials` untouched (single-account login keeps working).
- `accounts.ts`: new `addAccountFromKeychain(alias, target?)` reuses `saveAccount` so on-disk shape + refresh path stay consistent. New `KeychainImportError` carries `kind` + `candidates` for structured CLI rendering.
- `cli.ts`: parses `--from-keychain[=<target>]` (alias `--from-cc`), branches the existing `accounts add` handler, renders ambiguous/no-match cases as copy-paste lines.

## Version bump
`3.37.11 → 3.37.12`. On merge: `cc-drift-auto-release` tags `v3.37.12` and `docker-publish` ships `ghcr.io/askalf/dario:latest` + `:3.37.12`.

## Test plan
- [ ] CI green (typecheck + actionlint + CodeQL)
- [ ] Verified locally: `tsc --noEmit` clean
- [ ] Live (Linux): `dario accounts add work --from-keychain` with ≥1 CC entry → imports without OAuth, alias appears in `~/.dario/accounts/work.json`
- [ ] Live (Linux, 2+ entries): bare `--from-keychain` lists candidates with copy-paste lines
- [ ] Live: `--from-keychain="not-a-real-target"` → no-match error with candidates
- [ ] Live: `--from-keychain` on a host with 0 entries → "run `claude` first" hint
- [ ] Regression: existing `dario login` keychain fast-path still works (untouched)
- [ ] Regression: existing `dario accounts add` OAuth flow still works (untouched)