### PR TITLE
release: v3.37.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ checklist.
 
 ## [Unreleased]
 
+## [3.37.19] - 2026-05-14
+
+### Fixed — `dario doctor --usage` works when proxy auth is configured (#264)
+
+Probe construction now reads `DARIO_API_KEY` from env when authorizing against the local proxy. Previously the probe hard-coded `Authorization: Bearer dario`, so any deploy that set a real `DARIO_API_KEY` (every non-loopback bind per the README's documented security guidance) got 401 on every probe and the doctor reported `[WARN] Usage snapshot probe failed: all probe requests failed`.
+
+That command is the first thing `docs/why-now-2026-06.md` recommends migrating users run as a diagnostic. The WARN made dario look broken at exactly the wrong moment — first impression for users coming from competing proxies after 2026-06-15.
+
+Falls back to literal `dario` when `DARIO_API_KEY` is unset so local-dev probes against a no-auth proxy still work. The direct-to-Anthropic fallback path (when proxy isn't running) was unaffected.
+
+### CI — cap_drop ALL smoke test (#263)
+
+Adds a `docker-cap-drop-smoke` job to `.github/workflows/ci.yml` that builds the image from the PR's Dockerfile (single-arch, GHA-cached) and runs three smoke tests under `--cap-drop=ALL --security-opt=no-new-privileges:true`:
+
+1. `dario --help` — non-empty command-list output
+2. `dario doctor` — entrypoint successfully exec's the CLI
+3. `dario proxy` — proxy boots without restart-looping; defensive grep for the exact error strings v3.37.16 (`chown: ... Permission denied`) and v3.37.17 (`su-exec: setgroups: Operation not permitted`) emitted during their respective regressions
+
+~46s per CI run, GHA cache keeps subsequent runs fast. Complements the existing post-publish `--help` smoke from RELEASING.md (which catches dario#143 silent-CLI) — pre-release gate now covers both classes.
+
 ## [3.37.18] - 2026-05-14
 
 ### Fixed — restore `USER dario` default for cap_drop deploys (regression in v3.37.16 + v3.37.17)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "3.37.18",
+  "version": "3.37.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "3.37.18",
+      "version": "3.37.19",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.37.18",
+  "version": "3.37.19",
   "description": "A local LLM router. One endpoint, every provider — Claude subscriptions, OpenAI, OpenRouter, Groq, local LiteLLM, any OpenAI-compat endpoint — your tools don't need to change.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
Patch release bundling two PRs that landed today after v3.37.18.

| PR | Type | Topic |
|---|---|---|
| #263 | ci | cap_drop ALL Docker smoke gate (CI-only) |
| #264 | fix | \`dario doctor --usage\` probe reads \`DARIO_API_KEY\` for proxy auth |

User-visible: #264. The \`--usage\` diagnostic now works on every deploy with proxy auth configured. Previously WARN'd on every prod-style deploy.

## Pre-merge gates
- [x] \`npm run build\` — clean
- [x] \`npm test\` — 62/62 pass
- [x] \`package.json.version\` bumped \`3.37.18\` → \`3.37.19\`
- [x] CHANGELOG entry under \`[3.37.19] - 2026-05-14\`
- [x] \`package-lock.json\` re-synced
- [x] New cap-drop CI gate runs on this PR (self-test)

## Post-publish smoke
- [ ] \`npm install -g @askalf/dario@latest\` → \`dario --version\` reports 3.37.19
- [ ] **Hetzner re-deploy** (\`docker compose pull dario && up -d dario\`) and verify:
  - [ ] \`docker exec askalf-dario dario doctor --usage\` no longer WARNs on the Usage snapshot row
  - [ ] Container starts under \`cap_drop: ALL\` (regression guard)