### PR TITLE
fix(entrypoint): hotfix v3.37.16 regression under cap_drop: ALL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ checklist.
 
 ## [Unreleased]
 
+## [3.37.17] - 2026-05-14
+
+### Fixed — entrypoint hotfix for cap_drop deploys (regression in v3.37.16)
+
+**v3.37.16 broke container startup for any deploy that runs with `cap_drop: ALL` (a common hardening pattern in docker-compose configurations).** Anyone on v3.37.16 with a cap-dropped container saw an infinite restart loop with `chown: /home/dario/.dario: Permission denied` in the logs — please upgrade to v3.37.17.
+
+Root cause: the v3.37.16 self-heal entrypoint (#259) ran `chown -R dario:dario /home/dario/.dario` unconditionally at startup. Under `cap_drop: ALL`, the container is root but has no `CAP_CHOWN`, so the chown EPERMs and the entrypoint exits before su-exec can hand off to the dario user.
+
+Fix: make the chown conditional. The entrypoint now skips it entirely when the volume is already correctly owned (the normal case — every container start after the first), and degrades gracefully with a clear log message when chown is needed but unavailable. Net effect on the three deploy scenarios:
+
+- **Normal start (volume already dario-owned, any caps):** no chown attempted. Works under `cap_drop: ALL`.
+- **Recovery start (volume root-owned from a `--user 0` op) + caps available:** chown succeeds, volume is healed, log line confirms it.
+- **Recovery start + `cap_drop: ALL`:** chown fails, container still starts, log line explains how to recover (one boot with `cap_add: [CHOWN, FOWNER]`, then drop caps again).
+
+The mkdir at the start of the entrypoint is also now best-effort (`|| true`) for the same defensive reason.
+
 ## [3.37.16] - 2026-05-14
 
 ### Documentation — 2026-06-15 Anthropic plan-change positioning (#255, #256, #257)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,32 +2,58 @@
 #
 # dario container entrypoint.
 #
-# Self-heals the `/home/dario/.dario` config volume on startup, then drops
-# privileges to the dario user and execs the dario CLI.
+# Best-effort self-heal of the `/home/dario/.dario` config volume on startup,
+# then drops privileges to the dario user and execs the dario CLI.
 #
-# Without the chown, any prior recovery op that ran as root (e.g.
-# `docker run --user 0 ... -v dario-config:/home/dario/.dario` to fix
-# something like a stale credentials.json) leaves files owned by root,
-# and subsequent normal-user runs see EACCES on every write — credentials
-# can't refresh, login can't write, the container drifts into a broken
-# state that looks like an OAuth bug.
+# Pattern: run as root briefly, chown the volume IFF the volume isn't already
+# correctly owned and CAP_CHOWN is available, then `su-exec` down to the
+# unprivileged dario user before exec'ing the actual process.
 #
-# Pattern: run as root briefly, chown the volume, then `su-exec` down to
-# the unprivileged dario user before exec'ing the actual process.
+# The conditional chown is what makes this safe under hardened container
+# configs that drop all capabilities (e.g. compose's `cap_drop: ALL`). Without
+# CAP_CHOWN the chown fails with EPERM; if we attempt it unconditionally we
+# break every cap-dropped deploy. So:
+#
+#   - normal case (volume already dario-owned): skip chown, no caps needed
+#   - recovery case + caps available: chown succeeds, volume is healed
+#   - recovery case + caps dropped: chown fails silently, dario user still
+#     can't write, but the container starts — operator sees clear EACCES in
+#     subsequent operation logs rather than a cryptic entrypoint crash loop
+#
+# Why the recovery case existed: any prior `docker run --user 0 ... -v
+# dario-config:/home/dario/.dario` recovery op (the documented dance for
+# wiping credentials.json before --force-reauth shipped in v3.37.11) leaves
+# files owned by root. Subsequent normal-user runs then see EACCES on every
+# write — credentials can't refresh, login can't persist.
 
 set -e
 
 DARIO_HOME=/home/dario/.dario
+DARIO_UID=$(id -u dario)
+DARIO_GID=$(id -g dario)
 
 if [ "$(id -u)" = "0" ]; then
-  # Running as root — self-heal then drop privileges
-  # The mkdir handles the case where the volume mount created an empty dir
-  # that didn't inherit the build-stage ownership.
-  mkdir -p "$DARIO_HOME"
-  chown -R dario:dario "$DARIO_HOME"
+  # mkdir is best-effort — if the volume mount already created it, this is a
+  # no-op; if not, we get a fresh dir owned by root which the conditional
+  # chown below will fix.
+  mkdir -p "$DARIO_HOME" 2>/dev/null || true
+
+  # Only attempt chown if the volume isn't already correctly owned. The
+  # success path (volume previously written by dario user) skips the chown
+  # entirely, so no CAP_CHOWN is required for normal container starts under
+  # `cap_drop: ALL`.
+  CURRENT_OWNER=$(stat -c '%u:%g' "$DARIO_HOME" 2>/dev/null || echo 'unknown')
+  if [ "$CURRENT_OWNER" != "$DARIO_UID:$DARIO_GID" ]; then
+    if chown -R dario:dario "$DARIO_HOME" 2>/dev/null; then
+      echo "[entrypoint] self-healed $DARIO_HOME ownership ($CURRENT_OWNER → $DARIO_UID:$DARIO_GID)" >&2
+    else
+      echo "[entrypoint] WARN: $DARIO_HOME is $CURRENT_OWNER (expected $DARIO_UID:$DARIO_GID) but chown failed (no CAP_CHOWN). Container will start; subsequent writes may EACCES. To self-heal, restart with cap_add: [CHOWN, FOWNER] for one boot, then drop caps again." >&2
+    fi
+  fi
+
   exec su-exec dario node /app/dist/cli.js "$@"
 fi
 
-# Already running as a non-root user (operator opted out of the self-heal by
-# setting USER explicitly, or this is a CI runner without root) — just exec.
+# Already running as a non-root user (operator opted out of self-heal via
+# `docker run --user dario ...` or a CI runner without root) — just exec.
 exec node /app/dist/cli.js "$@"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "3.37.16",
+  "version": "3.37.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "3.37.16",
+      "version": "3.37.17",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.37.16",
+  "version": "3.37.17",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Hotfix: v3.37.16 → v3.37.17

**v3.37.16 is broken for any container deploy that runs with \`cap_drop: ALL\`** — a common docker-compose hardening pattern. Symptom is an infinite restart loop with \`chown: /home/dario/.dario: Permission denied\` in the logs. Caught on Hetzner production deploy ~3 minutes after #260 shipped.

## Root cause
#259's self-heal entrypoint runs \`chown -R dario:dario\` unconditionally at startup. Under \`cap_drop: ALL\`, the container is root (no \`USER\` directive in the Dockerfile, the entrypoint handles privilege drop itself) but has no \`CAP_CHOWN\` — so the chown EPERMs, \`set -e\` propagates, the entrypoint exits before \`su-exec\` hands off to the dario user, container restart loop, healthcheck never returns.

## Fix
Three changes to \`docker-entrypoint.sh\`:

1. **Conditional chown.** Stat the volume first; only attempt chown if the owner isn't already \`dario:dario\`. The normal case (volume previously written by dario) skips the chown entirely — works under \`cap_drop: ALL\`.
2. **Graceful chown failure.** When chown IS needed but \`CAP_CHOWN\` is dropped, log a clear warning instead of crashing. Container still starts; subsequent writes may EACCES, but operator gets a clear log line explaining the recovery path (one boot with \`cap_add: [CHOWN, FOWNER]\`, then drop caps again).
3. **mkdir best-effort.** \`mkdir -p ... 2>/dev/null || true\` — same reason; avoids crashing on permission-related corner cases.

## Three deploy scenarios after this PR
| Scenario | Behavior |
|---|---|
| Normal container start (volume already dario-owned) | No chown attempted. Works under \`cap_drop: ALL\`. |
| Recovery start (volume root-owned from a \`--user 0\` op) + caps available | chown succeeds, volume healed, log line confirms |
| Recovery start + \`cap_drop: ALL\` | chown fails gracefully, container starts, log explains recovery |

## Test plan
- [x] \`npm run build\` — clean
- [x] \`npm test\` — 62/62 pass
- [x] \`package.json.version\` bumped \`3.37.16\` → \`3.37.17\`
- [x] CHANGELOG entry with explicit \"anyone on v3.37.16 needs to upgrade\" line per RELEASING.md
- [x] \`package-lock.json\` re-synced

## Post-publish smoke (RELEASING.md mandatory)
- [ ] \`npm install -g @askalf/dario@latest\` → \`dario --version\` reports 3.37.17
- [ ] \`docker pull ghcr.io/askalf/dario:latest\` — verify digest changed
- [ ] **Hetzner re-deploy** with \`cap_drop: ALL\` + \`no-new-privileges: true\` — verify container starts and stays healthy (this is the exact config that caught the regression; first thing to re-verify)