### PR TITLE
fix(doctor): --usage probe reads DARIO_API_KEY for proxy auth

### DIFF
--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -451,11 +451,18 @@ export async function runChecks(opts: RunChecksOptions = {}): Promise<Check[]> {
       //   - Else fall back to direct-to-Anthropic with Haiku only.
       //     Unified buckets surface but per-model buckets won't.
       const dario_base = process.env.DARIO_TEST_URL || 'http://127.0.0.1:3456';
+      // The proxy validates Authorization against DARIO_API_KEY when set.
+      // Fall back to literal 'dario' (the documented loopback-only default)
+      // when unset so local-dev probes against a no-auth proxy continue to
+      // work. Without reading the env here, `dario doctor --usage` 401s on
+      // every deploy that sets a real auth secret — which is every prod
+      // deploy that follows the README's "non-loopback bind" guidance.
+      const dario_auth = process.env.DARIO_API_KEY || 'dario';
       let probeEndpoint = `${dario_base}/v1/messages`;
       let probeHeaders: Record<string, string> = {
         'content-type': 'application/json',
         'anthropic-version': '2023-06-01',
-        'authorization': 'Bearer dario',
+        'authorization': `Bearer ${dario_auth}`,
       };
       let proxyAvailable = false;
       try {


### PR DESCRIPTION
## Summary
The \`dario doctor --usage\` probe hard-coded \`Authorization: Bearer dario\` when constructing requests against the local proxy. Any deploy that sets a real \`DARIO_API_KEY\` (every non-loopback bind per the README's documented security guidance) gets 401 on every probe request, surfacing as:

\`\`\`
[WARN]  Usage snapshot  probe failed: all probe requests failed
\`\`\`

That command is the first thing [\`docs/why-now-2026-06.md\`](../docs/why-now-2026-06.md) recommends migrating users run as a diagnostic. A WARN on the recommended diagnostic makes dario look broken at exactly the wrong moment (the influx period leading up to 2026-06-15).

## Fix
\`src/doctor.ts\` probe construction now reads \`process.env.DARIO_API_KEY\`; falls back to literal \`dario\` when unset so local-dev probes against a no-auth proxy still work. The direct-to-Anthropic fallback path (when proxy isn't running) is unaffected — it already uses the OAuth bearer, not the dario auth header.

## Caught against
Live verification against the Hetzner production deploy this morning:

\`\`\`
$ docker exec askalf-dario dario doctor --usage
...
[WARN]  Usage snapshot  probe failed: all probe requests failed
\`\`\`

The container has \`DARIO_API_KEY\` set (loopback-only bind via host cloudflared); the probe was sending the wrong bearer.

## Test plan
- [x] \`npm run build\` — clean
- [x] \`npm test\` — 62/62 pass (no probe test exists today; the fix is to a read of \`process.env\` so the test path would just be 'env loaded')
- [ ] Post-merge: rebuild + redeploy dario on Hetzner, run \`dario doctor --usage\` — verify the WARN is replaced with \`[ OK ] Usage 5h/7d/...\` rows