### PR TITLE
fix(doctor): two misleading WARNs that look broken to new users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,10 @@ RUN addgroup -S dario \
 
 WORKDIR /app
 COPY --from=build --chown=dario:dario /app/dist ./dist
+# Doctor reads package.json (at __dirname/..) to surface the running version.
+# Without this copy, container deploys see `[WARN] dario package.json not
+# readable — version unknown` even though the binary itself works fine.
+COPY --from=build --chown=dario:dario /app/package.json ./package.json
 
 # Expose `dario` on PATH so `docker exec <container> dario login --manual`
 # works without falling back to `node /app/dist/cli.js`. The shebang in

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -253,10 +253,15 @@ export async function runChecks(opts: RunChecksOptions = {}): Promise<Check[]> {
       detail: `found at ${cc.path} but --version didn't parse — compat unchecked`,
     });
   } else {
+    // CC not installed locally is the correct, intended state for containerized
+    // deploys and CI runners — dario uses the bundled scrubbed template (whose
+    // freshness is surfaced by the separate "Template" row below). Marking
+    // this WARN scared container users into thinking something was broken;
+    // it's INFO with a hint pointing at the install upside instead.
     checks.push({
-      status: 'warn',
+      status: 'info',
       label: 'CC binary',
-      detail: 'not on PATH — dario falls back to bundled template',
+      detail: 'not installed locally — dario uses the bundled template. (Install @anthropic-ai/claude-code if you want auto-refresh from your own CC binary.)',
     });
   }
 


### PR DESCRIPTION
## Summary
Two diagnostics in \`dario doctor\` that scared new users into thinking the install was broken when it was actually fine:

1. **Dockerfile: copy \`package.json\` into the runtime image.** Doctor reads \`package.json\` at \`__dirname/..\` to surface the running version. The build stage only copied \`dist/\` to the runtime, so container deploys saw \`[WARN] dario  package.json not readable — version unknown\` even though every other system check passed. Fix is a one-line \`COPY\`.

2. **\`doctor.ts\`: CC-not-on-PATH is \`info\`, not \`warn\`.** For containerized deploys and CI runners, having no local Claude Code binary is the correct, intended state — dario uses the bundled scrubbed template (whose freshness is surfaced by the separate \"Template\" row). The WARN row read as \"something is wrong\" when it was actually \"this is fine.\" Downgraded to \`info\` with a message that explains both the current state and the upside of installing CC locally (auto-refresh from your own binary).

## Why now
Users coming from competing proxies over the next four weeks will run \`dario doctor\` as their first sanity check. Two yellow rows in that output is a conversion-killer when the actual operational state is healthy. After this PR the standard containerized \`dario doctor\` report is green-and-blue-only (assuming OAuth + template are themselves healthy).

## Caught against the live container
Running \`docker exec askalf-dario dario doctor\` on a healthy production deploy returned:
\`\`\`
[WARN]  dario           package.json not readable — version unknown
[ OK ]  Node            v24.3.0
...
[WARN]  CC binary       not on PATH — dario falls back to bundled template
[ OK ]  Template        live capture, CC v2.1.138 (4d old) (schema v3)
[ OK ]  OAuth           healthy (expires in 3h 1m)
\`\`\`
Both WARNs are now removed/downgraded; the same setup produces all \`[ OK ]\` / \`[INFO]\` rows after this PR.

## Test plan
- [ ] CI green
- [ ] After merge: rebuild \`ghcr.io/askalf/dario:latest\`, redeploy on Hetzner, re-run \`dario doctor\` — verify the version row says \`v3.37.x\` and the CC-binary row is \`[INFO]\` not \`[WARN]\`