### PR TITLE
fix(docker): self-heal entrypoint so volume ownership recovers automatically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ RUN npm run build
 
 FROM node:22-alpine AS runtime
 
+# su-exec is the alpine package that lets the entrypoint drop privileges
+# from root → dario after the volume self-heal. ~10KB; no shell, no PAM.
+RUN apk add --no-cache su-exec
+
 # Bun ships dario's runtime TLS fingerprint — without it, dario auto-detects
 # Node and falls back to bun-not-found mode. Copying the static binary from
 # oven/bun:1-alpine keeps the runtime image free of bun's build deps.
@@ -32,7 +36,19 @@ COPY --from=build --chown=dario:dario /app/package.json ./package.json
 RUN chmod +x /app/dist/cli.js \
  && ln -s /app/dist/cli.js /usr/local/bin/dario
 
-USER dario
+# Self-heal entrypoint: starts as root, chowns the mounted config volume to
+# dario:dario, then drops privileges via su-exec before running the CLI.
+# Required because Docker volume mounts don't inherit the build-time chown,
+# and any prior `--user 0` recovery op leaves the volume root-owned. Without
+# this the dario user can't write credentials and the container drifts into
+# a state that looks like an OAuth bug. See entrypoint script for details.
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Container starts as root briefly — the entrypoint script self-heals the
+# volume and drops to the dario user before exec'ing the CLI. Operators who
+# want to skip the self-heal (e.g. immutable CI runners) can override with
+# `docker run --user dario ...`.
 
 ENV DARIO_HOST=0.0.0.0 \
     DARIO_PORT=3456
@@ -43,5 +59,5 @@ VOLUME ["/home/dario/.dario"]
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD wget -qO- "http://127.0.0.1:${DARIO_PORT}/health" >/dev/null || exit 1
 
-ENTRYPOINT ["node", "/app/dist/cli.js"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["proxy"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# dario container entrypoint.
+#
+# Self-heals the `/home/dario/.dario` config volume on startup, then drops
+# privileges to the dario user and execs the dario CLI.
+#
+# Without the chown, any prior recovery op that ran as root (e.g.
+# `docker run --user 0 ... -v dario-config:/home/dario/.dario` to fix
+# something like a stale credentials.json) leaves files owned by root,
+# and subsequent normal-user runs see EACCES on every write — credentials
+# can't refresh, login can't write, the container drifts into a broken
+# state that looks like an OAuth bug.
+#
+# Pattern: run as root briefly, chown the volume, then `su-exec` down to
+# the unprivileged dario user before exec'ing the actual process.
+
+set -e
+
+DARIO_HOME=/home/dario/.dario
+
+if [ "$(id -u)" = "0" ]; then
+  # Running as root — self-heal then drop privileges
+  # The mkdir handles the case where the volume mount created an empty dir
+  # that didn't inherit the build-stage ownership.
+  mkdir -p "$DARIO_HOME"
+  chown -R dario:dario "$DARIO_HOME"
+  exec su-exec dario node /app/dist/cli.js "$@"
+fi
+
+# Already running as a non-root user (operator opted out of the self-heal by
+# setting USER explicitly, or this is a CI runner without root) — just exec.
+exec node /app/dist/cli.js "$@"


### PR DESCRIPTION
## Summary
Adds a small \`docker-entrypoint.sh\` that chowns \`/home/dario/.dario\` to \`dario:dario\` at container start, then drops privileges via \`su-exec\` before exec'ing the CLI. Removes the \`USER dario\` directive (the entrypoint handles privilege drop itself).

## What this fixes
Any prior \`docker run --user 0 ... -v dario-config:/home/dario/.dario\` recovery op (e.g. the 'rm credentials.json' incantation that was the documented re-auth dance until #242 shipped \`--force-reauth\`) leaves the config volume root-owned. Subsequent normal-user container starts see EACCES on every write — the dario user can't refresh credentials, can't persist a new login, and the container drifts into a state that *presents* as an OAuth bug (refresh failing, /health going degraded) but is actually a filesystem ownership issue.

This was bug #6 in the [\`reference_dario_lessons\`](#) operational memory.

## Why now
Users coming from competing proxies over the next four weeks will inevitably do recovery ops as root (the docs literally say \`docker run --user 0\` to wipe credentials in the worst case). Self-heal means a wrong choice doesn't compound — the next container start fixes the volume automatically.

## What the entrypoint does
\`\`\`sh
if [ "\$(id -u)" = "0" ]; then
  mkdir -p \$DARIO_HOME
  chown -R dario:dario \$DARIO_HOME
  exec su-exec dario node /app/dist/cli.js \"\$@\"
fi
exec node /app/dist/cli.js \"\$@\"
\`\`\`
The \`else\` branch covers operators who run \`docker run --user dario ...\` explicitly — they opted out of the self-heal, the script respects it and exec's directly.

## What it costs
- Adds the alpine \`su-exec\` package (~10KB, no shell, no PAM, common pattern across alpine-based runtime images)
- Container starts as root briefly (~milliseconds) before privilege drop — acceptable for the operational benefit

## Test plan
- [ ] CI green
- [ ] After merge: rebuild \`ghcr.io/askalf/dario:latest\`, pull on Hetzner, restart \`askalf-dario\` container, confirm \`docker exec askalf-dario id\` shows \`uid=1000(dario)\` and \`docker logs askalf-dario\` shows no chown errors
- [ ] Negative test: run \`docker run --user 0 --rm --entrypoint chown ghcr.io/askalf/dario:latest -R root:root /home/dario/.dario\`, then start a new container, confirm the volume is back to dario-owned after the entrypoint runs