### PR TITLE
chore(release): extract CHANGELOG-section logic to a tested script

### DIFF
--- a/.github/workflows/cc-drift-auto-release.yml
+++ b/.github/workflows/cc-drift-auto-release.yml
@@ -255,32 +255,19 @@ jobs:
         if: steps.gate.outputs.proceed == 'true'
         # Pull the section for this version from CHANGELOG.md so the
         # GitHub release body shows what was in the bump, not a generic
-        # "see changelog" link. Runs a tiny Node one-liner to avoid
-        # shell-escaping the markdown content.
+        # "see changelog" link.
         #
-        # Regex history: the original version (v3.38.x era) used
-        # `^## \[VERSION\]...(?=\n## \[|$)` with the multiline /m flag.
-        # That silently captured the empty string for every version
-        # because multiline /m makes `$` match before any `\n`, so the
-        # blank separator line right after the version heading triggers
-        # the lookahead's `$` alternative immediately, the lazy
-        # `[\s\S]*?` settles on zero chars, and every release shipped
-        # with an empty CHANGELOG body for 6+ versions before anyone
-        # noticed. Fix: drop the /m flag and anchor the start with
-        # `(?:^|\n)`. Without /m, `$` matches only end-of-string, so the
-        # lookahead now does what was intended — stop at the next
-        # version heading, or at end-of-file for the latest entry.
+        # The extraction logic lives in `scripts/extract-release-notes.mjs`
+        # with full unit-test coverage in `test/extract-release-notes.mjs`
+        # — a future regression to the empty-capture state breaks CI
+        # before it ships. Pre-refactor history (inline `node -e` regex
+        # with /m flag that silently captured the empty string for 39
+        # consecutive releases) is documented in the script's header
+        # and on PR #276.
         run: |
           set -eo pipefail
           VERSION="${{ steps.ver.outputs.version }}"
-          node -e "
-            const fs = require('fs');
-            const md = fs.readFileSync('CHANGELOG.md', 'utf-8');
-            const verEsc = '${VERSION}'.replace(/\\./g, '\\\\.');
-            const re = new RegExp('(?:^|\\\\n)## \\\\[' + verEsc + '\\\\][^\\\\n]*\\\\n([\\\\s\\\\S]*?)(?=\\\\n## \\\\[|$)');
-            const m = re.exec(md);
-            process.stdout.write(m ? m[1].trim() : '(no changelog section found for this version)');
-          " > release-notes.md
+          node scripts/extract-release-notes.mjs "$VERSION" --file CHANGELOG.md > release-notes.md
           echo "--- release-notes.md ---"
           cat release-notes.md
 

--- a/.github/workflows/cc-drift-watch.yml
+++ b/.github/workflows/cc-drift-watch.yml
@@ -127,7 +127,14 @@ jobs:
         if: always()
         id: ver
         run: |
-          CC_VERSION=$(node -e "try { console.log(JSON.parse(require('fs').readFileSync('drift-report.json','utf-8')).ccVersion || 'unknown') } catch (e) { console.log('unknown') }")
+          # `try/catch` falls back to 'unknown' so a missing-or-broken
+          # drift-report.json doesn't blow up the downstream issue-open
+          # step (which gracefully labels the issue "CC drift detected:
+          # vunknown"). The error itself goes to stderr so an operator
+          # debugging a silent run can tell "no report" from "broken
+          # report" — pre-2026-05-15 this swallowed errors with no
+          # diagnostic at all.
+          CC_VERSION=$(node -e "try { console.log(JSON.parse(require('fs').readFileSync('drift-report.json','utf-8')).ccVersion || 'unknown') } catch (e) { console.error('cc-version-extract failed: ' + e.message); console.log('unknown') }")
           echo "cc_version=$CC_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Open / update drift issue

--- a/scripts/extract-release-notes.mjs
+++ b/scripts/extract-release-notes.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// Extract a single version's section from CHANGELOG.md.
+//
+// Used by `cc-drift-auto-release.yml` to populate the GitHub release
+// body so users see what was in the bump instead of a generic
+// "see CHANGELOG" pointer.
+//
+// History: the original implementation was a `node -e` one-liner
+// embedded directly in the workflow YAML. The regex used `/m` flag +
+// lookahead on multiline `$`, which silently captured the empty
+// string for every version (because every section begins with a blank
+// separator line and `$` in /m matches before any `\n`). 39 releases
+// shipped with empty bodies before the bug was caught. The fix lives
+// here, in a real file that has real tests — `test/extract-release-
+// notes.mjs` locks the empirical contract so the same class of bug
+// can't ship again.
+//
+// CLI:
+//   node scripts/extract-release-notes.mjs <version> < CHANGELOG.md
+//   node scripts/extract-release-notes.mjs <version> --file <path>
+//
+// Stdin/file is the CHANGELOG markdown source. Stdout is the trimmed
+// section body (or a "(no changelog section …)" sentinel if the
+// version is absent or the section is empty). Always exits 0 — the
+// caller is the GitHub release body, not a fail-or-pass gate.
+
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+const FALLBACK = '(no changelog section found for this version)';
+
+/**
+ * Return the trimmed content of the `## [version]` section in
+ * CHANGELOG markdown, or null if not present / empty after trim.
+ *
+ * The regex:
+ *   (?:^|\n)## \[<verEsc>\][^\n]*\n([\s\S]*?)(?=\n## \[|$)
+ *
+ * Reads as: at start-of-string or after a newline, match the heading
+ * line for this version, then lazily capture everything up to the
+ * next `## [` heading (or end-of-string for the latest entry).
+ *
+ * Why this shape:
+ *   - `(?:^|\n)` instead of `^` with /m flag: with /m, `$` in the
+ *     lookahead would match before any `\n`, including the blank
+ *     separator line right after the heading, collapsing the lazy
+ *     capture to "". Without /m, `$` matches only end-of-string,
+ *     which is what the lookahead intends.
+ *   - `\d{1,2}` is NOT used here because version segments can be 2+
+ *     digits (e.g., `3.38.10`). The escape `version.replace(/\./g,
+ *     '\\.')` handles the regex metachar.
+ *   - `[^\n]*` after the closing `]` tolerates date suffixes like
+ *     ` - 2026-05-15` on the heading line without committing to a
+ *     specific format.
+ */
+export function extractReleaseNotes(md, version) {
+  if (typeof md !== 'string' || typeof version !== 'string' || version.length === 0) {
+    return null;
+  }
+  const verEsc = version.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(
+    `(?:^|\\n)## \\[${verEsc}\\][^\\n]*\\n([\\s\\S]*?)(?=\\n## \\[|$)`,
+  );
+  const m = re.exec(md);
+  if (!m) return null;
+  const trimmed = m[1].trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * CLI entry. Reads CHANGELOG markdown from stdin (default) or from
+ * `--file <path>`, writes the section (or the fallback sentinel) to
+ * stdout, exits 0.
+ */
+function runCli(argv) {
+  const args = argv.slice(2);
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    process.stderr.write(
+      'Usage: extract-release-notes.mjs <version> [--file CHANGELOG.md]\n' +
+      '  Reads stdin if --file is not given.\n' +
+      '  Always exits 0; prints fallback sentinel if the version section is missing or empty.\n'
+    );
+    return 0;
+  }
+  const version = args[0];
+  let md = '';
+  const fileIdx = args.indexOf('--file');
+  if (fileIdx >= 0 && args[fileIdx + 1]) {
+    try {
+      md = readFileSync(args[fileIdx + 1], 'utf-8');
+    } catch (err) {
+      process.stderr.write(`extract-release-notes: cannot read ${args[fileIdx + 1]}: ${err.message}\n`);
+      process.stdout.write(FALLBACK);
+      return 0;
+    }
+  } else {
+    md = readFileSync(0, 'utf-8');
+  }
+  const section = extractReleaseNotes(md, version);
+  process.stdout.write(section ?? FALLBACK);
+  return 0;
+}
+
+// CLI only when invoked directly (not when imported by tests).
+// `pathToFileURL` handles Windows backslashes vs POSIX consistently;
+// comparing against `import.meta.url` (which is always a file:// URL
+// with forward slashes) avoids the cross-platform mismatch a naive
+// string replace would have.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(runCli(process.argv));
+}

--- a/test/extract-release-notes.mjs
+++ b/test/extract-release-notes.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+// Tests for scripts/extract-release-notes.mjs.
+//
+// Locks the empirical contract that the workflow's release-body
+// extraction has to obey. The original implementation was a one-line
+// regex buried in `cc-drift-auto-release.yml` that silently captured
+// the empty string for every version — 39 releases shipped with
+// empty bodies before anyone noticed. This file makes that class of
+// silent regression impossible: a future change that breaks the
+// extraction breaks CI before it ships.
+//
+// Run: `node test/extract-release-notes.mjs` (or via npm test).
+
+import { extractReleaseNotes } from '../scripts/extract-release-notes.mjs';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+let pass = 0, fail = 0;
+function check(name, cond, detail) {
+  if (cond) { pass++; console.log(`  OK ${name}`); }
+  else { fail++; console.log(`  FAIL ${name}${detail ? ' :: ' + detail : ''}`); }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+// ─────────────────────────────────────────────────────────────
+header('Basic — single entry, no Unreleased header');
+{
+  const md = `# Changelog
+
+## [1.0.0] - 2026-01-01
+
+### Added — initial release
+
+First public release.
+`;
+  const out = extractReleaseNotes(md, '1.0.0');
+  check('extracts content', out && out.includes('initial release'));
+  check('trims leading/trailing whitespace', out === '### Added — initial release\n\nFirst public release.');
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Multiple entries — extracts only the requested one');
+{
+  const md = `# Changelog
+
+## [Unreleased]
+
+## [2.0.0] - 2026-02-01
+
+### Changed — v2 stuff
+
+Second release content.
+
+## [1.0.0] - 2026-01-01
+
+### Added — initial release
+
+First release content.
+`;
+  const v2 = extractReleaseNotes(md, '2.0.0');
+  const v1 = extractReleaseNotes(md, '1.0.0');
+  check('v2 extracts v2 content', v2 && v2.includes('Second release content'));
+  check('v2 does NOT include v1 content', v2 && !v2.includes('First release content'));
+  check('v2 does NOT include Unreleased boundary', v2 && !v2.includes('## ['));
+  check('v1 extracts v1 content', v1 && v1.includes('First release content'));
+  check('v1 (latest in file order) terminates at EOF', v1 && v1.endsWith('First release content.'));
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Regression — multiline /m flag bug that shipped 39 empty releases');
+{
+  // The pre-fix regex was:
+  //   ^## \[VERSION\][^\n]*\n([\s\S]*?)(?=\n## \[|$)  with /m flag
+  //
+  // Every CHANGELOG section begins with a blank line right after the
+  // heading — the position right after the heading's `\n` is at the
+  // start of that blank line, and `$` in /m mode matches before any
+  // `\n`. So the lookahead's `$` alternative fired on the first
+  // possible position, the lazy `[\s\S]*?` settled on 0 chars, and
+  // `m[1]` was empty.
+  //
+  // The fix drops /m and uses `(?:^|\n)` to anchor start. This test
+  // pins that behavior — extracting from a CHANGELOG that starts
+  // with the blank-separator-after-heading shape MUST return non-
+  // empty content, not the empty string.
+  const md = `# Changelog
+
+## [3.38.6] - 2026-05-15
+
+### Fixed — drop legacy todo mapping
+
+CC v2.1.142 removed the TodoWrite tool.
+
+## [3.38.5] - 2026-05-15
+
+### Fixed — adaptive thinking gate
+
+Per-model gate.
+`;
+  const out = extractReleaseNotes(md, '3.38.6');
+  check('regression: non-empty after blank separator', out && out.length > 30);
+  check('regression: contains the heading', out && out.includes('### Fixed — drop legacy todo mapping'));
+  check('regression: contains the prose', out && out.includes('CC v2.1.142 removed'));
+  check('regression: stops at next ## [', out && !out.includes('3.38.5'));
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Version with regex metacharacters');
+{
+  // SemVer always contains dots, which are regex metachars. Internal
+  // .replace() must escape them. Without escaping, `3.38.6` would
+  // match `3X38Y6` for any chars X/Y — a CHANGELOG with a typo
+  // version would be silently matched.
+  const md = `## [3.38.6] - 2026-05-15
+
+Real content.
+
+## [3X38Y6] - decoy
+
+This should not match.
+`;
+  const real = extractReleaseNotes(md, '3.38.6');
+  const decoy = extractReleaseNotes(md, '3X38Y6');
+  check('3.38.6 finds the real entry', real && real.includes('Real content'));
+  check('3.38.6 does NOT match 3X38Y6 (dot is escaped)', real && !real.includes('should not match'));
+  check('3X38Y6 finds the decoy entry verbatim', decoy && decoy.includes('should not match'));
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Missing version → null fallback');
+{
+  const md = `## [1.0.0] - 2026-01-01
+
+Content.
+`;
+  const out = extractReleaseNotes(md, '99.99.99');
+  check('returns null for missing version', out === null);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Empty section → null (treats as "missing")');
+{
+  // A version heading with nothing between it and the next heading
+  // should be treated the same as a missing version, so the
+  // workflow's fallback sentinel fires instead of writing zero bytes.
+  const md = `## [Unreleased]
+
+## [1.0.0] - 2026-01-01
+
+Content.
+`;
+  const out = extractReleaseNotes(md, 'Unreleased');
+  check('empty Unreleased section returns null', out === null);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Bad input handling');
+{
+  check('null markdown → null',       extractReleaseNotes(null, '1.0.0') === null);
+  check('undefined markdown → null',  extractReleaseNotes(undefined, '1.0.0') === null);
+  check('number markdown → null',     extractReleaseNotes(42, '1.0.0') === null);
+  check('null version → null',        extractReleaseNotes('## [1.0.0]\n\nx', null) === null);
+  check('empty-string version → null', extractReleaseNotes('## [1.0.0]\n\nx', '') === null);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Heading-only-then-EOF (latest entry has no trailing entry)');
+{
+  // The latest version's terminator is `$` (end-of-string), not
+  // `\n## [`. This used to be the broken case under /m mode.
+  const md = `## [1.0.0]\n\nOnly entry, no trailing heading.\n`;
+  const out = extractReleaseNotes(md, '1.0.0');
+  check('extracts content with EOF terminator', out === 'Only entry, no trailing heading.');
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Heading line variants — date suffix, no date, extra whitespace');
+{
+  const variants = [
+    { line: '## [1.0.0] - 2026-01-01',                  expectsMatch: true },
+    { line: '## [1.0.0]',                               expectsMatch: true },
+    { line: '## [1.0.0]   ',                            expectsMatch: true },
+    { line: '## [1.0.0] - 2026-01-01 - extra annotation', expectsMatch: true },
+    { line: '##[1.0.0] - missing space',                expectsMatch: false },
+  ];
+  for (const v of variants) {
+    const md = `${v.line}\n\nVariant content for: ${v.line}\n`;
+    const out = extractReleaseNotes(md, '1.0.0');
+    const ok = v.expectsMatch
+      ? (out !== null && out.includes('Variant content'))
+      : (out === null);
+    check(`heading "${v.line}" ${v.expectsMatch ? 'matches' : 'does NOT match'}`, ok);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Real CHANGELOG.md — every release section extracts content');
+{
+  // Cross-check against the live CHANGELOG.md. Every version listed
+  // in the file should extract a non-null section (no "(no changelog
+  // section …)" sentinel ever fires for a version that's actually
+  // present). This catches a regression where the regex
+  // accidentally stops working on the real document while still
+  // passing the synthetic cases above.
+  const repoRoot = join(__dirname, '..');
+  const md = readFileSync(join(repoRoot, 'CHANGELOG.md'), 'utf-8');
+  const headings = md.match(/^## \[[^\]]+\]/gm) || [];
+  check('CHANGELOG has at least 5 version headings', headings.length >= 5);
+  let extractedCount = 0;
+  let nullCount = 0;
+  for (const h of headings) {
+    const v = h.match(/^## \[([^\]]+)\]/)[1];
+    if (v === 'Unreleased') continue;          // intentionally empty most days
+    const section = extractReleaseNotes(md, v);
+    if (section === null) {
+      nullCount++;
+      console.log(`    [null] ${v}`);
+    } else {
+      extractedCount++;
+    }
+  }
+  check(`extracted ${extractedCount} sections`, extractedCount > 0);
+  check('every non-Unreleased section is non-null', nullCount === 0);
+}
+
+// ─────────────────────────────────────────────────────────────
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Follow-up to #276. The previous PR fixed the CHANGELOG-extraction regex; this PR makes the same class of silent bug **impossible to ship again** by promoting the inline `node -e` regex inside `cc-drift-auto-release.yml` to a real file with full unit-test coverage.

A regression of the regex now breaks CI on the PR, not the release page on master.

## What changed

| File | Change |
|---|---|
| `scripts/extract-release-notes.mjs` (new) | The extraction function + CLI. Documented with the full historical context: why /m was the trap, what the fix is, what each piece of the regex does. |
| `test/extract-release-notes.mjs` (new) | 30 assertions across 9 scenario groups (see below). Picked up automatically by `test/all.test.mjs`. |
| `.github/workflows/cc-drift-auto-release.yml` | "Extract release notes" step now calls `node scripts/extract-release-notes.mjs …` instead of inlining `node -e`. ~30 lines of escape-soup gone. |
| `.github/workflows/cc-drift-watch.yml` | Drive-by: line 130's `catch { console.log('unknown') }` swallowed JSON parse errors with no diagnostic. Now `console.error`s the error message before falling back, so an operator debugging a silent run can tell "no drift report" from "report exists but broken". Control flow unchanged. |

## Test coverage (30 assertions, all passing)

```
=== Basic — single entry, no Unreleased header ===
=== Multiple entries — extracts only the requested one ===
=== Regression — multiline /m flag bug that shipped 39 empty releases ===
=== Version with regex metacharacters ===
=== Missing version → null fallback ===
=== Empty section → null (treats as "missing") ===
=== Bad input handling ===
=== Heading-only-then-EOF (latest entry has no trailing entry) ===
=== Heading line variants — date suffix, no date, extra whitespace ===
=== Real CHANGELOG.md — every release section extracts content ===
  OK CHANGELOG has at least 5 version headings
  OK extracted 173 sections
  OK every non-Unreleased section is non-null

30 pass, 0 fail
```

The last group is the safety net — it pulls the actual `CHANGELOG.md` shipped on master, iterates every `## [version]` heading, and asserts every non-Unreleased section extracts non-null content. If a future CHANGELOG edit accidentally creates a section the regex can't see, CI fails before merge.

## Other findings from the workflow audit

Did a full read-through of all 9 workflow files looking for the same shape of silent-failure bug. Three patterns I considered and decided NOT to change:

- `cc-drift-auto-release.yml:130-133` — the audit flagged `git show HEAD^1:package.json … || echo ""` as silently skipping releases on shallow clones. False positive: the downstream `if [ "$CURRENT" = "$PARENT" ]` evaluates false when PARENT is empty, so an unresolvable parent falls through to a release rather than skipping it. Current code is correct.

- `ci.yml:65-70` — docker smoke test. Audit flagged that empty docker output could pass. False positive: the explicit `test -s /tmp/help-out.txt` on line 69 guards non-empty output before `grep -q` runs. With `set -e` (Actions default), either failure exits 1.

- `cc-drift-watch.yml:192-194` — `node -pe "JSON.parse(...).fixed"` would output literal `"undefined"` on missing field. The downstream `if [ "$FIXED" != "true" ]` cleanly exits 0 in that case, which is the intended behavior (no fix → no PR). `set -eo pipefail` at the top handles invalid JSON. Not a regression risk.

Audit yielded one real (LOW) improvement worth landing here: the `cc-drift-watch.yml:130` diagnostic logging in the drive-by above.

## No version bump

Workflow-side refactor only. The gate step's existing tag-exists check would short-circuit any accidental release attempt (master is at v3.38.6).

## Backfill follow-up

The 39 historical releases that shipped with empty bodies under the old regex are being backfilled separately via `gh release edit --notes-file`. The script driving the backfill uses the same extraction function this PR ships, so the backfilled bodies will match what the auto-release would have produced if the regex had been right from day one.
