### PR TITLE
fix(template): gate adaptive thinking per-model; older 4-5 Sonnet/Opus no longer 400s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ checklist.
 
 ## [Unreleased]
 
+## [3.38.5] - 2026-05-15
+
+### Fixed — adaptive-thinking gated per-model; older 4-5 Sonnet/Opus no longer 400s
+
+Live-probe diagnosis (2026-05-15) found that `thinking: { type: "adaptive" }` is gated per-model server-side on OAuth subscription auth. The split is at the 4.6 generation:
+
+| Model | `thinking:{adaptive}` |
+|---|---|
+| `claude-opus-4-7` | ✓ 200 |
+| `claude-opus-4-6` | ✓ 200 |
+| `claude-sonnet-4-6` | ✓ 200 |
+| `claude-opus-4-5` | ✗ 400 `"adaptive thinking is not supported on this model"` |
+| `claude-sonnet-4-5` | ✗ 400 same |
+
+Beta header state (full v2.1.142 set vs. minimal `oauth+claude-code`) does not change the outcome — adaptive is gated on the model, not on a beta flag. The same holds for the dependent `context_management.edits.clear_thinking_*` body field: the API rejects it without an enabled `thinking` field, so the two ride together.
+
+Before this release, dario's body builder unconditionally emitted `thinking:{type:"adaptive"}` for every non-Haiku model. In normal mode that meant **every Sonnet 4-5 / Opus 4-5 request through dario 400'd at the API**. Users on the codebase's default Sonnet 4-6 / Opus 4-7 path were unaffected; users explicitly targeting an older 4-5 model were broken.
+
+Fix: a new exported helper `supportsAdaptiveThinking(modelId)` allow-lists models verified to accept the field (Opus/Sonnet 4-6+, plus future 5+ majors). Default is deny — when a future model ships unrecognized, dario silently omits `thinking` (always accepted by the API) rather than 400-then-retry. Both `thinking` and `context_management` are gated together; `output_config.effort` is independent and ships unchanged for all non-Haiku.
+
+Sample matrix locked into `test/adaptive-thinking-gate.mjs`:
+- 37 unit assertions covering the empirical YES/NO sets plus forward-compat patterns (Opus 4.8/4.10/4.99, Opus/Sonnet 5+, Opus 10) and default-deny on nonsense inputs.
+- Bounded digit groups in the regex (`\d{1,2}`) so the pre-4.x `claude-3-5-sonnet-20241022` / `claude-3-7-sonnet-20250219` shape can't false-positive by parsing the date suffix as the major.
+
+`test/template-invariants.mjs` extended with a 4-5 generation block asserting `thinking` and `context_management` are absent for those models while `output_config` is still present.
+
+This is a wire-shape correction, no behavior change for the codebase-default Sonnet 4-6 / Opus 4-7 path.
+
 ## [3.38.4] - 2026-05-15
 
 ### Changed — `SUPPORTED_CC_RANGE.maxTested` bumped to v2.1.142 (#272, closes #269)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.38.4",
+  "version": "3.38.5",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -980,6 +980,52 @@ export function resolveEffort(flag: EffortValue | undefined, clientBody: Record<
   return flag;
 }
 
+/**
+ * Returns true if the given model accepts `thinking: { type: "adaptive" }`.
+ *
+ * Empirical results (2026-05-15, live OAuth-subscription probes against
+ * api.anthropic.com — see dario#NNN for the probe matrix):
+ *   claude-opus-4-7    ✓ accepts adaptive
+ *   claude-opus-4-6    ✓ accepts adaptive
+ *   claude-sonnet-4-6  ✓ accepts adaptive
+ *   claude-opus-4-5    ✗ "adaptive thinking is not supported on this model"
+ *   claude-sonnet-4-5  ✗ same
+ *   claude-haiku-4-5   ✗ same (already gated separately by isHaiku)
+ *
+ * The split is the 4.6 minor: Anthropic added adaptive support in the 4.6
+ * generation. Beta header state does not affect the outcome — adaptive is
+ * gated per-model, server-side.
+ *
+ * Allow-list pattern, default-deny: when a future model ships and isn't
+ * yet listed here, dario silently OMITS the `thinking` field rather than
+ * 400ing. Omitting `thinking` is always accepted by the API, so the
+ * worst-case regression is "no thinking blocks until allow-list update"
+ * — never a broken request.
+ */
+export function supportsAdaptiveThinking(modelId: string): boolean {
+  const m = modelId.toLowerCase();
+  // Opus/Sonnet, major-minor form: opus-4-6+, sonnet-4-6+, opus-5-X, etc.
+  //
+  // Digit groups are bounded to {1,2} so the dated-suffix pre-4.x line
+  // (`claude-3-5-sonnet-20241022`, `claude-3-7-sonnet-20250219`) doesn't
+  // accidentally match the date as `sonnet-2024-1022` and parse year as
+  // major. Realistic Anthropic version numbers are 1-2 digits.
+  const mm = m.match(/(?:opus|sonnet)-(\d{1,2})-(\d{1,2})\b/);
+  if (mm) {
+    const major = Number(mm[1]);
+    const minor = Number(mm[2]);
+    if (major > 4) return true;                       // any opus-5+ / sonnet-5+
+    if (major === 4 && minor >= 6) return true;       // 4-6, 4-7, …
+    return false;                                     // 4-5 and older
+  }
+  // Major-only form (e.g. `opus-5`, `opus-10`). The negative lookahead
+  // prevents matching the `5` in `opus-5-X` (handled above), and the
+  // {1,2} bound prevents matching long dated suffixes.
+  const majorOnly = m.match(/(?:opus|sonnet)-(\d{1,2})(?!\d|-)/);
+  if (majorOnly && Number(majorOnly[1]) >= 5) return true;
+  return false;
+}
+
 export function buildCCRequest(
   clientBody: Record<string, unknown>,
   billingTag: string,
@@ -1307,13 +1353,24 @@ export function buildCCRequest(
   ccRequest.max_tokens = resolveMaxTokens(opts.maxTokens, clientBody);
 
   // Model-specific fields — order: thinking, context_management, output_config
+  //
+  // `thinking: {type:"adaptive"}` is a 4.6-generation feature; older
+  // Opus/Sonnet 4-5 models 400 it (`"adaptive thinking is not supported
+  // on this model"`). `context_management.edits[clear_thinking_*]` is
+  // tied to thinking — sending it without an enabled thinking field
+  // 400s too (`"clear_thinking_* strategy requires thinking to be
+  // enabled or adaptive"`). So both are gated on the same model check,
+  // and either both ship or neither does.
+  //
+  // `output_config.effort` is independent of thinking and ships for all
+  // non-Haiku models. Default `'high'` matches CC 2.1.116's wire value;
+  // `--effort` flag overrides; `'client'` passes through whatever the
+  // client sent (or falls back to `'high'` if absent). See dario#87.
   if (!isHaiku) {
-    ccRequest.thinking = { type: 'adaptive' };
-    ccRequest.context_management = { edits: [{ type: 'clear_thinking_20251015', keep: 'all' }] };
-    // output_config.effort default is `'high'` (matches CC 2.1.116's wire
-    // value). `--effort` flag overrides; `'client'` passes through whatever
-    // the client sent (or falls back to `'high'` if the client didn't
-    // include an output_config). See dario#87.
+    if (supportsAdaptiveThinking(model)) {
+      ccRequest.thinking = { type: 'adaptive' };
+      ccRequest.context_management = { edits: [{ type: 'clear_thinking_20251015', keep: 'all' }] };
+    }
     ccRequest.output_config = { effort: resolveEffort(opts.effort, clientBody) };
   }
 

--- a/test/adaptive-thinking-gate.mjs
+++ b/test/adaptive-thinking-gate.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// Adaptive-thinking model gate — dario#NNN.
+//
+// `thinking: { type: "adaptive" }` is gated per-model server-side.
+// Live probe results (2026-05-15, OAuth subscription against
+// api.anthropic.com):
+//
+//   claude-opus-4-7    ✓ 200
+//   claude-opus-4-6    ✓ 200
+//   claude-sonnet-4-6  ✓ 200
+//   claude-opus-4-5    ✗ 400 "adaptive thinking is not supported on this model"
+//   claude-sonnet-4-5  ✗ 400 same
+//   claude-haiku-4-5   ✗ 400 same (but Haiku is already gated separately)
+//
+// The split is at the 4.6 minor — Anthropic added adaptive support in
+// the 4.6 generation. Beta header state is irrelevant (verified across
+// the full v2.1.142 beta set vs. minimal `oauth+claude-code` set; both
+// hit the same rejection on 4-5).
+//
+// This file locks the gate behavior at the unit-test level so a
+// regression to "always emit adaptive" breaks CI before it ships.
+
+import { supportsAdaptiveThinking, buildCCRequest } from '../dist/cc-template.js';
+
+let pass = 0, fail = 0;
+function check(name, cond, detail) {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else      { console.log(`  FAIL ${name}${detail ? ' :: ' + detail : ''}`); fail++; }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+// ─────────────────────────────────────────────────────────────
+header('supportsAdaptiveThinking — empirical matrix (2026-05-15)');
+
+// Models that empirically accept adaptive thinking
+const adaptiveYes = [
+  'claude-opus-4-7',
+  'claude-opus-4-6',
+  'claude-sonnet-4-6',
+];
+// Models that empirically 400 on adaptive thinking
+const adaptiveNo = [
+  'claude-opus-4-5',
+  'claude-sonnet-4-5',
+  'claude-haiku-4-5',
+  'claude-haiku-4-6',          // Haiku has never supported adaptive (matrix verified)
+  'claude-opus-4-1',
+  'claude-3-5-sonnet-20241022',
+  'claude-3-7-sonnet-20250219',
+];
+
+for (const m of adaptiveYes) {
+  check(`${m} → true`, supportsAdaptiveThinking(m) === true);
+}
+for (const m of adaptiveNo) {
+  check(`${m} → false`, supportsAdaptiveThinking(m) === false);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('supportsAdaptiveThinking — forward-compat patterns');
+
+// Future Opus 4-X (4.8, 4.10, 4.99) — assume same family extension
+check('claude-opus-4-8 → true',  supportsAdaptiveThinking('claude-opus-4-8') === true);
+check('claude-opus-4-10 → true', supportsAdaptiveThinking('claude-opus-4-10') === true);
+check('claude-opus-4-99 → true', supportsAdaptiveThinking('claude-opus-4-99') === true);
+
+// Future Opus 5+ (any minor or major-only)
+check('claude-opus-5 → true',    supportsAdaptiveThinking('claude-opus-5') === true);
+check('claude-opus-5-0 → true',  supportsAdaptiveThinking('claude-opus-5-0') === true);
+check('claude-opus-10 → true',   supportsAdaptiveThinking('claude-opus-10') === true);
+
+// Future Sonnet 5+
+check('claude-sonnet-5 → true',   supportsAdaptiveThinking('claude-sonnet-5') === true);
+check('claude-sonnet-5-0 → true', supportsAdaptiveThinking('claude-sonnet-5-0') === true);
+
+// Default-deny on unrecognized shapes — never returns true for nonsense
+check('empty string → false',    supportsAdaptiveThinking('') === false);
+check('random string → false',   supportsAdaptiveThinking('not-a-real-model') === false);
+check('gpt-4 → false',           supportsAdaptiveThinking('gpt-4') === false);
+check('claude-2 → false',        supportsAdaptiveThinking('claude-2') === false);
+
+// Dated suffixes (some 404, some work) — pattern should still match the
+// generation prefix
+check('claude-opus-4-7-20251024 → true',
+  supportsAdaptiveThinking('claude-opus-4-7-20251024') === true);
+check('claude-sonnet-4-5-20250929 → false',
+  supportsAdaptiveThinking('claude-sonnet-4-5-20250929') === false);
+
+// Case-insensitive
+check('MiXeD CaSe sonnet-4-6 → true',
+  supportsAdaptiveThinking('Claude-Sonnet-4-6') === true);
+
+// ─────────────────────────────────────────────────────────────
+header('buildCCRequest — gate applied on body output');
+
+const identity = { deviceId: 'D', accountUuid: 'A', sessionId: 'S' };
+const cacheControl = { type: 'ephemeral' };
+const billingTag = 'x-anthropic-billing-header: cc_version=test;';
+
+// Adaptive-supporting model: thinking + context_management present
+{
+  const body = buildCCRequest(
+    { model: 'claude-sonnet-4-6', messages: [{ role: 'user', content: 'hi' }], stream: false },
+    billingTag, cacheControl, identity,
+  ).body;
+  check('sonnet-4-6: thinking emitted',           body.thinking?.type === 'adaptive');
+  check('sonnet-4-6: context_management emitted', body.context_management?.edits?.[0]?.type === 'clear_thinking_20251015');
+  check('sonnet-4-6: output_config emitted',      typeof body.output_config?.effort === 'string');
+}
+
+// Non-adaptive model: both fields absent, output_config still present
+for (const model of ['claude-sonnet-4-5', 'claude-opus-4-5']) {
+  const body = buildCCRequest(
+    { model, messages: [{ role: 'user', content: 'hi' }], stream: false },
+    billingTag, cacheControl, identity,
+  ).body;
+  check(`${model}: thinking is absent`,           body.thinking === undefined);
+  check(`${model}: context_management is absent`, body.context_management === undefined);
+  check(`${model}: output_config still emitted`,  typeof body.output_config?.effort === 'string');
+}
+
+// Haiku: nothing emitted (existing gate is unchanged)
+{
+  const body = buildCCRequest(
+    { model: 'claude-haiku-4-5', messages: [{ role: 'user', content: 'hi' }], stream: false },
+    billingTag, cacheControl, identity,
+  ).body;
+  check('haiku: thinking is absent',           body.thinking === undefined);
+  check('haiku: context_management is absent', body.context_management === undefined);
+  check('haiku: output_config is absent',      body.output_config === undefined);
+}
+
+// ─────────────────────────────────────────────────────────────
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);

--- a/test/template-invariants.mjs
+++ b/test/template-invariants.mjs
@@ -42,14 +42,25 @@ function isPositiveInteger(x) {
 /**
  * Assert invariants that must hold for ANY non-haiku outbound body,
  * regardless of model, template version, mode. Throws on violation.
+ *
+ * The `adaptive` flag toggles the thinking/context_management assertions
+ * — those fields are gated on models that support adaptive thinking
+ * (4.6+ generation). For older 4-5 models, thinking and
+ * context_management are correctly absent and asserting them present
+ * would mis-describe the invariant.
  */
-function assertNonHaikuInvariants(body, context) {
+function assertNonHaikuInvariants(body, context, { adaptive = true } = {}) {
   // Top-level required fields
   check(`${context}: model is non-empty string`, isNonEmptyString(body.model));
   check(`${context}: messages is array`, Array.isArray(body.messages));
   check(`${context}: max_tokens is positive integer`, isPositiveInteger(body.max_tokens));
-  check(`${context}: thinking is object`, isPlainObject(body.thinking));
-  check(`${context}: context_management is object`, isPlainObject(body.context_management));
+  if (adaptive) {
+    check(`${context}: thinking is object`, isPlainObject(body.thinking));
+    check(`${context}: context_management is object`, isPlainObject(body.context_management));
+  } else {
+    check(`${context}: thinking is undefined (older model)`, body.thinking === undefined);
+    check(`${context}: context_management is undefined (older model)`, body.context_management === undefined);
+  }
   check(`${context}: output_config is object`, isPlainObject(body.output_config));
   check(`${context}: output_config.effort is non-empty string`, isNonEmptyString(body.output_config?.effort));
 
@@ -242,6 +253,24 @@ header('Haiku invariants — no output_config/thinking/context_management, syste
     });
   }
   assertMessageInvariants(body, 'haiku');
+}
+
+header('4-5 generation invariants — thinking/context_management absent, output_config still present');
+{
+  // Adaptive thinking is gated to 4.6+ generation models. Sonnet 4-5 and
+  // Opus 4-5 reject `thinking:{type:"adaptive"}` and dependent
+  // `context_management.edits.clear_thinking_*` with 400s on OAuth
+  // subscription auth (verified live 2026-05-15). dario must omit both
+  // fields for those models; output_config (effort) is independent and
+  // ships unchanged.
+  for (const model of ['claude-sonnet-4-5', 'claude-opus-4-5']) {
+    const body = buildCCRequest(
+      { model, messages: [{ role: 'user', content: 'hi' }], stream: false },
+      billingTag, cacheControl, identity,
+    ).body;
+    assertNonHaikuInvariants(body, `4-5:${model}`, { adaptive: false });
+    assertMessageInvariants(body, `4-5:${model}`);
+  }
 }
 
 header('Structural invariants — outbound body has no undefined leaves that JSON would drop silently');


### PR DESCRIPTION
## Summary

`thinking: { type: "adaptive" }` is gated per-model server-side on OAuth subscription auth — the split is at the 4.6 generation. dario was emitting it unconditionally for every non-Haiku model, so every Sonnet 4-5 / Opus 4-5 request through dario in normal mode 400'd at the API.

Codebase-default users (Sonnet 4-6 / Opus 4-7) were unaffected. Anyone explicitly targeting an older 4-5 model was broken.

## Live-probe matrix (2026-05-15)

Probed `/v1/messages` via dario passthrough against the live API with the user's OAuth subscription account; tiny prompts only.

| Model | `thinking:{adaptive}` | Notes |
|---|---|---|
| `claude-opus-4-7` | ✓ 200 | adaptive accepted |
| `claude-opus-4-6` | ✓ 200 | adaptive accepted, returns thinking blocks |
| `claude-sonnet-4-6` | ✓ 200 | adaptive accepted |
| `claude-opus-4-5` | ✗ 400 | `"adaptive thinking is not supported on this model"` |
| `claude-sonnet-4-5` | ✗ 400 | same |
| `claude-haiku-4-5` | ✗ 400 | same (already gated separately via `isHaiku`) |

Beta header state was independently varied (full v2.1.142 set vs. minimal `oauth+claude-code`) and is **not** what gates this. The check is server-side on the model. The dependent `context_management.edits.clear_thinking_*` body field is gated to "thinking enabled or adaptive" so the two ride together.

## Change

- New exported helper `supportsAdaptiveThinking(modelId)` in `src/cc-template.ts`. Allow-list, default-deny.
- Patterns match Opus/Sonnet 4-6+ and any future Opus/Sonnet 5+ majors. Bounded digit groups (`\d{1,2}`) so dated suffixes on the pre-4.x line (`claude-3-5-sonnet-20241022`, `claude-3-7-sonnet-20250219`) can't false-positive by parsing the date suffix as the major version.
- `buildCCRequest` gates both `thinking` AND `context_management` on the helper. `output_config.effort` stays for all non-Haiku (verified independent).
- New `test/adaptive-thinking-gate.mjs` — 37 assertions: empirical YES/NO matrix, forward-compat patterns (Opus 4.8/4.10/4.99, Opus 5+, Opus 10, Sonnet 5+), default-deny on nonsense input, body-shape checks.
- `test/template-invariants.mjs`: `assertNonHaikuInvariants` now takes `{ adaptive }`; new 4-5 generation scenario asserts `thinking` + `context_management` absent and `output_config` still present.

## Forward-compat behavior

Default-deny means an unrecognized future model **silently omits `thinking`** (which the API always accepts) instead of emitting it and round-tripping a 400 + retry. Worst case is "no thinking blocks until the allow-list catches up" — never a broken request.

## Tests

Full suite delta vs `master`: **62/63 → 62/63** — zero new failures.

The single pre-existing failure (`test/tool-schema-contract.mjs`: `todo_read → TodoWrite`, `todo_write → TodoWrite`) is unrelated drift from CC v2.1.142 dropping the Todo tool family in favor of the Task* family. Separate fix.

## Investigation context

This surfaced while running the 1M-context investigation scheduled from the prior session. Headline finding from that probe: there is **no path to >200K context for OAuth subscription auth** — the 200K cap is model-side and independent of beta state or body shape. dario's existing long-context retry path is correct in effect; no change needed there. Full writeup lives in the session transcript.
