### PR TITLE
chore(compat): bump SUPPORTED_CC_RANGE.maxTested to v2.1.142 — closes #269

### DIFF
--- a/src/live-fingerprint.ts
+++ b/src/live-fingerprint.ts
@@ -876,7 +876,7 @@ export function _resetInstalledVersionProbeForTest(): void {
  */
 export const SUPPORTED_CC_RANGE = {
   min: '1.0.0',
-  maxTested: '2.1.141',
+  maxTested: '2.1.142',
 } as const;
 
 /**


### PR DESCRIPTION
## Context

The automated drift watcher opened #269 when `@anthropic-ai/claude-code@2.1.142` hit npm, flagging two items:

1. **compat.range (medium)** — CC v2.1.142 is beyond `SUPPORTED_CC_RANGE.maxTested` (v2.1.141); v2.1.142 users get a soft "untested-above" warning from `dario doctor`.
2. **template.version (low)** — bundled `cc-template-data.json` was v2.1.141.

Item 2 was already resolved in #271 (v3.38.3) — bundled snapshot re-baked from a live CC v2.1.142 capture. This PR closes item 1.

## Why the bump is justified now

`maxTested` is deliberately *not* a version-number formality — it asserts "this dario release was actually exercised against this CC." That's now true for v2.1.142:

- **Full e2e suite green 12/12** against a live CC v2.1.142 capture (health, status, models, Haiku/Sonnet/Opus non-stream + stream, OpenAI-compat, tool use, rate-limit headers).
- A **24-case context-1m / context_management interaction matrix** run against v2.1.142's wire shape on live OAuth, confirming the re-baked template's beta set is what the API currently accepts (the v2.1.141 set carried `context-1m-2025-08-07`, which the API now categorically rejects on OAuth subscription auth — *"This authentication style is incompatible with the long context beta header."*).

## Effect

`dario doctor` on a v2.1.142 install moves from a `[WARN] ... untested` line to a clean in-range report. No proxy-path behaviour change — this constant only drives the doctor advisory and the `compat.range` drift item.

## Test plan

- [x] `npm run build` — clean
- [x] `node test/compat-range.mjs` — 28/28 (test reads `SUPPORTED_CC_RANGE` dynamically; bump flows through with no test edit)

Closes #269.