### PR TITLE
release: v3.37.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,28 @@ checklist.
 
 ## [Unreleased]
 
-### Documentation — 2026-06-15 Anthropic plan-change positioning (#255)
+## [3.37.16] - 2026-05-14
 
-Adds an explicit README section ("What changes 2026-06-15 (and why dario doesn't)") plus README + `docs/faq.md` FAQ entries explaining how dario's wire-fidelity replay design predates the upstream change and continues routing requests through the interactive Claude Code subscription pool regardless of whether the originating local tool was `claude -p`, the Claude Agent SDK, Cline, Aider, or anything else.
+### Documentation — 2026-06-15 Anthropic plan-change positioning (#255, #256, #257)
+
+Adds an explicit README section ("What changes 2026-06-15 (and why dario doesn't)") plus README + `docs/faq.md` FAQ entries explaining how dario's wire-fidelity replay design predates the upstream change and continues routing requests through the interactive Claude Code subscription pool regardless of whether the originating local tool was `claude -p`, the Claude Agent SDK, Cline, Aider, or anything else. Also adds a stand-alone deep doc at `docs/why-now-2026-06.md` that the README's new section links to — full mechanism explanation plus two diagnostic checks (rate-limit-header comparison + `dario doctor` sanity check) users can run after 2026-06-15 lands to verify their wire path is still classified as interactive subscription billing on their own setup.
 
 Background: starting 2026-06-15, Anthropic moves `claude -p` and Claude Agent SDK usage to a separate fixed monthly credit pool ($20 Pro / $100 Max 5x / $200 Max 20x), then per-token API pricing once exhausted. Proxies that forward those request shapes through unchanged will see their users' agentic traffic land in the smaller credit bucket. Dario's Claude backend has always rewritten outbound requests to look like interactive Claude Code (headers, body key order, TLS stack, session-id lifecycle) — this is what the wire-fidelity work in `docs/wire-fidelity.md` exists to do. No code changes were needed for the transition; the docs just make the structural advantage explicit.
 
-The README's new section includes a side-by-side table; the FAQ entries include two diagnostic checks users can run after 2026-06-15 lands to verify their wire path is still classified as interactive subscription billing on their own setup.
+### Fixed — `dario doctor` no longer shows misleading WARNs on container deploys (#258)
+
+Two diagnostics in `dario doctor` were marked `[WARN]` when the underlying state was actually fine, which scared new users on containerized deploys into thinking the install was broken:
+
+- **`dario` version row**: `package.json` is now copied into the runtime image so doctor can read the version. Previously container deploys saw `[WARN] dario  package.json not readable — version unknown` while the binary itself worked correctly.
+- **`CC binary` row**: not having a local `claude-code` install is the correct state for containerized deploys and CI runners — dario uses the bundled scrubbed template (whose freshness is surfaced by the separate "Template" row). Downgraded the row from `[WARN]` to `[INFO]` with a message that explains both the current state and the upside of installing CC locally (auto-refresh from your own binary).
+
+Net effect: the standard containerized `dario doctor` report is green-and-blue-only after this release (assuming OAuth + template are themselves healthy).
+
+### Fixed — Docker self-heal entrypoint recovers volume ownership automatically (#259)
+
+Adds `docker-entrypoint.sh` that runs as root briefly at container start, chowns `/home/dario/.dario` to `dario:dario`, then drops privileges via `su-exec` before exec'ing the CLI. Without this, any prior `docker run --user 0 ...` recovery op (the documented incantation for wiping a broken credentials file before `--force-reauth` shipped in v3.37.11) leaves the config volume root-owned. Subsequent normal-user container starts then see EACCES on every write — the dario user can't refresh credentials, can't persist a new login, and the container drifts into a state that *presents* as an OAuth bug (refresh failing, /health going degraded) but is actually a filesystem ownership issue.
+
+Operators who run `docker run --user dario ...` opt out of the self-heal and the entrypoint respects that (script detects non-root and exec's directly without chowning). Adds the alpine `su-exec` package (~10KB, no shell, no PAM).
 
 ## [3.37.15] - 2026-05-14
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "3.37.13",
+  "version": "3.37.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "3.37.13",
+      "version": "3.37.16",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.37.15",
+  "version": "3.37.16",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
Patch release bundling five PRs that shipped to master this morning.

| PR | Type | Topic |
|---|---|---|
| #255 | docs | Explicit 2026-06-15 README section + FAQ entry on Agent SDK / claude -p split |
| #256 | docs | CHANGELOG entry for #255 under \`[Unreleased]\` |
| #257 | docs | Stand-alone \`docs/why-now-2026-06.md\` deep technical breakdown + README link |
| #258 | fix | Two misleading WARNs in \`dario doctor\` downgraded to INFO/fixed (container deploys) |
| #259 | fix | Docker self-heal entrypoint — volume ownership recovers automatically |

See \`CHANGELOG.md\` for the full per-section detail. No breaking changes; patch-level only.

## Pre-merge gates (run locally on this branch)
- [x] \`npm run build\` — clean
- [x] \`npm test\` — 62/62 pass
- [x] \`package.json.version\` bumped \`3.37.15\` → \`3.37.16\`
- [x] \`CHANGELOG.md\` has \`## [3.37.16] - 2026-05-14\` above \`## [Unreleased]\`
- [x] \`package-lock.json\` re-synced (\`npm install --package-lock-only\`)
- [x] No \`Co-Authored-By:\` trailers in any commit on this branch

## Post-publish smoke (per RELEASING.md, run within 10 minutes of \`npm publish\` completing)
- [ ] \`npm install -g @askalf/dario@latest\` succeeds; \`dario --version\` reports \`3.37.16\`
- [ ] \`dario --help\` outputs the command list (not the silent-CLI regression from #143)
- [ ] \`dario doctor\` runs and outputs the full report; verify the two WARNs from #258 are gone (dario row shows \`v3.37.16\`, CC-binary row is INFO not WARN if no local CC)
- [ ] \`dario doctor --usage\` runs (exercises the per-model probe)
- [ ] \`DARIO_NO_BUN=1 dario proxy &\` binds + \`curl http://127.0.0.1:3456/health\` returns 200 JSON; kill the proxy

## Post-publish container smoke (specific to #259)
- [ ] \`docker pull ghcr.io/askalf/dario:latest\` — confirm digest changed
- [ ] \`docker run --rm ghcr.io/askalf/dario:latest doctor\` — confirm version row + CC-binary row both fixed
- [ ] Volume self-heal negative test:
  \`\`\`
  docker volume create dario-test
  docker run --rm --user 0 --entrypoint chown -v dario-test:/home/dario/.dario ghcr.io/askalf/dario:latest -R root:root /home/dario/.dario
  docker run --rm -v dario-test:/home/dario/.dario ghcr.io/askalf/dario:latest doctor
  # The chown-to-root should be self-healed back to dario:dario by the new entrypoint
  docker volume rm dario-test
  \`\`\`