### PR TITLE
feat(pacing): --stealth preset — one flag enables behavioral pacing defaults

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -269,6 +269,15 @@ async function proxy() {
   const sessionStartMinMs = parsePositiveIntFlag('--session-start-min=');
   const sessionStartJitterMs = parsePositiveIntFlag('--session-start-jitter=');
 
+  // --stealth flips all three pacing layers (pace, think, session-start)
+  // into their behavioral-stealth presets so the request inter-arrival
+  // distribution matches real interactive CC. One knob instead of six.
+  // Per-knob explicit flags / env vars still win, so operators can
+  // toggle stealth on and then tune individual axes.
+  const stealth = args.includes('--stealth')
+    || parseBooleanEnv(process.env['DARIO_STEALTH'])
+    || undefined;
+
   // --drain-on-close (v3.25, direction #5). When set, a client
   // disconnect no longer aborts the upstream SSE — dario keeps
   // draining the stream to EOF so Anthropic sees the CC-shaped
@@ -417,7 +426,7 @@ async function proxy() {
     process.exit(1);
   }
 
-  await startProxy({ port, host, verbose, verboseBodies, model, passthrough, preserveTools, hybridTools, mergeTools, noAutoDetect, strictTls, pacingMinMs, pacingJitterMs, thinkTimeBaseMs, thinkTimePerTokenMs, thinkTimeJitterMs, thinkTimeMaxMs, sessionStartMinMs, sessionStartJitterMs, drainOnClose, sessionIdleRotateMs, sessionRotateJitterMs, sessionMaxAgeMs, sessionPerClient, preserveOrchestrationTags, noLiveCapture, strictTemplate, maxConcurrent, maxQueued, queueTimeoutMs, effort, maxTokens, logFile, passthroughBetas, systemPrompt });
+  await startProxy({ port, host, verbose, verboseBodies, model, passthrough, preserveTools, hybridTools, mergeTools, noAutoDetect, strictTls, pacingMinMs, pacingJitterMs, thinkTimeBaseMs, thinkTimePerTokenMs, thinkTimeJitterMs, thinkTimeMaxMs, sessionStartMinMs, sessionStartJitterMs, stealth, drainOnClose, sessionIdleRotateMs, sessionRotateJitterMs, sessionMaxAgeMs, sessionPerClient, preserveOrchestrationTags, noLiveCapture, strictTemplate, maxConcurrent, maxQueued, queueTimeoutMs, effort, maxTokens, logFile, passthroughBetas, systemPrompt });
 }
 
 /**
@@ -1041,6 +1050,17 @@ async function help() {
                              from a stock CC request. Install Bun
                              (https://bun.sh) so dario auto-relaunches
                              under it, or use shim mode. (v3.23)
+    --stealth                Single-flag behavioral-stealth preset.
+                             Flips pace-jitter, think-time, and
+                             session-start defaults from 0 to non-zero
+                             values sized for real-CC inter-arrival
+                             statistics (pace-jitter=300, think
+                             base/perToken/jitter=800/4/1500 capped at
+                             25s, session-start min/jitter=1200/3000).
+                             Per-knob --pace-jitter / --think-time-* /
+                             --session-start-* flags and env vars
+                             still win — flip stealth on, tune any
+                             axis afterwards. Env: DARIO_STEALTH.
     --pace-min=MS            Minimum ms between upstream requests
                              (default: 500). Prevents request floods
                              that are distinguishable from human-paced

--- a/src/pacing.ts
+++ b/src/pacing.ts
@@ -68,15 +68,21 @@ export function computePacingDelay(
  *   2. DARIO_PACE_MIN_MS / DARIO_PACE_JITTER_MS env vars
  *   3. Legacy DARIO_MIN_INTERVAL_MS env var (minGap only — matches v3.23
  *      behavior so existing setups don't regress silently)
- *   4. Defaults: minGap=500, jitter=0
+ *   4. Defaults: minGap=500, jitter=0 (or jitter=300 under stealth)
+ *
+ * `stealth` enables a behavioral-stealth preset: when true and the
+ * specific knob isn't overridden by explicit/env, fall through to a
+ * non-zero default that adds inter-request jitter. The minGap floor is
+ * already 500ms by default and isn't touched.
  *
  * Invalid strings (non-numeric, negative) are ignored and fall through to
  * the next source — a typoed env var shouldn't fail-loud at startup.
  */
 export function resolvePacingConfig(
-  explicit: { minGapMs?: number; jitterMs?: number } = {},
+  explicit: { minGapMs?: number; jitterMs?: number; stealth?: boolean } = {},
   env: NodeJS.ProcessEnv = process.env,
 ): PacingConfig {
+  const stealth = explicit.stealth === true;
   const minGap = pickNonNegativeInt(
     explicit.minGapMs,
     env.DARIO_PACE_MIN_MS,
@@ -85,7 +91,7 @@ export function resolvePacingConfig(
   const jitter = pickNonNegativeInt(
     explicit.jitterMs,
     env.DARIO_PACE_JITTER_MS,
-  ) ?? 0;
+  ) ?? (stealth ? 300 : 0);
   return { minGapMs: minGap, jitterMs: jitter };
 }
 
@@ -162,13 +168,20 @@ export function computeThinkTimeDelay(
  * since the short-circuit above returns 0 first.
  */
 export function resolveThinkTimeConfig(
-  explicit: { baseMs?: number; perTokenMs?: number; jitterMs?: number; maxMs?: number } = {},
+  explicit: { baseMs?: number; perTokenMs?: number; jitterMs?: number; maxMs?: number; stealth?: boolean } = {},
   env: NodeJS.ProcessEnv = process.env,
 ): ThinkTimeConfig {
-  const base = pickNonNegativeInt(explicit.baseMs, env.DARIO_THINK_TIME_BASE_MS) ?? 0;
-  const perToken = pickNonNegativeInt(explicit.perTokenMs, env.DARIO_THINK_TIME_PER_TOKEN_MS) ?? 0;
-  const jitter = pickNonNegativeInt(explicit.jitterMs, env.DARIO_THINK_TIME_JITTER_MS) ?? 0;
-  const max = pickNonNegativeInt(explicit.maxMs, env.DARIO_THINK_TIME_MAX_MS) ?? 30000;
+  // Behavioral-stealth preset: when `stealth` is on and the specific
+  // knob isn't overridden by explicit/env, fall through to non-zero
+  // defaults sized for typical interactive CC pacing — ~800ms minimum
+  // read time, ~4ms per output token (skimming speed), ±1500ms jitter,
+  // capped at 25s so a 5000-token response doesn't pause for half a
+  // minute. Defaults all stay 0 (off) when stealth isn't set.
+  const stealth = explicit.stealth === true;
+  const base = pickNonNegativeInt(explicit.baseMs, env.DARIO_THINK_TIME_BASE_MS) ?? (stealth ? 800 : 0);
+  const perToken = pickNonNegativeInt(explicit.perTokenMs, env.DARIO_THINK_TIME_PER_TOKEN_MS) ?? (stealth ? 4 : 0);
+  const jitter = pickNonNegativeInt(explicit.jitterMs, env.DARIO_THINK_TIME_JITTER_MS) ?? (stealth ? 1500 : 0);
+  const max = pickNonNegativeInt(explicit.maxMs, env.DARIO_THINK_TIME_MAX_MS) ?? (stealth ? 25000 : 30000);
   return { baseMs: base, perTokenMs: perToken, jitterMs: jitter, maxMs: max };
 }
 
@@ -208,10 +221,13 @@ export function computeSessionStartDelay(
 }
 
 export function resolveSessionStartConfig(
-  explicit: { minMs?: number; jitterMs?: number } = {},
+  explicit: { minMs?: number; jitterMs?: number; stealth?: boolean } = {},
   env: NodeJS.ProcessEnv = process.env,
 ): SessionStartConfig {
-  const min = pickNonNegativeInt(explicit.minMs, env.DARIO_SESSION_START_MIN_MS) ?? 0;
-  const jitter = pickNonNegativeInt(explicit.jitterMs, env.DARIO_SESSION_START_JITTER_MS) ?? 0;
+  // Stealth preset: 1200ms floor + up to 3000ms uniform jitter ≈ 1.2s–4.2s
+  // first-request latency, matching observed real-CC session-open ranges.
+  const stealth = explicit.stealth === true;
+  const min = pickNonNegativeInt(explicit.minMs, env.DARIO_SESSION_START_MIN_MS) ?? (stealth ? 1200 : 0);
+  const jitter = pickNonNegativeInt(explicit.jitterMs, env.DARIO_SESSION_START_JITTER_MS) ?? (stealth ? 3000 : 0);
   return { minMs: min, jitterMs: jitter };
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -404,6 +404,11 @@ interface ProxyOptions {
   thinkTimeMaxMs?: number;        // Upper bound on think time (default 30000)
   sessionStartMinMs?: number;     // Floor on session-start delay
   sessionStartJitterMs?: number;  // Max uniform-random jitter on session-start delay
+  // Single-knob behavioral preset (default off). When set, the resolvers
+  // for pacing / think-time / session-start fall through to non-zero
+  // stealth defaults instead of 0, simulating real-CC inter-arrival
+  // statistics. Explicit per-knob flags and env vars still win.
+  stealth?: boolean;
   drainOnClose?: boolean;   // Keep draining upstream after client disconnects (v3.25, direction #5 — default off)
   sessionIdleRotateMs?: number;    // Idle ms before session-id rotates (v3.28, direction #1 — default 15min)
   sessionRotateJitterMs?: number;  // Uniform jitter on idle threshold (v3.28 — default 0)
@@ -909,23 +914,32 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
   // feeds the inter-request floor).
   let lastResponseTime = 0;
   let lastResponseTokens = 0;
+  // --stealth toggles the behavioral-stealth preset across all three
+  // pacing layers (pace, think-time, session-start). When on, each
+  // resolver's zero-default flips to its stealth preset; explicit flags
+  // and env vars still win.
+  const stealth = Boolean(opts.stealth);
   const pacingCfg = resolvePacingConfig({
     minGapMs: opts.pacingMinMs,
     jitterMs: opts.pacingJitterMs,
+    stealth,
   });
   const thinkTimeCfg = resolveThinkTimeConfig({
     baseMs: opts.thinkTimeBaseMs,
     perTokenMs: opts.thinkTimePerTokenMs,
     jitterMs: opts.thinkTimeJitterMs,
     maxMs: opts.thinkTimeMaxMs,
+    stealth,
   });
   const sessionStartCfg = resolveSessionStartConfig({
     minMs: opts.sessionStartMinMs,
     jitterMs: opts.sessionStartJitterMs,
+    stealth,
   });
   const thinkTimeEnabled = thinkTimeCfg.baseMs > 0 || thinkTimeCfg.perTokenMs > 0 || thinkTimeCfg.jitterMs > 0;
   const sessionStartEnabled = sessionStartCfg.minMs > 0 || sessionStartCfg.jitterMs > 0;
   if (verbose) {
+    if (stealth) console.log('[dario] stealth: behavioral-stealth preset active (pace+think+session-start defaults non-zero)');
     console.log(`[dario] pacing: min=${pacingCfg.minGapMs}ms jitter=${pacingCfg.jitterMs}ms`);
     if (thinkTimeEnabled) {
       console.log(`[dario] think-time: base=${thinkTimeCfg.baseMs}ms perToken=${thinkTimeCfg.perTokenMs}ms jitter=${thinkTimeCfg.jitterMs}ms max=${thinkTimeCfg.maxMs}ms`);

--- a/test/pacing.mjs
+++ b/test/pacing.mjs
@@ -385,6 +385,78 @@ header('resolveSessionStartConfig — defaults / env / explicit precedence');
 }
 
 // ======================================================================
+//  Stealth preset — pacing
+// ======================================================================
+header('resolvePacingConfig — stealth preset');
+{
+  // Stealth on, no explicit / env → jitter=300, minGap stays at 500.
+  const cfg = resolvePacingConfig({ stealth: true }, {});
+  check('stealth: jitter falls through to 300', cfg.jitterMs === 300);
+  check('stealth: minGap unchanged at 500', cfg.minGapMs === 500);
+
+  // Explicit jitter wins over stealth default.
+  const cfg2 = resolvePacingConfig({ stealth: true, jitterMs: 50 }, {});
+  check('explicit jitter beats stealth default', cfg2.jitterMs === 50);
+
+  // Env jitter wins over stealth default.
+  const cfg3 = resolvePacingConfig({ stealth: true }, { DARIO_PACE_JITTER_MS: '100' });
+  check('env jitter beats stealth default', cfg3.jitterMs === 100);
+
+  // Stealth off (omitted / false) — defaults still 0.
+  const cfg4 = resolvePacingConfig({ stealth: false }, {});
+  check('stealth=false keeps jitter at 0', cfg4.jitterMs === 0);
+}
+
+// ======================================================================
+//  Stealth preset — think-time
+// ======================================================================
+header('resolveThinkTimeConfig — stealth preset');
+{
+  const cfg = resolveThinkTimeConfig({ stealth: true }, {});
+  check('stealth base=800', cfg.baseMs === 800);
+  check('stealth perToken=4', cfg.perTokenMs === 4);
+  check('stealth jitter=1500', cfg.jitterMs === 1500);
+  check('stealth max=25000', cfg.maxMs === 25000);
+
+  // Explicit one knob overrides; the rest stay at stealth defaults.
+  const cfg2 = resolveThinkTimeConfig({ stealth: true, baseMs: 200 }, {});
+  check('explicit baseMs overrides stealth', cfg2.baseMs === 200);
+  check('perToken still stealth default', cfg2.perTokenMs === 4);
+
+  // Env one knob overrides; the rest stay at stealth defaults.
+  const cfg3 = resolveThinkTimeConfig({ stealth: true }, { DARIO_THINK_TIME_MAX_MS: '10000' });
+  check('env max overrides stealth', cfg3.maxMs === 10000);
+  check('jitter still stealth default', cfg3.jitterMs === 1500);
+
+  // Stealth off — everything 0 except max=30000.
+  const cfg4 = resolveThinkTimeConfig({ stealth: false }, {});
+  check('stealth off: base=0', cfg4.baseMs === 0);
+  check('stealth off: perToken=0', cfg4.perTokenMs === 0);
+  check('stealth off: jitter=0', cfg4.jitterMs === 0);
+  check('stealth off: max=30000', cfg4.maxMs === 30000);
+}
+
+// ======================================================================
+//  Stealth preset — session-start
+// ======================================================================
+header('resolveSessionStartConfig — stealth preset');
+{
+  const cfg = resolveSessionStartConfig({ stealth: true }, {});
+  check('stealth min=1200', cfg.minMs === 1200);
+  check('stealth jitter=3000', cfg.jitterMs === 3000);
+
+  // Explicit override.
+  const cfg2 = resolveSessionStartConfig({ stealth: true, minMs: 100 }, {});
+  check('explicit min wins', cfg2.minMs === 100);
+  check('jitter still stealth default', cfg2.jitterMs === 3000);
+
+  // Stealth off — both 0.
+  const cfg3 = resolveSessionStartConfig({}, {});
+  check('stealth off: min=0', cfg3.minMs === 0);
+  check('stealth off: jitter=0', cfg3.jitterMs === 0);
+}
+
+// ======================================================================
 //  Summary
 // ======================================================================
 console.log(`\n======================================================================`);


### PR DESCRIPTION
## Summary

v3.38.0 shipped six knobs for think-time + session-start jitter, all defaulting to 0 = off. The feature exists but nobody is going to tune six numbers — friction stays. `--stealth` flips each resolver's zero-default to a non-zero preset sized for real-CC inter-arrival statistics, all in one flag.

| Knob | v3.38.0 default | Under `--stealth` |
|---|---|---|
| `--pace-jitter` | 0 | **300** |
| `--think-time-base` | 0 | **800** |
| `--think-time-per-token` | 0 | **4** |
| `--think-time-jitter` | 0 | **1500** |
| `--think-time-max` | 30000 | **25000** |
| `--session-start-min` | 0 | **1200** |
| `--session-start-jitter` | 0 | **3000** |

Per-knob explicit flags and env vars still beat the stealth default — workflow is *flip stealth on, tune any axis afterwards*. Env mirror: `DARIO_STEALTH=1`.

## Implementation

Each resolver (`resolvePacingConfig`, `resolveThinkTimeConfig`, `resolveSessionStartConfig`) accepts a `stealth` boolean alongside the explicit options. The `??` chain falls through to the stealth default instead of 0 when stealth is on and no override was supplied. No behavior change for v3.38.0 callers — stealth omitted or false keeps every default at zero.

## Test plan

- [x] `npm run build` — clean
- [x] 93 pacing assertions (23 new cases: preset values, explicit-overrides-stealth, env-overrides-stealth, stealth-off-keeps-zero)
- [x] `npm test` — 62 / 62 suites passing