### PR TITLE
docs: add docs/why-now-2026-06.md — deep technical breakdown for the cliff

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ What this means concretely:
 
 If you're coming from a proxy that doesn't replay the full CC wire shape, your agentic workloads are about to land in the smaller credit bucket on 2026-06-15. Dario keeps them on the subscription pool you already pay for.
 
-Same install. Same `localhost:3456`. No config change needed for the cliff.
+Same install. Same `localhost:3456`. No config change needed for the cliff. Full technical breakdown — including the two diagnostic checks you can run after 2026-06-15 lands to verify the classification on your own setup — is in [`docs/why-now-2026-06.md`](./docs/why-now-2026-06.md).
 
 ---
 

--- a/docs/why-now-2026-06.md
+++ b/docs/why-now-2026-06.md
@@ -1,0 +1,100 @@
+# What changes 2026-06-15
+
+Anthropic [announced](https://www.anthropic.com/) that starting **2026-06-15**, Claude Agent SDK and `claude -p` (Claude Code headless mode) usage will no longer count toward Claude plan usage limits. Instead, eligible plans receive a fixed monthly Agent-SDK credit:
+
+| Plan | Subscription pool (interactive Claude Code, Claude Cowork, Claude.ai) | Separate Agent-SDK / `claude -p` credit (new) |
+|---|---|---|
+| Pro | $20/mo | $20/mo |
+| Max 5x | $100/mo | $100/mo |
+| Max 20x | $200/mo | $200/mo |
+| Team Premium | $100/mo | $100/mo |
+| Enterprise (seat-based) | included | $200/mo |
+
+Once the Agent-SDK credit is exhausted, those calls flip to **metered per-token API pricing**. The subscription pool stays reserved for interactive use.
+
+For autonomous workloads — sustained coding agents, background scripts, anything that calls Anthropic unattended — the new credit is small. A long Cline or Aider session can chew $100 of API-rate tokens in an evening; sustained agentic loops blow past $200 in days.
+
+## Why dario isn't affected
+
+Dario's Claude backend was designed to make every outbound request look like an **interactive Claude Code session** at the wire level. That predates the 2026-06-15 announcement — it's the same mechanism that's been routing your traffic through your Pro / Max 5x / Max 20x subscription pool since v3.22.
+
+The relevant property: Anthropic's billing classifier identifies traffic by what arrives at `api.anthropic.com`, not by what initiated it locally. A `claude -p` invocation that talks to dario gets rewritten into an interactive Claude Code request shape before it leaves your machine. The classifier sees interactive CC, applies the subscription pool, doesn't apply the new Agent-SDK bucket.
+
+This is the entire point of the wire-fidelity work in [`wire-fidelity.md`](./wire-fidelity.md). Six axes — body key order, TLS ClientHello, inter-request timing, stream-consumption shape, session-ID lifecycle, request headers — were closed between v3.22 and v3.28 specifically so the upstream classifier has no observable signal that the request originated outside an interactive CC session. The work was scoped around subscription-billing recognition, which is now what the 2026-06-15 split tests.
+
+## What this means concretely
+
+| Setup | Pre-2026-06-15 | Post-2026-06-15 |
+|---|---|---|
+| Direct Anthropic API with API key (Cline default, Aider default, your scripts) | Per-token API billing | Per-token API billing (unchanged) |
+| Proxy that forwards `claude -p` / Agent SDK request shape unchanged | Subscription pool | **Separate $20–200/mo Agent-SDK credit, then per-token API** |
+| **dario** | **Subscription pool** | **Subscription pool (unchanged — request is rewritten as interactive CC)** |
+| Claude Code itself (you, sitting at a terminal) | Subscription pool | Subscription pool (unchanged) |
+
+No config change is needed on the user side for the 2026-06-15 transition. Same install. Same `localhost:3456`. Same `ANTHROPIC_BASE_URL=http://localhost:3456` env var. The wire-rewrite has been doing this job in production for months.
+
+## How to verify on your own setup (after 2026-06-15 lands)
+
+Two diagnostics will tell you the classification is still working as expected.
+
+### Verify the rate-limit headers
+
+Every response from `api.anthropic.com` includes rate-limit metadata. The bucket the request was charged against is visible in the response headers. After 2026-06-15, run:
+
+```bash
+# 1. Direct claude -p, no dario. This is the new Agent-SDK credit bucket.
+unset ANTHROPIC_BASE_URL ANTHROPIC_API_KEY
+claude -p "say hi" 2>&1 | grep -i 'rate-limit\|representative'
+
+# 2. The same prompt through dario. Should land in the subscription bucket.
+export ANTHROPIC_BASE_URL=http://localhost:3456
+export ANTHROPIC_API_KEY=dario
+claude -p "say hi" 2>&1 | grep -i 'rate-limit\|representative'
+```
+
+What to look for:
+- The direct call should reference an Agent-SDK / claude-agent / claude-headless bucket (Anthropic's exact header names will land alongside the 2026-06-15 rollout; today's name is `representative-claim`).
+- The dario call should reference `five_hour` or `seven_day` — both subscription-billing accounting buckets. See [Discussion #1](https://github.com/askalf/dario/discussions/1) for the full breakdown of subscription rate-limit headers.
+
+If both calls land in the same bucket as dario, the wire-rewrite is doing its job. If dario's path lands in the new Agent-SDK bucket, file an issue — that's the kind of upstream classifier drift the live template extractor and the [drift detector](../scripts/capture-full-body.mjs) exist to catch.
+
+### Verify via dario doctor
+
+```bash
+dario doctor
+```
+
+The output includes:
+- **Template source + age + drift status** — confirms the bundled wire template matches your installed CC binary
+- **OAuth status** — confirms the access token is healthy (broken tokens 401 regardless of wire fidelity)
+- **Runtime / TLS class** — confirms `bun-match` (or surfaces the divergence with a hint)
+
+A clean `dario doctor` report is the per-machine equivalent of running the rate-limit-header check above. Run it before you assume dario is correctly classified.
+
+## What this doesn't promise
+
+A few things worth being precise about:
+
+1. **No verified post-2026-06-15 behavior yet.** As of this writing (2026-05-14), the cliff is four weeks out. The wire-rewrite has been classified as interactive subscription billing every day for months — but Anthropic could add a new signal on 2026-06-15 that none of the six current axes covers. If that happens, the live template extractor and drift detector will surface it on your first call, and the fix follows the same pattern as every other CC drift event the project has shipped.
+2. **No claim about competitor products specifically.** The table above refers to architectural patterns (`proxy that forwards request shape unchanged`), not named tools. If a particular tool also implements wire-fidelity replay, it gets the same outcome dario does. The reason this doc exists is that most subscription-billing proxies don't — they extract OAuth tokens and forward the raw client request, which is exactly the request shape that's about to be reclassified.
+3. **Beyond the subscription cap, Anthropic still rate-limits.** Dario doesn't multiply your subscription — it routes through the plan you have. Multi-account pool mode ([`multi-account-pool.md`](./multi-account-pool.md)) is the answer for hitting the cap on a single account; the 2026-06-15 work is orthogonal to it.
+4. **Anthropic terms of service still apply.** This project is independent, unofficial, third-party — see [DISCLAIMER.md](../DISCLAIMER.md). Whether any particular use complies with Anthropic's current terms is between you and Anthropic.
+
+## If you're coming from another proxy
+
+The migration is roughly:
+
+1. `npm install -g @askalf/dario` (or pull `ghcr.io/askalf/dario:latest` — see [`docker.md`](./docker.md))
+2. `dario login` — if you have Claude Code already installed and logged in, this picks up existing credentials. Otherwise it runs its own OAuth flow. For SSH / headless setups, `dario login --manual`.
+3. `dario proxy` — starts the local proxy on `localhost:3456`
+4. Update your tools' `ANTHROPIC_BASE_URL` env var to `http://localhost:3456` and `ANTHROPIC_API_KEY` to `dario` (literal string `dario` if you bind to loopback; a real `DARIO_API_KEY` if you bind to `0.0.0.0`)
+5. `dario doctor` — confirms everything is wired correctly
+
+Backends other than the Claude subscription (OpenAI, Groq, OpenRouter, Ollama, etc.) are configured separately via `dario backend add` — see the [README's 30-seconds section](../README.md#30-seconds).
+
+## Related reading
+
+- [`wire-fidelity.md`](./wire-fidelity.md) — the six wire-rewrite axes that make this possible
+- [`returning.md`](./returning.md) — if you used dario before and are coming back
+- [`multi-account-pool.md`](./multi-account-pool.md) — running multiple subscriptions in a pool
+- [Discussion #1](https://github.com/askalf/dario/discussions/1) — rate-limit header reference for subscription billing


### PR DESCRIPTION
## Summary
- Adds \`docs/why-now-2026-06.md\` — stand-alone deep-dive for the 2026-06-15 Anthropic plan change and the technical mechanism by which dario stays unaffected. Linked from the README section added in #255.
- One-line README addition pointing to the new doc.

## What's in it
- The plan-change table by tier (Pro/Max5/Max20/Team/Enterprise) with both pool sizes
- The wire-fidelity mechanism explanation — references docs/wire-fidelity.md rather than duplicating the axis table
- The pre/post-2026-06-15 setup comparison (same table that's in the README, slightly sharpened)
- **Two verifiable diagnostic checks** users can run after the cliff lands — rate-limit-header comparison and \`dario doctor\` sanity check
- A \"what this doesn't promise\" section: no verified post-2026-06-15 behavior yet, no competitor product callouts (architectural patterns only), Anthropic ToS still applies
- Migration steps for users coming from another proxy

## Why now
Users coming from proxies that don't do wire-rewrite are likely searching for alternatives over the next four weeks. The README already calls out the structural advantage; this doc is for the technical reader who wants the full mechanism + verification path before they commit to switching.

## What this is not
- No code changes. Docs only.
- No comparison to specific named competitors.
- No claim of \"verified working post-2026-06-15.\" Explicitly framed as forward-looking, with the diagnostic recipes users need to verify on their own setups.

## Test plan
- [ ] CI green
- [ ] Cross-reference links resolve in rendered GitHub view