### PR TITLE
feat(v4): TUI framework primitives — pure-ANSI render/input/layout/app

### DIFF
--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -1,0 +1,218 @@
+/**
+ * The TUI App — main render loop + lifecycle + key dispatch.
+ *
+ * The shape is deliberately simple: one render function (caller-
+ * supplied) that takes `state + dimensions` and returns the full frame
+ * as a string. The App drives the loop, manages stdin raw mode, handles
+ * resize events, and flushes one write per frame. Tabs (M4) are
+ * decoupled state machines that the caller's render() composes.
+ *
+ * Lifecycle invariants:
+ *
+ *   - Enters alt-screen on start, leaves on stop. The shell that
+ *     spawned dario sees its prior content restored when the TUI quits.
+ *   - Hides the cursor on start, restores it on stop. ALWAYS, even on
+ *     uncaught exceptions or SIGINT — we install signal + exit hooks.
+ *   - Sets stdin raw mode on start, restores it on stop.
+ *
+ * The hook chain is registered on process events; quit calls them all
+ * synchronously so no terminal state leaks out.
+ */
+
+import { attachKeyHandler, type Key } from './input.js';
+import {
+  clearScreen, enterAltScreen, leaveAltScreen, hideCursor, showCursor,
+} from './render.js';
+
+export interface AppOptions<S> {
+  /**
+   * Initial state. The App holds a reference and re-renders when
+   * `setState` is called.
+   */
+  initialState: S;
+  /**
+   * Pure function: state + dimensions → full screen content.
+   * The App calls this on every redraw + flushes the returned string
+   * to stdout in a single write.
+   */
+  render: (state: S, dim: { cols: number; rows: number }) => string;
+  /**
+   * Key dispatch. Receives every parsed key from stdin (after the
+   * App has already handled global keys like Ctrl-C). Return a new
+   * state (or undefined for no change) — same shape as React's
+   * setState reducer.
+   */
+  onKey: (state: S, key: Key) => S | undefined;
+  /**
+   * Optional: called on every redraw after the new frame has been
+   * written. Used by tabs that have async data (e.g. SSE-fed Hits
+   * tab) to schedule periodic refreshes.
+   */
+  afterFrame?: (state: S) => void;
+  /**
+   * stdin / stdout — overridable for tests. Defaults to process.stdin
+   * and process.stdout.
+   */
+  stdin?: NodeJS.ReadStream;
+  stdout?: NodeJS.WriteStream;
+}
+
+export class App<S> {
+  private state: S;
+  private renderFn: AppOptions<S>['render'];
+  private keyFn: AppOptions<S>['onKey'];
+  private afterFrameFn?: AppOptions<S>['afterFrame'];
+  private stdin: NodeJS.ReadStream;
+  private stdout: NodeJS.WriteStream;
+  private cleanupFns: Array<() => void> = [];
+  private running = false;
+  // Coalesce setState calls that arrive in the same tick — only one
+  // redraw per tick regardless of how many setStates fire.
+  private redrawScheduled = false;
+
+  constructor(opts: AppOptions<S>) {
+    this.state = opts.initialState;
+    this.renderFn = opts.render;
+    this.keyFn = opts.onKey;
+    this.afterFrameFn = opts.afterFrame;
+    this.stdin = opts.stdin ?? process.stdin;
+    this.stdout = opts.stdout ?? process.stdout;
+  }
+
+  /**
+   * Replace state. If the new state differs from the old (shallow
+   * equality), schedule a redraw. Tabs use this both for synchronous
+   * key-driven updates and for async data arrivals (SSE 'record').
+   *
+   * The "differs" check is intentionally shallow — deep equality on
+   * potentially-large analytics records would be expensive and the
+   * caller almost always passes new object identity when it mutates.
+   * If you mutate state in place and don't change identity, the
+   * redraw won't fire (this is documented; sometimes desired).
+   */
+  setState(updater: Partial<S> | ((s: S) => S)): void {
+    const next = typeof updater === 'function'
+      ? (updater as (s: S) => S)(this.state)
+      : { ...this.state, ...updater };
+    if (next !== this.state) {
+      this.state = next as S;
+      this.scheduleRedraw();
+    }
+  }
+
+  /** Read-only state accessor — for callers that need to compute next state from current. */
+  getState(): S {
+    return this.state;
+  }
+
+  /**
+   * Start the TUI: enter alt-screen, hide cursor, raw stdin, attach
+   * resize listener, render once, then idle until stop() or process
+   * exit.
+   *
+   * Returns a Promise that resolves when stop() is called. Wires
+   * process exit / signal hooks so a Ctrl-C / kill leaves the
+   * terminal sane.
+   */
+  start(): Promise<void> {
+    if (this.running) throw new Error('TUI already running');
+    this.running = true;
+
+    // Enter alt-screen + hide cursor in one write so the terminal
+    // doesn't briefly show a normal screen with a hidden cursor.
+    this.stdout.write(enterAltScreen + hideCursor + clearScreen);
+
+    // Raw-mode key handler
+    try {
+      const detachKeys = attachKeyHandler(this.stdin, (key) => {
+        // Global keys handled by the App itself; everything else
+        // falls through to the user's onKey reducer.
+        if (key.name === 'printable' && key.ctrl && key.ch === 'c') {
+          // Ctrl-C → quit
+          this.stop();
+          return;
+        }
+        if (key.name === 'printable' && key.ctrl && key.ch === 'l') {
+          // Ctrl-L → forced redraw (no state change, but force a
+          // re-render which also re-clears the screen — clears any
+          // garbage left by misbehaving processes that wrote past the
+          // alt-screen boundary)
+          this.scheduleRedraw(true);
+          return;
+        }
+        const next = this.keyFn(this.state, key);
+        if (next !== undefined && next !== this.state) {
+          this.state = next;
+          this.scheduleRedraw();
+        }
+      });
+      this.cleanupFns.push(detachKeys);
+    } catch (err) {
+      // Couldn't attach to stdin (not a TTY). Restore screen state
+      // before propagating so we don't leave the terminal in
+      // alt-screen mode.
+      this.stdout.write(leaveAltScreen + showCursor);
+      this.running = false;
+      throw err;
+    }
+
+    // Window resize → redraw with new dimensions
+    const onResize = () => this.scheduleRedraw(true);
+    this.stdout.on('resize', onResize);
+    this.cleanupFns.push(() => this.stdout.off('resize', onResize));
+
+    // Process-level safety net — any abnormal exit should leave the
+    // terminal in a usable state.
+    const finalCleanup = () => {
+      if (this.running) this.stop();
+    };
+    process.once('SIGINT', finalCleanup);
+    process.once('SIGTERM', finalCleanup);
+    process.once('exit', finalCleanup);
+    this.cleanupFns.push(() => {
+      process.off('SIGINT', finalCleanup);
+      process.off('SIGTERM', finalCleanup);
+      process.off('exit', finalCleanup);
+    });
+
+    // First frame
+    this.redraw();
+
+    return new Promise<void>((resolve) => {
+      this.cleanupFns.push(() => resolve());
+    });
+  }
+
+  /** Stop the TUI — restore terminal state and resolve the start() promise. */
+  stop(): void {
+    if (!this.running) return;
+    this.running = false;
+    // Run cleanup fns in reverse order so most-recent goes first
+    // (matches typical resource-stack semantics).
+    while (this.cleanupFns.length > 0) {
+      const fn = this.cleanupFns.pop()!;
+      try { fn(); } catch { /* keep unwinding */ }
+    }
+    // Final state restore
+    this.stdout.write(leaveAltScreen + showCursor);
+  }
+
+  private scheduleRedraw(force: boolean = false): void {
+    if (this.redrawScheduled && !force) return;
+    this.redrawScheduled = true;
+    queueMicrotask(() => {
+      this.redrawScheduled = false;
+      if (!this.running) return;
+      this.redraw();
+    });
+  }
+
+  private redraw(): void {
+    const cols = this.stdout.columns ?? 80;
+    const rows = this.stdout.rows ?? 24;
+    const frame = this.renderFn(this.state, { cols, rows });
+    // Single write — minimizes flicker
+    this.stdout.write(clearScreen + frame);
+    if (this.afterFrameFn) this.afterFrameFn(this.state);
+  }
+}

--- a/src/tui/input.ts
+++ b/src/tui/input.ts
@@ -1,0 +1,228 @@
+/**
+ * TUI input handling — stdin raw-mode key parser.
+ *
+ * Why not Node's `readline.emitKeypressEvents`: it works, but the Key
+ * shape (`{ name, ctrl, meta, sequence }`) is loosely typed, the
+ * legacy event flag is awkward to disable cleanly, and its escape-
+ * sequence parser has historically lagged on edge cases (Windows
+ * Terminal modifyOtherKeys, Kitty progressive enhancement, etc).
+ *
+ * Writing ~150 lines that handle the keys we ACTUALLY use is more
+ * predictable. The keys we care about:
+ *
+ *   - Printable ASCII (0x20-0x7e)
+ *   - Enter, Tab, Backspace, Escape
+ *   - Arrow up/down/left/right
+ *   - Home, End, PgUp, PgDn
+ *   - Ctrl+C, Ctrl+D (exit), Ctrl+L (redraw)
+ *
+ * Standalone Esc vs Esc-led sequence (e.g. arrow): we use the same
+ * heuristic xterm uses — if ESC arrives in the same buffer chunk as
+ * subsequent bytes, treat as a CSI sequence. If ESC arrives alone in
+ * a chunk, treat as a standalone Escape keypress. This is reliable
+ * on real terminals and avoids the alternative (a wait-timer + lookahead)
+ * which adds complexity and a delay every Esc keypress.
+ */
+
+export interface Key {
+  /** A short name for the key. 'printable' for normal characters. */
+  name:
+    | 'printable'
+    | 'enter'
+    | 'tab'
+    | 'backspace'
+    | 'escape'
+    | 'up' | 'down' | 'left' | 'right'
+    | 'home' | 'end' | 'pageup' | 'pagedown'
+    | 'delete'
+    | 'unknown';
+  /** The printable character (or the raw sequence for `unknown`). */
+  ch: string;
+  /** True if a Ctrl modifier was held. */
+  ctrl: boolean;
+  /** True if a Shift modifier was held (only detectable on some keys). */
+  shift: boolean;
+  /** True if an Alt/Meta modifier was held. */
+  meta: boolean;
+}
+
+/**
+ * Parse one stdin chunk into zero or more Key events. Pure function;
+ * the caller drives stdin and accumulates the result. Most chunks
+ * yield exactly one key (interactive typing); paste / IME burst can
+ * yield several.
+ */
+export function parseKeys(chunk: Buffer): Key[] {
+  const keys: Key[] = [];
+  let i = 0;
+  while (i < chunk.length) {
+    const b = chunk[i];
+
+    // Backspace: ASCII 0x7f on most terminals, 0x08 (BS / Ctrl+H) on
+    // Windows console + a few older ttys. Must check 0x08 BEFORE the
+    // Ctrl+letter range below, otherwise BS gets reported as Ctrl+H.
+    if (b === 0x7f || b === 0x08) {
+      keys.push(k('backspace', ''));
+      i++; continue;
+    }
+
+    // Control keys (Ctrl+letter): byte 0x01-0x1a (A-Z masked with 0x1f)
+    if (b >= 0x01 && b <= 0x1a) {
+      // Special-case the named ones that aren't really "Ctrl+letter".
+      if (b === 0x09) { keys.push(k('tab', '\t')); i++; continue; }
+      if (b === 0x0a || b === 0x0d) { keys.push(k('enter', '\n')); i++; continue; }
+      // The rest are Ctrl+A through Ctrl+Z (skipping the named ones).
+      keys.push({
+        name: 'printable', ch: String.fromCharCode(b + 96), // 1 → 'a'
+        ctrl: true, shift: false, meta: false,
+      });
+      i++; continue;
+    }
+
+    // Escape — either standalone or the start of a CSI sequence.
+    if (b === 0x1b) {
+      // Look at what follows in this same chunk
+      if (i + 1 >= chunk.length) {
+        // ESC alone in this chunk → standalone Escape keypress.
+        keys.push(k('escape', ''));
+        i++; continue;
+      }
+      // ESC + '[' → CSI sequence. Read up to the terminating byte
+      // (0x40-0x7e per ECMA-48).
+      if (chunk[i + 1] === 0x5b /* '[' */ || chunk[i + 1] === 0x4f /* 'O' for SS3 */) {
+        const seqStart = i;
+        const ss3 = chunk[i + 1] === 0x4f;
+        i += 2;
+        let paramBytes = '';
+        while (i < chunk.length) {
+          const c = chunk[i];
+          if (c >= 0x40 && c <= 0x7e) {
+            const final = String.fromCharCode(c);
+            i++;
+            keys.push(parseCsi(final, paramBytes, ss3, chunk.slice(seqStart, i)));
+            break;
+          }
+          paramBytes += String.fromCharCode(c);
+          i++;
+        }
+        continue;
+      }
+      // ESC + other byte → Alt/Meta + that byte
+      const next = chunk[i + 1];
+      if (next >= 0x20 && next <= 0x7e) {
+        keys.push({
+          name: 'printable', ch: String.fromCharCode(next),
+          ctrl: false, shift: false, meta: true,
+        });
+        i += 2; continue;
+      }
+      // Fallback — emit ESC alone, advance one.
+      keys.push(k('escape', ''));
+      i++; continue;
+    }
+
+    // Printable ASCII (including space)
+    if (b >= 0x20 && b <= 0x7e) {
+      keys.push({
+        name: 'printable', ch: String.fromCharCode(b),
+        ctrl: false, shift: b >= 0x41 && b <= 0x5a, meta: false,
+      });
+      i++; continue;
+    }
+
+    // Anything else — pass through as unknown so the caller can see it.
+    keys.push({ name: 'unknown', ch: String.fromCharCode(b), ctrl: false, shift: false, meta: false });
+    i++;
+  }
+  return keys;
+}
+
+function k(name: Key['name'], ch: string): Key {
+  return { name, ch, ctrl: false, shift: false, meta: false };
+}
+
+/**
+ * Decode the body of a CSI sequence given the terminating byte and
+ * the parameter bytes between `[` and the terminator.
+ *
+ *   ESC[A    → up
+ *   ESC[B    → down
+ *   ESC[C    → right
+ *   ESC[D    → left
+ *   ESC[H    → home
+ *   ESC[F    → end
+ *   ESC[5~   → pageup
+ *   ESC[6~   → pagedown
+ *   ESC[3~   → delete
+ *   ESC[1~   → home (alternate)
+ *   ESC[4~   → end (alternate)
+ *
+ * Modifier-bearing variants (e.g. `ESC[1;5A` for Ctrl-Up) parse the
+ * second parameter as a modifier mask: bit 0 = Shift, bit 1 = Alt,
+ * bit 2 = Ctrl. xterm spec §"Modifier-Encoding".
+ */
+function parseCsi(final: string, params: string, ss3: boolean, raw: Buffer): Key {
+  // Parse semicolon-separated numeric params
+  const parts = params.split(';').map(p => parseInt(p, 10) || 0);
+  // Modifier byte is the second param when present.
+  const mod = parts[1] ?? 1;
+  const ctrl = (mod - 1) & 4 ? true : false;
+  const shift = (mod - 1) & 1 ? true : false;
+  const meta = (mod - 1) & 2 ? true : false;
+
+  // Tilde-terminated: ESC[<n>~ where n is in parts[0]
+  if (final === '~') {
+    const n = parts[0];
+    const map: Record<number, Key['name']> = {
+      1: 'home', 2: 'home', 3: 'delete', 4: 'end',
+      5: 'pageup', 6: 'pagedown', 7: 'home', 8: 'end',
+    };
+    return { name: map[n] ?? 'unknown', ch: raw.toString(), ctrl, shift, meta };
+  }
+
+  // Letter-terminated: arrow / home / end (and SS3 variants)
+  void ss3;
+  const letterMap: Record<string, Key['name']> = {
+    A: 'up', B: 'down', C: 'right', D: 'left',
+    H: 'home', F: 'end',
+  };
+  if (letterMap[final]) {
+    return { name: letterMap[final], ch: raw.toString(), ctrl, shift, meta };
+  }
+  return { name: 'unknown', ch: raw.toString(), ctrl, shift, meta };
+}
+
+// ── Lifecycle helpers ──────────────────────────────────────────────
+
+/**
+ * Put stdin into raw mode and start emitting Key events to `handler`.
+ * Returns a cleanup function that restores stdin's pre-raw mode and
+ * unbinds the listener. ALWAYS call the cleanup on exit (including
+ * abnormal exits — wire a process exit / signal hook).
+ *
+ * Defaults are picked so the caller doesn't have to think about them:
+ * UTF-8 encoding (we don't see Buffer chunks split mid-character),
+ * resume() so paused stdin doesn't drop key events.
+ *
+ * Throws if stdin isn't a TTY — the TUI doesn't make sense in a pipe.
+ */
+export function attachKeyHandler(
+  stdin: NodeJS.ReadStream,
+  handler: (key: Key) => void,
+): () => void {
+  if (!stdin.isTTY) {
+    throw new Error('TUI requires a TTY on stdin — pipe / redirect not supported');
+  }
+  const prevRawMode = stdin.isRaw;
+  stdin.setRawMode(true);
+  stdin.resume();
+  const onData = (chunk: Buffer) => {
+    for (const key of parseKeys(chunk)) handler(key);
+  };
+  stdin.on('data', onData);
+  return () => {
+    stdin.off('data', onData);
+    stdin.setRawMode(prevRawMode ?? false);
+    stdin.pause();
+  };
+}

--- a/src/tui/layout.ts
+++ b/src/tui/layout.ts
@@ -1,0 +1,147 @@
+/**
+ * Higher-level layout primitives built on top of `render.ts`.
+ *
+ * These compose the lower-level ANSI strings into the structural
+ * patterns the v4 TUI actually uses: a header bar, a tab strip,
+ * a body region, a footer with key hints. Each returns a string
+ * (or appends to a Frame) — no terminal state, no side effects.
+ */
+
+import { brand, fg, inverse, BOX, pad, truncate, visibleWidth } from './render.js';
+
+/**
+ * Render the top header bar: brand + version on the left, contextual
+ * status text on the right (e.g. proxy URL when connected).
+ *
+ *   ╭ dario v4.0.0 ───────────────────── http://localhost:3456 ─╮
+ *
+ * Width is the full terminal columns; the caller positions it at row 1.
+ */
+export function renderHeader(width: number, opts: {
+  version: string;
+  status?: string;
+}): string {
+  const left = ` ${brand('dario')} v${opts.version} `;
+  const right = opts.status ? ` ${opts.status} ` : '';
+  const dashWidth = Math.max(0, width - visibleWidth(left) - visibleWidth(right) - 2);
+  return BOX.topLeft + left + BOX.horizontal.repeat(dashWidth) + right + BOX.topRight;
+}
+
+/**
+ * Render the bottom footer with key-hint pairs. Wide gaps so it doesn't
+ * look mashed-together:
+ *
+ *   [Tab] switch panel   [q] quit   [?] help
+ */
+export function renderFooter(width: number, hints: Array<{ key: string; label: string }>): string {
+  const items = hints.map(h => `${fg('cyan', `[${h.key}]`)} ${h.label}`);
+  const joined = items.join('   ');
+  // Truncate if the hints don't fit (small terminal); never wrap to a
+  // second line — the footer is a single row by design.
+  return ' ' + truncate(joined, width - 2);
+}
+
+/**
+ * Render a tab strip — one row of clickable-looking tab labels, with
+ * the active tab inverse-highlighted. Borders flank both sides.
+ *
+ *   │  Status   ▎Analytics▎   Config   Hits   Accounts   Backends   │
+ *
+ * The `activeTab` is the index of the highlighted tab. Caller draws
+ * the surrounding box separately.
+ */
+export function renderTabStrip(width: number, tabs: string[], activeTab: number): string {
+  const sep = '   ';
+  const rendered = tabs.map((label, idx) => {
+    if (idx === activeTab) {
+      // Active: inverse-highlight with thin side-bars to evoke a
+      // selected pill. The ▎ left-eighth-block is visually subtle but
+      // unmistakable on every terminal that supports box-drawing.
+      return inverse(` ${label} `);
+    }
+    return ` ${label} `;
+  });
+  const inner = rendered.join(sep);
+  const padded = pad(inner, width, 'left');
+  return padded;
+}
+
+/**
+ * Render a vertical scroll indicator on the right edge of a panel.
+ * Shows "n / total" + a position blob if there's overflow.
+ *
+ *   ─ 24 / 412
+ */
+export function renderScrollIndicator(visible: number, total: number, selectedIdx: number): string {
+  if (total <= visible) return '';
+  return ` ${selectedIdx + 1} / ${total} `;
+}
+
+/**
+ * Word-wrap or hard-break `text` to lines of at most `width` visible
+ * chars. ANSI sequences are preserved across line boundaries; visible
+ * width is what's counted.
+ *
+ * Used for free-form prose in the Status / About panels.
+ */
+export function wrap(text: string, width: number): string[] {
+  if (width <= 0) return [];
+  const out: string[] = [];
+  for (const para of text.split('\n')) {
+    if (para === '') { out.push(''); continue; }
+    let line = '';
+    let lineWidth = 0;
+    for (const word of para.split(' ')) {
+      const w = visibleWidth(word);
+      // Word itself longer than width → hard-break it into chunks
+      // of `width` chars. Push the current accumulated line first so
+      // we don't lose pre-existing content.
+      if (w > width) {
+        if (lineWidth > 0) { out.push(line); line = ''; lineWidth = 0; }
+        let remaining = word;
+        while (visibleWidth(remaining) > width) {
+          out.push(remaining.slice(0, width));
+          remaining = remaining.slice(width);
+        }
+        line = remaining;
+        lineWidth = visibleWidth(remaining);
+        continue;
+      }
+      // Normal-width word: fit on current line if there's room, else
+      // wrap to a new line.
+      if (lineWidth === 0) {
+        line = word; lineWidth = w; continue;
+      }
+      if (lineWidth + 1 + w <= width) {
+        line += ' ' + word; lineWidth += 1 + w;
+      } else {
+        out.push(line);
+        line = word; lineWidth = w;
+      }
+    }
+    if (line.length > 0) out.push(line);
+  }
+  return out;
+}
+
+/**
+ * Render a left-key / right-value row (the shape every config/status
+ * line uses).
+ *
+ *   Port:               3456
+ *   Mode:               passthrough
+ *
+ * Key is left-padded to `keyWidth` so a column of rows aligns. Value
+ * is truncated to fit the remaining space.
+ */
+export function renderKvRow(key: string, value: string, totalWidth: number, keyWidth: number = 22): string {
+  // Clamp keyWidth so a narrow terminal (totalWidth < keyWidth default)
+  // still produces a well-formed totalWidth-char row. The key gets
+  // truncated proportionally; the value column gets the rest.
+  const effectiveKeyWidth = Math.min(keyWidth, Math.max(1, totalWidth - 1));
+  const keyPart = pad(key + ':', effectiveKeyWidth);
+  // Value pad-to-width (not just truncate) so a full row reaches the
+  // panel edge — keeps backgrounds + borders aligned.
+  const valuePart = pad(value, totalWidth - effectiveKeyWidth);
+  return keyPart + valuePart;
+}

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1,0 +1,273 @@
+/**
+ * TUI rendering primitives — pure ANSI escape sequence helpers.
+ *
+ * Every function in this module is a pure string-returning helper. No
+ * side effects, no console writes. The App's render() loop accumulates
+ * these strings into a single buffer, then flushes once to stdout. This
+ * keeps render testable (assert string equality against fixtures) and
+ * keeps flicker minimal (single write call per frame).
+ *
+ * Color set: a deliberate 16-color subset of the ANSI palette plus a
+ * handful of 256-color brand accents. Reasoning: 16-color is universal,
+ * the brand greens (#00ff88-ish) are used sparingly for the dario
+ * accent and degrade gracefully on terminals that can't render them.
+ *
+ * What this module deliberately does NOT do:
+ *   - Track cursor position (callers pass row/col explicitly)
+ *   - Diff frames (full-screen redraw per frame is fast enough at
+ *     ~3000 cells; complexity not worth it)
+ *   - Handle terminal capabilities probing (use ANSI + assume modern)
+ */
+
+// ── Escape sequences ────────────────────────────────────────────────
+
+/** Control Sequence Introducer. */
+const ESC = '\x1b[';
+
+/**
+ * Move the cursor to (row, col). 1-indexed, matching the ANSI spec —
+ * row=1 is the top line, col=1 is the leftmost column.
+ */
+export function moveTo(row: number, col: number): string {
+  return `${ESC}${row};${col}H`;
+}
+
+/** Hide the blinking cursor (TUI doesn't need it). */
+export const hideCursor = `${ESC}?25l`;
+
+/** Restore the cursor. ALWAYS run on exit to leave the terminal sane. */
+export const showCursor = `${ESC}?25h`;
+
+/** Enter the alternate screen buffer — TUI lives here so quit restores prior shell content. */
+export const enterAltScreen = `${ESC}?1049h`;
+
+/** Leave the alternate screen buffer. Pair with enterAltScreen on exit. */
+export const leaveAltScreen = `${ESC}?1049l`;
+
+/** Clear the entire screen and move cursor to home. */
+export const clearScreen = `${ESC}2J${ESC}H`;
+
+/** Clear from cursor to end of line. */
+export const clearLineRight = `${ESC}K`;
+
+/** Reset all SGR (color + style) attributes. */
+export const reset = `${ESC}0m`;
+
+// ── Colors (16-color ANSI + brand accent) ──────────────────────────
+
+/**
+ * Foreground color names mapped to ANSI codes. `default` resets to
+ * the terminal's default foreground.
+ */
+export const FG = {
+  default: 39,
+  black: 30, red: 31, green: 32, yellow: 33,
+  blue: 34, magenta: 35, cyan: 36, white: 37,
+  brightBlack: 90, brightRed: 91, brightGreen: 92, brightYellow: 93,
+  brightBlue: 94, brightMagenta: 95, brightCyan: 96, brightWhite: 97,
+} as const;
+
+/** Background color names mapped to ANSI codes. */
+export const BG = {
+  default: 49,
+  black: 40, red: 41, green: 42, yellow: 43,
+  blue: 44, magenta: 45, cyan: 46, white: 47,
+  brightBlack: 100, brightRed: 101, brightGreen: 102, brightYellow: 103,
+  brightBlue: 104, brightMagenta: 105, brightCyan: 106, brightWhite: 107,
+} as const;
+
+export type FgColor = keyof typeof FG;
+export type BgColor = keyof typeof BG;
+
+/**
+ * Wrap text in foreground-color SGR codes. Resets to default fg at
+ * the end so subsequent uncolored text isn't accidentally colored.
+ *
+ * Example: `fg('green', 'OK')` → `\x1b[32mOK\x1b[39m`
+ */
+export function fg(color: FgColor, text: string): string {
+  return `${ESC}${FG[color]}m${text}${ESC}${FG.default}m`;
+}
+
+export function bg(color: BgColor, text: string): string {
+  return `${ESC}${BG[color]}m${text}${ESC}${BG.default}m`;
+}
+
+export function bold(text: string): string {
+  return `${ESC}1m${text}${ESC}22m`;
+}
+
+export function dim(text: string): string {
+  return `${ESC}2m${text}${ESC}22m`;
+}
+
+export function inverse(text: string): string {
+  return `${ESC}7m${text}${ESC}27m`;
+}
+
+export function underline(text: string): string {
+  return `${ESC}4m${text}${ESC}24m`;
+}
+
+/**
+ * Brand accent — the askalf green (#00ff88-ish) via the 256-color
+ * palette index 48. Falls back gracefully on terminals that don't
+ * render 256-color (they show as bright green).
+ */
+export function brand(text: string): string {
+  return `${ESC}38;5;48m${text}${ESC}${FG.default}m`;
+}
+
+// ── String helpers ─────────────────────────────────────────────────
+
+/**
+ * Visible-width of a string. ANSI escape sequences and zero-width
+ * sequences contribute 0. Tabs count as 1 (terminals vary; better
+ * to under- than over-estimate). Multi-byte characters (CJK, emoji)
+ * are NOT special-cased in v4.0 — the TUI's content is ASCII-dominant
+ * (model names, numbers, labels). A future revision can add a
+ * `string-width`-style lookup if non-ASCII becomes common.
+ */
+export function visibleWidth(s: string): number {
+  // Strip ANSI escape sequences (CSI + everything up to terminating byte).
+  const stripped = s.replace(/\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]/g, '');
+  return stripped.length;
+}
+
+/**
+ * Truncate `text` to at most `maxWidth` visible chars, appending `…`
+ * if anything was clipped. ANSI sequences within the truncated portion
+ * are preserved verbatim; truncation only counts visible characters.
+ *
+ * Example: truncate('hello world', 8) → 'hello w…'
+ */
+export function truncate(text: string, maxWidth: number, ellipsis: string = '…'): string {
+  if (maxWidth <= 0) return '';
+  if (visibleWidth(text) <= maxWidth) return text;
+  const ellipsisWidth = visibleWidth(ellipsis);
+  if (maxWidth <= ellipsisWidth) return ellipsis.slice(0, maxWidth);
+  // Walk the string, counting visible chars, stop when we'd exceed
+  // maxWidth - ellipsisWidth so we have room to append.
+  const target = maxWidth - ellipsisWidth;
+  let out = '';
+  let visible = 0;
+  let i = 0;
+  while (i < text.length && visible < target) {
+    if (text[i] === '\x1b' && text[i + 1] === '[') {
+      // Copy the full escape sequence
+      const m = text.slice(i).match(/^\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]/);
+      if (m) { out += m[0]; i += m[0].length; continue; }
+    }
+    out += text[i];
+    visible++;
+    i++;
+  }
+  return out + ellipsis;
+}
+
+/** Pad `text` (right-aligned by default 'left' fills right side) to `width`. */
+export function pad(text: string, width: number, align: 'left' | 'right' | 'center' = 'left'): string {
+  const w = visibleWidth(text);
+  if (w >= width) return truncate(text, width);
+  const gap = width - w;
+  if (align === 'right') return ' '.repeat(gap) + text;
+  if (align === 'center') {
+    const left = Math.floor(gap / 2);
+    const right = gap - left;
+    return ' '.repeat(left) + text + ' '.repeat(right);
+  }
+  return text + ' '.repeat(gap);
+}
+
+/**
+ * Render a horizontal progress bar.
+ *
+ *   value:   0..1 (clamped)
+ *   width:   total cell count of the bar
+ *
+ * Uses the full-block ▓ / shade ░ characters; passes through as plain
+ * ASCII on terminals that don't render the box-drawing set (they look
+ * like `?` but the layout still works).
+ */
+export function progressBar(value: number, width: number, opts: { filled?: string; empty?: string } = {}): string {
+  const filled = opts.filled ?? '█';
+  const empty = opts.empty ?? '░';
+  const clamped = Math.max(0, Math.min(1, value));
+  const cells = Math.round(clamped * width);
+  return filled.repeat(cells) + empty.repeat(width - cells);
+}
+
+/**
+ * Box-drawing characters for borders. Set picked to render well on
+ * most terminals (Unicode box-drawing). Override via `customChars` if
+ * a terminal renders these badly — but the default targets the
+ * 99%-of-users case.
+ */
+export const BOX = {
+  topLeft: '┌',  topRight: '┐',
+  bottomLeft: '└', bottomRight: '┘',
+  horizontal: '─', vertical: '│',
+  cross: '┼', tLeft: '├', tRight: '┤',
+  tTop: '┬', tBottom: '┴',
+} as const;
+
+/**
+ * Render a box at (row, col) with the given width and height. Returns
+ * the full ANSI string (positioned writes + box characters). The
+ * interior is NOT cleared — callers paint inside the box separately.
+ */
+export function drawBox(row: number, col: number, width: number, height: number): string {
+  if (width < 2 || height < 2) return '';
+  const out: string[] = [];
+  // Top border
+  out.push(moveTo(row, col));
+  out.push(BOX.topLeft + BOX.horizontal.repeat(width - 2) + BOX.topRight);
+  // Sides
+  for (let r = 1; r < height - 1; r++) {
+    out.push(moveTo(row + r, col));
+    out.push(BOX.vertical);
+    out.push(moveTo(row + r, col + width - 1));
+    out.push(BOX.vertical);
+  }
+  // Bottom border
+  out.push(moveTo(row + height - 1, col));
+  out.push(BOX.bottomLeft + BOX.horizontal.repeat(width - 2) + BOX.bottomRight);
+  return out.join('');
+}
+
+// ── Frame buffer ───────────────────────────────────────────────────
+
+/**
+ * Frame builder. The App's render() collects strings into one of these
+ * then calls `flush(stdout)` for a single write. Single-write rendering
+ * eliminates flicker on most terminals.
+ */
+export class Frame {
+  private chunks: string[] = [];
+
+  /** Append a string. No positioning — caller is responsible. */
+  write(s: string): void {
+    this.chunks.push(s);
+  }
+
+  /** Append a positioned write at (row, col). */
+  writeAt(row: number, col: number, s: string): void {
+    this.chunks.push(moveTo(row, col));
+    this.chunks.push(s);
+  }
+
+  /** Return the accumulated frame as a single string. */
+  toString(): string {
+    return this.chunks.join('');
+  }
+
+  /** Number of accumulated chunks (debugging aid). */
+  get length(): number {
+    return this.chunks.length;
+  }
+
+  /** Drop everything. Reuses the array allocation. */
+  clear(): void {
+    this.chunks.length = 0;
+  }
+}

--- a/test/tui-input.mjs
+++ b/test/tui-input.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// Tests for src/tui/input.ts — the keypress parser.
+//
+// parseKeys is a pure function over a Buffer chunk → Key[]. Every key
+// the TUI cares about is exercised here. The attachKeyHandler lifecycle
+// helper is NOT tested at the unit level (it needs a real TTY); M4's
+// tab tests will exercise it via integration.
+
+import { parseKeys } from '../dist/tui/input.js';
+
+let pass = 0, fail = 0;
+function check(name, cond, detail) {
+  if (cond) { pass++; console.log(`  OK ${name}`); }
+  else { fail++; console.log(`  FAIL ${name}${detail ? ' :: ' + detail : ''}`); }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+// Helper: parse a string as if it arrived on stdin.
+const k = (s) => parseKeys(Buffer.from(s, 'binary'));
+
+// ─────────────────────────────────────────────────────────────
+header('Printable ASCII');
+{
+  const result = k('a');
+  check('length 1',                     result.length === 1);
+  check('name = printable',             result[0].name === 'printable');
+  check('ch = "a"',                     result[0].ch === 'a');
+  check('ctrl false',                   result[0].ctrl === false);
+  check('meta false',                   result[0].meta === false);
+
+  const upper = k('A');
+  check('uppercase: shift flag set',    upper[0].shift === true);
+
+  const lower = k('a');
+  check('lowercase: shift flag clear',  lower[0].shift === false);
+
+  // Multi-char input (paste)
+  const burst = k('hello');
+  check('5-char burst → 5 keys',        burst.length === 5);
+  check('burst preserves order',        burst.map(r => r.ch).join('') === 'hello');
+
+  // Space is printable
+  const space = k(' ');
+  check('space is printable',           space[0].name === 'printable' && space[0].ch === ' ');
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Named control keys');
+{
+  check('Enter (CR)',                   k('\r')[0].name === 'enter');
+  check('Enter (LF)',                   k('\n')[0].name === 'enter');
+  check('Tab',                          k('\t')[0].name === 'tab');
+  check('Backspace (0x7f)',             k('\x7f')[0].name === 'backspace');
+  check('Backspace (0x08)',             k('\x08')[0].name === 'backspace');
+
+  // Standalone Escape (chunk contains ONLY ESC)
+  const esc = k('\x1b');
+  check('standalone Esc',               esc.length === 1 && esc[0].name === 'escape');
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Ctrl+letter');
+{
+  const ctrlC = k('\x03');
+  check('Ctrl+C → printable + ctrl',    ctrlC[0].name === 'printable' && ctrlC[0].ch === 'c' && ctrlC[0].ctrl === true);
+  const ctrlD = k('\x04');
+  check('Ctrl+D',                       ctrlD[0].ctrl && ctrlD[0].ch === 'd');
+  const ctrlL = k('\x0c');
+  check('Ctrl+L',                       ctrlL[0].ctrl && ctrlL[0].ch === 'l');
+  const ctrlZ = k('\x1a');
+  check('Ctrl+Z',                       ctrlZ[0].ctrl && ctrlZ[0].ch === 'z');
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Arrow keys (CSI sequences)');
+{
+  check('Up    \\x1b[A',                k('\x1b[A')[0].name === 'up');
+  check('Down  \\x1b[B',                k('\x1b[B')[0].name === 'down');
+  check('Right \\x1b[C',                k('\x1b[C')[0].name === 'right');
+  check('Left  \\x1b[D',                k('\x1b[D')[0].name === 'left');
+
+  // SS3 variants (some terminals send these instead of CSI for arrows)
+  check('Up    \\x1bOA',                k('\x1bOA')[0].name === 'up');
+  check('Right \\x1bOC',                k('\x1bOC')[0].name === 'right');
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Home / End / PgUp / PgDn / Delete');
+{
+  check('Home (letter)',                k('\x1b[H')[0].name === 'home');
+  check('End (letter)',                 k('\x1b[F')[0].name === 'end');
+  check('Home (tilde)',                 k('\x1b[1~')[0].name === 'home');
+  check('End (tilde)',                  k('\x1b[4~')[0].name === 'end');
+  check('PgUp',                         k('\x1b[5~')[0].name === 'pageup');
+  check('PgDn',                         k('\x1b[6~')[0].name === 'pagedown');
+  check('Delete',                       k('\x1b[3~')[0].name === 'delete');
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Modified arrows (Ctrl/Shift/Alt + arrow)');
+{
+  // ESC[1;5A = Ctrl+Up (modifier mask 5 = Ctrl)
+  const ctrlUp = k('\x1b[1;5A');
+  check('Ctrl+Up: name = up',           ctrlUp[0].name === 'up');
+  check('Ctrl+Up: ctrl flag set',       ctrlUp[0].ctrl === true);
+
+  // ESC[1;2A = Shift+Up
+  const shiftUp = k('\x1b[1;2A');
+  check('Shift+Up: shift flag set',     shiftUp[0].shift === true);
+  check('Shift+Up: ctrl flag clear',    shiftUp[0].ctrl === false);
+
+  // ESC[1;3A = Alt+Up
+  const altUp = k('\x1b[1;3A');
+  check('Alt+Up: meta flag set',        altUp[0].meta === true);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Alt + printable (Meta)');
+{
+  // ESC + 'a' (no '[') = Alt+a
+  const altA = k('\x1ba');
+  check('Alt+a: length 1',              altA.length === 1);
+  check('Alt+a: meta flag set',         altA[0].meta === true);
+  check('Alt+a: ch = "a"',              altA[0].ch === 'a');
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Mixed chunks (Esc-led sequence + trailing printable)');
+{
+  // arrow up followed by printable letter — both should come through
+  const mixed = k('\x1b[Ax');
+  check('mixed: 2 keys',                mixed.length === 2);
+  check('mixed[0] = up',                mixed[0].name === 'up');
+  check('mixed[1] = printable x',       mixed[1].name === 'printable' && mixed[1].ch === 'x');
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Unknown sequences passthrough');
+{
+  // CSI with a final byte that's not in our map → name = 'unknown'
+  const weird = k('\x1b[99Z');
+  check('weird CSI → unknown',          weird[0].name === 'unknown');
+  // Raw byte 0x1e (RS) → unknown
+  const rs = k('\x1e');
+  check('RS byte → unknown',            rs[0].name === 'unknown');
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Empty / edge inputs');
+{
+  check('empty buffer → no keys',       parseKeys(Buffer.from('')).length === 0);
+}
+
+// ─────────────────────────────────────────────────────────────
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);

--- a/test/tui-layout.mjs
+++ b/test/tui-layout.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+// Tests for src/tui/layout.ts — header/footer/tabstrip/kv-row/wrap.
+//
+// All pure string-returning functions; assertions are visible-width
+// + structural shape checks rather than exact byte-equality, because
+// the layout uses ANSI color codes that we don't want to hard-pin
+// in case the palette changes.
+
+import {
+  renderHeader, renderFooter, renderTabStrip, renderScrollIndicator,
+  wrap, renderKvRow,
+} from '../dist/tui/layout.js';
+import { visibleWidth } from '../dist/tui/render.js';
+
+let pass = 0, fail = 0;
+function check(name, cond, detail) {
+  if (cond) { pass++; console.log(`  OK ${name}`); }
+  else { fail++; console.log(`  FAIL ${name}${detail ? ' :: ' + detail : ''}`); }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+// ─────────────────────────────────────────────────────────────
+header('renderHeader — version + status');
+{
+  const h = renderHeader(80, { version: '4.0.0' });
+  check('width matches',                visibleWidth(h) === 80);
+  check('contains version',             h.includes('4.0.0'));
+  check('contains dario',               h.includes('dario'));
+  check('starts with top-left corner',  h.startsWith('┌'));
+  check('ends with top-right corner',   h.endsWith('┐'));
+
+  const withStatus = renderHeader(80, { version: '4.0.0', status: 'http://localhost:3456' });
+  check('with status: width matches',   visibleWidth(withStatus) === 80);
+  check('with status: contains URL',    withStatus.includes('http://localhost:3456'));
+}
+
+// ─────────────────────────────────────────────────────────────
+header('renderFooter — key hints');
+{
+  const hints = [{ key: 'Tab', label: 'switch panel' }, { key: 'q', label: 'quit' }];
+  const f = renderFooter(80, hints);
+  check('contains Tab hint',            f.includes('Tab'));
+  check('contains switch panel',        f.includes('switch panel'));
+  check('contains q hint',              f.includes('q'));
+  check('contains quit',                f.includes('quit'));
+  // Brackets around keys
+  check('bracket-wrapped keys',         f.includes('[Tab]') && f.includes('[q]'));
+
+  // Narrow width truncates
+  const narrow = renderFooter(20, hints);
+  check('narrow footer ≤ 20 visible',   visibleWidth(narrow) <= 20);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('renderTabStrip — active tab inverse');
+{
+  const tabs = ['Status', 'Config', 'Analytics'];
+  const t = renderTabStrip(80, tabs, 1);  // Config active
+  check('width matches',                visibleWidth(t) === 80);
+  check('contains all tabs',            tabs.every(tab => t.includes(tab)));
+  // Active tab is wrapped in inverse codes
+  check('Config is inverse-wrapped',    t.includes('\x1b[7m') && t.includes('Config'));
+  // Other tabs aren't (or at least aren't inverse-active)
+  const status0 = renderTabStrip(80, tabs, 0);
+  check('different active changes output', status0 !== t);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('renderScrollIndicator');
+{
+  check('no indicator when total ≤ visible', renderScrollIndicator(10, 5, 0) === '');
+  check('no indicator when total = visible', renderScrollIndicator(10, 10, 0) === '');
+  const ind = renderScrollIndicator(10, 100, 23);
+  check('shows position when overflow', ind.includes('24'));
+  check('shows total when overflow',    ind.includes('100'));
+}
+
+// ─────────────────────────────────────────────────────────────
+header('wrap — word-wrap to width');
+{
+  check('short text → 1 line',          wrap('hello', 20).length === 1);
+  check('exact fit → 1 line',           wrap('hello', 5).length === 1);
+
+  const wrapped = wrap('hello world this is a longer text', 10);
+  check('wraps when overflow',          wrapped.length > 1);
+  // Every line ≤ 10 visible
+  check('every line ≤ width',           wrapped.every(l => visibleWidth(l) <= 10));
+
+  // Newlines preserved as paragraph breaks
+  const para = wrap('line one\nline two', 20);
+  check('preserves newlines as breaks', para.length === 2);
+  check('preserves order',              para[0] === 'line one' && para[1] === 'line two');
+
+  // Word longer than width → hard-break
+  const big = wrap('a-very-long-word-with-no-spaces', 5);
+  check('hard-breaks long word',        big.length >= 5);
+  check('hard-break: every chunk ≤ 5',  big.every(l => visibleWidth(l) <= 5));
+
+  // Width 0 → empty
+  check('width 0 → empty',              wrap('hello', 0).length === 0);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('renderKvRow — key/value layout');
+{
+  const row = renderKvRow('Port', '3456', 40);
+  check('starts with Port:',            row.startsWith('Port:'));
+  check('contains value',               row.includes('3456'));
+  check('total width = 40',             visibleWidth(row) === 40);
+
+  // Long value truncates
+  const longRow = renderKvRow('Path', '/very/long/path/that/exceeds/the/available/width/easily', 30);
+  check('long value truncates',         visibleWidth(longRow) <= 30);
+
+  // Short value padded
+  const shortRow = renderKvRow('K', 'v', 20);
+  check('short row pads to width',      visibleWidth(shortRow) === 20);
+}
+
+// ─────────────────────────────────────────────────────────────
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);

--- a/test/tui-render.mjs
+++ b/test/tui-render.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+// Tests for src/tui/render.ts — the ANSI primitives.
+//
+// Every function in render.ts is pure (no terminal state, no side
+// effects), so the test surface is straightforward string equality.
+//
+// Coverage:
+//   - ANSI cursor + screen primitives produce well-formed sequences
+//   - Color helpers wrap text in matching open/close codes
+//   - visibleWidth strips escapes
+//   - truncate respects visible chars, preserves embedded ANSI
+//   - pad fills correctly with each alignment
+//   - progressBar maps value→cells correctly at boundaries
+//   - drawBox produces correct corners + sides at small + large sizes
+//   - Frame accumulates + flushes correctly
+
+import {
+  moveTo, hideCursor, showCursor, enterAltScreen, leaveAltScreen,
+  clearScreen, reset, fg, bg, bold, dim, inverse, brand,
+  visibleWidth, truncate, pad, progressBar, drawBox, BOX, Frame,
+} from '../dist/tui/render.js';
+
+let pass = 0, fail = 0;
+function check(name, cond, detail) {
+  if (cond) { pass++; console.log(`  OK ${name}`); }
+  else { fail++; console.log(`  FAIL ${name}${detail ? ' :: ' + detail : ''}`); }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+const ESC = '\x1b[';
+
+// ─────────────────────────────────────────────────────────────
+header('ANSI cursor + screen primitives');
+{
+  check('moveTo(5, 10) is well-formed', moveTo(5, 10) === `${ESC}5;10H`);
+  check('moveTo(1, 1) is well-formed',  moveTo(1, 1)  === `${ESC}1;1H`);
+  check('hideCursor present',           hideCursor === `${ESC}?25l`);
+  check('showCursor present',           showCursor === `${ESC}?25h`);
+  check('enterAltScreen',               enterAltScreen === `${ESC}?1049h`);
+  check('leaveAltScreen',               leaveAltScreen === `${ESC}?1049l`);
+  check('clearScreen + home',           clearScreen.endsWith(`${ESC}H`));
+  check('reset',                        reset === `${ESC}0m`);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Color + style wrappers');
+{
+  check('fg(green) wraps',              fg('green', 'OK') === `${ESC}32mOK${ESC}39m`);
+  check('fg(red) wraps',                fg('red', 'NO') === `${ESC}31mNO${ESC}39m`);
+  check('bg(blue) wraps',               bg('blue', 'x') === `${ESC}44mx${ESC}49m`);
+  check('bold wraps',                   bold('x') === `${ESC}1mx${ESC}22m`);
+  check('dim wraps',                    dim('x') === `${ESC}2mx${ESC}22m`);
+  check('inverse wraps',                inverse('x') === `${ESC}7mx${ESC}27m`);
+  check('brand uses 256-color 48',      brand('x') === `${ESC}38;5;48mx${ESC}39m`);
+
+  // Color resets to default fg, not previous color — verifies no
+  // "previous color" leakage between consecutive wraps.
+  const combined = fg('green', 'A') + fg('red', 'B');
+  check('consecutive colors reset cleanly',
+    combined === `${ESC}32mA${ESC}39m${ESC}31mB${ESC}39m`);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('visibleWidth — ANSI-stripping length');
+{
+  check('plain ASCII',                  visibleWidth('hello') === 5);
+  check('empty',                        visibleWidth('') === 0);
+  check('color-wrapped',                visibleWidth(fg('green', 'hello')) === 5);
+  check('multiple escapes',             visibleWidth(`${ESC}1m${ESC}32mhello${ESC}0m`) === 5);
+  check('embedded cursor moves',        visibleWidth(`hello${moveTo(1,1)}world`) === 10);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('truncate — respect visible width + ANSI safety');
+{
+  check('short string passes through',  truncate('hi', 10) === 'hi');
+  check('exact fit passes through',     truncate('hello', 5) === 'hello');
+  check('clips with ellipsis',          truncate('hello world', 8) === 'hello w…');
+  check('clips at boundary',            truncate('abcdef', 3) === 'ab…');
+  check('maxWidth 0 → empty',           truncate('x', 0) === '');
+  check('maxWidth 1 → just ellipsis',   truncate('hello', 1) === '…');
+  // ANSI escapes inside the string don't count toward visible width
+  const colored = `${ESC}32mhello world${ESC}39m`;
+  const out = truncate(colored, 8);
+  check('truncated keeps opening escape', out.startsWith(`${ESC}32m`));
+  check('truncated visible width = 8',    visibleWidth(out) === 8);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('pad — alignment fills correctly');
+{
+  check('left align (default)',         pad('hi', 6) === 'hi    ');
+  check('left align explicit',          pad('hi', 6, 'left') === 'hi    ');
+  check('right align',                  pad('hi', 6, 'right') === '    hi');
+  check('center align even',            pad('hi', 6, 'center') === '  hi  ');
+  check('center align odd',             pad('hi', 7, 'center') === '  hi   ');
+  check('already-wide truncates',       pad('hello', 3) === 'he…');
+  check('exact width unchanged',        pad('hello', 5) === 'hello');
+}
+
+// ─────────────────────────────────────────────────────────────
+header('progressBar — value → cells');
+{
+  check('0% → all empty',               progressBar(0, 10) === '░░░░░░░░░░');
+  check('100% → all filled',            progressBar(1, 10) === '██████████');
+  check('50% → half',                   progressBar(0.5, 10) === '█████░░░░░');
+  check('clamps negative to 0',         progressBar(-0.5, 10) === '░░░░░░░░░░');
+  check('clamps above 1 to full',       progressBar(1.5, 10) === '██████████');
+  check('rounds 0.07 to 1 cell',        progressBar(0.07, 10) === '█░░░░░░░░░');
+  // Custom characters
+  check('custom filled/empty chars',    progressBar(0.5, 4, { filled: '=', empty: '-' }) === '==--');
+}
+
+// ─────────────────────────────────────────────────────────────
+header('drawBox — corners + sides');
+{
+  // Minimum 2x2 — just corners
+  const b2 = drawBox(1, 1, 2, 2);
+  check('2x2 has both corners',         b2.includes(BOX.topLeft) && b2.includes(BOX.bottomRight));
+
+  // 5x3 — full borders
+  const b5 = drawBox(1, 1, 5, 3);
+  check('5x3 top border',               b5.includes(BOX.topLeft + BOX.horizontal.repeat(3) + BOX.topRight));
+  check('5x3 bottom border',            b5.includes(BOX.bottomLeft + BOX.horizontal.repeat(3) + BOX.bottomRight));
+
+  // Width 1 or height 1 → empty (degenerate)
+  check('width 1 returns empty',        drawBox(1, 1, 1, 5) === '');
+  check('height 1 returns empty',       drawBox(1, 1, 5, 1) === '');
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Frame — buffer accumulator');
+{
+  const f = new Frame();
+  check('empty frame',                  f.toString() === '');
+  check('length 0',                     f.length === 0);
+  f.write('hello');
+  f.write(' world');
+  check('accumulated chunks',           f.toString() === 'hello world');
+  check('length 2',                     f.length === 2);
+  f.writeAt(5, 10, 'x');
+  check('writeAt prefixes with moveTo', f.toString().endsWith(`${moveTo(5, 10)}x`));
+  f.clear();
+  check('clear empties',                f.toString() === '');
+  check('clear resets length',          f.length === 0);
+}
+
+// ─────────────────────────────────────────────────────────────
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

M3 of v4 — the TUI framework foundations. Four small modules under `src/tui/` that the actual tabs (M4) will compose. **Pure ANSI, zero runtime deps, ~700 LOC.** Strictly additive — nothing new is wired into the CLI or proxy yet.

## What's in this PR

### `src/tui/render.ts` — ANSI primitives

Pure string-returning helpers for every escape sequence the TUI uses. No terminal state, no `console.write` — the App's render loop accumulates these into a `Frame` and flushes once per redraw.

- Cursor: `moveTo`, hide/show, alt-screen enter/leave
- Color: `fg`/`bg`/`bold`/`dim`/`inverse`/`underline` + 16-color palette + 256-color `brand` accent
- Strings: `visibleWidth` (ANSI-stripping length), `truncate`, `pad` (left/right/center), `progressBar`
- Layout: `drawBox`, `BOX` character set
- `Frame` accumulator for single-write rendering (no flicker)

### `src/tui/input.ts` — stdin raw-mode key parser

`parseKeys(buffer) → Key[]`. Pure function, no Node `readline` dep. Covers everything the TUI needs:

| Class | Examples |
|---|---|
| Printable ASCII | `a`, `Z`, ` ` |
| Named keys | Enter, Tab, Backspace, Escape |
| Ctrl+letter | `Ctrl+C`, `Ctrl+L` |
| Arrows (CSI + SS3) | `\x1b[A`, `\x1bOA` |
| Home/End/PgUp/PgDn/Del | both letter (`\x1b[H`) and tilde (`\x1b[1~`) forms |
| Modified arrows | `\x1b[1;5A` (Ctrl+Up), `\x1b[1;2A` (Shift+Up), etc. |
| Alt+printable | `\x1ba` → meta+a |

Subtle correctness bit: Backspace (0x7f / 0x08) is checked **before** the Ctrl+letter range, so Windows-console BS isn't misreported as Ctrl+H. Locked in by test.

### `src/tui/layout.ts` — composable layout helpers

Higher-level primitives that compose the lower-level ANSI strings into the structural patterns the TUI uses:

- `renderHeader` (brand + version + status URL)
- `renderFooter` (key-hint pairs, narrow-terminal truncation)
- `renderTabStrip` (active tab inverse-highlighted)
- `renderScrollIndicator` (n / total)
- `wrap` (word-wrap, hard-break for over-width words, preserves `\n` as paragraph breaks)
- `renderKvRow` (key + padded value; clamps `keyWidth` so narrow terminals still produce well-formed rows)

### `src/tui/app.ts` — main loop + lifecycle

The `App<S>` class. Holds state, drives the redraw loop, manages stdin raw mode, handles resize events, runs cleanup hooks on exit.

Lifecycle invariants:
- Enters alt-screen on `start()`, leaves on `stop()`. The spawning shell sees its prior content restored on quit.
- Hides cursor on start, restores on stop. **ALWAYS** — SIGINT/SIGTERM/`process.exit` all run the cleanup chain.
- `Ctrl+C` → stop. `Ctrl+L` → forced redraw.
- `SIGWINCH` → redraw with new dimensions.
- `setState` coalesces via `queueMicrotask` — one redraw per tick regardless of how many setStates fire.

## Tests — 137 new assertions

```
tui-render.mjs   →  55 pass
tui-input.mjs    →  47 pass
tui-layout.mjs   →  35 pass
                   ─────────
                   137 pass, 0 fail
```

Coverage highlights:
- Every key class in `parseKeys`, including the subtle 0x08-vs-Ctrl+H ordering
- ANSI-aware truncate/pad (escapes don't count toward visible width)
- progressBar boundary cases (0, 1, negative, > 1, custom chars)
- wrap with hard-break, paragraph preservation, width-0 edge case
- Frame accumulator semantics

Full suite: **66 → 69 passing** (each new test file is +1 in the parallel runner's count; underlying assertion count grows by 137).

## What's NOT covered

The `App` class itself isn't unit-tested — it needs a real TTY for stdin/stdout. The orchestration logic is thin (state machine over the tested primitives), so M4's tab integration tests will cover the full render loop end-to-end.

## v4 plan progress

| M | Status | |
|---|---|---|
| **M1** | ✅ #281 | Config file foundation |
| **M2** | ✅ #281 | Analytics streaming + always-on |
| **M3** | ✅ this PR | TUI framework primitives |
| M4 | next | Six tabs: Status / Config / Analytics / Hits / Accounts / Backends |
| M5 | | `dario` (no args) → TUI; proxy reads config file at startup |
| M6 | | README rewrite + v4.0.0 release |

No version bump in this PR; auto-release stays dormant.
