### PR TITLE
docs(readme): TUI overage-guard surfaces + live e2e test

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,15 +172,24 @@ The moment any upstream response carries `representative-claim: overage`, dario 
 }
 ```
 
-The TUI's Status tab pins the loud version:
+The state surfaces in four TUI tabs simultaneously — each answers a different question a user has when their bill suddenly starts moving:
+
+| Tab | Question it answers | What it renders |
+|---|---|---|
+| **Status** | What's happening RIGHT NOW? | `⚠ HALTED` banner with triggering request, cause, live countdown to auto-resume, manual-resume hint |
+| **Hits** | Which specific request triggered it? | Pinned banner across the top + red `!` marker + red row on the triggering request in the live buffer + 503-status row for any blocked-while-halted requests |
+| **Analytics** | How often is this happening across my traffic? | New "Overage" bar in the rate-limit cluster, alongside 5h/7d — red the moment count is non-zero |
+| **Config** | How do I tune this? | Four in-place-editable fields: `overageGuard.enabled`, `.behavior` (enum-validated halt/warn), `.cooldownMs`, `.notifyOs` |
+
+Status and Hits during an active halt:
 
 ```
-┌─ dario v4 ──────────────────────────[ q quit · Tab next · ? help ]──┐
+┌─ dario v4.1 ────────────────────────[ q quit · Tab next · ? help ]──┐
 │  ▎Status▎  Config   Analytics   Hits   Accounts   Backends         │
 ├─────────────────────────────────────────────────────────────────────┤
 │  Overage-guard                                                      │
 │  ⚠ HALTED   overage detected 12s ago                                │
-│    Request:        claude-opus-4-7  account=default                 │
+│    Request:        claude-opus-4-7  account=work                    │
 │    Cause:          representative-claim = overage                   │
 │    Auto-resume in  29m 48s                                          │
 │    Manual resume   press R here, or `dario resume` from any shell   │
@@ -189,9 +198,60 @@ The TUI's Status tab pins the loud version:
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
+```
+┌─ dario v4.1 ────────────────────────[ q quit · Tab next · ? help ]──┐
+│  Status   Config   Analytics   ▎Hits▎   Accounts   Backends         │
+├─────────────────────────────────────────────────────────────────────┤
+│  Hits   248 buffered · live                                         │
+│                                                                     │
+│   ⚠ HALTED  overage detected at 15:54:28 on opus-4-7 acct=work      │
+│   → New /v1/messages return 503 until R here, or `dario resume`     │
+│                                                                     │
+│     time      model           in     out    lat     st              │
+│   ▎15:54:31  opus-4-7        2.1k   —     —      503                │
+│     15:54:29  haiku-4-5      120    24    0.3s   200                │
+│   ! 15:54:28  opus-4-7       1.4k   216   1.2s   200    ◀ red row   │
+│     15:54:25  sonnet-4-6     1.2k   480   0.8s   200                │
+│     15:54:20  opus-4-7       842    216   1.2s   200                │
+│   ──────────────────────────────────────────────────────────────    │
+│   Selected: 15:54:31  req_011Cb52VKMBsB6z6w28NvMn                   │
+│     Account:         work                                           │
+│     Model:           claude-opus-4-7                                │
+│     Billing bucket:  (halted before upstream — no claim)            │
+│     Status:          503  dario_overage_guard                       │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+Analytics — the burn-rate view, with the new Overage bar at the bottom of the rate-limit cluster (here showing one overage hit out of 248 — which is enough to halt by default):
+
+```
+┌─ dario v4.1 ────────────────────────[ q quit · Tab next · ? help ]──┐
+│  Status   Config   ▎Analytics▎   Hits   Accounts   Backends         │
+├─────────────────────────────────────────────────────────────────────┤
+│  Analytics — last 60 min                                            │
+│                                                                     │
+│   Requests:        248  (4.1/min)                                   │
+│   Tokens in:       142,830                                          │
+│   Tokens out:       38,200                                          │
+│   Subscription %:    99%                                            │
+│                                                                     │
+│  Rate-limit                                                         │
+│   5h       ████░░░░░░░░░░░░░░░░░░░░░░░░  18%                        │
+│   7d       ██░░░░░░░░░░░░░░░░░░░░░░░░░░   8%                        │
+│   Overage  █░░░░░░░░░░░░░░░░░░░░░░░░░░░   1 req of 248              │
+│            ⮤ red — the moment count is non-zero                     │
+│                                                                     │
+│  Billing                                                            │
+│   subscription           247 req                                    │
+│   extra_usage              1 req                                    │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
 Why "halt at hit #1" is the right default: subscribers should never see a single overage response during normal operation. One means something is wrong — wire-shape drift, classifier change, account misconfig — and continuing to forward requests in the same shape bleeds real money for accounts with extra-usage enabled, or returns wall-of-rejections for accounts without it. The first hit is the signal; the second through hundredth are damage.
 
 **Resume paths** — `dario resume` from any shell, `R` on the TUI Status tab, or the cooldown timer (default 30 min). **Configuration** — `~/.dario/config.json` → `overageGuard`, or CLI flags (`--overage-behavior=warn` for visibility-only, `--no-overage-guard` to disable, `--overage-cooldown=<ms>` to tune). **OS notification** — best-effort native toast (osascript / notify-send / BurntToast) plus terminal BEL as the unconditional floor. See [#288](https://github.com/askalf/dario/issues/288).
+
+**Verified end-to-end live.** [`test/overage-guard-e2e-live.mjs`](./test/overage-guard-e2e-live.mjs) patches `globalThis.fetch` to mock the upstream, starts a real dario proxy in-process, and drives the five-stage halt cycle through real HTTP: subscription request flows → upstream returns overage → guard halts → next request returns 503 with the `dario_overage_guard` body → `POST /admin/resume` clears state → requests flow again. 20/20 assertions, 3 upstream calls intercepted (the halted request short-circuited at the request handler, never touched the upstream). Run with `node test/overage-guard-e2e-live.mjs`.
 
 ---
 

--- a/test/all.test.mjs
+++ b/test/all.test.mjs
@@ -46,6 +46,9 @@ const EXCLUDED = new Set([
   'infra-probe.mjs',
   'compat.mjs',
   'stealth-test.mjs',
+  // Live in-process e2e — patches global fetch and starts a real proxy.
+  // Run manually with: node test/overage-guard-e2e-live.mjs (dario#288).
+  'overage-guard-e2e-live.mjs',
 ]);
 
 const files = readdirSync(__dirname)

--- a/test/overage-guard-e2e-live.mjs
+++ b/test/overage-guard-e2e-live.mjs
@@ -35,21 +35,29 @@ let upstreamMode = 'subscription'; // 'subscription' | 'overage'
 let upstreamCalls = 0;
 
 globalThis.fetch = async function patchedFetch(input, init = {}) {
-  const url = typeof input === 'string' ? input : (input?.url ?? String(input));
+  const rawUrl = typeof input === 'string' ? input : (input?.url ?? String(input));
+  // Parse properly to avoid the substring-sanitization trap: `url.includes(
+  // 'api.anthropic.com')` would match `https://evil.com/api.anthropic.com.fake`
+  // and any other URL with that string anywhere. Exact-host match instead.
+  // CodeQL: js/incomplete-url-substring-sanitization (alert #20 on PR #291).
+  let parsed;
+  try { parsed = new URL(rawUrl); } catch { parsed = null; }
+  const host = parsed?.hostname ?? '';
+  const path = parsed?.pathname ?? '';
 
   // Catch outbound calls to api.anthropic.com — these are the ones the
   // proxy makes on behalf of clients (the path we want to mock).
-  if (url.includes('api.anthropic.com')) {
+  if (host === 'api.anthropic.com') {
     upstreamCalls++;
 
     // /v1/code/sessions/.../client/presence — heartbeat. Return empty 200.
-    if (url.includes('/client/presence')) {
+    if (path.endsWith('/client/presence')) {
       return new Response('', { status: 200 });
     }
 
     // /v1/messages — the real path. Return a synthetic Anthropic response
     // with the chosen claim header.
-    if (url.includes('/v1/messages')) {
+    if (path === '/v1/messages') {
       const body = JSON.stringify({
         id: 'msg_test_e2e',
         type: 'message',

--- a/test/overage-guard-e2e-live.mjs
+++ b/test/overage-guard-e2e-live.mjs
@@ -1,0 +1,224 @@
+/**
+ * test/overage-guard-e2e-live.mjs
+ *
+ * Live end-to-end test of the overage-guard halt cycle.
+ *
+ * The unit tests (test/overage-guard.mjs) cover the OverageGuard class's
+ * internal state machine. This test exercises the FULL pipeline against
+ * a real proxy:
+ *
+ *   1. Monkey-patch globalThis.fetch BEFORE importing the proxy so the
+ *      proxy's outbound calls hit a synthetic upstream we control.
+ *   2. Start a real dario proxy on a test port with the bundled template
+ *      (no live CC capture).
+ *   3. Drive real HTTP requests through the proxy and verify:
+ *        a) normal subscription request → 200, halt=false
+ *        b) upstream returns overage → request still 200 (upstream succeeded)
+ *           but guard transitions to halted state via analytics record
+ *        c) subsequent request → 503 with Anthropic-shaped dario_overage_guard body
+ *        d) POST /admin/resume → wasHalted=true, state cleared
+ *        e) post-resume request → 200 again
+ *
+ * Excluded from the default `npm test` runner (filename ends in
+ * `-e2e-live.mjs` rather than `.mjs`-only; test/all.test.mjs scans for
+ * filename matches). Run with:
+ *
+ *   npm run build && node test/overage-guard-e2e-live.mjs
+ */
+
+import { setTimeout as sleep } from 'node:timers/promises';
+
+// ── Step 1: Patch globalThis.fetch BEFORE importing the proxy ─────────
+
+const realFetch = globalThis.fetch;
+let upstreamMode = 'subscription'; // 'subscription' | 'overage'
+let upstreamCalls = 0;
+
+globalThis.fetch = async function patchedFetch(input, init = {}) {
+  const url = typeof input === 'string' ? input : (input?.url ?? String(input));
+
+  // Catch outbound calls to api.anthropic.com — these are the ones the
+  // proxy makes on behalf of clients (the path we want to mock).
+  if (url.includes('api.anthropic.com')) {
+    upstreamCalls++;
+
+    // /v1/code/sessions/.../client/presence — heartbeat. Return empty 200.
+    if (url.includes('/client/presence')) {
+      return new Response('', { status: 200 });
+    }
+
+    // /v1/messages — the real path. Return a synthetic Anthropic response
+    // with the chosen claim header.
+    if (url.includes('/v1/messages')) {
+      const body = JSON.stringify({
+        id: 'msg_test_e2e',
+        type: 'message',
+        role: 'assistant',
+        model: 'claude-haiku-4-5-20251001',
+        content: [{ type: 'text', text: `E2E synthetic response (mode=${upstreamMode})` }],
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+      });
+      const headers = new Headers({
+        'content-type': 'application/json',
+        'anthropic-ratelimit-unified-representative-claim': upstreamMode === 'overage' ? 'overage' : 'five_hour',
+        'anthropic-ratelimit-unified-status': 'allowed',
+        'anthropic-ratelimit-unified-5h-utilization': '0.1',
+        'anthropic-ratelimit-unified-7d-utilization': '0.05',
+        'anthropic-ratelimit-unified-overage-status': 'available',
+      });
+      return new Response(body, { status: 200, headers });
+    }
+
+    // Any other anthropic path — return a minimal 200 so the proxy doesn't
+    // crash on an unexpected outbound call.
+    return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+  }
+
+  // Anything else (oauth.claude.com, our own loopback /v1/messages from
+  // the test driver below, etc.) passes through to the real fetch.
+  return realFetch(input, init);
+};
+
+// ── Step 2: Start the proxy ───────────────────────────────────────────
+
+// Imported AFTER the fetch patch so any module-level fetch references
+// inside dist/proxy.js resolve through the patched function.
+const { startProxy } = await import('../dist/proxy.js');
+const TEST_PORT = 13456;
+
+await startProxy({
+  port: TEST_PORT,
+  host: '127.0.0.1',
+  noLiveCapture: true, // skip the CC binary capture; use bundled template
+  overageGuardEnabled: true,
+  overageGuardBehavior: 'halt',
+  overageGuardCooldownMs: 5000, // shorter for the test
+  overageGuardNotifyOs: false,  // no native toast during the test
+});
+
+console.log(`\n[e2e] proxy started on http://127.0.0.1:${TEST_PORT}\n`);
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+const BASE = `http://127.0.0.1:${TEST_PORT}`;
+
+async function post(path, body = {}) {
+  // Use realFetch so the test client's outbound call to localhost doesn't
+  // get caught by our mock (it wouldn't anyway since the host check
+  // excludes localhost, but be explicit).
+  return realFetch(`${BASE}${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+async function get(path) {
+  return realFetch(`${BASE}${path}`);
+}
+async function postMessages() {
+  return post('/v1/messages', {
+    model: 'claude-haiku-4-5',
+    max_tokens: 50,
+    messages: [{ role: 'user', content: 'hi' }],
+  });
+}
+
+let pass = 0, fail = 0;
+function check(label, cond) {
+  if (cond) { console.log(`  ✅ ${label}`); pass++; }
+  else      { console.error(`  ❌ ${label}`); fail++; }
+}
+function checkEq(label, actual, expected) {
+  const ok = actual === expected;
+  if (ok) { console.log(`  ✅ ${label}`); pass++; }
+  else    { console.error(`  ❌ ${label} — expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`); fail++; }
+}
+
+// ── STAGE 1: normal subscription request flows ───────────────────────
+
+console.log('=== STAGE 1: normal subscription request ===');
+upstreamMode = 'subscription';
+const r1 = await postMessages();
+checkEq('r1 status 200', r1.status, 200);
+const r1Body = await r1.json();
+check('r1 body.content[0].text contains E2E', r1Body?.content?.[0]?.text?.includes('E2E'));
+
+// Wait for analytics to settle and the guard to (not) react.
+await sleep(300);
+
+const guard1 = await get('/admin/resume').then(r => r.json());
+checkEq('after subscription request, halted=false', guard1.halted, false);
+checkEq('after subscription request, state=null', guard1.state, null);
+
+// ── STAGE 2: upstream returns overage → guard halts ──────────────────
+
+console.log('\n=== STAGE 2: upstream returns overage → guard halts ===');
+upstreamMode = 'overage';
+
+const r2 = await postMessages();
+// The triggering request itself returns normally — the response is
+// already on the wire by the time analytics records the claim.
+checkEq('r2 (triggering) status 200', r2.status, 200);
+
+// Wait for the analytics record → guard halt transition.
+await sleep(300);
+
+const guard2 = await get('/admin/resume').then(r => r.json());
+checkEq('after overage record, halted=true', guard2.halted, true);
+checkEq('halt reason=overage_detected', guard2.state?.reason, 'overage_detected');
+checkEq('halt request.claim=overage', guard2.state?.request?.claim, 'overage');
+
+// ── STAGE 3: subsequent /v1/messages → 503 ───────────────────────────
+
+console.log('\n=== STAGE 3: halted proxy returns 503 ===');
+const r3 = await postMessages();
+checkEq('r3 status 503 (halted)', r3.status, 503);
+const r3Body = await r3.json();
+checkEq('503 body.type=error', r3Body.type, 'error');
+checkEq('503 body.error.type=dario_overage_guard', r3Body.error?.type, 'dario_overage_guard');
+check('503 body.error.message mentions dario resume',
+  typeof r3Body.error?.message === 'string' && r3Body.error.message.includes('dario resume'));
+
+// Confirm the upstream was NOT hit for the halted request — the proxy
+// short-circuited at the request handler.
+const upstreamCountBeforeResume = upstreamCalls;
+
+// ── STAGE 4: POST /admin/resume clears halt ──────────────────────────
+
+console.log('\n=== STAGE 4: POST /admin/resume clears the halt ===');
+const resume = await post('/admin/resume', {});
+checkEq('resume status 200', resume.status, 200);
+const resumeBody = await resume.json();
+checkEq('resume.ok=true', resumeBody.ok, true);
+checkEq('resume.wasHalted=true', resumeBody.wasHalted, true);
+
+const guard4 = await get('/admin/resume').then(r => r.json());
+checkEq('after resume, halted=false', guard4.halted, false);
+checkEq('after resume, state=null', guard4.state, null);
+
+// ── STAGE 5: requests flow again post-resume ─────────────────────────
+
+console.log('\n=== STAGE 5: requests flow after resume ===');
+upstreamMode = 'subscription'; // flip back to normal upstream
+const r5 = await postMessages();
+checkEq('post-resume request returns 200', r5.status, 200);
+const r5Body = await r5.json();
+check('post-resume body.content[0].text reflects mode=subscription',
+  r5Body?.content?.[0]?.text?.includes('mode=subscription'));
+
+// Verify the post-resume request HIT the upstream (proxy is no longer
+// short-circuiting at the halt check).
+check('upstream count increased after resume',
+  upstreamCalls > upstreamCountBeforeResume);
+
+// ── Done ─────────────────────────────────────────────────────────────
+
+console.log(`\n${pass} pass, ${fail} fail  ·  ${upstreamCalls} upstream calls intercepted`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Expands the v4.1 overage-guard section of the README so all four wired-in TUI surfaces are visible (Status / Hits / Analytics / Config) and ships the live e2e test that's been running locally as a permanent regression file.

Docs + test infra only — **no package.json bump → no auto-release fires**. GitHub master gets the updated README + new test file; npm-published README stays on v4.1.1 until the next legitimate release.

## What's in this PR

### README changes (+66 lines, 1 file)

1. **Per-tab wiring table** — maps each TUI surface to the user question it answers:

   | Tab | Question | What renders |
   |---|---|---|
   | Status | What's happening RIGHT NOW? | Halt banner + countdown + resume hint |
   | Hits | Which request triggered it? | Pinned banner + red row + 503 status rows |
   | Analytics | How often across my traffic? | Overage bar in rate-limit cluster |
   | Config | How do I tune it? | 4 editable fields with enum validation |

2. **New Hits-tab mockup** showing the pinned halt banner + red `!` marker on the triggering request + 503-status row for the request blocked while halted.

3. **New Analytics-tab mockup** showing the Overage bar in the rate-limit cluster (sits alongside 5h / 7d; red the moment count is non-zero).

4. **Closing paragraph** referencing the live e2e and what it proves — turns the "trust the code" claim into "here's the test you can re-run to verify it works on your machine."

### New test file (test/overage-guard-e2e-live.mjs, 200 lines)

Patches `globalThis.fetch` BEFORE importing the proxy, starts a real dario proxy in-process on port 13456, drives the full halt cycle through real HTTP:

```
=== STAGE 1: normal subscription request ===
  ✅ r1 status 200
  ✅ r1 body.content[0].text contains E2E
  ✅ after subscription request, halted=false
  ✅ after subscription request, state=null

=== STAGE 2: upstream returns overage → guard halts ===
  ✅ r2 (triggering) status 200
  ✅ after overage record, halted=true
  ✅ halt reason=overage_detected
  ✅ halt request.claim=overage

=== STAGE 3: halted proxy returns 503 ===
  ✅ r3 status 503 (halted)
  ✅ 503 body.type=error
  ✅ 503 body.error.type=dario_overage_guard
  ✅ 503 body.error.message mentions dario resume

=== STAGE 4: POST /admin/resume clears the halt ===
  ✅ resume status 200
  ✅ resume.ok=true
  ✅ resume.wasHalted=true
  ✅ after resume, halted=false
  ✅ after resume, state=null

=== STAGE 5: requests flow after resume ===
  ✅ post-resume request returns 200
  ✅ post-resume body.content[0].text reflects mode=subscription
  ✅ upstream count increased after resume

20 pass, 0 fail  ·  3 upstream calls intercepted
```

3 upstream calls intercepted (not 4) — the halted request short-circuited at the request handler, never touched upstream. That's the whole product story.

### test/all.test.mjs

Added `overage-guard-e2e-live.mjs` to the `EXCLUDED` set so the default `npm test` runner doesn't spawn it (it patches global fetch + starts a real proxy on a port; not a unit test).

## Run the e2e yourself

```bash
npm run build
node test/overage-guard-e2e-live.mjs
```

## Why no version bump

This PR is README + new test scaffolding only. The product (overage-guard module, halt enforcement, /admin/resume endpoint, CLI command, TUI tabs) all shipped in v4.1.0 and was polished in v4.1.1. This PR adds zero new product surface — it documents what's there and locks in the regression test. Bumping the patch number for a pure docs+test PR would burn CHANGELOG / npm / GHCR / SLSA cycles for no user-visible change.

When the next release naturally happens (next CC drift / new feature / next polish batch), npm's bundled README will pick up the new content automatically. Until then, GitHub master diverges by ~60 lines of README content from the npm-bundled version.

## Checklist
- [x] `npm run build` passes
- [x] `npm test` passes (offline regression test, no credentials required)
- [ ] For changes that touch `proxy.ts`, `cc-template.ts`, or streaming behavior: tested with `dario proxy --verbose` + `node test/compat.mjs` (requires credentials) — _N/A: docs + new e2e test, proxy.ts unchanged_
- [x] No new runtime dependencies added
- [x] No tokens/secrets in code or logs