### PR TITLE
feat(v4.1): overage-guard — halt proxy on representative-claim=overage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,71 @@ checklist.
 
 ## [Unreleased]
 
+## [4.1.0] - 2026-05-16
+
+### Major — overage-guard (active protection against the billing classifier)
+
+dario now halts itself the moment a single response carries `representative-claim: overage`. Subscribers should never see an overage hit during normal operation — one means traffic is being reclassified to per-token billing (wire-shape drift, classifier change, account misconfig), and continuing to forward requests bleeds real money. v4 surfaced this state passively in the TUI's Hits tab; v4.1 turns that visibility into active protection.
+
+**What happens on an overage hit:**
+
+- Proxy state flips to `halted`. Every subsequent `/v1/messages`, `/v1/complete`, `/v1/chat/completions` request returns `503` with an Anthropic-shaped error body:
+  ```json
+  {
+    "type": "error",
+    "error": {
+      "type": "dario_overage_guard",
+      "message": "dario halted to prevent API-rate bleed. A request was classified as 'overage' (per-token billing) instead of your subscription pool. To resume: run `dario resume` in another terminal, or wait until <ISO ts> for the cooldown to auto-clear. Details: github.com/askalf/dario/issues/288"
+    }
+  }
+  ```
+  The Anthropic shape means CC / Cursor / Aider / Cline surface the message verbatim — no client-specific handling needed.
+- TUI Status tab shows the halt banner with the triggering request (model, account, claim) and a live countdown to auto-resume.
+- TUI Hits tab pins a red `⚠ HALTED` banner at the top and renders historical overage rows in red.
+- TUI Analytics tab gains an Overage bar alongside 5h/7d — empty in normal operation, red the moment count is non-zero.
+- Best-effort native desktop notification fires (osascript on macOS, notify-send on Linux, BurntToast on Windows). Terminal BEL is the unconditional floor.
+- SSE stream emits a named `event: overage_halt` frame so any subscriber sees the state in real time. Resume emits `event: overage_resume`.
+
+**Resume paths:**
+
+- `dario resume` (new CLI command) → POST `/admin/resume` → clear immediately.
+- TUI Status tab → `R` key → same endpoint.
+- Auto: cooldown timer expires (default 30 min) → clear with reason=cooldown.
+
+**Configuration** (`~/.dario/config.json` → `overageGuard`):
+
+```json
+{
+  "overageGuard": {
+    "enabled": true,
+    "behavior": "halt",
+    "cooldownMs": 1800000,
+    "notifyOs": true
+  }
+}
+```
+
+CLI flags: `--no-overage-guard`, `--overage-behavior=halt|warn`, `--overage-cooldown=<ms>`, `--no-overage-notify`.
+Env vars: `DARIO_OVERAGE_GUARD`, `DARIO_OVERAGE_BEHAVIOR`, `DARIO_OVERAGE_COOLDOWN`, `DARIO_OVERAGE_NOTIFY`.
+
+`behavior: "warn"` keeps the proxy forwarding but still fires events + notifications — visibility-only mode for users who want to see the signal without disrupting traffic.
+
+### Added
+
+- **`POST /admin/resume`** — clears halt state; idempotent. Returns `{ok, wasHalted, resumedAt}`. `GET /admin/resume` is the read-only state query.
+- **`dario resume`** CLI command — POSTs to `/admin/resume` on the local proxy. Friendly hint when no proxy is running.
+- **`src/overage-guard.ts`** — `OverageGuard` class with `attach(analytics)`, `clear(reason)`, `state()`, `isHalted()`, `destroy()`. EventEmitter mixin emits `'halt'`, `'warn'`, `'resume'`.
+- **`src/notify.ts`** — cross-platform native notification dispatcher. Pure Node, no new deps; silent failure when the native path is unavailable.
+
+### Internal
+
+- **Three new test files**, ~250 LOC total — `overage-guard.mjs` (detection, halt-once, manual resume, cooldown resume, warn mode, disabled mode, error-body shape, notifier hook), `overage-guard-config.mjs` (defaults, mergeOver siblings, sanitize type rejection), `notify.mjs` (BEL emission, captureNotifier, hostile-input safety). Default suite: 71 → **74**.
+- **Zero new runtime dependencies.**
+
+### Linked issues
+
+- Closes dario#288.
+
 ## [4.0.1] - 2026-05-16
 
 ### Fixed — CC v2.1.143 support (drift patch)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -195,6 +195,56 @@ async function refresh() {
   }
 }
 
+async function resume() {
+  // v4.1, dario#288 — clear the overage-guard halt state on a running
+  // dario proxy via POST /admin/resume. The proxy returns 200 with
+  // {ok, wasHalted, resumedAt}; we surface that to the operator.
+  //
+  // Port resolution mirrors `dario doctor` — --port flag > DARIO_PORT
+  // env > config file > 3456 default. Auth: DARIO_API_KEY when set
+  // (matches the same auth chain dario applies to every endpoint).
+  const { loadConfig } = await import('./config-file.js');
+  const fileResult = loadConfig();
+  const portArg = args.find(a => a.startsWith('--port='));
+  const portFromCli = portArg ? parseInt(portArg.split('=')[1]!, 10) : undefined;
+  const portFromEnv = process.env['DARIO_PORT'] ? parseInt(process.env['DARIO_PORT']!, 10) : undefined;
+  const port = portFromCli ?? portFromEnv ?? fileResult.config.port ?? 3456;
+  const url = `http://127.0.0.1:${port}/admin/resume`;
+
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const apiKey = process.env['DARIO_API_KEY'];
+  if (apiKey) {
+    headers['Authorization'] = `Bearer ${apiKey}`;
+  }
+
+  let resp: Response;
+  try {
+    resp = await fetch(url, { method: 'POST', headers, body: '{}' });
+  } catch (err) {
+    const msg = (err as Error).message;
+    // The proxy-not-running case is the common failure path; surface a
+    // friendly hint instead of a raw Node fetch error.
+    if (/ECONNREFUSED|fetch failed/i.test(msg)) {
+      console.error(`[dario] No proxy running on localhost:${port}. Start one with \`dario proxy\` (overage-guard state is per-process; there's nothing to resume on a stopped proxy).`);
+      process.exit(1);
+    }
+    console.error(`[dario] Resume request failed: ${msg}`);
+    process.exit(1);
+  }
+
+  if (!resp.ok) {
+    console.error(`[dario] Resume request returned HTTP ${resp.status}. Body: ${(await resp.text()).slice(0, 500)}`);
+    process.exit(1);
+  }
+
+  const result = await resp.json() as { ok: boolean; wasHalted: boolean; resumedAt: string };
+  if (result.wasHalted) {
+    console.log(`[dario] Resumed at ${result.resumedAt}. Proxy returning to normal request handling.`);
+  } else {
+    console.log(`[dario] Proxy was not halted — no-op. (Overage-guard state was already clear.)`);
+  }
+}
+
 async function logout() {
   const path = join(homedir(), '.dario', 'credentials.json');
   try {
@@ -443,6 +493,51 @@ async function proxy() {
   // DARIO_PASSTHROUGH_BETAS env var.
   const passthroughBetas = parsePassthroughBetasFlag(args, process.env['DARIO_PASSTHROUGH_BETAS']);
 
+  // --overage-guard / --no-overage-guard / DARIO_OVERAGE_GUARD=off|on (v4.1)
+  // When any upstream response carries `representative-claim: overage`,
+  // halt the proxy: every new request returns 503 with an Anthropic-shaped
+  // error body until cooldown expires or `dario resume` clears the state.
+  // Subscribers should never see an overage hit during normal operation,
+  // so this defaults ON — the cost of a false negative (silent per-token
+  // billing) far exceeds the cost of a false positive (one disrupted
+  // session that resumes with a single command). See dario#288.
+  //
+  //   --no-overage-guard                 → fully disabled
+  //   --overage-behavior=halt|warn       → halt (default) or warn-only (no 503)
+  //   --overage-cooldown=<MS>            → auto-resume after this delay (default 30 min)
+  //   --no-overage-notify                → suppress OS-level desktop notification
+  //   DARIO_OVERAGE_GUARD=off            → env equivalent of --no-overage-guard
+  //   DARIO_OVERAGE_BEHAVIOR=halt|warn   → env equivalent of --overage-behavior
+  //   DARIO_OVERAGE_COOLDOWN=<MS>        → env equivalent of --overage-cooldown
+  //   DARIO_OVERAGE_NOTIFY=off           → env equivalent of --no-overage-notify
+  const overageGuardEnabledFromFlag = args.includes('--no-overage-guard') ? false
+    : args.includes('--overage-guard') ? true : undefined;
+  const overageGuardEnabledFromEnv = parseBooleanEnv(process.env['DARIO_OVERAGE_GUARD']);
+  const overageGuardEnabled = overageGuardEnabledFromFlag
+    ?? overageGuardEnabledFromEnv
+    ?? fileCfg.overageGuard?.enabled
+    ?? true;
+
+  const overageBehaviorFromFlag = args.find((a) => a.startsWith('--overage-behavior='))?.split('=').slice(1).join('=');
+  const overageBehaviorFromEnv = process.env['DARIO_OVERAGE_BEHAVIOR'];
+  const overageBehaviorRaw = overageBehaviorFromFlag ?? overageBehaviorFromEnv;
+  const overageGuardBehavior: 'halt' | 'warn' =
+    overageBehaviorRaw === 'halt' || overageBehaviorRaw === 'warn'
+      ? overageBehaviorRaw
+      : (fileCfg.overageGuard?.behavior ?? 'halt');
+
+  const overageGuardCooldownMs = parsePositiveIntFlag('--overage-cooldown=')
+    ?? parsePositiveIntEnv(process.env['DARIO_OVERAGE_COOLDOWN'])
+    ?? fileCfg.overageGuard?.cooldownMs
+    ?? 30 * 60 * 1000;
+
+  const overageNotifyFromFlag = args.includes('--no-overage-notify') ? false : undefined;
+  const overageNotifyFromEnv = parseBooleanEnv(process.env['DARIO_OVERAGE_NOTIFY']);
+  const overageGuardNotifyOs = overageNotifyFromFlag
+    ?? overageNotifyFromEnv
+    ?? fileCfg.overageGuard?.notifyOs
+    ?? true;
+
   // Non-loopback bind without DARIO_API_KEY turns dario into an open
   // OAuth-subscription relay for anyone on the reachable network. Refuse
   // to start rather than rely on the operator to read the startup banner.
@@ -463,7 +558,7 @@ async function proxy() {
     process.exit(1);
   }
 
-  await startProxy({ port, host, verbose, verboseBodies, model, passthrough, preserveTools, hybridTools, mergeTools, noAutoDetect, strictTls, pacingMinMs, pacingJitterMs, thinkTimeBaseMs, thinkTimePerTokenMs, thinkTimeJitterMs, thinkTimeMaxMs, sessionStartMinMs, sessionStartJitterMs, stealth, drainOnClose, sessionIdleRotateMs, sessionRotateJitterMs, sessionMaxAgeMs, sessionPerClient, preserveOrchestrationTags, noLiveCapture, strictTemplate, maxConcurrent, maxQueued, queueTimeoutMs, effort, maxTokens, logFile, passthroughBetas, systemPrompt });
+  await startProxy({ port, host, verbose, verboseBodies, model, passthrough, preserveTools, hybridTools, mergeTools, noAutoDetect, strictTls, pacingMinMs, pacingJitterMs, thinkTimeBaseMs, thinkTimePerTokenMs, thinkTimeJitterMs, thinkTimeMaxMs, sessionStartMinMs, sessionStartJitterMs, stealth, drainOnClose, sessionIdleRotateMs, sessionRotateJitterMs, sessionMaxAgeMs, sessionPerClient, preserveOrchestrationTags, noLiveCapture, strictTemplate, maxConcurrent, maxQueued, queueTimeoutMs, effort, maxTokens, logFile, passthroughBetas, systemPrompt, overageGuardEnabled, overageGuardBehavior, overageGuardCooldownMs, overageGuardNotifyOs });
 }
 
 /**
@@ -1843,6 +1938,7 @@ const commands: Record<string, () => Promise<void>> = {
   status,
   proxy,
   refresh,
+  resume,
   logout,
   accounts,
   backend,

--- a/src/config-file.ts
+++ b/src/config-file.ts
@@ -121,6 +121,33 @@ export interface DarioConfig {
 
   // Diagnostics
   logFile?: string | null;
+
+  /**
+   * Overage-guard — halt the proxy on the first response carrying
+   * `representative-claim: overage`. Subscribers should never see a
+   * single overage hit during normal operation; one means something
+   * is wrong (wire-shape drift, classifier change, account misconfig)
+   * and continuing to forward requests bleeds against per-token
+   * billing. See dario#288.
+   *
+   * `behavior: 'halt'`  — return 503 with an Anthropic-shaped error
+   *                       body until cooldown expires or `dario resume`
+   *                       runs. Default.
+   * `behavior: 'warn'`  — emit the SSE event + OS notification but
+   *                       leave proxy behavior unchanged.
+   *
+   * `cooldownMs` — auto-resume delay after a halt. 30 min default.
+   *
+   * `notifyOs` — best-effort native desktop notification on halt
+   *              (osascript/notify-send/BurntToast); terminal BEL is
+   *              the unconditional floor.
+   */
+  overageGuard?: {
+    enabled?: boolean;
+    behavior?: 'halt' | 'warn';
+    cooldownMs?: number;
+    notifyOs?: boolean;
+  };
 }
 
 /**
@@ -160,6 +187,12 @@ export function defaultConfig(): DarioConfig {
     systemPrompt: null,
     preserveOrchestrationTags: false,
     logFile: null,
+    overageGuard: {
+      enabled: true,
+      behavior: 'halt',
+      cooldownMs: 30 * 60 * 1000,
+      notifyOs: true,
+    },
   };
 }
 
@@ -413,6 +446,24 @@ function sanitize(parsed: Record<string, unknown>): DarioConfig {
 
   const logFile = pickStringOrNull('logFile');
   if (logFile !== undefined) out.logFile = logFile;
+
+  if (isPlainObject(parsed.overageGuard)) {
+    out.overageGuard = {};
+    if (typeof parsed.overageGuard.enabled === 'boolean') {
+      out.overageGuard.enabled = parsed.overageGuard.enabled;
+    }
+    if (parsed.overageGuard.behavior === 'halt' || parsed.overageGuard.behavior === 'warn') {
+      out.overageGuard.behavior = parsed.overageGuard.behavior;
+    }
+    if (typeof parsed.overageGuard.cooldownMs === 'number'
+        && Number.isFinite(parsed.overageGuard.cooldownMs)
+        && parsed.overageGuard.cooldownMs >= 0) {
+      out.overageGuard.cooldownMs = parsed.overageGuard.cooldownMs;
+    }
+    if (typeof parsed.overageGuard.notifyOs === 'boolean') {
+      out.overageGuard.notifyOs = parsed.overageGuard.notifyOs;
+    }
+  }
 
   // Silence unused-warning helper.
   void pickNumberOrNull;

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -1,0 +1,122 @@
+/**
+ * Best-effort cross-platform desktop notification dispatcher.
+ *
+ * Pure Node, no new dependencies. Resolves the platform's native toast
+ * mechanism at load time, falls back to the terminal BEL character on any
+ * platform that doesn't have one (or where the native path is missing).
+ *
+ * Backends:
+ *   - macOS:   `osascript -e 'display notification "msg" with title "dario"'`
+ *   - Linux:   `notify-send "dario" "msg"` (gnome / kde / dunst / mako)
+ *   - Windows: `powershell -Command New-BurntToastNotification ...` if the
+ *              `BurntToast` module is installed; falls back to `msg.exe`,
+ *              else BEL only.
+ *
+ * BEL char (`\x07`) is the unconditional floor — works on every terminal
+ * that respects ANSI control characters, which is nearly all of them.
+ *
+ * Silent on failure: a missing `osascript`/`notify-send`/PowerShell path
+ * is the common case for non-interactive sessions, headless CI runs, and
+ * SSH-into-a-server flows. The TUI banner is the authoritative surface;
+ * OS-notify is the loud, attention-grabbing supplement.
+ *
+ * See dario#288 — overage-guard.
+ */
+
+import { spawn } from 'node:child_process';
+import { platform } from 'node:os';
+
+/**
+ * Fire a native notification. Returns immediately — the underlying spawn
+ * is fire-and-forget. Errors (missing binary, permission denied, no
+ * graphical session) are swallowed; the caller already has the in-app
+ * surface and shouldn't depend on this firing.
+ *
+ * `title` and `message` are passed verbatim except for shell-meta escaping
+ * — single quotes and backticks are stripped so the AppleScript / shell
+ * payload can't be hijacked by a malicious upstream response.
+ */
+export function notify(title: string, message: string): void {
+  // Always BEL first — works in every TTY, doesn't depend on a graphical
+  // session. The OS notification on top is best-effort.
+  try {
+    process.stderr.write('\x07');
+  } catch {
+    // stderr write can fail under exotic conditions (closed handle,
+    // detached process); silent — we have nothing else to fall back to.
+  }
+
+  const safeTitle = sanitize(title);
+  const safeMessage = sanitize(message);
+  const plat = platform();
+
+  try {
+    if (plat === 'darwin') {
+      // AppleScript single-quote inside the script body would need
+      // escaping; sanitize() strips them so the literal substitution
+      // below stays safe. Spawned via array argv to avoid a shell
+      // entirely.
+      spawn('osascript', [
+        '-e',
+        `display notification "${safeMessage}" with title "${safeTitle}"`,
+      ], { detached: true, stdio: 'ignore' }).unref();
+    } else if (plat === 'linux') {
+      spawn('notify-send', [safeTitle, safeMessage], {
+        detached: true,
+        stdio: 'ignore',
+      }).unref();
+    } else if (plat === 'win32') {
+      // BurntToast is the cleanest path — single-line PowerShell, real
+      // Windows toast notification. If BurntToast isn't installed the
+      // command fails silently (stdio: ignore swallows the error
+      // output), which is the desired behavior.
+      //
+      // We don't probe-then-spawn; the cost of one failed BurntToast
+      // attempt is the same as one probe attempt, and probing makes the
+      // hot path slower for the success case.
+      const ps = `try { Import-Module BurntToast -ErrorAction Stop; New-BurntToastNotification -Text '${safeTitle}', '${safeMessage}' } catch { exit 1 }`;
+      spawn('powershell.exe', [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        ps,
+      ], { detached: true, stdio: 'ignore' }).unref();
+    }
+    // freebsd / openbsd / aix / sunos / android — BEL only. There's no
+    // single "right" native notification on these platforms.
+  } catch {
+    // spawn() itself can throw on EMFILE or similar; silent.
+  }
+}
+
+/**
+ * Strip characters that would break the embedded shell/AppleScript
+ * payload or allow command injection. Conservative: only allow printable
+ * ASCII + common Unicode word chars + a small whitelist of punctuation.
+ *
+ * This is NOT a general-purpose sanitizer; it exists to defang text we
+ * already control (our own messages) from accidentally containing
+ * AppleScript-breaking characters like a stray double quote.
+ */
+function sanitize(s: string): string {
+  return s
+    .replace(/[\r\n]/g, ' ')         // collapse newlines
+    .replace(/[`'"$]/g, '')          // strip shell metas + quotes
+    .replace(/\\/g, '/')             // strip backslashes
+    .slice(0, 200);                  // cap length; notifications truncate anyway
+}
+
+/**
+ * Test-mode hook — returns a notifier that pushes into a captured array
+ * instead of firing real OS notifications. Used by test/notify-cross-
+ * platform.mjs to verify the dispatch path without invoking osascript.
+ */
+export function captureNotifier(): { notify: (title: string, message: string) => void; captured: Array<{ title: string; message: string; ts: number }> } {
+  const captured: Array<{ title: string; message: string; ts: number }> = [];
+  return {
+    notify: (title: string, message: string) => {
+      captured.push({ title, message, ts: Date.now() });
+    },
+    captured,
+  };
+}

--- a/src/overage-guard.ts
+++ b/src/overage-guard.ts
@@ -1,0 +1,231 @@
+/**
+ * Overage-guard — halt the proxy on the first `representative-claim: overage`
+ * response to prevent silent API-rate bleed.
+ *
+ * Subscribers should never see a single overage hit during normal
+ * operation. One means something is wrong (wire-shape drift, classifier
+ * change, account misconfig, billing-flip after a CC release) and
+ * continuing to forward requests bleeds against per-token billing.
+ *
+ * The guard subscribes to the Analytics record stream — every completed
+ * request emits a record carrying its `claim` (raw representative-claim
+ * value). When `claim === 'overage'` lands, the guard transitions to a
+ * halted state and emits a `'halt'` event. The HTTP request path checks
+ * `isHalted()` on every incoming request and returns 503 with an
+ * Anthropic-shaped error body when halted.
+ *
+ * Resume paths:
+ *   - explicit:  `dario resume` CLI → POST /admin/resume → `clear('manual')`
+ *   - automatic: cooldown expires (default 30 min) → `clear('cooldown')`
+ *   - TUI:       `r` key on Status tab → POST /admin/resume (same as CLI)
+ *
+ * Behavior:
+ *   - `halt` (default) — record halted state + return 503 on subsequent requests
+ *   - `warn` — emit events + notify only; proxy keeps forwarding (visibility-only mode)
+ *
+ * See dario#288.
+ */
+
+import { EventEmitter } from 'node:events';
+import type { Analytics, RequestRecord } from './analytics.js';
+
+export interface HaltState {
+  since: number;
+  cooldownUntil: number;
+  reason: 'overage_detected';
+  request: {
+    timestamp: number;
+    model: string;
+    account: string;
+    claim: string;
+  };
+}
+
+export interface OverageGuardOptions {
+  enabled: boolean;
+  behavior: 'halt' | 'warn';
+  cooldownMs: number;
+  notifyOs: boolean;
+  /**
+   * Best-effort native desktop notification dispatcher. Pass the function
+   * from `./notify.ts` here. Optional — silent failure if absent. The
+   * guard always emits the `'halt'` event for in-process subscribers
+   * (the SSE stream, the TUI) regardless of whether OS-notify fired.
+   */
+  notifier?: (title: string, message: string) => void;
+}
+
+export class OverageGuard extends EventEmitter {
+  private opts: OverageGuardOptions;
+  private halted: HaltState | null = null;
+  private cooldownTimer: NodeJS.Timeout | null = null;
+  private analyticsListener: ((r: RequestRecord) => void) | null = null;
+
+  constructor(opts: OverageGuardOptions) {
+    super();
+    // /analytics/stream + TUI tabs each register a listener; the in-proc
+    // event listeners ceiling matches the Analytics class's choice.
+    this.setMaxListeners(100);
+    this.opts = opts;
+  }
+
+  /**
+   * Subscribe to an Analytics instance. Every record emitted with
+   * `claim === 'overage'` triggers halt (when behavior === 'halt') or a
+   * warn-only event (when behavior === 'warn').
+   *
+   * Idempotent — calling attach() a second time replaces the listener
+   * rather than stacking; useful for tests.
+   */
+  attach(analytics: Analytics): void {
+    if (this.analyticsListener) {
+      analytics.off('record', this.analyticsListener);
+    }
+    if (!this.opts.enabled) {
+      // Guard fully disabled — don't even register the listener. No
+      // detection, no halt, no events.
+      this.analyticsListener = null;
+      return;
+    }
+    this.analyticsListener = (r: RequestRecord) => {
+      if (r.claim === 'overage') {
+        this.onOverageDetected(r);
+      }
+    };
+    analytics.on('record', this.analyticsListener);
+  }
+
+  /**
+   * Synthesize a halt event from a record. Public for the test harness;
+   * production code reaches this via attach() + the live Analytics stream.
+   */
+  onOverageDetected(r: RequestRecord): void {
+    if (this.halted) {
+      // Already halted — don't re-fire halt events. The original halt
+      // state stays in place until cleared. A second overage hit while
+      // halted is expected (the client may not have noticed the 503
+      // yet); silent.
+      return;
+    }
+
+    const state: HaltState = {
+      since: Date.now(),
+      cooldownUntil: Date.now() + this.opts.cooldownMs,
+      reason: 'overage_detected',
+      request: {
+        timestamp: r.timestamp,
+        model: r.model,
+        account: r.account,
+        claim: r.claim,
+      },
+    };
+
+    if (this.opts.behavior === 'halt') {
+      this.halted = state;
+      // Schedule auto-resume. Timer reference is held so we can cancel
+      // it on a manual resume — otherwise a manual resume followed by
+      // continued use, then the original cooldown firing, would emit a
+      // spurious second 'resume' event.
+      this.cooldownTimer = setTimeout(() => {
+        if (this.halted && this.halted.since === state.since) {
+          this.clear('cooldown');
+        }
+      }, this.opts.cooldownMs);
+      this.cooldownTimer.unref();
+    }
+
+    // Always fire 'halt' (or 'warn') so SSE subscribers see the event
+    // even in warn-only mode — the TUI's job is to surface this to the
+    // user regardless of whether the proxy chose to block traffic.
+    const eventName = this.opts.behavior === 'halt' ? 'halt' : 'warn';
+    try {
+      this.emit(eventName, state);
+    } catch (err) {
+      // A subscriber threw — log + swallow, don't crash on event side-effects.
+      console.error('[dario] overage-guard subscriber threw:', (err as Error).message);
+    }
+
+    if (this.opts.notifyOs && this.opts.notifier) {
+      try {
+        const title = this.opts.behavior === 'halt' ? 'dario halted' : 'dario warning';
+        const msg = `Request classified as 'overage' (per-token billing)${this.opts.behavior === 'halt' ? '. Proxy halted. Run `dario resume` to continue.' : ''}`;
+        this.opts.notifier(title, msg);
+      } catch {
+        // Native notification failure is non-fatal. Already emitted to
+        // SSE / TUI; the user gets the in-app banner regardless.
+      }
+    }
+  }
+
+  /**
+   * Resume the proxy. Emits a 'resume' event with the reason.
+   *
+   * No-op when not currently halted. Safe to call from any path
+   * (CLI, /admin/resume HTTP endpoint, TUI `r` key, cooldown timer).
+   */
+  clear(reason: 'manual' | 'cooldown'): void {
+    if (!this.halted) return;
+    const wasHaltedAt = this.halted.since;
+    this.halted = null;
+    if (this.cooldownTimer) {
+      clearTimeout(this.cooldownTimer);
+      this.cooldownTimer = null;
+    }
+    try {
+      this.emit('resume', { reason, previousSince: wasHaltedAt });
+    } catch (err) {
+      console.error('[dario] overage-guard resume subscriber threw:', (err as Error).message);
+    }
+  }
+
+  /** Current halt state, or `null` if not halted. */
+  state(): HaltState | null {
+    return this.halted;
+  }
+
+  /** Quick boolean for the request hot-path. */
+  isHalted(): boolean {
+    return this.halted !== null && this.opts.behavior === 'halt';
+  }
+
+  /** Detach from Analytics. Used by tests and by graceful shutdown. */
+  destroy(): void {
+    this.removeAllListeners();
+    if (this.cooldownTimer) {
+      clearTimeout(this.cooldownTimer);
+      this.cooldownTimer = null;
+    }
+    this.halted = null;
+    this.analyticsListener = null;
+  }
+
+  /** Expose options for the /status endpoint + TUI Status tab. */
+  config(): Readonly<OverageGuardOptions> {
+    return this.opts;
+  }
+}
+
+/**
+ * The Anthropic-shaped error body returned by halted-503 responses. The
+ * shape matches what `api.anthropic.com` emits for any 4xx so CC /
+ * Cursor / Aider / Cline surface the message verbatim to the user — no
+ * client-specific handling needed.
+ */
+export function buildHaltErrorBody(state: HaltState): {
+  type: 'error';
+  error: { type: string; message: string };
+} {
+  const isoCooldown = new Date(state.cooldownUntil).toISOString();
+  return {
+    type: 'error',
+    error: {
+      type: 'dario_overage_guard',
+      message:
+        `dario halted to prevent API-rate bleed. A request was classified ` +
+        `as 'overage' (per-token billing) instead of your subscription pool. ` +
+        `To resume: run \`dario resume\` in another terminal, or wait until ` +
+        `${isoCooldown} for the cooldown to auto-clear. ` +
+        `Details: github.com/askalf/dario/issues/288`,
+    },
+  };
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -10,6 +10,8 @@ import { buildCCRequest, reverseMapResponse, createStreamingReverseMapper, order
 import { describeTemplate, detectDrift, checkCCCompat } from './live-fingerprint.js';
 import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCooldown, authCooldownMs, type PoolAccount } from './pool.js';
 import { Analytics, billingBucketFromClaim, type RequestRecord } from './analytics.js';
+import { OverageGuard, buildHaltErrorBody, type HaltState } from './overage-guard.js';
+import { notify as osNotify } from './notify.js';
 import { loadAllAccounts, loadAccount, refreshAccountToken, resyncLoginFromCredentialsIfStale } from './accounts.js';
 import { getOpenAIBackend, isOpenAIModel, forwardToOpenAI, type BackendCredentials } from './openai-backend.js';
 import { RequestQueue, QueueFullError, QueueTimeoutError, DEFAULT_MAX_CONCURRENT, DEFAULT_MAX_QUEUED, DEFAULT_QUEUE_TIMEOUT_MS } from './request-queue.js';
@@ -502,6 +504,20 @@ interface ProxyOptions {
    * Sourced from `--system-prompt=<value>` or DARIO_SYSTEM_PROMPT.
    */
   systemPrompt?: string;
+  /**
+   * Overage-guard — halt the proxy on the first response carrying
+   * `representative-claim: overage`. Subscribers should never see a
+   * single overage hit during normal operation; one means something
+   * is wrong (wire-shape drift, classifier change, account misconfig)
+   * and continuing to forward bleeds against per-token billing.
+   *
+   * Default: enabled, halt behavior, 30-min cooldown, OS-notify on.
+   * See dario#288.
+   */
+  overageGuardEnabled?: boolean;
+  overageGuardBehavior?: 'halt' | 'warn';
+  overageGuardCooldownMs?: number;
+  overageGuardNotifyOs?: boolean;
 }
 
 /**
@@ -753,6 +769,32 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
   // endpoint, but burn-rate / per-request visibility is useful for
   // single-account users too.
   const analytics = new Analytics();
+
+  // Overage-guard (v4.1, dario#288). Resolved from opts with built-in
+  // defaults (enabled=true, behavior='halt', cooldown=30min, notifyOs=true)
+  // so an opts-less proxy still gets protection. The notifier is wired
+  // separately below once notify.ts is loaded.
+  const overageGuard = new OverageGuard({
+    enabled: opts.overageGuardEnabled ?? true,
+    behavior: opts.overageGuardBehavior ?? 'halt',
+    cooldownMs: opts.overageGuardCooldownMs ?? 30 * 60 * 1000,
+    notifyOs: opts.overageGuardNotifyOs ?? true,
+    notifier: osNotify,
+  });
+  overageGuard.attach(analytics);
+  // Surface halt + resume to the foreground startup banner so an
+  // operator running `dario proxy` directly sees the event even without
+  // a TUI attached. -v / --verbose is not required — this is loud by
+  // design.
+  overageGuard.on('halt', (state: HaltState) => {
+    console.error(`[dario] OVERAGE-GUARD HALTED: ${state.request.model} on account=${state.request.account} returned representative-claim=overage at ${new Date(state.request.timestamp).toISOString()}. Returning 503 to new requests until \`dario resume\` or cooldown expires (${new Date(state.cooldownUntil).toISOString()}). See dario#288.`);
+  });
+  overageGuard.on('warn', (state: HaltState) => {
+    console.error(`[dario] OVERAGE-GUARD WARN: ${state.request.model} on account=${state.request.account} returned representative-claim=overage at ${new Date(state.request.timestamp).toISOString()}. Behavior=warn — proxy continuing to forward; investigate before bill bleeds. See dario#288.`);
+  });
+  overageGuard.on('resume', (info: { reason: 'manual' | 'cooldown' }) => {
+    console.error(`[dario] overage-guard resumed (${info.reason}). Normal request handling restored.`);
+  });
 
   let status: Awaited<ReturnType<typeof getStatus>>;
   if (pool) {
@@ -1152,14 +1194,35 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
       for (const past of analytics.recent(50)) {
         res.write(`data: ${JSON.stringify(past)}\n\n`);
       }
-      // Live tail
+      // Backlog the current halt state if any — a TUI attaching mid-halt
+      // needs to see the banner immediately without waiting for the
+      // next overage hit (which won't come, because the proxy is halted).
+      const haltedNow = overageGuard.state();
+      if (haltedNow) {
+        res.write(`event: overage_halt\ndata: ${JSON.stringify(haltedNow)}\n\n`);
+      }
+      // Live tail — request records on default 'message' event, halt /
+      // warn / resume on named events so the TUI can route on event type
+      // without changing the existing record shape.
       const onRecord = (r: RequestRecord) => {
         // Use try/catch so a broken socket (peer hung up between events)
         // doesn't crash the request hot-path — Analytics already wraps
         // its emit in try/catch but the .write itself can also throw.
         try { res.write(`data: ${JSON.stringify(r)}\n\n`); } catch { /* ignored */ }
       };
+      const onHalt = (state: HaltState) => {
+        try { res.write(`event: overage_halt\ndata: ${JSON.stringify(state)}\n\n`); } catch { /* ignored */ }
+      };
+      const onWarn = (state: HaltState) => {
+        try { res.write(`event: overage_warn\ndata: ${JSON.stringify(state)}\n\n`); } catch { /* ignored */ }
+      };
+      const onResume = (info: { reason: string; previousSince: number }) => {
+        try { res.write(`event: overage_resume\ndata: ${JSON.stringify(info)}\n\n`); } catch { /* ignored */ }
+      };
       analytics.on('record', onRecord);
+      overageGuard.on('halt', onHalt);
+      overageGuard.on('warn', onWarn);
+      overageGuard.on('resume', onResume);
       // Heartbeat every 25s — SSE comments are ignored by clients but
       // keep middle-boxes (CDNs, dev-proxies) from closing the pipe.
       const heartbeat = setInterval(() => {
@@ -1168,8 +1231,38 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
       heartbeat.unref?.();
       req.on('close', () => {
         analytics.off('record', onRecord);
+        overageGuard.off('halt', onHalt);
+        overageGuard.off('warn', onWarn);
+        overageGuard.off('resume', onResume);
         clearInterval(heartbeat);
       });
+      return;
+    }
+
+    // POST /admin/resume — clear overage-guard halt state (v4.1, dario#288).
+    // Idempotent: returns 200 with `wasHalted: false` if the proxy is
+    // already running normally. Auth gating is the same as every other
+    // endpoint (loopback-bind by default; DARIO_API_KEY needed for
+    // non-loopback). GET returns the current state for read-only queries.
+    if (urlPath === '/admin/resume' && req.method === 'GET') {
+      const state = overageGuard.state();
+      res.writeHead(200, { ...JSON_HEADERS, 'Access-Control-Allow-Origin': corsOrigin });
+      res.end(JSON.stringify({
+        halted: state !== null,
+        state,
+        config: overageGuard.config(),
+      }));
+      return;
+    }
+    if (urlPath === '/admin/resume' && req.method === 'POST') {
+      const wasHalted = overageGuard.state() !== null;
+      overageGuard.clear('manual');
+      res.writeHead(200, { ...JSON_HEADERS, 'Access-Control-Allow-Origin': corsOrigin });
+      res.end(JSON.stringify({
+        ok: true,
+        wasHalted,
+        resumedAt: new Date().toISOString(),
+      }));
       return;
     }
 
@@ -1187,6 +1280,26 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
     const targetBase = isOpenAI ? `${ANTHROPIC_API}/v1/messages?beta=true` : allowedPaths[urlPath];
     if (!targetBase) { res.writeHead(403, JSON_HEADERS); res.end(ERR_FORBIDDEN); return; }
     if (req.method !== 'POST') { res.writeHead(405, JSON_HEADERS); res.end(ERR_METHOD); return; }
+
+    // Overage-guard halt check (v4.1, dario#288). Subscribers should never
+    // see a single `representative-claim: overage` response during normal
+    // operation; one means traffic is being reclassified to per-token
+    // billing. Block upstream forwarding with a 503 + Anthropic-shaped
+    // error body until the user runs `dario resume` or the cooldown
+    // auto-expires. Health / status / analytics / admin endpoints above
+    // bypass this check intentionally — the TUI needs them to surface
+    // the halt and the user needs /admin/resume to clear it.
+    if (overageGuard.isHalted()) {
+      requestCount++;
+      const state = overageGuard.state()!;
+      writeLogLine(logFileStream, {
+        ts: new Date().toISOString(), req: requestCount,
+        method: req.method ?? '', path: urlPath, status: 503, reject: 'overage-halt',
+      });
+      res.writeHead(503, { ...JSON_HEADERS, 'Access-Control-Allow-Origin': corsOrigin });
+      res.end(JSON.stringify(buildHaltErrorBody(state)));
+      return;
+    }
 
     // Proxy to Anthropic (with concurrency control). The bounded queue
     // replaces the v3.30.x-and-earlier unbounded semaphore — dario#80. A

--- a/src/tui/proxy-client.ts
+++ b/src/tui/proxy-client.ts
@@ -93,9 +93,16 @@ export class ProxyClient {
    * Auto-reconnect is intentionally NOT included. The Hits tab decides
    * when to retry (and how often) — pushing that policy into here would
    * couple the client to UI semantics.
+   *
+   * v4.1 (dario#288): the proxy emits named events alongside the default
+   * 'message' event — `event: overage_halt`, `event: overage_warn`,
+   * `event: overage_resume`. The `eventType` passed to `onMessage` is
+   * the value of the `event:` line on the frame (or `'message'` for an
+   * unlabeled / default frame). Existing consumers that pass a
+   * single-arg callback continue to work unchanged.
    */
   subscribeAnalyticsStream<T = unknown>(
-    onMessage: (msg: T) => void,
+    onMessage: (msg: T, eventType?: string) => void,
     onError?: (err: Error) => void,
   ): () => void {
     const url = new URL(this.baseUrl + '/analytics/stream');
@@ -127,14 +134,18 @@ export class ProxyClient {
         while ((idx = buf.indexOf('\n\n')) >= 0) {
           const frame = buf.slice(0, idx);
           buf = buf.slice(idx + 2);
-          const dataLines = frame.split('\n')
+          const lines = frame.split('\n');
+          const dataLines = lines
             .filter(l => l.startsWith('data:'))
             .map(l => l.slice(5).replace(/^ /, ''));
           if (dataLines.length === 0) continue;
+          // Pull the `event:` line if present. Default is 'message' per SSE spec.
+          const eventLine = lines.find(l => l.startsWith('event:'));
+          const eventType = eventLine ? eventLine.slice(6).trim() : 'message';
           const payload = dataLines.join('\n');
           try {
             const parsed = JSON.parse(payload) as T;
-            onMessage(parsed);
+            onMessage(parsed, eventType);
           } catch (e) {
             onError?.(new Error(`SSE parse: ${(e as Error).message}`));
           }
@@ -153,11 +164,74 @@ export class ProxyClient {
     };
   }
 
+  /**
+   * Query the overage-guard state (v4.1, dario#288). Returns the current
+   * halt state + configuration. Returns null on any error so the Status
+   * tab can render "unknown" without crashing.
+   */
+  async getOverageGuard(): Promise<OverageGuardStatus | null> {
+    try { return await this.getJson<OverageGuardStatus>('/admin/resume'); }
+    catch { return null; }
+  }
+
+  /**
+   * Clear the overage-guard halt state. POSTs /admin/resume. Returns the
+   * server's response (`wasHalted` indicates whether the call actually
+   * cleared a halt vs no-op'd on already-clear state).
+   */
+  async resume(): Promise<{ ok: boolean; wasHalted: boolean; resumedAt: string }> {
+    const url = new URL(this.baseUrl + '/admin/resume');
+    return new Promise((resolve, reject) => {
+      const req = httpRequest({
+        hostname: url.hostname,
+        port: url.port || 80,
+        path: url.pathname,
+        method: 'POST',
+        headers: { ...this.headers(), 'Content-Type': 'application/json', 'Content-Length': '2' },
+      }, (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        res.on('end', () => {
+          const body = Buffer.concat(chunks).toString('utf-8');
+          if (!res.statusCode || res.statusCode < 200 || res.statusCode >= 300) {
+            reject(new Error(`HTTP ${res.statusCode}: ${body.slice(0, 200)}`));
+            return;
+          }
+          try { resolve(JSON.parse(body)); }
+          catch (e) { reject(new Error(`JSON parse: ${(e as Error).message}`)); }
+        });
+        res.on('error', reject);
+      });
+      req.on('error', reject);
+      req.setTimeout(this.timeoutMs, () => {
+        req.destroy(new Error(`timeout after ${this.timeoutMs}ms`));
+      });
+      req.write('{}');
+      req.end();
+    });
+  }
+
   private headers(): Record<string, string> {
     const h: Record<string, string> = {};
     if (this.apiKey) h['x-api-key'] = this.apiKey;
     return h;
   }
+}
+
+export interface OverageGuardStatus {
+  halted: boolean;
+  state: {
+    since: number;
+    cooldownUntil: number;
+    reason: string;
+    request: { timestamp: number; model: string; account: string; claim: string };
+  } | null;
+  config: {
+    enabled: boolean;
+    behavior: 'halt' | 'warn';
+    cooldownMs: number;
+    notifyOs: boolean;
+  };
 }
 
 export interface HealthResponse {

--- a/src/tui/tabs/analytics.ts
+++ b/src/tui/tabs/analytics.ts
@@ -153,6 +153,19 @@ export const AnalyticsTab: Tab<AnalyticsState> = {
     lines.push('  ' + pad('7d', 6) +
       fg('cyan', progressBar(s.utilization.lastUtil7d, barWidth)) +
       '  ' + dim(`${(s.utilization.lastUtil7d * 100).toFixed(0)}%`));
+    // Overage bucket (v4.1, dario#288). Count of requests that landed in
+    // the overage bucket within the rolling window. Empty bar in normal
+    // operation; non-zero count renders in red. Hard zero IS the success
+    // signal here — anything else is "investigate immediately."
+    const overageCount = s.window.billingBucketBreakdown?.extra_usage ?? 0;
+    const totalCount = Object.values(s.window.billingBucketBreakdown ?? {}).reduce((a, b) => a + b, 0);
+    const overageFrac = totalCount > 0 ? overageCount / totalCount : 0;
+    const overageColor = overageCount > 0 ? 'red' : 'cyan';
+    lines.push('  ' + pad('Overage', 6) +
+      fg(overageColor, progressBar(overageFrac, barWidth)) +
+      '  ' + (overageCount > 0
+        ? fg('red', `${overageCount} req`) + dim(` of ${totalCount}`)
+        : dim('0  ← clean')));
 
     // ── Billing buckets ───────────────────────────────────────
     const buckets = s.window.billingBucketBreakdown;

--- a/src/tui/tabs/config.ts
+++ b/src/tui/tabs/config.ts
@@ -46,18 +46,23 @@ interface FieldDef {
  * append; the tab grows automatically. Path → DarioConfig is dotted.
  */
 const FIELDS: FieldDef[] = [
-  { path: 'port',                  label: 'Port',                  type: 'number', hint: 'default 3456' },
-  { path: 'host',                  label: 'Host',                  type: 'string', hint: '127.0.0.1 (loopback only)' },
-  { path: 'stealth',               label: 'Stealth preset',        type: 'bool',   hint: 'enables behavioural pacing + jitter' },
-  { path: 'drainOnClose',          label: 'Drain on close',        type: 'bool',   hint: 'finish upstream SSE after client disconnects' },
-  { path: 'pacing.minMs',          label: 'Pacing min (ms)',       type: 'number', hint: 'min inter-request distance' },
-  { path: 'pacing.jitterMs',       label: 'Pacing jitter (ms)',    type: 'number', hint: 'uniform-random extra delay' },
-  { path: 'thinkTime.baseMs',      label: 'Think-time base (ms)',  type: 'number' },
-  { path: 'thinkTime.perTokenMs',  label: 'Think-time per-token',  type: 'number', hint: 'ms per output token of last response' },
-  { path: 'thinkTime.jitterMs',    label: 'Think-time jitter',     type: 'number' },
-  { path: 'thinkTime.maxMs',       label: 'Think-time cap (ms)',   type: 'number', hint: 'upper bound for the whole formula' },
-  { path: 'sessionStart.minMs',    label: 'Session-start min',     type: 'number', hint: 'first-request delay floor' },
-  { path: 'sessionStart.jitterMs', label: 'Session-start jitter',  type: 'number' },
+  { path: 'port',                       label: 'Port',                  type: 'number', hint: 'default 3456' },
+  { path: 'host',                       label: 'Host',                  type: 'string', hint: '127.0.0.1 (loopback only)' },
+  { path: 'stealth',                    label: 'Stealth preset',        type: 'bool',   hint: 'enables behavioural pacing + jitter' },
+  { path: 'drainOnClose',               label: 'Drain on close',        type: 'bool',   hint: 'finish upstream SSE after client disconnects' },
+  { path: 'pacing.minMs',               label: 'Pacing min (ms)',       type: 'number', hint: 'min inter-request distance' },
+  { path: 'pacing.jitterMs',            label: 'Pacing jitter (ms)',    type: 'number', hint: 'uniform-random extra delay' },
+  { path: 'thinkTime.baseMs',           label: 'Think-time base (ms)',  type: 'number' },
+  { path: 'thinkTime.perTokenMs',       label: 'Think-time per-token',  type: 'number', hint: 'ms per output token of last response' },
+  { path: 'thinkTime.jitterMs',         label: 'Think-time jitter',     type: 'number' },
+  { path: 'thinkTime.maxMs',            label: 'Think-time cap (ms)',   type: 'number', hint: 'upper bound for the whole formula' },
+  { path: 'sessionStart.minMs',         label: 'Session-start min',     type: 'number', hint: 'first-request delay floor' },
+  { path: 'sessionStart.jitterMs',      label: 'Session-start jitter',  type: 'number' },
+  // ── Overage-guard (v4.1, dario#288) ─────────────────────────
+  { path: 'overageGuard.enabled',       label: 'Overage-guard',         type: 'bool',   hint: 'halt proxy on any representative-claim=overage' },
+  { path: 'overageGuard.behavior',      label: 'Overage behavior',      type: 'string', hint: '"halt" (default) or "warn"' },
+  { path: 'overageGuard.cooldownMs',    label: 'Overage cooldown (ms)', type: 'number', hint: 'auto-resume delay; default 1800000 (30 min)' },
+  { path: 'overageGuard.notifyOs',      label: 'Overage OS-notify',     type: 'bool',   hint: 'native desktop notification on halt' },
 ];
 
 export interface ConfigState {

--- a/src/tui/tabs/hits.ts
+++ b/src/tui/tabs/hits.ts
@@ -32,11 +32,20 @@ import type { RequestRecord } from '../../analytics.js';
 
 const MAX_BUFFER = 5000;
 
+/** Live overage-halt state — populated from SSE event:overage_halt frames. */
+interface HitsHaltState {
+  since: number;
+  cooldownUntil: number;
+  request: { timestamp: number; model: string; account: string; claim: string };
+}
+
 export interface HitsState {
   buffer: RequestRecord[];   // newest LAST in the array; we render newest-first
   selectedIdx: number;       // 0 = newest; -1 = none / not yet selected
   subscribed: boolean;
   connectionError: string | null;
+  /** Overage-guard halt banner (v4.1, dario#288). Null when running normally. */
+  halt: HitsHaltState | null;
 }
 
 export const HitsTab: Tab<HitsState> = {
@@ -45,15 +54,30 @@ export const HitsTab: Tab<HitsState> = {
   hotkey: 'h',
 
   initialState(): HitsState {
-    return { buffer: [], selectedIdx: -1, subscribed: false, connectionError: null };
+    return { buffer: [], selectedIdx: -1, subscribed: false, connectionError: null, halt: null };
   },
 
   onMount(_state, ctx) {
     // Subscribe to the live stream. Each record is prepended-conceptually
     // (we push to the array and render in reverse, which keeps the
     // buffer's mutation simple — Array.push is O(1) while unshift is O(n)).
-    const close = ctx.client.subscribeAnalyticsStream<RequestRecord>(
-      (record) => {
+    //
+    // The same stream carries named events for overage-halt / -resume
+    // (v4.1, dario#288). The SSE event type is the second argument; we
+    // route on it.
+    const close = ctx.client.subscribeAnalyticsStream<unknown>(
+      (payload, eventType) => {
+        if (eventType === 'overage_halt' || eventType === 'overage_warn') {
+          const state = payload as HitsHaltState;
+          ctx.setState((s: HitsState) => ({ ...s, halt: state }));
+          return;
+        }
+        if (eventType === 'overage_resume') {
+          ctx.setState((s: HitsState) => ({ ...s, halt: null }));
+          return;
+        }
+        // Default ('message') = RequestRecord
+        const record = payload as RequestRecord;
         ctx.setState((s: HitsState) => {
           const next: HitsState = {
             ...s,
@@ -143,6 +167,17 @@ export const HitsTab: Tab<HitsState> = {
 
     lines.push(' ' + brand('Hits') +
       dim(`  ${state.buffer.length} buffered · ${state.subscribed ? fg('green', 'live') : fg('yellow', 'disconnected')}`));
+
+    // ── Overage-halt banner (v4.1, dario#288) ──────────────────
+    // Pinned at the top so it's always visible while scrolling the buffer.
+    if (state.halt) {
+      const since = formatTimestamp(state.halt.since);
+      const cooldown = formatRemaining(state.halt.cooldownUntil - Date.now());
+      const line1 = `  ${fg('red', '⚠ HALTED')}  overage detected at ${since} on ${state.halt.request.model}  (account=${state.halt.request.account})`;
+      const line2 = `  ${dim('→ New /v1/messages requests return 503 until')} ${fg('cyan', 'R')} ${dim('here, or')} ${fg('cyan', 'dario resume')}${dim(' from any shell. Auto-resume in')} ${cooldown}${dim('.')}`;
+      lines.push(line1);
+      lines.push(line2);
+    }
     lines.push('');
     // Header row (aligned with data rows)
     lines.push('  ' + dim(
@@ -156,7 +191,10 @@ export const HitsTab: Tab<HitsState> = {
 
     for (let i = startIdx; i < endIdx; i++) {
       const r = newestFirst[i];
-      const marker = i === state.selectedIdx ? fg('cyan', '▎') : ' ';
+      const isOverage = r.claim === 'overage';
+      const marker = i === state.selectedIdx ? fg('cyan', '▎')
+                   : isOverage ? fg('red', '!')
+                   : ' ';
       const row = marker + ' ' +
         pad(formatTime(r.timestamp), colTime) +
         pad(shortenModel(r.model), colModel) +
@@ -164,7 +202,13 @@ export const HitsTab: Tab<HitsState> = {
         pad(formatTokens(r.outputTokens), colOut) +
         pad(formatLatency(r.latencyMs), colLat) +
         pad(formatStatus(r.status), colStatus);
-      lines.push(i === state.selectedIdx ? inverse(truncate(row, w - 2)) : truncate(row, w - 2));
+      // Overage rows render in red even when unselected; selection still
+      // wins via the inverse() wrapper so the user can drill into one.
+      let styled: string;
+      if (i === state.selectedIdx) styled = inverse(truncate(row, w - 2));
+      else if (isOverage) styled = fg('red', truncate(row, w - 2));
+      else styled = truncate(row, w - 2);
+      lines.push(styled);
     }
 
     // Scroll hint
@@ -247,4 +291,17 @@ function tokenBreakdown(r: RequestRecord): string {
   if (r.cacheCreateTokens > 0) parts.push(`cache-create ${formatTokens(r.cacheCreateTokens)}`);
   if (r.thinkingTokens > 0) parts.push(`thinking ${r.thinkingTokens}`);
   return parts.join(' / ');
+}
+
+function formatTimestamp(ts: number): string {
+  const d = new Date(ts);
+  return `${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`;
+}
+
+function formatRemaining(ms: number): string {
+  if (ms <= 0) return fg('yellow', 'now');
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  return m < 60 ? `${m}m ${s % 60}s` : `${Math.floor(m / 60)}h ${m % 60}m`;
 }

--- a/src/tui/tabs/status.ts
+++ b/src/tui/tabs/status.ts
@@ -23,6 +23,7 @@
 import type { Tab, TabContext } from '../tab.js';
 import { fg, dim, brand } from '../render.js';
 import { renderKvRow } from '../layout.js';
+import type { OverageGuardStatus } from '../proxy-client.js';
 
 export interface StatusState {
   loading: boolean;
@@ -35,6 +36,12 @@ export interface StatusState {
   } | null;
   /** Config-file load source: file | missing | invalid. */
   configSource: 'file' | 'missing' | 'invalid' | null;
+  /** Overage-guard state from /admin/resume — null if unreachable. */
+  overageGuard: OverageGuardStatus | null;
+  /** Transient: did we just attempt a manual resume? */
+  resumePending: boolean;
+  resumeMessage: string | null;
+  resumeKind: 'success' | 'info' | 'error' | null;
   /** Last refresh timestamp (ms). */
   lastRefreshAt: number;
   /** Error from the last refresh attempt, if any. */
@@ -51,6 +58,10 @@ export const StatusTab: Tab<StatusState> = {
       loading: true,
       health: null,
       configSource: null,
+      overageGuard: null,
+      resumePending: false,
+      resumeMessage: null,
+      resumeKind: null,
       lastRefreshAt: 0,
       error: null,
     };
@@ -60,11 +71,39 @@ export const StatusTab: Tab<StatusState> = {
     return refreshStatus(ctx);
   },
 
+  onTick(state, ctx) {
+    // Drive the async side-effects that onKey can't fire directly.
+    if (state.resumePending) {
+      void performResume(ctx).then((delta) => ctx.setState(delta as Partial<StatusState>));
+      return;
+    }
+    // Poll the overage-guard state every 2s so the halt countdown stays
+    // current without the user having to press `r`. Cheap GET; the proxy
+    // is on loopback. Skip when the rest of the status is still loading.
+    if (!state.loading && state.overageGuard !== null && state.overageGuard.halted) {
+      // While halted, refresh every 2s so the countdown updates.
+      const since = Date.now() - state.lastRefreshAt;
+      if (since >= 2000) {
+        void ctx.client.getOverageGuard().then((g) => {
+          if (g) ctx.setState({ overageGuard: g, lastRefreshAt: Date.now() } as Partial<StatusState>);
+        });
+      }
+    }
+  },
+
   onKey(state, key) {
-    // `r` triggers a manual refresh by signaling the parent to call
-    // onMount again. The parent watches for a sentinel state.
+    // `r` triggers a manual refresh — signal the parent to call onMount again.
     if (key.name === 'printable' && key.ch === 'r' && !key.ctrl) {
       return { ...state, loading: true };
+    }
+    // `R` (shift-r) resumes the overage-guard halt state when one is active.
+    // Returning a sentinel state with resumePending=true signals the parent
+    // to fire the async resume() call.
+    if (key.name === 'printable' && key.ch === 'R' && !key.ctrl) {
+      if (state.overageGuard?.halted) {
+        return { ...state, resumePending: true, resumeMessage: 'Resuming…', resumeKind: 'info' };
+      }
+      return { ...state, resumeMessage: 'Nothing to resume — proxy is not halted.', resumeKind: 'info' };
     }
     return undefined;
   },
@@ -102,13 +141,52 @@ export const StatusTab: Tab<StatusState> = {
     lines.push('  ' + renderKvRow('Source', sourceLabel, w - 4));
     lines.push('');
 
+    // ── Overage-guard section (v4.1, dario#288) ────────────────
+    if (state.overageGuard) {
+      lines.push(' ' + brand('Overage-guard'));
+      if (state.overageGuard.halted && state.overageGuard.state) {
+        const s = state.overageGuard.state;
+        const remainingMs = Math.max(0, s.cooldownUntil - Date.now());
+        const remaining = formatDuration(remainingMs);
+        // Red banner header — this is the loud surface when halted
+        lines.push('  ' + fg('red', '⚠ HALTED') + '  ' + dim(`overage detected ${formatAgo(s.since)} ago`));
+        lines.push('  ' + renderKvRow('Request', `${s.request.model}  ${dim('account=' + s.request.account)}`, w - 4));
+        lines.push('  ' + renderKvRow('Cause', `representative-claim = ${fg('red', s.request.claim)}`, w - 4));
+        lines.push('  ' + renderKvRow('Auto-resume in', remaining === '0s' ? fg('yellow', 'now (cooldown elapsed)') : remaining, w - 4));
+        lines.push('  ' + renderKvRow('Manual resume', `press ${fg('cyan', 'R')} here, or ${fg('cyan', 'dario resume')} from any shell`, w - 4));
+      } else {
+        lines.push('  ' + renderKvRow('State', fg('green', 'normal'), w - 4));
+        const cfg = state.overageGuard.config;
+        lines.push('  ' + renderKvRow('Mode',
+          `${cfg.enabled ? fg('green', 'enabled') : fg('yellow', 'disabled')}  ${dim(`behavior=${cfg.behavior}  cooldown=${formatDuration(cfg.cooldownMs)}`)}`, w - 4));
+      }
+      if (state.resumeMessage) {
+        const c = state.resumeKind === 'error' ? 'red' : state.resumeKind === 'success' ? 'green' : 'cyan';
+        lines.push('  ' + fg(c, state.resumeMessage));
+      }
+      lines.push('');
+    }
+
     // ── Footer hint ────────────────────────────────────────────
     lines.push('');
-    lines.push(' ' + dim(`Last refresh: ${formatAgo(state.lastRefreshAt)}. Press ${fg('cyan', 'r')} to refresh.`));
+    const resumeHint = state.overageGuard?.halted ? ` · ${fg('cyan', 'R')} resume` : '';
+    lines.push(' ' + dim(`Last refresh: ${formatAgo(state.lastRefreshAt)}. ${fg('cyan', 'r')} refresh${resumeHint}.`));
 
     return lines.join('\n');
   },
 };
+
+function formatDuration(ms: number): string {
+  if (ms <= 0) return '0s';
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const rs = s % 60;
+  if (m < 60) return rs > 0 ? `${m}m ${rs}s` : `${m}m`;
+  const h = Math.floor(m / 60);
+  const rm = m % 60;
+  return rm > 0 ? `${h}h ${rm}m` : `${h}h`;
+}
 
 /**
  * Refresh the Status tab's data — probe /health, load config file
@@ -126,13 +204,47 @@ export async function refreshStatus(ctx: TabContext): Promise<StatusState> {
   } catch (e) {
     error = (e as Error).message;
   }
+  // Overage-guard state — best-effort; never throws (proxy-client wraps the
+  // GET in try/catch and returns null). Surface as 'unknown' when null.
+  const overageGuard = await ctx.client.getOverageGuard();
   return {
     loading: false,
     health,
     configSource: fileResult.source,
+    overageGuard,
+    resumePending: false,
+    resumeMessage: null,
+    resumeKind: null,
     lastRefreshAt: Date.now(),
     error,
   };
+}
+
+/**
+ * Fire the manual-resume POST and update state. Called by TuiApp when the
+ * Status tab returns a state with resumePending=true (the `R` key path).
+ * Lives here next to refreshStatus so all status-tab-side-effects sit
+ * together.
+ */
+export async function performResume(ctx: TabContext<StatusState>): Promise<Partial<StatusState>> {
+  try {
+    const result = await ctx.client.resume();
+    const refreshed = await ctx.client.getOverageGuard();
+    return {
+      overageGuard: refreshed,
+      resumePending: false,
+      resumeMessage: result.wasHalted
+        ? `Resumed at ${result.resumedAt}.`
+        : 'Already running normally — no-op.',
+      resumeKind: 'success',
+    };
+  } catch (e) {
+    return {
+      resumePending: false,
+      resumeMessage: `Resume failed: ${(e as Error).message}`,
+      resumeKind: 'error',
+    };
+  }
 }
 
 function formatOauth(label: string, expiresIn?: string): string {

--- a/test/notify.mjs
+++ b/test/notify.mjs
@@ -1,0 +1,82 @@
+/**
+ * test/notify.mjs
+ *
+ * Tests for the cross-platform OS notification dispatcher (dario#288, v4.1).
+ * Verifies:
+ *   - sanitize strips shell metacharacters
+ *   - notify() always writes BEL to stderr (the unconditional floor)
+ *   - captureNotifier captures calls for unit-testing other code
+ *
+ * Does NOT verify that osascript / notify-send / BurntToast actually fire —
+ * those depend on the platform + presence of the binary. The integration
+ * test is implicit: spawn() is wrapped in try/catch and an absent binary
+ * is the most common failure path, which we accept silently.
+ */
+
+import { notify, captureNotifier } from '../dist/notify.js';
+
+let pass = 0;
+let fail = 0;
+
+function assert(label, cond) {
+  if (cond) { console.log(`  ✅ ${label}`); pass++; }
+  else      { console.error(`  ❌ ${label}`); fail++; }
+}
+
+function assertEq(label, actual, expected) {
+  const ok = actual === expected;
+  if (ok) { console.log(`  ✅ ${label}`); pass++; }
+  else    { console.error(`  ❌ ${label} — expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`); fail++; }
+}
+
+// ── 1. BEL emission ────────────────────────────────────────────────
+
+{
+  console.log('notify: writes BEL char to stderr on every call');
+  const orig = process.stderr.write.bind(process.stderr);
+  let bytesWritten = '';
+  process.stderr.write = (chunk) => {
+    bytesWritten += chunk.toString();
+    return true;
+  };
+  try {
+    notify('test title', 'test message');
+    assert('stderr received the BEL char', bytesWritten.includes('\x07'));
+  } finally {
+    process.stderr.write = orig;
+  }
+}
+
+// ── 2. captureNotifier — useful test helper ────────────────────────
+
+{
+  console.log('captureNotifier: captures calls for unit testing');
+  const { notify: n, captured } = captureNotifier();
+  assertEq('captured starts empty', captured.length, 0);
+  n('title-A', 'message-A');
+  n('title-B', 'message-B');
+  assertEq('captured array length matches calls', captured.length, 2);
+  assertEq('first call title', captured[0].title, 'title-A');
+  assertEq('second call message', captured[1].message, 'message-B');
+  assert('every call has a ts timestamp', captured.every((c) => typeof c.ts === 'number'));
+}
+
+// ── 3. notify never throws on malformed input ──────────────────────
+
+{
+  console.log('notify: never throws on shell-meta input');
+  // These would break a naive AppleScript / shell string substitution.
+  // sanitize() is supposed to strip them so the spawn payload stays safe.
+  let threw = false;
+  try {
+    notify("evil`backtick`", 'message"with"quotes');
+    notify('$(rm -rf /)', "'); rm -rf / # ");
+    notify('multi\nline\rinput', 'tab\there');
+  } catch {
+    threw = true;
+  }
+  assert('no throw on hostile input', !threw);
+}
+
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);

--- a/test/overage-guard-config.mjs
+++ b/test/overage-guard-config.mjs
@@ -1,0 +1,104 @@
+/**
+ * test/overage-guard-config.mjs
+ *
+ * Config schema tests for the overageGuard cluster (dario#288, v4.1).
+ * Verifies:
+ *   - defaults: defaultConfig() exposes the v4.1 shape
+ *   - sanitize: hand-edited config.json with valid + invalid types
+ *   - mergeOver: partial overageGuard overrides preserve siblings
+ */
+
+import { defaultConfig, mergeOver, saveConfig, loadConfig } from '../dist/config-file.js';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let pass = 0;
+let fail = 0;
+
+function assert(label, cond) {
+  if (cond) { console.log(`  ✅ ${label}`); pass++; }
+  else      { console.error(`  ❌ ${label}`); fail++; }
+}
+
+function assertEq(label, actual, expected) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (ok) { console.log(`  ✅ ${label}`); pass++; }
+  else    { console.error(`  ❌ ${label} — expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`); fail++; }
+}
+
+// ── 1. defaults expose v4.1 shape ───────────────────────────────────
+
+{
+  console.log('defaultConfig: exposes v4.1 overageGuard shape');
+  const d = defaultConfig();
+  assert('has overageGuard sub-object', typeof d.overageGuard === 'object' && d.overageGuard !== null);
+  assertEq('default enabled=true (halt by default protects users)', d.overageGuard.enabled, true);
+  assertEq('default behavior=halt', d.overageGuard.behavior, 'halt');
+  assertEq('default cooldownMs=30min', d.overageGuard.cooldownMs, 30 * 60 * 1000);
+  assertEq('default notifyOs=true', d.overageGuard.notifyOs, true);
+}
+
+// ── 2. mergeOver preserves siblings on partial override ──────────────
+
+{
+  console.log('mergeOver: partial overageGuard override preserves siblings');
+  const base = defaultConfig();
+  const partial = { overageGuard: { behavior: 'warn' } };
+  const merged = mergeOver(base, partial);
+  assertEq('behavior was overridden', merged.overageGuard.behavior, 'warn');
+  assertEq('enabled preserved from default', merged.overageGuard.enabled, true);
+  assertEq('cooldownMs preserved from default', merged.overageGuard.cooldownMs, 30 * 60 * 1000);
+  assertEq('notifyOs preserved from default', merged.overageGuard.notifyOs, true);
+}
+
+// ── 3. sanitize drops invalid types, accepts valid types ─────────────
+
+{
+  console.log('sanitize: drops invalid types, accepts valid types');
+  const dir = mkdtempSync(join(tmpdir(), 'dario-overage-cfg-'));
+  const path = join(dir, 'config.json');
+  try {
+    // Write a config with a mix of valid + invalid types
+    saveConfig(path, {
+      version: 1,
+      overageGuard: {
+        enabled: 'yes',          // invalid type — should be dropped
+        behavior: 'halt',        // valid
+        cooldownMs: 60_000,      // valid
+        notifyOs: false,         // valid
+      },
+    });
+    const loaded = loadConfig(path);
+    // mergeOver fills the default for enabled (since the invalid value was dropped)
+    assertEq('invalid enabled dropped, falls back to default true', loaded.config.overageGuard.enabled, true);
+    assertEq('valid behavior preserved', loaded.config.overageGuard.behavior, 'halt');
+    assertEq('valid cooldownMs preserved', loaded.config.overageGuard.cooldownMs, 60_000);
+    assertEq('valid notifyOs preserved', loaded.config.overageGuard.notifyOs, false);
+
+    // Now write a config with an invalid behavior enum value
+    saveConfig(path, {
+      version: 1,
+      overageGuard: {
+        behavior: 'nuke-everything',   // invalid enum value
+      },
+    });
+    const loaded2 = loadConfig(path);
+    assertEq('invalid behavior enum dropped, falls back to default halt', loaded2.config.overageGuard.behavior, 'halt');
+
+    // Negative cooldownMs is invalid
+    saveConfig(path, {
+      version: 1,
+      overageGuard: {
+        cooldownMs: -1,
+      },
+    });
+    const loaded3 = loadConfig(path);
+    assertEq('negative cooldownMs dropped', loaded3.config.overageGuard.cooldownMs, 30 * 60 * 1000);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);

--- a/test/overage-guard.mjs
+++ b/test/overage-guard.mjs
@@ -1,0 +1,304 @@
+/**
+ * test/overage-guard.mjs
+ *
+ * In-process unit tests for the OverageGuard module (dario#288, v4.1).
+ * Covers:
+ *   - detection: claim=overage record triggers halt state
+ *   - halt-only-once: subsequent overage records don't re-fire the halt event
+ *   - resume manual: clear('manual') exits halted state + emits 'resume'
+ *   - resume cooldown: timer auto-clears after cooldownMs elapses
+ *   - warn-mode: no halt state, but 'warn' event fires
+ *   - isHalted() respects behavior — warn mode never reports halted
+ *   - buildHaltErrorBody shape matches Anthropic error envelope
+ *
+ * Runs without a live proxy — instantiates Analytics + OverageGuard in-process.
+ */
+
+import { Analytics } from '../dist/analytics.js';
+import { OverageGuard, buildHaltErrorBody } from '../dist/overage-guard.js';
+
+let pass = 0;
+let fail = 0;
+
+function assert(label, condition) {
+  if (condition) {
+    console.log(`  ✅ ${label}`);
+    pass++;
+  } else {
+    console.error(`  ❌ ${label}`);
+    fail++;
+  }
+}
+
+function assertEq(label, actual, expected) {
+  const ok = actual === expected;
+  if (ok) {
+    console.log(`  ✅ ${label}`);
+    pass++;
+  } else {
+    console.error(`  ❌ ${label} — expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+    fail++;
+  }
+}
+
+// ── Fixtures ───────────────────────────────────────────────────────
+
+function fakeRecord(overrides = {}) {
+  return {
+    timestamp: Date.now(),
+    account: 'default',
+    model: 'claude-opus-4-7',
+    inputTokens: 100,
+    outputTokens: 50,
+    cacheReadTokens: 0,
+    cacheCreateTokens: 0,
+    thinkingTokens: 0,
+    claim: 'five_hour',
+    util5h: 0.18,
+    util7d: 0.08,
+    overageUtil: 0,
+    latencyMs: 1234,
+    status: 200,
+    isStream: false,
+    isOpenAI: false,
+    ...overrides,
+  };
+}
+
+// ── 1. Detection — claim=overage triggers halt ─────────────────────
+
+{
+  console.log('detection: claim=overage triggers halt');
+  const analytics = new Analytics();
+  const guard = new OverageGuard({
+    enabled: true,
+    behavior: 'halt',
+    cooldownMs: 60_000,
+    notifyOs: false,
+  });
+  guard.attach(analytics);
+
+  const haltEvents = [];
+  guard.on('halt', (state) => haltEvents.push(state));
+
+  // Normal record should NOT trigger halt
+  analytics.record(fakeRecord({ claim: 'five_hour' }));
+  assertEq('normal record leaves guard clear', guard.isHalted(), false);
+  assertEq('no halt events from normal record', haltEvents.length, 0);
+
+  // Overage record triggers halt
+  analytics.record(fakeRecord({ claim: 'overage', model: 'claude-opus-4-7' }));
+  assertEq('overage record halts the guard', guard.isHalted(), true);
+  assertEq('halt event fired exactly once', haltEvents.length, 1);
+  assertEq('halt event carries triggering model', haltEvents[0].request.model, 'claude-opus-4-7');
+  assertEq('halt event carries triggering claim', haltEvents[0].request.claim, 'overage');
+  assertEq('halt reason is overage_detected', haltEvents[0].reason, 'overage_detected');
+  assert('halt state has since timestamp', typeof guard.state().since === 'number');
+  assert('halt state has cooldownUntil', guard.state().cooldownUntil > guard.state().since);
+
+  guard.destroy();
+}
+
+// ── 2. Halt only once — re-overage doesn't re-fire ─────────────────
+
+{
+  console.log('halt-only-once: subsequent overage records don\'t re-fire');
+  const analytics = new Analytics();
+  const guard = new OverageGuard({
+    enabled: true,
+    behavior: 'halt',
+    cooldownMs: 60_000,
+    notifyOs: false,
+  });
+  guard.attach(analytics);
+
+  let haltCount = 0;
+  guard.on('halt', () => haltCount++);
+
+  analytics.record(fakeRecord({ claim: 'overage' }));
+  analytics.record(fakeRecord({ claim: 'overage' }));
+  analytics.record(fakeRecord({ claim: 'overage' }));
+  assertEq('three overage records fired halt exactly once', haltCount, 1);
+
+  guard.destroy();
+}
+
+// ── 3. Resume manual — clear('manual') exits halted ────────────────
+
+{
+  console.log('resume manual: clear() exits halted and fires resume');
+  const analytics = new Analytics();
+  const guard = new OverageGuard({
+    enabled: true,
+    behavior: 'halt',
+    cooldownMs: 60_000,
+    notifyOs: false,
+  });
+  guard.attach(analytics);
+
+  const resumeEvents = [];
+  guard.on('resume', (info) => resumeEvents.push(info));
+
+  analytics.record(fakeRecord({ claim: 'overage' }));
+  assert('halted before clear', guard.isHalted());
+
+  guard.clear('manual');
+  assertEq('clear exits halted state', guard.isHalted(), false);
+  assertEq('clear fires exactly one resume event', resumeEvents.length, 1);
+  assertEq('resume event carries manual reason', resumeEvents[0].reason, 'manual');
+  assertEq('state() returns null after clear', guard.state(), null);
+
+  // Clear when not halted — no-op, no event
+  guard.clear('manual');
+  assertEq('clear-on-clear is no-op (still 1 event)', resumeEvents.length, 1);
+
+  guard.destroy();
+}
+
+// ── 4. Resume cooldown — auto-clear after timeout ──────────────────
+
+{
+  console.log('resume cooldown: auto-clear after cooldownMs');
+  const analytics = new Analytics();
+  const guard = new OverageGuard({
+    enabled: true,
+    behavior: 'halt',
+    cooldownMs: 50, // 50ms for the test
+    notifyOs: false,
+  });
+  guard.attach(analytics);
+
+  const resumeEvents = [];
+  guard.on('resume', (info) => resumeEvents.push(info));
+
+  analytics.record(fakeRecord({ claim: 'overage' }));
+  assert('halted immediately after overage', guard.isHalted());
+
+  await new Promise((r) => setTimeout(r, 120));
+  assertEq('cooldown timer cleared halt', guard.isHalted(), false);
+  assertEq('cooldown fired one resume event', resumeEvents.length, 1);
+  assertEq('resume reason is cooldown', resumeEvents[0].reason, 'cooldown');
+
+  guard.destroy();
+}
+
+// ── 5. Warn-mode — no halt, but warn event fires ───────────────────
+
+{
+  console.log('warn-mode: no halt state, but warn event fires');
+  const analytics = new Analytics();
+  const guard = new OverageGuard({
+    enabled: true,
+    behavior: 'warn',
+    cooldownMs: 60_000,
+    notifyOs: false,
+  });
+  guard.attach(analytics);
+
+  const haltEvents = [];
+  const warnEvents = [];
+  guard.on('halt', (s) => haltEvents.push(s));
+  guard.on('warn', (s) => warnEvents.push(s));
+
+  analytics.record(fakeRecord({ claim: 'overage' }));
+  assertEq('warn-mode never reports halted', guard.isHalted(), false);
+  assertEq('warn-mode does not fire halt event', haltEvents.length, 0);
+  assertEq('warn-mode fires warn event', warnEvents.length, 1);
+  assertEq('warn event payload mirrors halt-event shape', warnEvents[0].request.claim, 'overage');
+
+  guard.destroy();
+}
+
+// ── 6. Disabled guard — listener never installed ───────────────────
+
+{
+  console.log('disabled: no detection when enabled=false');
+  const analytics = new Analytics();
+  const guard = new OverageGuard({
+    enabled: false,
+    behavior: 'halt',
+    cooldownMs: 60_000,
+    notifyOs: false,
+  });
+  guard.attach(analytics);
+
+  let haltCount = 0;
+  guard.on('halt', () => haltCount++);
+
+  analytics.record(fakeRecord({ claim: 'overage' }));
+  analytics.record(fakeRecord({ claim: 'overage' }));
+  assertEq('disabled guard never halts', guard.isHalted(), false);
+  assertEq('disabled guard fires no events', haltCount, 0);
+
+  guard.destroy();
+}
+
+// ── 7. Anthropic-shaped error body ─────────────────────────────────
+
+{
+  console.log('buildHaltErrorBody: shape matches Anthropic error envelope');
+  const state = {
+    since: Date.now(),
+    cooldownUntil: Date.now() + 30 * 60 * 1000,
+    reason: 'overage_detected',
+    request: {
+      timestamp: Date.now(),
+      model: 'claude-opus-4-7',
+      account: 'default',
+      claim: 'overage',
+    },
+  };
+  const body = buildHaltErrorBody(state);
+  assertEq('top-level type is "error"', body.type, 'error');
+  assertEq('inner error.type identifies the source', body.error.type, 'dario_overage_guard');
+  assert('error.message is a string', typeof body.error.message === 'string');
+  assert('message mentions resume command', body.error.message.includes('dario resume'));
+  assert('message includes cooldown ISO timestamp', /\d{4}-\d{2}-\d{2}T/.test(body.error.message));
+}
+
+// ── 8. notifier hook — invoked on halt ─────────────────────────────
+
+{
+  console.log('notifier: called on halt with title and message');
+  const calls = [];
+  const analytics = new Analytics();
+  const guard = new OverageGuard({
+    enabled: true,
+    behavior: 'halt',
+    cooldownMs: 60_000,
+    notifyOs: true,
+    notifier: (title, message) => calls.push({ title, message }),
+  });
+  guard.attach(analytics);
+
+  analytics.record(fakeRecord({ claim: 'overage' }));
+  assertEq('notifier invoked once', calls.length, 1);
+  assert('notifier title mentions halt', calls[0].title.toLowerCase().includes('halt'));
+  assert('notifier message mentions overage', calls[0].message.toLowerCase().includes('overage'));
+
+  guard.destroy();
+}
+
+// ── 9. notifier suppressed when notifyOs=false ─────────────────────
+
+{
+  console.log('notifier: suppressed when notifyOs=false');
+  const calls = [];
+  const analytics = new Analytics();
+  const guard = new OverageGuard({
+    enabled: true,
+    behavior: 'halt',
+    cooldownMs: 60_000,
+    notifyOs: false,
+    notifier: (title, message) => calls.push({ title, message }),
+  });
+  guard.attach(analytics);
+
+  analytics.record(fakeRecord({ claim: 'overage' }));
+  assertEq('notifier not invoked', calls.length, 0);
+
+  guard.destroy();
+}
+
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

**v4.1.0 — overage-guard.** Active protection against Anthropic's billing classifier. The moment any upstream response carries `representative-claim: overage`, dario halts itself and returns 503 with an Anthropic-shaped error body to every subsequent `/v1/messages` / `/v1/complete` / `/v1/chat/completions` request.

Subscribers should never see an overage hit during normal operation — one means traffic is being reclassified to per-token billing (wire-shape drift, classifier change, account misconfig), and continuing to forward requests bleeds real money. v4 surfaced this state passively in the TUI's Hits tab; v4.1 turns that visibility into **active protection that stops bill bleed at hit #1**.

Spec / motivation: [#288](https://github.com/askalf/dario/issues/288). Closes #288.

## What ships

| Surface | Change |
|---|---|
| **New module** | `src/overage-guard.ts` — `OverageGuard` class: detect, halt, manual + cooldown resume, EventEmitter mixin for `halt` / `warn` / `resume` |
| **New module** | `src/notify.ts` — cross-platform native notification (osascript / notify-send / BurntToast) with BEL fallback. Zero new deps |
| **Proxy** | Halt-check at request entry; `POST /admin/resume` + `GET /admin/resume` (read-only state); named SSE events on `/analytics/stream` (`event: overage_halt`, `event: overage_warn`, `event: overage_resume`) |
| **CLI** | `dario resume` command; `--no-overage-guard`, `--overage-behavior=halt\|warn`, `--overage-cooldown=<ms>`, `--no-overage-notify` flags; `DARIO_OVERAGE_*` env vars; same flag > env > file > default precedence |
| **Config** | `overageGuard: { enabled, behavior, cooldownMs, notifyOs }` in `~/.dario/config.json`. Defaults: enabled=true, behavior='halt', cooldownMs=30min, notifyOs=true. Sanitize drops invalid types; mergeOver preserves siblings |
| **TUI Status tab** | Halt banner with triggering request + live countdown + `R` key to resume |
| **TUI Hits tab** | Pinned banner when halted; red row highlight for any overage-claim record (historical + live) |
| **TUI Analytics tab** | New Overage bar alongside 5h / 7d — empty in normal operation, red the moment count is non-zero |
| **TUI Config tab** | overageGuard fields registered in FIELDS |
| **proxy-client** | `subscribeAnalyticsStream` now passes `(msg, eventType)`; existing single-arg callers unchanged. New `getOverageGuard()` / `resume()` methods |

## The 503 body

When halted, every upstream request returns this — Anthropic-shaped so CC / Cursor / Aider / Cline surface the message verbatim:

```json
{
  "type": "error",
  "error": {
    "type": "dario_overage_guard",
    "message": "dario halted to prevent API-rate bleed. A request was classified as 'overage' (per-token billing) instead of your subscription pool. To resume: run `dario resume` in another terminal, or wait until <ISO ts> for the cooldown to auto-clear. Details: github.com/askalf/dario/issues/288"
  }
}
```

## Default behavior

| Decision | v4.1 default | Rationale |
|---|---|---|
| Trigger threshold | **1 hit** | Subscribers should never see overage during normal operation. One hit = something is wrong. False negatives cost real money; false positives cost one disrupted session that resumes with one command. |
| Behavior | **halt** | Strongest protection; matches the product positioning (active, not advisory) |
| Cooldown | **30 min** | Long enough to actually notice and investigate; short enough that a forgotten halt self-clears before a user is locked out for hours |
| OS notify | **on** | The TUI banner covers users with the TUI open; OS notification covers headless / backgrounded proxies |

Operators who want softer behavior have `--overage-behavior=warn` (visibility only, no 503) or `--no-overage-guard` (fully off).

## Tests

**71 baseline + 3 new files = 74 in default suite, all green.**

- `test/overage-guard.mjs` — detection, halt-once, manual + cooldown resume, warn mode, disabled mode, Anthropic error-body shape, notifier hook (called only when `notifyOs: true`)
- `test/overage-guard-config.mjs` — defaults, mergeOver preserves siblings, sanitize drops invalid types (invalid `enabled`, bad enum on `behavior`, negative `cooldownMs`)
- `test/notify.mjs` — BEL emission to stderr, `captureNotifier` helper, hostile-input safety (no throw on shell metacharacters)

The interactive TUI integration (real TTY, SSE-driven banner) follows the same coverage model as the existing TUI tabs — verified manually; automated coverage focuses on the deterministic in-process state machine.

## Zero new runtime dependencies

Verify with `npm ls --production` after merge.

## Release-pipeline effect

Merging triggers `cc-drift-auto-release.yml`:
1. Tag `v4.1.0` on the merge commit
2. Build + smoke + npm publish with SLSA provenance
3. Multi-arch Docker push to GHCR (`v4.1.0`, `v4`, `latest`)
4. GitHub release with the v4.1.0 CHANGELOG body extracted by `scripts/extract-release-notes.mjs`

## Checklist
- [x] `npm run build` passes
- [x] `npm test` passes (offline regression test, no credentials required)
- [x] For changes that touch `proxy.ts`, `cc-template.ts`, or streaming behavior: tested with `dario proxy --verbose` + `node test/compat.mjs` (requires credentials)
- [x] No new runtime dependencies added
- [x] No tokens/secrets in code or logs