### PR TITLE
fix(template): drop legacy todo_read/todo_write → TodoWrite mapping (CC v2.1.142 deprecation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ checklist.
 
 ## [3.38.5] - 2026-05-15
 
+### Fixed — drop legacy `todo_read`/`todo_write` → `TodoWrite` mapping (CC v2.1.142 deprecation)
+
+CC v2.1.142 removed the `TodoWrite` / `TodoRead` tools from its catalog in favor of the Task* family (`TaskCreate`, `TaskGet`, `TaskList`, `TaskOutput`, `TaskStop`, `TaskUpdate`). dario's TOOL_MAP entries for `todo_read` and `todo_write` still pointed at `TodoWrite` — a destination that no longer exists in the bundled or live template — so `test/tool-schema-contract.mjs` had been failing 2/127 since the v2.1.142 re-bake.
+
+The mappings are dropped, not re-pointed. Re-mapping to a Task* member would silently lose semantics: `TodoWrite` replaced an entire flat list per call; `TaskCreate` / `TaskUpdate` operate on individual tasks by ID. A `todo_write` → `TaskCreate` rewrite would truncate a list-write to creating only the first item.
+
+Legacy clients now fall through to the existing unmapped-tool path (same shape as the v3.18.0 `message` / `ask_followup_question` / `clarify` / `notebook_read` drops):
+
+  - default mode → round-robin to a fallback CC tool (lossy but the upstream accepts);
+  - hybrid mode → dropped, so the model doesn't see a phantom tool;
+  - `--preserve-tools` → client's real schema flows through untouched (recommended for clients that actually depend on todo semantics).
+
+`test/tool-schema-contract.mjs` now adds `todo_read` / `todo_write` to `INTENTIONALLY_UNMAPPED` with the rationale inline. Full suite: 63/63 passing.
+
 ### Fixed — adaptive-thinking gated per-model; older 4-5 Sonnet/Opus no longer 400s
 
 Live-probe diagnosis (2026-05-15) found that `thinking: { type: "adaptive" }` is gated per-model server-side on OAuth subscription auth. The split is at the 4.6 generation:

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -903,16 +903,24 @@ const TOOL_MAP: Record<string, ToolMapping> = {
   //   • hybrid mode → dropped, so the model doesn't see a broken tool;
   //   • --preserve-tools → client's real schema flows through untouched
   //     (recommended for agents that depend on ask-user flows).
-  todo_read: {
-    ccTool: 'TodoWrite',
-    translateArgs: () => ({ todos: [] }),
-    translateBack: () => ({}),
-  },
-  todo_write: {
-    ccTool: 'TodoWrite',
-    translateArgs: (a) => ({ todos: a.todos || [] }),
-    translateBack: (a) => ({ todos: a.todos ?? [] }),
-  },
+  // Intentionally unmapped (CC v2.1.142): Anthropic removed TodoWrite /
+  // TodoRead from the CC tool catalog in favor of the Task* family
+  // (TaskCreate / TaskGet / TaskList / TaskOutput / TaskStop / TaskUpdate).
+  // The previous `todo_read`/`todo_write` → `TodoWrite` mappings now point
+  // at a destination tool that no longer exists in the bundled or live
+  // template, so the schema-contract test correctly fails for them.
+  //
+  // We drop the mappings rather than remap to Task* because the semantics
+  // diverge: TodoWrite replaced an entire flat todo list per call; Task*
+  // is single-task-by-ID. A `todo_write` → `TaskCreate` rewrite would
+  // silently truncate a list-write to creating only the first item. The
+  // unmapped-tool path handles legacy clients honestly:
+  //   • default mode → round-robin to a fallback CC tool (lossy but the
+  //     upstream accepts the request);
+  //   • hybrid mode → dropped, so the model doesn't see a phantom tool;
+  //   • --preserve-tools → client's real schema flows through untouched
+  //     (recommended for clients that actually depend on todo semantics).
+  //
   // Intentionally unmapped (dario#43): CC has no notebook-read tool, and
   // routing a read to NotebookEdit with empty new_source either fails the
   // schema (`new_source` required) or executes a destructive no-op edit.

--- a/test/tool-schema-contract.mjs
+++ b/test/tool-schema-contract.mjs
@@ -98,6 +98,10 @@ const samples = {
   browser: { url: 'https://example.com' },
   todo_read: {},
   todo_write: { todos: [{ content: 'x', status: 'pending', activeForm: 'doing x' }] },
+  // ↑ todo_read/todo_write were mapped to CC's `TodoWrite` until CC
+  //   v2.1.142 dropped the Todo tool family in favor of Task*. Samples
+  //   stay so the unmapped-tool regression guard at the bottom catches
+  //   any future re-introduction of a half-correct mapping.
   enter_plan_mode: {},
   exit_plan_mode: {},
   enter_worktree: { path: '/tmp/w' },
@@ -112,13 +116,25 @@ const samples = {
   notebook_read: { notebook_path: '/tmp/n.ipynb' },
 };
 
-// Tools intentionally dropped from TOOL_MAP in v3.18.0 (dario#43).
-// Their samples above exist only to exercise the unmapped-tool path.
+// Tools intentionally dropped from TOOL_MAP. Their samples above exist
+// only to exercise the unmapped-tool path.
+//
+//   v3.18.0 (dario#43): message, ask_followup_question, clarify,
+//     notebook_read — no faithful CC destination from day one.
+//
+//   v3.38.5: todo_read, todo_write — destination tool `TodoWrite` was
+//     removed from CC in v2.1.142 (Anthropic moved to the Task* family,
+//     which is single-task-by-ID and doesn't translate from a flat
+//     todo-list semantic). Legacy clients fall through to
+//     unmapped-tool handling: default → round-robin fallback, hybrid →
+//     dropped, --preserve-tools → client schema passes through.
 const INTENTIONALLY_UNMAPPED = new Set([
   'message',
   'ask_followup_question',
   'clarify',
   'notebook_read',
+  'todo_read',
+  'todo_write',
 ]);
 
 // Minimal JSON-Schema subset — covers every construct used in
@@ -216,8 +232,19 @@ for (const [clientName, mapping] of toolMap.entries()) {
 // Regression guard: the three ask-user mappings must stay dropped — re-adding
 // them without fixing the shape would silently break every upstream request
 // carrying one of those client tools.
+// Label the assertion with the issue/release that dropped each tool so
+// a failure points straight at the relevant changelog entry.
+const UNMAPPED_REASON = {
+  message: 'dario#43',
+  ask_followup_question: 'dario#43',
+  clarify: 'dario#43',
+  notebook_read: 'dario#43',
+  todo_read: 'v3.38.5',
+  todo_write: 'v3.38.5',
+};
 for (const name of INTENTIONALLY_UNMAPPED) {
-  check(`dropped (dario#43): ${name}`, unmappedTools.includes(name));
+  const tag = UNMAPPED_REASON[name] ?? 'unmapped';
+  check(`dropped (${tag}): ${name}`, unmappedTools.includes(name));
 }
 
 console.log(`\n  ${pass} pass, ${fail} fail`);


### PR DESCRIPTION
## Summary

Clears the last pre-existing CI failure on master: 2/127 in `tool-schema-contract.mjs` for the legacy `todo_read` and `todo_write` mappings. CC v2.1.142 removed `TodoWrite` / `TodoRead` from its tool catalog in favor of the Task* family, so dario's TOOL_MAP entries pointed at a destination that no longer exists.

After this PR the full suite is **63/63** for the first time since the v2.1.142 re-bake (#271).

## Why drop, not re-map

Re-mapping to a Task* member would silently lose semantics:

- `TodoWrite` replaced an entire flat todo list per call. Items had `content` + `status` + `activeForm`.
- The Task* family is single-task-by-ID: `TaskCreate` adds one, `TaskUpdate` updates one, `TaskList` reads.

A `todo_write` → `TaskCreate` rewrite would silently truncate a list-write to creating only the first item — worse than the current "schema not found" failure because users would see the broken behavior at runtime instead of in the test.

Same treatment as the v3.18.0 drops (`message` / `ask_followup_question` / `clarify` / `notebook_read` in dario#43). Different cause (deprecated destination, not "no faithful translation from day one"), same outcome:

- default mode → round-robin to a fallback CC tool (lossy but the upstream accepts);
- hybrid mode → dropped, so the model doesn't see a phantom tool;
- `--preserve-tools` → client's real schema flows through untouched (the path for anyone who actually needs todo semantics).

## Changes

- `src/cc-template.ts`: remove the two TOOL_MAP entries; replace with a comment block explaining the deprecation + rationale.
- `test/tool-schema-contract.mjs`: add `todo_read` / `todo_write` to `INTENTIONALLY_UNMAPPED`. Refactor the dropped-tool assertion to attribute each entry to its drop reason (`dario#43` for the v3.18.0 set, `v3.38.5` for the new pair) so a future failure points at the relevant changelog entry.
- `CHANGELOG.md`: extend the v3.38.5 entry with this fix.

## Tests

```
--- tool-schema-contract ---
  ✅ dropped (dario#43): message
  ✅ dropped (dario#43): ask_followup_question
  ✅ dropped (dario#43): clarify
  ✅ dropped (dario#43): notebook_read
  ✅ dropped (v3.38.5): todo_read
  ✅ dropped (v3.38.5): todo_write

  127 pass, 0 fail

--- full suite ---
# tests 63 / pass 63 / fail 0
```

Lands alongside #273 (adaptive-thinking gate) in the v3.38.5 release cut — release is still held per prior direction.
