### PR TITLE
docs(readme): temporarily hide Discord references until channels are set up

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://github.com/askalf/dario/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/@askalf/dario" alt="License"></a>
   <a href="https://www.npmjs.com/package/@askalf/dario"><img src="https://img.shields.io/npm/dm/@askalf/dario" alt="Downloads"></a>
   <a href="https://x.com/ask_alf"><img src="https://img.shields.io/badge/follow-@ask_alf-1da1f2?style=flat-square" alt="Follow on X"></a>
-  <a href="https://discord.gg/fENVZpdYcX"><img src="https://img.shields.io/badge/discord-join-5865f2?style=flat-square&logo=discord&logoColor=white" alt="Join Discord"></a>
+  <!-- <a href="https://discord.gg/fENVZpdYcX"><img src="https://img.shields.io/badge/discord-join-5865f2?style=flat-square&logo=discord&logoColor=white" alt="Join Discord"></a> -->
 </p>
 
 <p align="center"><em>Zero runtime dependencies · <a href="https://www.npmjs.com/package/@askalf/dario">SLSA-attested</a> every release · nothing phones home · ~17.5k lines you can read in a weekend · independent, unofficial, third-party (<a href="DISCLAIMER.md">DISCLAIMER.md</a>)</em></p>
@@ -466,7 +466,7 @@ How to contribute to that record:
 - **File drift.** Open an issue when your rate-limit header flips, when a tool you used yesterday breaks today, when a CC release lands without a wire-level note. We document it in public alongside the fix.
 - **Share the install line.** Slack channel, group chat, the next Cursor/Aider/Cline user who's quietly paying their second bill. Pricing-aware proxying is a baseline subscriber capability, not a privilege.
 
-Follow [@ask_alf](https://x.com/ask_alf) for drift bulletins as they happen. Join the [Discord](https://discord.gg/fENVZpdYcX) for the receipt-log community + early access to the [askalf platform](https://askalf.org) — a self-hosted AI workforce that builds on dario, shipping soon.
+Follow [@ask_alf](https://x.com/ask_alf) for drift bulletins as they happen. The [askalf platform](https://askalf.org) — a self-hosted AI workforce that builds on dario — is shipping soon.
 
 ---
 


### PR DESCRIPTION
## Summary

Defers the README Discord mentions until you have a chance to set up channels + welcome flow tonight/tomorrow. A bare Discord at HN-launch time would bounce new members; better to not link to it publicly until the destination is polished.

Reverses both Discord mentions added in #296:

1. **Top badges row** — Discord badge wrapped in an HTML comment (one-line uncomment when ready)
2. **Receipt-log footer** — removed the Discord clause; kept @ask_alf follow + askalf platform shipping-soon mention

## Re-enabling later

Two edits:

1. Uncomment line 13 (the Discord badge HTML comment)
2. Restore the footer to the v4.1.1 version:
   > Follow [@ask_alf](https://x.com/ask_alf) for drift bulletins as they happen. Join the [Discord](https://discord.gg/fENVZpdYcX) for the receipt-log community + early access to the [askalf platform](https://askalf.org) — a self-hosted AI workforce that builds on dario, shipping soon.

## Tests

74/74 default suite green. No code change.

## Checklist
- [x] `npm run build` passes
- [x] `npm test` passes (offline regression test, no credentials required)
- [ ] For changes that touch `proxy.ts`, `cc-template.ts`, or streaming behavior: tested with `dario proxy --verbose` + `node test/compat.mjs` (requires credentials) — _N/A: README-only_
- [x] No new runtime dependencies added
- [x] No tokens/secrets in code or logs