### PR TITLE
fix(release): CHANGELOG extraction returns the section body, not empty string

### DIFF
--- a/.github/workflows/cc-drift-auto-release.yml
+++ b/.github/workflows/cc-drift-auto-release.yml
@@ -257,13 +257,27 @@ jobs:
         # GitHub release body shows what was in the bump, not a generic
         # "see changelog" link. Runs a tiny Node one-liner to avoid
         # shell-escaping the markdown content.
+        #
+        # Regex history: the original version (v3.38.x era) used
+        # `^## \[VERSION\]...(?=\n## \[|$)` with the multiline /m flag.
+        # That silently captured the empty string for every version
+        # because multiline /m makes `$` match before any `\n`, so the
+        # blank separator line right after the version heading triggers
+        # the lookahead's `$` alternative immediately, the lazy
+        # `[\s\S]*?` settles on zero chars, and every release shipped
+        # with an empty CHANGELOG body for 6+ versions before anyone
+        # noticed. Fix: drop the /m flag and anchor the start with
+        # `(?:^|\n)`. Without /m, `$` matches only end-of-string, so the
+        # lookahead now does what was intended — stop at the next
+        # version heading, or at end-of-file for the latest entry.
         run: |
           set -eo pipefail
           VERSION="${{ steps.ver.outputs.version }}"
           node -e "
             const fs = require('fs');
             const md = fs.readFileSync('CHANGELOG.md', 'utf-8');
-            const re = new RegExp('^## \\\\[' + '${VERSION}' + '\\\\][^\\\\n]*\\\\n([\\\\s\\\\S]*?)(?=\\\\n## \\\\[|$)', 'm');
+            const verEsc = '${VERSION}'.replace(/\\./g, '\\\\.');
+            const re = new RegExp('(?:^|\\\\n)## \\\\[' + verEsc + '\\\\][^\\\\n]*\\\\n([\\\\s\\\\S]*?)(?=\\\\n## \\\\[|$)');
             const m = re.exec(md);
             process.stdout.write(m ? m[1].trim() : '(no changelog section found for this version)');
           " > release-notes.md


### PR DESCRIPTION
## Summary

The auto-release workflow has been silently shipping every GitHub release with an empty CHANGELOG body since at least v3.37 — discovered while investigating why v3.38.5 / v3.38.6 came out empty.

## Evidence

`gh release view v3.38.x --json body --jq '.body | length'`:

| Release | Body size | Content |
|---|---|---|
| v3.38.0 | 239 | boilerplate only |
| v3.38.1 | 239 | boilerplate only |
| v3.38.2 | 239 | boilerplate only |
| v3.38.3 | 239 | boilerplate only |
| v3.38.4 | 239 | boilerplate only |
| v3.38.5 | 239 | boilerplate only |
| v3.38.6 | 239 | boilerplate only |

239 bytes is the "Auto-released from merge of [PR #N]…" wrapper plus the "Built + tested" footer. **Every CHANGELOG section was being dropped between extraction and release.**

## Root cause

The regex used:

```js
new RegExp('^## \\[VERSION\\][^\\n]*\\n([\\s\\S]*?)(?=\\n## \\[|$)', 'm')
```

With the `/m` flag, `$` matches before any `\n`, not just end-of-string. Every version section begins with a blank separator line right after the heading, so at the start of the lazy capture the very next char is `\n`. The `$` alternative of the lookahead matches immediately, the lazy `[\s\S]*?` settles on zero chars, and `m[1]` returns the empty string.

The downstream `process.stdout.write(m ? m[1].trim() : '...fallback...')` saw `m` truthy (match succeeded — just captured nothing), so the fallback string never fired either. The file silently wrote 0 bytes.

## Fix

Drop the `/m` flag and anchor the start with `(?:^|\n)`. Without `/m`, `$` matches only end-of-string, so the lookahead does what was intended — stop at the next `## [` heading, or at EOF for the latest entry.

```diff
-const re = new RegExp('^## \\[' + VERSION + '\\][^\\n]*\\n([\\s\\S]*?)(?=\\n## \\[|$)', 'm');
+const verEsc = VERSION.replace(/\./g, '\\.');
+const re = new RegExp('(?:^|\\n)## \\[' + verEsc + '\\][^\\n]*\\n([\\s\\S]*?)(?=\\n## \\[|$)');
```

Also picked up the version-string regex-escape (`.` is a regex metachar; previously a typo'd version like `3-38-5` would still match `3.38.5`).

## Verification

Simulated the workflow's bash → node invocation exactly (script written to a temp file, no extra shell-quoting layers), against the current CHANGELOG.md:

| Version | Extracted bytes | First line of content |
|---|---|---|
| v3.38.6 | 1729 | `### Fixed — drop legacy todo_read/todo_write → TodoWrite mapping …` |
| v3.38.5 | 2384 | `### Fixed — adaptive-thinking gated per-model …` |
| v3.38.4 | 1253 | `### Changed — SUPPORTED_CC_RANGE.maxTested bumped …` |
| v3.38.3 | 2258 | `### Fixed — bundled template re-baked from CC v2.1.142 …` |
| v3.38.0 | 2526 | `### Added — response-correlated think time + session-start jitter …` |

All match the expected section bodies. The fix is correct for both mid-file entries (next `## [` terminator) and the latest entry (EOF terminator).

## No version bump

Workflow-only change. Won't fire its own auto-release — and even if it tried, the gate step's `gh release view` check would short-circuit since v3.38.6 already exists.

## Backfill plan

After this merges, I'll `gh release edit --notes-file` v3.38.5 and v3.38.6 with their extracted CHANGELOG content so users browsing the Releases page see the actual fixes. Older releases (v3.37–v3.38.4) also have empty bodies, but their changelog content remains accessible via `CHANGELOG.md`; backfilling those is optional and tracked separately.
