### PR TITLE
docs: explicit 2026-06-15 positioning + FAQ entry on Agent SDK / claude -p split

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,29 @@ Already have **Pro + Max** stacked? Pool mode (`dario accounts add work` / `dari
 
 ---
 
+## What changes 2026-06-15 (and why dario doesn't)
+
+Anthropic announced that starting **2026-06-15**, Claude Agent SDK and `claude -p` (Claude Code headless mode) usage will no longer count toward Claude plan usage limits. Eligible plans get a separate fixed monthly credit instead — **$20/mo on Pro, $100/mo on Max 5x, $200/mo on Max 20x**. Once exhausted, those calls go to metered API pricing.
+
+For autonomous workloads — long-running coding agents, background scripts, anything that runs unattended — that credit pool is small. A single sustained Cline or Aider session can chew through $100 in an evening; agentic workloads blow past $200 in days.
+
+**Dario is unaffected by this split.** The Claude backend was designed from day one to send requests as **interactive Claude Code wire-shape** — full template replay from your installed CC binary (headers, body key order, TLS stack, session-id lifecycle). The upstream billing path sees a Claude Code interactive session, not a `claude -p` invocation or an Agent SDK call, regardless of what tool actually originated the request locally. That's the whole point of the wire-fidelity work in [`docs/wire-fidelity.md`](./docs/wire-fidelity.md) — and it was already shipping in production before the 2026-06-15 announcement.
+
+What this means concretely:
+
+| Setup | Pre-2026-06-15 | Post-2026-06-15 |
+|---|---|---|
+| Cline / Aider / Cursor → Anthropic API direct with API key | Per-token API billing | Per-token API billing (unchanged) |
+| Cline / Aider / Cursor → naive proxy that passes `claude -p` / Agent SDK calls through unchanged | Subscription pool | **Separate $20–200/mo credit pool, then per-token API** |
+| **Cline / Aider / Cursor → dario** | **Subscription pool** | **Subscription pool (unchanged — dario rewrites as interactive CC)** |
+| Claude Code itself, used interactively | Subscription pool | Subscription pool (unchanged) |
+
+If you're coming from a proxy that doesn't replay the full CC wire shape, your agentic workloads are about to land in the smaller credit bucket on 2026-06-15. Dario keeps them on the subscription pool you already pay for.
+
+Same install. Same `localhost:3456`. No config change needed for the cliff.
+
+---
+
 ## Why you'll install this
 
 - **One URL for every provider.** Cursor, Aider, Continue, Zed, OpenHands, Claude Code, your own scripts — every tool you own has its own per-provider config. Dario collapses that into a single `localhost:3456` that speaks both Anthropic and OpenAI protocols and routes by model name.
@@ -285,6 +308,9 @@ No reinstall. `dario login` re-uses any existing Claude Code credentials on your
 
 **I'm seeing `representative-claim: seven_day` in my rate-limit headers — am I being downgraded?**
 **No.** Both `five_hour` and `seven_day` are subscription billing — different accounting buckets inside the same subscription mode. `overage` is the one that flips you to per-token. See [Discussion #1](https://github.com/askalf/dario/discussions/1) for the full rate-limit-header breakdown.
+
+**I heard Anthropic is moving `claude -p` and Agent SDK to a separate credit pool on 2026-06-15. Will my dario setup break?**
+**No.** Dario rewrites every outbound request to look like an interactive Claude Code session before it hits `api.anthropic.com` — headers, body, TLS, session-id lifecycle. The upstream billing classifier sees interactive CC, not `claude -p` or Agent SDK, regardless of which local tool originated the call. Your workloads continue billing against your existing Pro / Max 5x / Max 20x subscription pool, same as today. Naive proxies that pass `claude -p` requests through unchanged will see their users' agentic traffic shift to the new $20–200/mo credit pool and then to metered API pricing — but that's not how dario was built. See the [2026-06-15 section](#what-changes-2026-06-15-and-why-dario-doesnt) above for the full breakdown.
 
 ---
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,6 +12,22 @@ On 2026-04-21 Anthropic temporarily removed Claude Code from new Pro signups, pe
 **Does it work with Team / Enterprise?**
 Yes — tested and confirmed working as long as your plan includes Claude Code access.
 
+**Anthropic announced that `claude -p` and Agent SDK usage moves to a separate credit pool on 2026-06-15. Will dario's Claude backend keep working?**
+Yes. The Claude backend was designed to send requests as **interactive Claude Code** wire-shape — full template replay of headers, body key order, TLS ClientHello, session-id lifecycle, inter-request timing. The upstream billing classifier sees an interactive CC session regardless of which local tool (claude -p subprocess, Agent SDK app, Cline, Aider, your own scripts) originated the call. That's the entire point of the wire-fidelity work in [`wire-fidelity.md`](./wire-fidelity.md), and it predates the 2026-06-15 announcement.
+
+What that means in practice:
+
+- Workloads that route through dario continue billing against your **subscription pool** (Pro $20, Max 5x $100, Max 20x $200) post-2026-06-15, same as before.
+- Workloads that bypass dario and call `claude -p` directly will count against the **new separate credit pool** (same dollar amounts, but a fixed monthly grant rather than the rolling subscription bucket — and once exhausted, those calls flip to metered API pricing).
+- Workloads that bypass dario and use the Agent SDK with API keys are unaffected (they were already metered API and remain so).
+
+Two questions to verify after 2026-06-15 lands:
+
+1. **Did Anthropic add a new fingerprint to `claude -p` that dario doesn't yet strip?** Run `claude -p "hi"` directly (no dario), check `representative-claim` and related rate-limit headers — that tells you what bucket Anthropic put the direct call in. Then run the same prompt through dario and check the same headers. If both show the same bucket (interactive subscription), the wire-rewrite is still doing its job. If dario's path shows the new agent-credit bucket, file an issue — that's the kind of CC drift the live template extractor and the [drift detector](./../scripts/capture-full-body.mjs) exist to catch.
+2. **Did Anthropic tighten OAuth-token classification?** If access-token bearer alone now signals "non-interactive," dario would have to add session affinity or a re-auth dance. Same diagnostic via the rate-limit headers will surface it. None of this is observed today (verified 2026-05-14 on v3.37.15).
+
+No config change is needed on the user side for the 2026-06-15 transition — same install, same `localhost:3456`, same `ANTHROPIC_BASE_URL=http://localhost:3456` env var.
+
 **Do I need Claude Code installed?**
 Recommended for the Claude backend, not strictly required. With CC installed, `dario login` picks up your credentials automatically, and the live template extractor reads your CC binary on every startup so the template stays current. Without CC, dario runs its own OAuth flow and falls back to the bundled template snapshot (scrubbed of host context at bake time as of v3.21). Drift detection warns you if your installed CC doesn't match the captured template, so upgrade windows don't silently ship stale templates.
 


### PR DESCRIPTION
## Summary
- Adds a dedicated README section (\"What changes 2026-06-15 (and why dario doesn't)\") between Cost comparison and Why-you'll-install, with a side-by-side table comparing direct API / naive proxy / dario / Claude Code itself across the transition
- Adds a README FAQ entry that maps to the new section
- Adds a deeper FAQ entry in \`docs/faq.md\` paralleling the README's lighter version, plus two diagnostic checks users can run after 2026-06-15 lands to verify their wire path is still classified as interactive subscription billing

## Why
2026-06-15 Anthropic plan change moves \`claude -p\` and Claude Agent SDK usage to a separate fixed monthly credit pool (\$20 Pro / \$100 Max 5x / \$200 Max 20x), then per-token API pricing beyond it.

Dario's wire-fidelity design (see \`docs/wire-fidelity.md\`) was already shipping in production before the announcement — every request is rewritten to interactive Claude Code wire-shape regardless of which local tool originated it, so the upstream billing classifier continues seeing interactive subscription traffic. That's the central value prop for the 2026-06-15 moment but it wasn't called out anywhere in the docs.

Users coming from proxies that don't replay the full CC wire shape are likely searching for alternatives over the next four weeks. The README should make the structural advantage explicit at the spot people land first.

## What this is not
- No code changes. Docs only.
- No comparison to specific named competitors. The table compares architectural patterns (\"naive proxy that passes \`claude -p\` through unchanged\"), not products.
- No claim of \"verified working post-2026-06-15\" — the cliff hasn't happened yet. The FAQ explicitly gives users two diagnostic checks to run after the date lands so they can verify on their own setup.

## Test plan
- [ ] CI green
- [ ] Cross-reference link \`#what-changes-2026-06-15-and-why-dario-doesnt\` resolves in the rendered GitHub view (heading slug check)