### PR TITLE
fix(docker): restore USER dario default for cap_drop deploys (v3.37.16/17 regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ checklist.
 
 ## [Unreleased]
 
+## [3.37.18] - 2026-05-14
+
+### Fixed — restore `USER dario` default for cap_drop deploys (regression in v3.37.16 + v3.37.17)
+
+**Both v3.37.16 and v3.37.17 break container startup under `cap_drop: ALL`.** v3.37.16 failed on `chown` (no CAP_CHOWN); v3.37.17 fixed the chown to be conditional but still failed on `su-exec: setgroups: Operation not permitted` (privilege-drop requires CAP_SETGID/CAP_SETUID, also gone under `cap_drop: ALL`). The fundamental issue: any privilege-drop pathway needs caps that the hardened config strips.
+
+Fix: restore `USER dario` as the default in the Dockerfile. The entrypoint script is still present and still does self-heal when explicitly invoked as root, but that's now an opt-in operation rather than the default startup flow.
+
+What this means concretely:
+
+- **Default deploy (`USER` not overridden, any compose hardening including `cap_drop: ALL`):** container starts as the dario user. Entrypoint's `id -u != 0` branch exec's the CLI directly. No chown, no su-exec, no caps required. Works.
+- **Recovery deploy (`docker run --user 0 ...` + `cap_add: [CHOWN, SETUID, SETGID, FOWNER]` for one boot):** entrypoint chowns the volume, su-exec's down to dario, normal operation. Operator can then drop caps again on subsequent boots.
+- **Recovery deploy without re-adding caps:** entrypoint logs warnings about missing capabilities and gracefully degrades. Subsequent writes may EACCES but the container itself starts.
+
+The original automatic-self-heal-on-every-start design from v3.37.16 was incompatible with `cap_drop: ALL` because that pattern requires either (a) staying as root (which dario shouldn't) or (b) privilege-dropping via su-exec (which needs caps the hardened config drops). The current design preserves the security default for everyone, and makes self-heal an explicit operator action for the recovery case.
+
+Anyone on v3.37.16 or v3.37.17 with cap-dropped containers needs to upgrade.
+
 ## [3.37.17] - 2026-05-14
 
 ### Fixed — entrypoint hotfix for cap_drop deploys (regression in v3.37.16)

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,10 +45,19 @@ RUN chmod +x /app/dist/cli.js \
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-# Container starts as root briefly — the entrypoint script self-heals the
-# volume and drops to the dario user before exec'ing the CLI. Operators who
-# want to skip the self-heal (e.g. immutable CI runners) can override with
-# `docker run --user dario ...`.
+# Default to the unprivileged dario user. The entrypoint detects this and
+# exec's directly without chown/su-exec, which is what makes the image
+# compatible with hardened compose configs that use `cap_drop: ALL` (these
+# strip CAP_CHOWN AND CAP_SETUID/SETGID, so neither chown nor su-exec can
+# succeed regardless of whether the container starts as root).
+#
+# Operators who want the self-heal entrypoint to actually chown the volume
+# (e.g. after a `docker run --user 0 ...` recovery op left files root-owned)
+# override the user explicitly: `docker run --user 0 ...` AND provide
+# `cap_add: [CHOWN, SETUID, SETGID, FOWNER]` for that one boot. The
+# entrypoint will then chown, su-exec down to dario, and from then on the
+# volume is correctly owned again so normal cap-dropped starts work.
+USER dario
 
 ENV DARIO_HOST=0.0.0.0 \
     DARIO_PORT=3456

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "3.37.17",
+  "version": "3.37.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "3.37.17",
+      "version": "3.37.18",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.37.17",
+  "version": "3.37.18",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Hotfix: v3.37.17 → v3.37.18

**v3.37.17 still breaks container startup under \`cap_drop: ALL\`.** v3.37.16 failed on \`chown\`; v3.37.17 fixed the chown to be conditional but then failed on \`su-exec: setgroups: Operation not permitted\` — privilege-drop requires \`CAP_SETGID\`/\`CAP_SETUID\` which are also stripped by \`cap_drop: ALL\`. The fundamental issue: any privilege-drop pathway needs caps the hardened config removes.

## Fix
Restore \`USER dario\` as the Dockerfile default. The entrypoint script is still present and still does self-heal when explicitly invoked as root, but that's now an opt-in operator action rather than the default startup flow.

## Three deploy scenarios after this PR
| Scenario | Behavior |
|---|---|
| **Default deploy** (any compose hardening including \`cap_drop: ALL\`) | Container starts as dario user. Entrypoint exec's CLI directly. No chown, no su-exec, no caps required. Works. |
| **Recovery deploy** (\`docker run --user 0 ...\` + \`cap_add: [CHOWN, SETUID, SETGID, FOWNER]\` for one boot) | Entrypoint chowns the volume, su-exec's down to dario, normal operation. Operator drops caps again on subsequent boots. |
| **Recovery without re-adding caps** | Entrypoint logs warnings about missing capabilities. Container starts; subsequent writes may EACCES but operator gets a clear log line. |

## Trade-off acknowledged
The original v3.37.16 design promised automatic self-heal on every container start. That goal is incompatible with \`cap_drop: ALL\` — you can't be root-then-drop without caps. The current design preserves the security default for everyone (most users never need recovery), and makes self-heal an explicit operator action for the rare recovery case.

## Test plan
- [x] \`npm run build\` — clean
- [x] \`npm test\` — 62/62 pass
- [x] \`package.json.version\` bumped \`3.37.17\` → \`3.37.18\`
- [x] CHANGELOG entry with explicit \"anyone on v3.37.16/17 needs to upgrade\" line per RELEASING.md hotfix convention
- [x] \`package-lock.json\` re-synced

## Post-publish smoke (RELEASING.md mandatory)
- [ ] \`npm install -g @askalf/dario@latest\` → \`dario --version\` reports 3.37.18
- [ ] \`docker pull ghcr.io/askalf/dario:latest\` — verify digest changed
- [ ] **Hetzner re-deploy** with \`cap_drop: ALL\` + \`no-new-privileges: true\` — verify container starts and stays healthy (this is the exact config that caught both regressions)