### PR TITLE
docs(readme): pre-launch tightening — Discord + askalf platform framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   <a href="https://github.com/askalf/dario/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/@askalf/dario" alt="License"></a>
   <a href="https://www.npmjs.com/package/@askalf/dario"><img src="https://img.shields.io/npm/dm/@askalf/dario" alt="Downloads"></a>
   <a href="https://x.com/ask_alf"><img src="https://img.shields.io/badge/follow-@ask_alf-1da1f2?style=flat-square" alt="Follow on X"></a>
+  <a href="https://discord.gg/fENVZpdYcX"><img src="https://img.shields.io/badge/discord-join-5865f2?style=flat-square&logo=discord&logoColor=white" alt="Join Discord"></a>
 </p>
 
 <p align="center"><em>Zero runtime dependencies · <a href="https://www.npmjs.com/package/@askalf/dario">SLSA-attested</a> every release · nothing phones home · ~17.5k lines you can read in a weekend · independent, unofficial, third-party (<a href="DISCLAIMER.md">DISCLAIMER.md</a>)</em></p>
@@ -369,7 +370,7 @@ cd $(npm root -g)/@askalf/dario && npm ls --production
 
 **Best fit:** developers juggling multiple LLM tools and per-tool API keys · Claude Pro/Max subscribers who want their plan usable everywhere, not just in Claude Code · teams running local/hosted OpenAI-compat servers who want one stable local endpoint · Agent SDK users who want OAuth-subscription routing with zero code change (`baseURL: 'http://localhost:3456'`) · power users wanting multi-account pooling + 429 failover on their own machine.
 
-**Not a fit:** you need vendor-managed production SLAs (use the provider APIs) · you need a hosted multi-tenant platform with a dashboard and team auth (that's the [askalf platform](https://askalf.org)) · you want a chat UI (use claude.ai).
+**Not a fit:** you need vendor-managed production SLAs (use the provider APIs) · you want a hosted, multi-tenant team platform with dashboard / SSO / audit logs (that's coming — the [askalf platform](https://askalf.org) is in active development, shipping soon) · you want a chat UI (use claude.ai).
 
 ---
 
@@ -465,7 +466,7 @@ How to contribute to that record:
 - **File drift.** Open an issue when your rate-limit header flips, when a tool you used yesterday breaks today, when a CC release lands without a wire-level note. We document it in public alongside the fix.
 - **Share the install line.** Slack channel, group chat, the next Cursor/Aider/Cline user who's quietly paying their second bill. Pricing-aware proxying is a baseline subscriber capability, not a privilege.
 
-Follow [@ask_alf](https://x.com/ask_alf) for drift bulletins as they happen.
+Follow [@ask_alf](https://x.com/ask_alf) for drift bulletins as they happen. Join the [Discord](https://discord.gg/fENVZpdYcX) for the receipt-log community + early access to the [askalf platform](https://askalf.org) — a self-hosted AI workforce that builds on dario, shipping soon.
 
 ---
 


### PR DESCRIPTION
## Summary

Three small README edits before this weeks HN/Reddit launch. The launch funnel uses Discord as the active capture mechanism (since askalf.org is currently a holding page); without these edits, dario readers had no path into the community.

## What changes

### 1. Top badges row — add Discord badge

After the `@ask_alf` X badge, add a Discord-purple badge that links to discord.gg/fENVZpdYcX. Visitors see the community link in the first scroll.

### 2. Soften the askalf platform mention

**Before** (line 372, Not a fit section):
> "you need a hosted multi-tenant platform with a dashboard and team auth (thats the [askalf platform](https://askalf.org))"

**After:**
> "you want a hosted, multi-tenant team platform with dashboard / SSO / audit logs (thats coming — the [askalf platform](https://askalf.org) is in active development, shipping soon)"

Honest about state. Sets expectations for HN readers who click the link and land on a holding page.

### 3. Extend the receipt-log footer with Discord + platform link

**Before** (last line of "Be part of the receipt log" section):
> Follow [@ask_alf](https://x.com/ask_alf) for drift bulletins as they happen.

**After:**
> Follow [@ask_alf](https://x.com/ask_alf) for drift bulletins as they happen. Join the [Discord](https://discord.gg/fENVZpdYcX) for the receipt-log community + early access to the [askalf platform](https://askalf.org) — a self-hosted AI workforce that builds on dario, shipping soon.

For a reader whos reached the bottom of the README looking for "what now?", this is the dominant CTA paragraph. Three options (X follow / Discord / platform waitlist), all with clear semantics.

## Whats NOT in this PR

- No version bump
- No new TS code
- No test changes
- No CHANGELOG entry (its a docs-only nudge, not user-facing functionality)

## Tests

74/74 default suite green. Build clean.

## Diff stat

```
 1 file changed, 3 insertions(+), 2 deletions(-)
```

The README content moved by about 3 lines. The structural shape is unchanged.

## Checklist
- [x] `npm run build` passes
- [x] `npm test` passes (offline regression test, no credentials required)
- [ ] For changes that touch `proxy.ts`, `cc-template.ts`, or streaming behavior: tested with `dario proxy --verbose` + `node test/compat.mjs` (requires credentials) — _N/A: README-only_
- [x] No new runtime dependencies added
- [x] No tokens/secrets in code or logs