### PR TITLE
docs(drift-monitor): document gh CLI + label-create prereqs

### DIFF
--- a/docs/drift-monitor.md
+++ b/docs/drift-monitor.md
@@ -66,17 +66,34 @@ including `node_modules`).
 curl -fsSL https://deb.nodesource.com/setup_22.x | sudo bash -
 sudo apt-get install -y nodejs
 
-# 2. CC + dario CLI (dario provides the headless OAuth flow)
+# 2. GitHub CLI (`gh`) — the workflow's issue-open step shells out to it.
+#    Without this, --check correctly detects drift but the "Open / update
+#    drift issue" step fails with `gh: command not found`.
+sudo apt-get install -y gh   # or follow https://github.com/cli/cli#installation
+
+# 3. CC + dario CLI (dario provides the headless OAuth flow)
 sudo npm i -g @anthropic-ai/claude-code @askalf/dario
 
-# 3. OAuth — manual flow for headless boxes. Run from the host's shell,
+# 4. OAuth — manual flow for headless boxes. Run from the host's shell,
 #    follow the printed URL in any browser, paste the post-login callback
 #    URL back into the SSH session. Drops a credentials file at
 #    ~/.claude/.credentials.json.
 dario login --manual
 
-# 4. Smoke test
+# 5. Smoke test
 echo "Reply with PONG" | claude --print     # should print PONG
+```
+
+### One-time repo setup
+
+The workflow's issue-open step calls `gh issue create --label cc-drift-template`
+which fails if the label doesn't exist in the repo. Create it once before the
+runner's first execution:
+
+```bash
+gh label create cc-drift-template \
+  --description "Bundled CC template has drifted from live capture" \
+  --color FBCA04
 ```
 
 ### Register the runner


### PR DESCRIPTION
## What does this PR do?

Two operator-setup gaps surfaced when v4.2.2's self-hosted drift watcher first ran in production. Both are first-run-only triage you'd otherwise rediscover by reading workflow logs:

1. The workflow's "Open / update drift issue" step shells out to \`gh\`, which isn't part of standard Ubuntu/Debian server images. Without it, \`--check\` correctly detects drift and exits 2, but the subsequent step fails with \`gh: command not found\`.
2. \`gh issue create --label cc-drift-template\` requires the label to already exist in the repo, otherwise \`could not add label: 'cc-drift-template' not found\`.

Docs fix only — adds the two missing setup steps to docs/drift-monitor.md so the next runner registration walks through them.

## How to test

```bash
# Read it:
git fetch origin docs/drift-monitor-runner-prereqs
gh pr view <this-PR-number> --web

# Or follow it on a fresh host to verify the watcher's first cycle succeeds end-to-end (already verified against the production runner during v4.2.2 triage).
```

## Checklist
- [x] \`npm run build\` passes — no code change, vacuously
- [x] \`npm test\` passes — docs-only, no code touched
- [x] For changes that touch \`proxy.ts\`, \`cc-template.ts\`, or streaming behavior: tested with \`dario proxy --verbose\` + \`node test/compat.mjs\` (requires credentials) — *N/A: docs-only*
- [x] No new runtime dependencies added
- [x] No tokens/secrets in code or logs