### PR TITLE
release: v4.0.0 — interactive TUI is the default surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,98 @@ checklist.
 
 ## [Unreleased]
 
+## [4.0.0] - 2026-05-16
+
+### Major — interactive TUI is now the default surface
+
+`dario` invoked with no arguments now opens an interactive terminal UI. The TUI is the new way to configure dario, watch token analytics, and inspect live requests — replacing the v3 pattern of hand-editing shell scripts and reading help text to find the right `--flag`.
+
+```
+┌─ dario v4.0.0 ─────────────[ q quit · ? help · Tab next panel ]─┐
+│  Status   Config   ▎Analytics▎   Hits   Accounts   Backends    │
+├─────────────────────────────────────────────────────────────────┤
+│  Analytics — last 60 min                                        │
+│                                                                 │
+│  Requests:        247  (4.1/min)                                │
+│  Tokens in:    142,830                                          │
+│  Tokens out:    38,200                                          │
+│                                                                 │
+│  Per-model:                                                     │
+│   opus-4-7    ████████████████████░  72%                        │
+│   sonnet-4-6  █████░░░░░░░░░░░░░░░░  22%                        │
+│   haiku-4-5   █░░░░░░░░░░░░░░░░░░░░   6%                        │
+│                                                                 │
+│  Rate-limit:                                                    │
+│   5h ████░░░░░░░░░░░░░░░░░░░░░░  18%                            │
+│   7d ██░░░░░░░░░░░░░░░░░░░░░░░░   8%                            │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Six tabs**:
+- **Status** — proxy health, OAuth expiry, config source
+- **Config** — edit `~/.dario/config.json` (port, host, stealth, pacing, think-time, session-start); bool toggles in place, number/string opens an inline prompt; save / discard / reload
+- **Analytics** — rolling-window summary, per-model + rate-limit bars, billing-bucket breakdown; auto-refreshes every 2s
+- **Hits** — live SSE stream of every request as it lands; arrow keys navigate, detail pane shows full per-record fields
+- **Accounts** — pool listing with OAuth expiry; mutations still via CLI (commands in the footer)
+- **Backends** — OpenAI-compat backends; same shape
+
+**Zero new runtime dependencies.** ~2700 LOC of pure-ANSI rendering, raw-stdin key parsing, layout helpers, and tab state machines — no `blessed`, no `ink`, no React. The dario zero-deps stance survives v4.
+
+### Breaking change — `dario` (no args) opens TUI instead of starting proxy
+
+| | v3.x | v4.0 |
+|---|---|---|
+| `dario` | starts proxy server | opens TUI |
+| `dario proxy` | starts proxy server | starts proxy server (unchanged) |
+| `dario --no-tui` | (didn't exist) | falls back to help (escape hatch) |
+
+Scripts that ran bare `dario` to launch the proxy need to switch to `dario proxy`. The TUI surfaces `"proxy unreachable — start it with dario proxy"` if it can't reach localhost:3456, so users falling into the old habit get pointed at the fix immediately.
+
+See [MIGRATION.md](./MIGRATION.md) for the full migration playbook.
+
+### New — persistent config file
+
+`~/.dario/config.json` holds settings the TUI's Config tab edits. The proxy reads it at startup; precedence is `CLI flag > env var > config file > built-in default`. Existing `--flag` and `DARIO_*` env vars still win — the file is purely additive.
+
+Fields covered in v4.0:
+- `port`, `host`
+- `stealth`, `drainOnClose`
+- `pacing.{minMs, jitterMs}`
+- `thinkTime.{baseMs, perTokenMs, jitterMs, maxMs}`
+- `sessionStart.{minMs, jitterMs}`
+
+Other settings (`preserveTools`, `hybridTools`, queue limits) still come from flag/env only. v4.x can extend the Config tab + file schema to more fields without API change.
+
+### New — `/analytics/stream` SSE endpoint
+
+The proxy now exposes Server-Sent Events at `GET /analytics/stream`. One event per request as it's appended to the analytics rolling window — backlog of 50 recent records on connect, then live tail. Drives the TUI's Hits tab, but also usable directly: `curl -N http://localhost:3456/analytics/stream`.
+
+### Changed — analytics is always-on (previously pool-mode only)
+
+Pre-v4 the `/analytics` endpoint was gated to multi-account pool mode and returned `{mode:'single-account', note:'…'}` for the >99% of users on single-account. The note is gone; every install gets the full rolling-window summary now. The four record sites in the proxy hot path work in both modes — `account` defaults to a synthetic single-account key when there's no `poolAccount`, rate-limit snapshot falls back to `parseRateLimits(upstream.headers)`.
+
+### Internal — release pipeline fixes (from the v3.38.x backlog, all live before v4.0)
+
+Three meaningful pipeline improvements landed during the v3.38.x sprint and ride into v4:
+
+- **CHANGELOG-extraction regex fix** (#276 + #277): every auto-released GitHub release body since v3.31.12 had been shipping empty because the `/m`-flag regex captured the empty string after every version's blank-separator line. Fixed + extracted to `scripts/extract-release-notes.mjs` with 30 unit tests. All 39 affected historical releases (v3.31.12 through v3.38.4) had their bodies backfilled.
+- **Adaptive-thinking per-model gate** (#273): live-probed `thinking:{type:"adaptive"}` is server-side-gated to Opus/Sonnet 4.6+; dario was unconditionally emitting it for every non-Haiku model, 400ing Sonnet 4-5 / Opus 4-5 requests. New `supportsAdaptiveThinking()` allow-list with empirical matrix locked into tests.
+- **TodoWrite legacy mapping drop** (#274): CC v2.1.142 dropped `TodoWrite`/`TodoRead` for the Task* family; the dario `todo_*` → `TodoWrite` mapping pointed at a destination that no longer exists. Dropped both mappings + routed legacy clients through the unmapped-tool path.
+
+### Tests
+
+Suite: 64 → 71 passing across the v4 cycle. New test files:
+
+- `test/config-file.mjs` — 59 assertions
+- `test/analytics-stream.mjs` — 25 assertions
+- `test/tui-render.mjs` — 55 assertions
+- `test/tui-input.mjs` — 47 assertions
+- `test/tui-layout.mjs` — 35 assertions
+- `test/tui-tabs.mjs` — 86 assertions
+- `test/tui-app-wiring.mjs` — 1 assertion (smoke)
+
+Total v4 contribution: ~308 new assertions. The interactive App lifecycle (real TTY, stdin raw mode, alt-screen) isn't covered by automated tests — manual e2e confirms it on Linux + macOS + Windows Terminal.
+
 ## [3.38.6] - 2026-05-15
 
 ### Fixed — drop legacy `todo_read`/`todo_write` → `TodoWrite` mapping (CC v2.1.142 deprecation)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,101 @@
+# Migrating from dario v3.x to v4.0
+
+v4 introduces an interactive TUI as the default surface for `dario`. The proxy server is unchanged; what changes is how you launch it and how you discover / tune settings.
+
+## TL;DR
+
+**One breaking change.** Two changes you'll likely notice:
+
+| Concern | v3.x | v4.0 |
+|---|---|---|
+| Bare `dario` | starts proxy server | opens TUI |
+| Start the proxy explicitly | `dario` | `dario proxy` |
+| See current state | `dario status` / `dario doctor` | `dario` (TUI's Status tab) |
+| Edit a setting | hand-edit shell script / env vars | `dario` → Config tab → Enter / `s` |
+| Watch token burn | `dario usage` (one-shot) | `dario` → Analytics tab (live, 2s refresh) |
+| See requests as they happen | `--verbose` proxy log | `dario` → Hits tab |
+
+**If you have a script or systemd unit that runs `dario`**, change it to `dario proxy`.
+
+## The breaking change in one paragraph
+
+In v3.x, `dario` with no arguments started the proxy server. In v4, `dario` with no arguments opens the interactive TUI. The proxy server is unchanged — `dario proxy` does exactly what bare `dario` did in v3. If your shell history says `dario &` to start a background proxy, you now want `dario proxy &`.
+
+Everything else is opt-in additive.
+
+## How to migrate, step by step
+
+### 1. Update any startup script
+
+```diff
+-# my-startup.sh
+-dario &
++# my-startup.sh
++dario proxy &
+```
+
+Same for systemd / launchd / Docker entrypoints — anywhere you spawn `dario` non-interactively, point at `dario proxy` explicitly.
+
+### 2. Try the TUI
+
+```sh
+dario
+```
+
+The TUI opens. Tabs cycle with **Tab** (or jump by hotkey: `s` Status, `c` Config, `A` Analytics, `h` Hits, `a` Accounts, `b` Backends). **q** quits. **r** refreshes the active tab.
+
+If the TUI shows "proxy unreachable" — that's expected when no proxy is running. Start one in another terminal:
+
+```sh
+dario proxy
+```
+
+Then come back to the TUI and the Analytics / Hits / Status tabs populate live.
+
+### 3. (Optional) Persist settings in `~/.dario/config.json`
+
+v4 introduces a config file the TUI's Config tab can write. Schema:
+
+```json
+{
+  "version": 1,
+  "port": 3456,
+  "host": "127.0.0.1",
+  "stealth": true,
+  "drainOnClose": false,
+  "pacing":      { "minMs": 500,  "jitterMs": 300 },
+  "thinkTime":   { "baseMs": 800, "perTokenMs": 4, "jitterMs": 1500, "maxMs": 25000 },
+  "sessionStart":{ "minMs": 1200, "jitterMs": 3000 }
+}
+```
+
+Precedence: `CLI flag > env var > config file > built-in default`. The file is purely additive — everything in v3.x continues to work unchanged.
+
+The TUI is the easiest editor; alternatively you can write this file by hand or via your own tool.
+
+### 4. (Optional) Use `--no-tui` for CI scripts
+
+If a CI script greps the output of bare `dario` for help text, the v4 default opens a TUI that won't render usefully in a non-TTY pipe (it exits 1 with `"TUI requires an interactive terminal"`). The clean migration is `dario help` or `dario --help`. As a temporary escape hatch:
+
+```sh
+dario --no-tui    # falls back to help
+```
+
+## What didn't change
+
+- The proxy server's HTTP behavior is identical to v3.38.6. Same endpoints, same wire shapes, same OAuth flow, same rate-limit semantics. v4 is purely a UX layer + analytics-streaming addition on top.
+- All v3 CLI subcommands continue to work: `dario login`, `dario status`, `dario doctor`, `dario accounts`, `dario backend`, `dario usage`, `dario config`, `dario shim`, `dario subagent`, `dario mcp`, `dario upgrade`. Same flags, same env vars.
+- Existing `--flag` and `DARIO_*` env vars take precedence over the new config file. Nothing in your environment auto-changes meaning.
+- The bundled CC template, OAuth flow, account pool, OpenAI-compat backends — all unchanged.
+
+## New things to know about
+
+- **`dario` (no args)** opens the TUI. **`dario proxy`** starts the server.
+- **`~/.dario/config.json`** is read at proxy startup if present.
+- **`GET /analytics/stream`** on the running proxy is a Server-Sent Events feed of every request as it lands. Drives the TUI's Hits tab; also usable directly: `curl -N http://localhost:3456/analytics/stream`.
+- **Analytics is always-on** now. Pre-v4 the `/analytics` endpoint was gated to pool mode; in v4 single-account users get the full summary too.
+
+## Reporting issues
+
+- TUI bugs: tag with `v4-tui` on dario#new
+- Migration friction: same — we'd rather hear about it than have it sit silently broken on your machine

--- a/README.md
+++ b/README.md
@@ -23,12 +23,34 @@ You're already paying $20, $100, or $200 a month for Claude. Then Cursor wants a
 ```bash
 npm install -g @askalf/dario
 dario login          # uses your existing Claude Code credentials
-dario proxy
+dario proxy          # start the server (separate terminal or background)
 export ANTHROPIC_BASE_URL=http://localhost:3456
 export ANTHROPIC_API_KEY=dario
 ```
 
 That's the whole setup. Every tool that honors those env vars now runs on your subscription.
+
+**New in v4:** type `dario` (no args) in another terminal to open the interactive TUI — live request stream, per-model burn-rate, rate-limit utilization, and a config editor that writes to `~/.dario/config.json`. Migrating from v3? See [MIGRATION.md](MIGRATION.md).
+
+```
+┌─ dario v4.0.0 ───────────────[ q quit · ? help · Tab next panel ]┐
+│  Status   Config   ▎Analytics▎   Hits   Accounts   Backends      │
+├──────────────────────────────────────────────────────────────────┤
+│  Analytics — last 60 min                                         │
+│                                                                  │
+│  Requests:        247  (4.1/min)                                 │
+│  Tokens in:    142,830                                           │
+│  Tokens out:    38,200                                           │
+│                                                                  │
+│  Per-model:                                                      │
+│   opus-4-7    ████████████████████░  72%                         │
+│   sonnet-4-6  █████░░░░░░░░░░░░░░░░  22%                         │
+│                                                                  │
+│  Rate-limit:                                                     │
+│   5h ████░░░░░░░░░░░░░░░░░░░░░░  18%                             │
+│   7d ██░░░░░░░░░░░░░░░░░░░░░░░░   8%                             │
+└──────────────────────────────────────────────────────────────────┘
+```
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "3.38.6",
+  "version": "4.0.0",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

**M6 — the release cut.** The actual v4 code already merged across PRs #281, #282, #283, #284. This PR is the docs + version bump that fires the auto-release pipeline.

Merging this triggers (via the fixed `cc-drift-auto-release.yml` from #277):
1. Tag `v4.0.0` against the merge commit
2. Build + smoke + npm publish with SLSA provenance
3. Multi-arch Docker push to GHCR (`ghcr.io/askalf/dario:v4.0.0`, `:v4`, `:latest`)
4. GitHub release with the full CHANGELOG body extracted from this commit (regex extraction verified — 7052 chars of body content for v4.0.0)

## What's in this PR

| File | Change |
|---|---|
| `package.json` | `3.38.6` → `4.0.0` |
| `CHANGELOG.md` | Full v4.0.0 entry — TUI screenshot, six tabs, breaking change, new config file, /analytics/stream, always-on analytics, internal pipeline fixes from the 3.38.x sprint |
| `MIGRATION.md` (new) | Step-by-step v3 → v4 playbook |
| `README.md` | New "New in v4" callout with TUI mockup, points at MIGRATION.md |

No code changes — purely docs + version + release-trigger.

## What v4 actually ships (the code already merged)

| M | PR | Content |
|---|---|---|
| M1 | #281 | `src/config-file.ts` — atomic load/save/merge for `~/.dario/config.json` |
| M2 | #281 | Analytics promoted to always-on + `GET /analytics/stream` SSE |
| M3 | #282 | TUI framework — pure-ANSI render/input/layout/app primitives |
| M4 | #283 | Six tabs + TuiApp composition + prototype-pollution defence |
| M5 | #284 | `dario` (no args) → TUI; proxy reads config file at startup |
| **M6** | **this PR** | Docs + version bump + release ceremony |

## Breaking change

`dario` (no args) opens the TUI instead of starting the proxy. `dario proxy` is the explicit way to start the proxy. The TUI shows "proxy unreachable — start it with `dario proxy`" when it can't reach localhost, so users falling into the v3 habit get pointed at the fix immediately.

See [MIGRATION.md](https://github.com/askalf/dario/blob/release/v4.0.0/MIGRATION.md) for the full playbook.

## Tests

Suite: 71/71 passing (this PR adds no tests — all logic landed in M1–M5).

The interactive TUI run (real TTY, stdin raw mode, alt-screen) isn't covered by automated tests. Manual e2e on Linux + macOS + Windows Terminal confirmed before this release cut.

## Release-pipeline correctness

Verified end-to-end by running the (post-#277-fix) extraction locally:

```sh
$ node scripts/extract-release-notes.mjs 4.0.0 --file CHANGELOG.md | wc -c
7052
```

7052 chars of CHANGELOG content will land in the GitHub release body. No empty-boilerplate body this time around.

## Post-merge

The auto-release pipeline takes ~3-5 minutes after merge. I'll watch it through, verify v4.0.0 lands on npm + `latest` tag points correctly + GHCR Docker image is pushable + GitHub release body is non-empty.
