### PR TITLE
release: v3.38.6 — TodoWrite legacy mapping drop, riding on v3.38.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ checklist.
 
 ## [Unreleased]
 
-## [3.38.5] - 2026-05-15
+## [3.38.6] - 2026-05-15
 
 ### Fixed — drop legacy `todo_read`/`todo_write` → `TodoWrite` mapping (CC v2.1.142 deprecation)
 
@@ -25,7 +25,11 @@ Legacy clients now fall through to the existing unmapped-tool path (same shape a
   - hybrid mode → dropped, so the model doesn't see a phantom tool;
   - `--preserve-tools` → client's real schema flows through untouched (recommended for clients that actually depend on todo semantics).
 
-`test/tool-schema-contract.mjs` now adds `todo_read` / `todo_write` to `INTENTIONALLY_UNMAPPED` with the rationale inline. Full suite: 63/63 passing.
+`test/tool-schema-contract.mjs` now adds `todo_read` / `todo_write` to `INTENTIONALLY_UNMAPPED` with the rationale inline. Full suite: 63/63 passing (first fully-green run since the v2.1.142 re-bake in #271 — v3.38.5 shipped at 62/63, this closes the held-back failure).
+
+This release rides on top of v3.38.5 because the auto-release fired on #273's merge before #274 (the TodoWrite drop) landed.
+
+## [3.38.5] - 2026-05-15
 
 ### Fixed — adaptive-thinking gated per-model; older 4-5 Sonnet/Opus no longer 400s
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.38.5",
+  "version": "3.38.6",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Cuts v3.38.6 carrying the TodoWrite legacy-mapping drop (which landed in #274 but missed the v3.38.5 auto-release window by 7 minutes).

## Timeline

| Time (UTC) | Event |
|---|---|
| 21:20:16 | v3.38.5 auto-released on #273's merge — **adaptive-thinking gate only** |
| 21:27:20 | #274 (TodoWrite drop) merged — **post-release**, sitting on master |
| Now | Bump 3.38.5 → 3.38.6 so npm catches up to master |

npm v3.38.5 therefore ships with one fix (adaptive-thinking gate). This PR pushes the TodoWrite drop out as v3.38.6 so the registry is consistent with master.

## CHANGELOG re-attribution

The TodoWrite "### Fixed —" section that was sitting under `[3.38.5]` moves to its own `[3.38.6]` entry. The adaptive-thinking section stays in `[3.38.5]` (correctly — that's what npm 3.38.5 actually contains).

## Tests

Full suite is **63/63** at v3.38.6 (was 62/63 at v3.38.5 with the TodoWrite failure held back). This is the first fully-green run since the CC v2.1.142 re-bake in #271.

## No code change

This commit only repoints `package.json` and re-attributes the CHANGELOG sections. The TodoWrite fix itself already landed in `8d8f6ae` (#274). The auto-release workflow will see the version bump on merge and ship v3.38.6 from the current master HEAD (which already includes #274).

## Follow-up tracked separately

The v3.38.5 GitHub release body came out empty (the `cc-drift-auto-release.yml` CHANGELOG-extraction step didn't match the section). Worth a separate investigation so v3.38.6's release body lands populated.
