### PR TITLE
docs(readme): principled prefix + The Principle section

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@
 
 ---
 
+**Anthropic ships restrictions to subscribers through wire-shape changes that don't appear in any user-facing changelog. dario makes them visible.** The hourly drift watcher catches each silent change, the public PR record names what shifted and when, and the proxy keeps your subscription doing what it did yesterday until you choose otherwise. Receipts below.
+
 You're already paying $20, $100, or $200 a month for Claude. Then Cursor wants an API key. Aider wants an API key. Cline, Continue, Zed, your scripts — every one of them bills you **again**, per token, while the subscription you already bought sits idle in Claude Code.
 
 **dario is one local endpoint that routes all of them through the Claude subscription you already pay for.** Point any Anthropic- or OpenAI-compatible tool at `http://localhost:3456` and you're done. No per-tool config, no second bill.
-
-And — increasingly — dario is the only layer that keeps your subscription doing what it did yesterday. **Anthropic ships restrictions to subscribers through wire-shape changes that don't appear in any user-facing changelog.** dario detects those changes within the hour, ships fixes within minutes, and rebuilds your tool's request into the shape Claude Code's billing classifier expects. Receipts below.
 
 ```bash
 npm install -g @askalf/dario
@@ -115,6 +115,21 @@ dario doesn't. Every outbound request is rebuilt into **interactive Claude Code 
 | Claude Code, interactive | subscription pool — unchanged |
 
 Same install, same `localhost:3456`, no config change for the cliff. Verify on your own machine: `dario doctor --usage` fires one request and surfaces the rate-limit headers — `representative-claim` should read `five_hour` or `seven_day` (subscription buckets). Full breakdown: [`docs/why-now-2026-06.md`](./docs/why-now-2026-06.md).
+
+---
+
+## The principle dario operates on
+
+Two layers, separated:
+
+1. **Tiered pricing is fine.** Anthropic can charge differently for first-party use vs. third-party use. Every SaaS does this.
+2. **Hiding the tier from the customer is not.** When the public docs page says "1M context available on Sonnet/Opus" but the auth layer rejects every attempt to access it on the OAuth path most subscribers use — when the billing classifier silently flips your request to overage without saying which signal triggered it — that's information asymmetry weaponized into product design.
+
+OpenAI does this cleanly: ChatGPT Plus is a chat product, the API is a separate metered product, you choose. Anthropic uses one URL and a hidden classifier. **dario's job is to make the classifier visible.**
+
+We don't bypass auth. We don't fake who you are. We replay the exact wire shape Claude Code emits — captured live from your installed binary — so the classifier sees what it expects. That's a transparency tool, not a circumvention tool. Your subscription is doing what your subscription does; you're authenticating as you.
+
+This is also why every dario release ships receipts: the [eight-signal classifier table](https://github.com/askalf/dario/discussions/13), the [drift watch records](.github/workflows/cc-drift-watch.yml), the auto-PR history. Anthropic doesn't publish what their classifier reads. dario does.
 
 ---
 


### PR DESCRIPTION
## Summary

Two coordinated README additions that establish the principled position dario operates from before the technical pitch. Sets up HN/Reddit/share readers to understand WHY dario exists before the WHAT.

Driven by the launch-prep conversation: dario is strongest when it leads with the principle (visibility, not circumvention) and lets the receipts back it up. The current README leads with the practical pitch (your subscription, in any tool); this PR adds principled framing AROUND that pitch so the principled and the practical reinforce each other.

## Change 1 — principled prefix at the top of the README

Three-sentence opener inserted before the existing "you are already paying $20/100/200" pitch:

> **Anthropic ships restrictions to subscribers through wire-shape changes that do not appear in any user-facing changelog. dario makes them visible.** The hourly drift watcher catches each silent change, the public PR record names what shifted and when, and the proxy keeps your subscription doing what it did yesterday until you choose otherwise. Receipts below.

Reorders the opening so the principle reads first. Old paragraph beginning "And — increasingly — dario is the only layer that keeps your subscription doing what it did yesterday" is removed because the new prefix supersedes it (was redundant).

## Change 2 — new section "The principle dario operates on"

Sits between the 2026-06-15 deadline section and the "What Anthropic shipped this month" receipt table.

Articulates the position in two layers:

1. **Tiered pricing is fine.** Anthropic can charge differently for first-party vs. third-party use. Every SaaS does this.
2. **Hiding the tier from the customer is not.** When the docs page says "1M context" but the auth layer rejects every OAuth attempt to access it — when the billing classifier silently flips your request to overage without naming which signal triggered it — that is information asymmetry weaponized into product design.

Names the OpenAI contrast (ChatGPT Plus + API as two clean products) vs. Anthropic single-URL-with-hidden-classifier, then states dario role:

> We do not bypass auth. We do not fake who you are. We replay the exact wire shape Claude Code emits — captured live from your installed binary — so the classifier sees what it expects. **That is a transparency tool, not a circumvention tool.**

Closes by cross-referencing Discussion #13 (the 8-signal classifier table) and the drift-watch workflow.

## What this is NOT

- **Not a manifesto.** The word "movement" does not appear in the new copy. Receipts carry the framing without rhetoric.
- **Not an accusation.** Intent is never claimed. Effect is described from observable behavior.
- **Not a pivot.** Same product, same code, same scope. Sharpened argument.

## Tests

74/74 default suite green. No code change. Pure README work.

## Diff stat

```
 1 file changed, 17 insertions(+), 2 deletions(-)
```

## Checklist
- [x] `npm run build` passes
- [x] `npm test` passes (offline regression test, no credentials required)
- [ ] For changes that touch `proxy.ts`, `cc-template.ts`, or streaming behavior: tested with `dario proxy --verbose` + `node test/compat.mjs` (requires credentials) — _N/A: README-only_
- [x] No new runtime dependencies added
- [x] No tokens/secrets in code or logs