### PR TITLE
feat(pacing): response-correlated think time + session-start jitter

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -258,6 +258,17 @@ async function proxy() {
   const pacingMinMs = parsePositiveIntFlag('--pace-min=');
   const pacingJitterMs = parsePositiveIntFlag('--pace-jitter=');
 
+  // --think-time-* / --session-start-* — behavioral smoothing extension.
+  // Closes the temporal axis the wire-fidelity work doesn't touch:
+  // response-length-correlated read time between requests, and per-
+  // session opening latency. All defaults 0 = off (opt-in).
+  const thinkTimeBaseMs = parsePositiveIntFlag('--think-time-base=');
+  const thinkTimePerTokenMs = parsePositiveIntFlag('--think-time-per-token=');
+  const thinkTimeJitterMs = parsePositiveIntFlag('--think-time-jitter=');
+  const thinkTimeMaxMs = parsePositiveIntFlag('--think-time-max=');
+  const sessionStartMinMs = parsePositiveIntFlag('--session-start-min=');
+  const sessionStartJitterMs = parsePositiveIntFlag('--session-start-jitter=');
+
   // --drain-on-close (v3.25, direction #5). When set, a client
   // disconnect no longer aborts the upstream SSE — dario keeps
   // draining the stream to EOF so Anthropic sees the CC-shaped
@@ -406,7 +417,7 @@ async function proxy() {
     process.exit(1);
   }
 
-  await startProxy({ port, host, verbose, verboseBodies, model, passthrough, preserveTools, hybridTools, mergeTools, noAutoDetect, strictTls, pacingMinMs, pacingJitterMs, drainOnClose, sessionIdleRotateMs, sessionRotateJitterMs, sessionMaxAgeMs, sessionPerClient, preserveOrchestrationTags, noLiveCapture, strictTemplate, maxConcurrent, maxQueued, queueTimeoutMs, effort, maxTokens, logFile, passthroughBetas, systemPrompt });
+  await startProxy({ port, host, verbose, verboseBodies, model, passthrough, preserveTools, hybridTools, mergeTools, noAutoDetect, strictTls, pacingMinMs, pacingJitterMs, thinkTimeBaseMs, thinkTimePerTokenMs, thinkTimeJitterMs, thinkTimeMaxMs, sessionStartMinMs, sessionStartJitterMs, drainOnClose, sessionIdleRotateMs, sessionRotateJitterMs, sessionMaxAgeMs, sessionPerClient, preserveOrchestrationTags, noLiveCapture, strictTemplate, maxConcurrent, maxQueued, queueTimeoutMs, effort, maxTokens, logFile, passthroughBetas, systemPrompt });
 }
 
 /**
@@ -1039,6 +1050,37 @@ async function help() {
                              Default: 0 (off). Set to e.g. 300 to hide
                              the floor from long-run inter-arrival
                              statistics. (v3.24)
+    --think-time-base=MS     Post-response "think time" base — constant
+                             ms added before the next request fires.
+                             Models the wall-clock pause between an
+                             interactive CC user reading a response and
+                             typing the next message. Default: 0 (off).
+                             Env: DARIO_THINK_TIME_BASE_MS.
+    --think-time-per-token=MS
+                             Additional ms per output token of the
+                             previous response (linear). e.g. 5 → a
+                             1000-token response adds 5s of read time
+                             before the next request. Default: 0.
+                             Env: DARIO_THINK_TIME_PER_TOKEN_MS.
+    --think-time-jitter=MS   Max uniform-random jitter on top of
+                             base+perToken*tokens. Hides the formula
+                             from long-run inter-arrival statistics.
+                             Default: 0.
+                             Env: DARIO_THINK_TIME_JITTER_MS.
+    --think-time-max=MS      Upper bound on think time so a 50k-token
+                             response doesn't pause for minutes.
+                             Default: 30000 (30s).
+                             Env: DARIO_THINK_TIME_MAX_MS.
+    --session-start-min=MS   Floor on session-start delay — applied to
+                             the first request only (lastResponseTime
+                             === 0). Real CC sessions open with seconds
+                             of startup latency, not microseconds.
+                             Default: 0 (off).
+                             Env: DARIO_SESSION_START_MIN_MS.
+    --session-start-jitter=MS
+                             Max uniform-random jitter on session-start
+                             delay. Default: 0.
+                             Env: DARIO_SESSION_START_JITTER_MS.
     --drain-on-close         When the client disconnects mid-stream,
                              keep consuming the upstream SSE to EOF
                              so Anthropic sees the same read-to-

--- a/src/pacing.ts
+++ b/src/pacing.ts
@@ -97,3 +97,121 @@ function pickNonNegativeInt(...candidates: (number | string | undefined)[]): num
   }
   return undefined;
 }
+
+/**
+ * Post-response "think time" simulation (behavioral smoothing extension).
+ *
+ * Inter-request `computePacingDelay` enforces a floor on the wall-clock
+ * distance between two outbound requests. Think time models the
+ * orthogonal axis: how long a real interactive Claude Code user would
+ * spend reading a response before sending the next message. Without it,
+ * agentic loops fire the next request as fast as the client can stamp
+ * one out, which creates an inter-arrival distribution that's
+ * structurally absent in real interactive sessions (read-then-type has
+ * variance correlated with response length; agent loops don't).
+ *
+ *   delay = baseMs + perTokenMs * lastResponseTokens + U(0, jitterMs)
+ *
+ * Then clamped to [0, maxMs] and reduced by elapsed time since the
+ * response completed (so a slow downstream consumer doesn't double-pay).
+ *
+ * `lastResponseTime === 0` returns 0 — there's no response to read on
+ * the first request of a session. Session-start jitter is a separate
+ * function (`computeSessionStartDelay`) since it has different semantics.
+ */
+export interface ThinkTimeConfig {
+  /** Constant ms added to every think-time sample, regardless of tokens. */
+  baseMs: number;
+  /** Additional ms per output token of the previous response (linear). */
+  perTokenMs: number;
+  /** Max uniform-random jitter (ms) added on top. */
+  jitterMs: number;
+  /** Upper bound on think time. Prevents pathological pauses on very long responses. */
+  maxMs: number;
+}
+
+export function computeThinkTimeDelay(
+  now: number,
+  lastResponseTime: number,
+  lastResponseTokens: number,
+  cfg: ThinkTimeConfig,
+  rng: () => number = Math.random,
+): number {
+  if (lastResponseTime <= 0) return 0;
+  const base = Math.max(0, cfg.baseMs);
+  const perToken = Math.max(0, cfg.perTokenMs);
+  const jitter = Math.max(0, cfg.jitterMs);
+  const max = Math.max(0, cfg.maxMs);
+  const tokens = Math.max(0, lastResponseTokens);
+  // Short-circuit when all knobs are zero — avoids unnecessary rng calls
+  // and the elapsed-time math on the hot path when think time is off.
+  if (base === 0 && perToken === 0 && jitter === 0) return 0;
+  const jitterAdd = jitter > 0 ? Math.floor(rng() * jitter) : 0;
+  let target = base + perToken * tokens + jitterAdd;
+  if (max > 0 && target > max) target = max;
+  const elapsed = now - lastResponseTime;
+  if (elapsed >= target) return 0;
+  return target - elapsed;
+}
+
+/**
+ * Resolve a ThinkTimeConfig from explicit options, env vars, and
+ * defaults. All defaults are 0 — feature is opt-in. `maxMs` defaults to
+ * 30000 (30s) when any think-time knob is enabled and the user hasn't
+ * set their own cap; on a fully-disabled config the cap doesn't matter
+ * since the short-circuit above returns 0 first.
+ */
+export function resolveThinkTimeConfig(
+  explicit: { baseMs?: number; perTokenMs?: number; jitterMs?: number; maxMs?: number } = {},
+  env: NodeJS.ProcessEnv = process.env,
+): ThinkTimeConfig {
+  const base = pickNonNegativeInt(explicit.baseMs, env.DARIO_THINK_TIME_BASE_MS) ?? 0;
+  const perToken = pickNonNegativeInt(explicit.perTokenMs, env.DARIO_THINK_TIME_PER_TOKEN_MS) ?? 0;
+  const jitter = pickNonNegativeInt(explicit.jitterMs, env.DARIO_THINK_TIME_JITTER_MS) ?? 0;
+  const max = pickNonNegativeInt(explicit.maxMs, env.DARIO_THINK_TIME_MAX_MS) ?? 30000;
+  return { baseMs: base, perTokenMs: perToken, jitterMs: jitter, maxMs: max };
+}
+
+/**
+ * Session-start delay (behavioral smoothing extension).
+ *
+ * Every new single-account session — first request after startup, first
+ * request after a session-id rotation — currently fires at machine
+ * speed (lastRequestTime resets to 0, computePacingDelay returns 0).
+ * Every session opens with an identical zero-delay first request, which
+ * is a detectable signal on long-run traffic statistics. Real CC users
+ * open a new session by opening the binary and typing a prompt — that's
+ * seconds of latency, not microseconds.
+ *
+ *   delay = minMs + U(0, jitterMs)
+ *
+ * Returns the sampled delay directly (no elapsed-time check — this is a
+ * one-shot delay applied to the first request of a session, before any
+ * upstream call has happened).
+ */
+export interface SessionStartConfig {
+  /** Constant ms floor for session-start delay. */
+  minMs: number;
+  /** Max uniform-random jitter (ms) added on top. */
+  jitterMs: number;
+}
+
+export function computeSessionStartDelay(
+  cfg: SessionStartConfig,
+  rng: () => number = Math.random,
+): number {
+  const min = Math.max(0, cfg.minMs);
+  const jitter = Math.max(0, cfg.jitterMs);
+  if (min === 0 && jitter === 0) return 0;
+  const jitterAdd = jitter > 0 ? Math.floor(rng() * jitter) : 0;
+  return min + jitterAdd;
+}
+
+export function resolveSessionStartConfig(
+  explicit: { minMs?: number; jitterMs?: number } = {},
+  env: NodeJS.ProcessEnv = process.env,
+): SessionStartConfig {
+  const min = pickNonNegativeInt(explicit.minMs, env.DARIO_SESSION_START_MIN_MS) ?? 0;
+  const jitter = pickNonNegativeInt(explicit.jitterMs, env.DARIO_SESSION_START_JITTER_MS) ?? 0;
+  return { minMs: min, jitterMs: jitter };
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -393,6 +393,17 @@ interface ProxyOptions {
   strictTls?: boolean;      // Refuse to start if not running under Bun (v3.23, direction #3)
   pacingMinMs?: number;     // Minimum ms between requests (v3.24, direction #6 — default 500)
   pacingJitterMs?: number;  // Max uniform-random jitter added on top of pacingMinMs (v3.24 — default 0)
+  // Behavioral smoothing extension (post-response think time + session-start
+  // jitter). All defaults 0 = off — opt-in. Closes the temporal/behavioral
+  // axis that wire-fidelity work doesn't touch: response-length-correlated
+  // read time and per-session opening latency, both present in real CC
+  // traffic and absent in machine-paced agent loops.
+  thinkTimeBaseMs?: number;       // Constant ms added to every think-time sample
+  thinkTimePerTokenMs?: number;   // Additional ms per output token of the previous response
+  thinkTimeJitterMs?: number;     // Max uniform-random jitter added on top
+  thinkTimeMaxMs?: number;        // Upper bound on think time (default 30000)
+  sessionStartMinMs?: number;     // Floor on session-start delay
+  sessionStartJitterMs?: number;  // Max uniform-random jitter on session-start delay
   drainOnClose?: boolean;   // Keep draining upstream after client disconnects (v3.25, direction #5 — default off)
   sessionIdleRotateMs?: number;    // Idle ms before session-id rotates (v3.28, direction #1 — default 15min)
   sessionRotateJitterMs?: number;  // Uniform jitter on idle threshold (v3.28 — default 0)
@@ -882,14 +893,46 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
   // 500ms floor keeps the default behavior identical to v3.23; `--pace-min`
   // and `--pace-jitter` let callers tune the distribution. Pure calc lives
   // in src/pacing.ts so the edge cases are unit-tested without timers.
-  const { computePacingDelay, resolvePacingConfig } = await import('./pacing.js');
+  const {
+    computePacingDelay,
+    resolvePacingConfig,
+    computeThinkTimeDelay,
+    resolveThinkTimeConfig,
+    computeSessionStartDelay,
+    resolveSessionStartConfig,
+  } = await import('./pacing.js');
   let lastRequestTime = 0;
+  // Behavioral smoothing state: when the last response *completed* and
+  // how many output tokens it had. Used by computeThinkTimeDelay to
+  // model human read-time before the next request. Distinct from
+  // lastRequestTime (which tracks when the last request *started* and
+  // feeds the inter-request floor).
+  let lastResponseTime = 0;
+  let lastResponseTokens = 0;
   const pacingCfg = resolvePacingConfig({
     minGapMs: opts.pacingMinMs,
     jitterMs: opts.pacingJitterMs,
   });
+  const thinkTimeCfg = resolveThinkTimeConfig({
+    baseMs: opts.thinkTimeBaseMs,
+    perTokenMs: opts.thinkTimePerTokenMs,
+    jitterMs: opts.thinkTimeJitterMs,
+    maxMs: opts.thinkTimeMaxMs,
+  });
+  const sessionStartCfg = resolveSessionStartConfig({
+    minMs: opts.sessionStartMinMs,
+    jitterMs: opts.sessionStartJitterMs,
+  });
+  const thinkTimeEnabled = thinkTimeCfg.baseMs > 0 || thinkTimeCfg.perTokenMs > 0 || thinkTimeCfg.jitterMs > 0;
+  const sessionStartEnabled = sessionStartCfg.minMs > 0 || sessionStartCfg.jitterMs > 0;
   if (verbose) {
     console.log(`[dario] pacing: min=${pacingCfg.minGapMs}ms jitter=${pacingCfg.jitterMs}ms`);
+    if (thinkTimeEnabled) {
+      console.log(`[dario] think-time: base=${thinkTimeCfg.baseMs}ms perToken=${thinkTimeCfg.perTokenMs}ms jitter=${thinkTimeCfg.jitterMs}ms max=${thinkTimeCfg.maxMs}ms`);
+    }
+    if (sessionStartEnabled) {
+      console.log(`[dario] session-start: min=${sessionStartCfg.minMs}ms jitter=${sessionStartCfg.jitterMs}ms`);
+    }
   }
 
   // Stream-consumption replay (v3.25, direction #5). When on, a client
@@ -1120,7 +1163,8 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
     // Hoisted so the finally block can clean up whatever was set.
     let upstreamTimeout: ReturnType<typeof setTimeout> | null = null;
     let onClientClose: (() => void) | null = null;
-    let upstreamAbortReason: 'timeout' | 'client_closed' | 'sse_overflow' | null = null;
+    type UpstreamAbortReason = 'timeout' | 'client_closed' | 'sse_overflow' | null;
+    let upstreamAbortReason = null as UpstreamAbortReason;
     // Hoisted so the catch can include them in the request log line. The
     // body-parsing block below assigns these once the request is parsed;
     // before that point they remain at their initial values, which is
@@ -1465,10 +1509,29 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
       }
 
       // Rate governor — prevent inhuman request cadence. See src/pacing.ts
-      // for the pure delay calculator (floor + uniform jitter).
-      const pacingDelay = computePacingDelay(Date.now(), lastRequestTime, pacingCfg);
-      if (pacingDelay > 0) {
-        await new Promise(r => setTimeout(r, pacingDelay));
+      // for the pure delay calculators. Three layers, all defaults preserve
+      // v3.37.20 behaviour:
+      //   1. pacingDelay      — floor on inter-request distance (always on,
+      //                         500ms default since v3.24).
+      //   2. thinkTimeDelay   — post-response read-time, proportional to
+      //                         the previous response's output tokens.
+      //                         Opt-in via --think-time-* flags.
+      //   3. sessionStartDelay — one-shot startup latency on the first
+      //                          request of a session (lastResponseTime===0).
+      //                          Opt-in via --session-start-* flags.
+      // We take the max because each layer enforces an independent floor
+      // — waiting longer satisfies all of them, so we never need to sum.
+      const nowForPacing = Date.now();
+      const pacingDelay = computePacingDelay(nowForPacing, lastRequestTime, pacingCfg);
+      const thinkDelay = thinkTimeEnabled
+        ? computeThinkTimeDelay(nowForPacing, lastResponseTime, lastResponseTokens, thinkTimeCfg)
+        : 0;
+      const sessionStartDelay = (sessionStartEnabled && lastResponseTime === 0 && lastRequestTime === 0)
+        ? computeSessionStartDelay(sessionStartCfg)
+        : 0;
+      const totalDelay = Math.max(pacingDelay, thinkDelay, sessionStartDelay);
+      if (totalDelay > 0) {
+        await new Promise(r => setTimeout(r, totalDelay));
       }
       lastRequestTime = Date.now();
 
@@ -1981,6 +2044,15 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           if (verbose) console.error('[dario] Stream error:', sanitizeError(err));
         }
         res.end();
+        // Stamp the response-completion timestamp + token count so the
+        // next request's think-time delay can model human read time.
+        // Only on 2xx — error responses don't represent content the user
+        // would read, and using their (often zero) output_tokens would
+        // pin think time to baseMs+jitter on the next request needlessly.
+        if (upstream.status >= 200 && upstream.status < 300) {
+          lastResponseTime = Date.now();
+          lastResponseTokens = streamOutputTokens;
+        }
         if (analytics && poolAccount) {
           analytics.record({
             timestamp: Date.now(), account: poolAccount.alias, model: requestModel,
@@ -2029,6 +2101,15 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           const parsed = JSON.parse(responseBody) as Record<string, unknown>;
           bufferedUsage = Analytics.parseUsage(parsed);
         } catch { /* malformed body — log without usage */ }
+
+        // Stamp response-completion state for the next request's think-time
+        // delay. Same 2xx-only rule as the streaming path. Falls back to 0
+        // tokens when the body wasn't JSON or had no usage block — base +
+        // jitter still apply but the per-token component is 0.
+        if (upstream.status >= 200 && upstream.status < 300) {
+          lastResponseTime = Date.now();
+          lastResponseTokens = bufferedUsage?.outputTokens ?? 0;
+        }
 
         if (analytics && poolAccount && bufferedUsage) {
           try {

--- a/test/pacing.mjs
+++ b/test/pacing.mjs
@@ -3,7 +3,14 @@
 // explicit inputs (no clocks, no process.env reads) so every branch is
 // exercised without spawning timers.
 
-import { computePacingDelay, resolvePacingConfig } from '../dist/pacing.js';
+import {
+  computePacingDelay,
+  resolvePacingConfig,
+  computeThinkTimeDelay,
+  resolveThinkTimeConfig,
+  computeSessionStartDelay,
+  resolveSessionStartConfig,
+} from '../dist/pacing.js';
 
 let pass = 0, fail = 0;
 function check(label, cond) {
@@ -193,6 +200,188 @@ header('resolvePacingConfig — explicit number args (from CLI parser)');
   const cfg = resolvePacingConfig({ minGapMs: 600, jitterMs: 150 }, {});
   check('number minGap passes through', cfg.minGapMs === 600);
   check('number jitter passes through', cfg.jitterMs === 150);
+}
+
+// ======================================================================
+//  computeThinkTimeDelay — first request returns 0
+// ======================================================================
+header('computeThinkTimeDelay — no previous response → 0');
+{
+  const d = computeThinkTimeDelay(1000, 0, 500, { baseMs: 200, perTokenMs: 5, jitterMs: 100, maxMs: 30000 });
+  check('lastResponseTime=0 → 0', d === 0);
+  const d2 = computeThinkTimeDelay(1000, -1, 500, { baseMs: 200, perTokenMs: 5, jitterMs: 100, maxMs: 30000 });
+  check('lastResponseTime=-1 → 0', d2 === 0);
+}
+
+// ======================================================================
+//  computeThinkTimeDelay — fully-zero config short-circuits
+// ======================================================================
+header('computeThinkTimeDelay — all-zero config → 0 (no rng call)');
+{
+  let rngCalls = 0;
+  const d = computeThinkTimeDelay(2000, 1000, 500, { baseMs: 0, perTokenMs: 0, jitterMs: 0, maxMs: 30000 }, () => { rngCalls++; return 0.5; });
+  check('all-zero config returns 0', d === 0);
+  check('rng not called on hot path when disabled', rngCalls === 0);
+}
+
+// ======================================================================
+//  computeThinkTimeDelay — base only
+// ======================================================================
+header('computeThinkTimeDelay — base-only think time');
+{
+  // 0ms elapsed since response, base=1000, perToken=0, jitter=0 → 1000
+  const d = computeThinkTimeDelay(1000, 1000, 500, { baseMs: 1000, perTokenMs: 0, jitterMs: 0, maxMs: 30000 });
+  check('elapsed=0, base=1000 → 1000', d === 1000);
+
+  // 500ms elapsed, base=1000 → 500 remaining
+  const d2 = computeThinkTimeDelay(1500, 1000, 500, { baseMs: 1000, perTokenMs: 0, jitterMs: 0, maxMs: 30000 });
+  check('elapsed=500, base=1000 → 500 remaining', d2 === 500);
+
+  // 2000ms elapsed > base=1000 → 0
+  const d3 = computeThinkTimeDelay(3000, 1000, 500, { baseMs: 1000, perTokenMs: 0, jitterMs: 0, maxMs: 30000 });
+  check('elapsed=2000 > base=1000 → 0', d3 === 0);
+}
+
+// ======================================================================
+//  computeThinkTimeDelay — per-token scales with response size
+// ======================================================================
+header('computeThinkTimeDelay — perTokenMs * tokens');
+{
+  // base=0, perToken=5, tokens=200 → 1000ms target, 0 elapsed → 1000
+  const d = computeThinkTimeDelay(1000, 1000, 200, { baseMs: 0, perTokenMs: 5, jitterMs: 0, maxMs: 30000 });
+  check('perToken=5, tokens=200 → 1000ms', d === 1000);
+
+  // base=100, perToken=2, tokens=500 → 1100ms
+  const d2 = computeThinkTimeDelay(1000, 1000, 500, { baseMs: 100, perTokenMs: 2, jitterMs: 0, maxMs: 30000 });
+  check('base=100 + perToken=2 * tokens=500 → 1100', d2 === 1100);
+
+  // tokens=0 falls back to base only
+  const d3 = computeThinkTimeDelay(1000, 1000, 0, { baseMs: 800, perTokenMs: 5, jitterMs: 0, maxMs: 30000 });
+  check('tokens=0 → base only (800)', d3 === 800);
+
+  // negative tokens clamped to 0
+  const d4 = computeThinkTimeDelay(1000, 1000, -100, { baseMs: 500, perTokenMs: 5, jitterMs: 0, maxMs: 30000 });
+  check('negative tokens clamped → base only (500)', d4 === 500);
+}
+
+// ======================================================================
+//  computeThinkTimeDelay — max cap
+// ======================================================================
+header('computeThinkTimeDelay — maxMs caps the target');
+{
+  // base=1000, perToken=10, tokens=10000 → would be 101000, capped at maxMs=5000
+  const d = computeThinkTimeDelay(1000, 1000, 10000, { baseMs: 1000, perTokenMs: 10, jitterMs: 0, maxMs: 5000 });
+  check('huge target capped at maxMs=5000', d === 5000);
+
+  // maxMs=0 disables cap (target wins)
+  const d2 = computeThinkTimeDelay(1000, 1000, 100, { baseMs: 500, perTokenMs: 0, jitterMs: 0, maxMs: 0 });
+  check('maxMs=0 → no cap, target wins', d2 === 500);
+}
+
+// ======================================================================
+//  computeThinkTimeDelay — jitter via deterministic rng
+// ======================================================================
+header('computeThinkTimeDelay — jitter integrates via injectable rng');
+{
+  // base=500, perToken=0, jitter=1000, rng=0.5 → jitterAdd=500 → target=1000
+  const d = computeThinkTimeDelay(1000, 1000, 0, { baseMs: 500, perTokenMs: 0, jitterMs: 1000, maxMs: 30000 }, () => 0.5);
+  check('rng=0.5, jitter=1000 → +500 → target=1000', d === 1000);
+
+  // rng=0 → no jitter add
+  const d2 = computeThinkTimeDelay(1000, 1000, 0, { baseMs: 500, perTokenMs: 0, jitterMs: 1000, maxMs: 30000 }, () => 0);
+  check('rng=0 → target=base=500', d2 === 500);
+}
+
+// ======================================================================
+//  resolveThinkTimeConfig — defaults
+// ======================================================================
+header('resolveThinkTimeConfig — no inputs → all-zero except maxMs=30000');
+{
+  const cfg = resolveThinkTimeConfig({}, {});
+  check('baseMs defaults to 0', cfg.baseMs === 0);
+  check('perTokenMs defaults to 0', cfg.perTokenMs === 0);
+  check('jitterMs defaults to 0', cfg.jitterMs === 0);
+  check('maxMs defaults to 30000', cfg.maxMs === 30000);
+}
+
+// ======================================================================
+//  resolveThinkTimeConfig — env vars
+// ======================================================================
+header('resolveThinkTimeConfig — DARIO_THINK_TIME_* env vars');
+{
+  const cfg = resolveThinkTimeConfig({}, {
+    DARIO_THINK_TIME_BASE_MS: '300',
+    DARIO_THINK_TIME_PER_TOKEN_MS: '4',
+    DARIO_THINK_TIME_JITTER_MS: '500',
+    DARIO_THINK_TIME_MAX_MS: '15000',
+  });
+  check('base from env', cfg.baseMs === 300);
+  check('perToken from env', cfg.perTokenMs === 4);
+  check('jitter from env', cfg.jitterMs === 500);
+  check('max from env', cfg.maxMs === 15000);
+}
+
+// ======================================================================
+//  resolveThinkTimeConfig — explicit overrides env
+// ======================================================================
+header('resolveThinkTimeConfig — explicit args win over env');
+{
+  const cfg = resolveThinkTimeConfig(
+    { baseMs: 100, perTokenMs: 1, jitterMs: 200, maxMs: 5000 },
+    { DARIO_THINK_TIME_BASE_MS: '999', DARIO_THINK_TIME_MAX_MS: '99999' },
+  );
+  check('explicit base wins', cfg.baseMs === 100);
+  check('explicit perToken wins', cfg.perTokenMs === 1);
+  check('explicit jitter wins', cfg.jitterMs === 200);
+  check('explicit max wins', cfg.maxMs === 5000);
+}
+
+// ======================================================================
+//  computeSessionStartDelay — basic
+// ======================================================================
+header('computeSessionStartDelay — sampled startup delay');
+{
+  // min=0, jitter=0 → short-circuit to 0
+  let rngCalls = 0;
+  const d = computeSessionStartDelay({ minMs: 0, jitterMs: 0 }, () => { rngCalls++; return 0.5; });
+  check('all-zero config returns 0', d === 0);
+  check('rng not called when disabled', rngCalls === 0);
+
+  // min=1000, jitter=0 → exactly 1000
+  const d2 = computeSessionStartDelay({ minMs: 1000, jitterMs: 0 });
+  check('min=1000, jitter=0 → 1000', d2 === 1000);
+
+  // min=500, jitter=2000, rng=0.5 → 500 + 1000 = 1500
+  const d3 = computeSessionStartDelay({ minMs: 500, jitterMs: 2000 }, () => 0.5);
+  check('min=500 + rng=0.5*jitter=2000 → 1500', d3 === 1500);
+
+  // negative min/jitter clamped
+  const d4 = computeSessionStartDelay({ minMs: -100, jitterMs: -50 });
+  check('negative config clamped to 0', d4 === 0);
+}
+
+// ======================================================================
+//  resolveSessionStartConfig — defaults and env
+// ======================================================================
+header('resolveSessionStartConfig — defaults / env / explicit precedence');
+{
+  const cfg = resolveSessionStartConfig({}, {});
+  check('minMs defaults to 0', cfg.minMs === 0);
+  check('jitterMs defaults to 0', cfg.jitterMs === 0);
+
+  const cfg2 = resolveSessionStartConfig({}, {
+    DARIO_SESSION_START_MIN_MS: '800',
+    DARIO_SESSION_START_JITTER_MS: '3000',
+  });
+  check('minMs from env', cfg2.minMs === 800);
+  check('jitterMs from env', cfg2.jitterMs === 3000);
+
+  const cfg3 = resolveSessionStartConfig(
+    { minMs: 100, jitterMs: 200 },
+    { DARIO_SESSION_START_MIN_MS: '999' },
+  );
+  check('explicit minMs wins over env', cfg3.minMs === 100);
+  check('explicit jitterMs honored', cfg3.jitterMs === 200);
 }
 
 // ======================================================================


### PR DESCRIPTION
## Summary

Closes the behavioral/temporal axis the wire-fidelity work doesn't touch. Existing inter-request pacing (`--pace-min`, `--pace-jitter`) enforces a floor on wall-clock distance between requests but doesn't model two patterns present in real interactive CC sessions and absent in machine-paced agent loops:

1. **Post-response read time correlated with response length.** Real users read the response before sending the next message; long responses → longer pauses. Agent loops fire the next request as soon as the client can stamp one out — a detectable inter-arrival distribution.

2. **Session-start latency.** Every new session-id (single-account rotation, first startup) currently fires the first request at machine speed (`lastRequestTime=0` short-circuits pacing). Every session opens identically — long-run statistical signal. Real CC users open a session by opening the binary and typing — seconds of latency, not microseconds.

All defaults 0 = off. v3.37.20 behaviour is preserved exactly. When enabled, the three pacing layers (pace, think, session-start) combine with `Math.max` — each enforces an independent floor.

## Flags

| Flag | Env | Default |
|---|---|---|
| `--think-time-base=MS` | `DARIO_THINK_TIME_BASE_MS` | 0 |
| `--think-time-per-token=MS` | `DARIO_THINK_TIME_PER_TOKEN_MS` | 0 |
| `--think-time-jitter=MS` | `DARIO_THINK_TIME_JITTER_MS` | 0 |
| `--think-time-max=MS` | `DARIO_THINK_TIME_MAX_MS` | 30000 |
| `--session-start-min=MS` | `DARIO_SESSION_START_MIN_MS` | 0 |
| `--session-start-jitter=MS` | `DARIO_SESSION_START_JITTER_MS` | 0 |

`think_time_delay = base + perToken * lastResponseTokens + U(0, jitter)`, clamped to `max`. Stamped only on 2xx responses so error responses don't pin the next request's delay to `base` needlessly.

## Test plan

- [x] `npm run build` — clean
- [x] `node test/pacing.mjs` — 70 / 70 passing (new edge cases: short-circuits, perToken scaling, max cap, jitter via injected rng, env var precedence)
- [x] `npm test` — 62 / 62 suites passing
- [x] `npm run e2e` — 12 / 12 passing
- [x] Verified end-to-end with `--think-time-base=500 --think-time-per-token=10 --think-time-jitter=200 --session-start-min=1500 --session-start-jitter=1000`:
  - First request: ~3.9s (upstream + ~1.5–2.5s session-start delay)
  - Second request: ~1.7s (upstream + ~0.5–0.75s think-time on a ~5-token response)

Also incidentally widens `upstreamAbortReason` declaration via `as UpstreamAbortReason` cast so TS flow narrowing from the synchronous `sse_overflow` assignment in the streaming branch doesn't shadow the callback-based `timeout` / `client_closed` assignments at the catch site (uncovered when the new code paths shifted line numbers).