### PR TITLE
release: v4.3.0 — PR-time compat test on the self-hosted runner

### DIFF
--- a/.github/workflows/compat-test-self-hosted.yml
+++ b/.github/workflows/compat-test-self-hosted.yml
@@ -113,7 +113,7 @@ jobs:
             pid=$(cat proxy.pid)
             kill "$pid" 2>/dev/null || true
             # Give it 2s for graceful shutdown, then SIGKILL.
-            for i in 1 2; do
+            for _ in 1 2; do
               sleep 1
               kill -0 "$pid" 2>/dev/null || break
             done
@@ -171,7 +171,9 @@ jobs:
 
       - name: Set job status
         if: always()
+        env:
+          COMPAT_EXIT_CODE: ${{ steps.compat.outputs.exit_code }}
         run: |
           # The job's pass/fail is the compat suite's exit code, regardless
           # of whether the comment step succeeded.
-          exit ${{ steps.compat.outputs.exit_code }}
+          exit "$COMPAT_EXIT_CODE"

--- a/.github/workflows/compat-test-self-hosted.yml
+++ b/.github/workflows/compat-test-self-hosted.yml
@@ -1,0 +1,177 @@
+name: Compat test (self-hosted)
+
+# Runs `node test/compat.mjs` against a live `dario proxy --passthrough`
+# instance on the same self-hosted runner that hosts the drift watcher.
+# Catches wire-shape regressions BEFORE merge instead of relying on the
+# post-release drift watcher to flag them after the fact.
+#
+# The compat suite is the only test in the repo that exercises dario as a
+# full HTTP service against real Anthropic — it sends ~11 small requests
+# through the proxy and verifies streaming framing, tool use, OpenAI-compat
+# shape, header pass-through, no thinking-injection in passthrough mode,
+# and client-beta preservation. ~10–20s of wall time, ~11 subscription
+# requests per run.
+#
+# Github-hosted runners can't host this: they have no Pro/Max subscription
+# session, no OAuth credential, no way to authenticate against
+# api.anthropic.com. The runner labeled `dario-drift` already has all of
+# the above (set up for the v4.2.2 template drift watcher; the same
+# credential file authenticates both).
+#
+# Triggered only on PRs that touch the wire-shape surface — the proxy
+# entrypoint, the request template, streaming code paths, the bundled
+# template JSON, or compat.mjs itself. Other PRs (docs, CI, unrelated
+# tests) skip this job entirely to keep runner cycles and subscription
+# requests low.
+#
+# Fork PRs are skipped — a self-hosted runner with credentials must never
+# execute arbitrary code from forks.
+
+on:
+  pull_request:
+    paths:
+      - 'src/proxy.ts'
+      - 'src/cc-template.ts'
+      - 'src/cc-template-data.json'
+      - 'src/streaming/**'
+      - 'src/sse/**'
+      - 'src/shim/runtime.cjs'
+      - 'test/compat.mjs'
+      - '.github/workflows/compat-test-self-hosted.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# Cancel previous in-flight runs on the same ref when a new commit lands.
+# Saves runner time + subscription requests when a PR is updated rapidly.
+concurrency:
+  group: compat-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compat:
+    # Fork-PR guard: only the source repo can run on the self-hosted runner.
+    # `workflow_dispatch` always runs (maintainer-triggered).
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, dario-drift]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Install + build
+        run: |
+          npm ci --no-audit --no-fund
+          npm run build
+
+      - name: Start dario proxy (passthrough mode)
+        run: |
+          # Background-start the proxy, capture PID for the always-run
+          # teardown step. --passthrough disables the canonical wire-shape
+          # rebuild path so compat.mjs can verify dario forwards the
+          # client's exact request shape (the explicit guarantee
+          # passthrough mode makes).
+          node dist/cli.js proxy --passthrough > proxy.log 2>&1 &
+          echo $! > proxy.pid
+          echo "started dario proxy with PID $(cat proxy.pid)"
+
+          # Wait up to 30s for /health to respond 200 before running tests.
+          # Bail with the proxy log if it never comes up.
+          ready=false
+          for i in $(seq 1 30); do
+            if curl -sf -o /dev/null --max-time 2 http://127.0.0.1:3456/health; then
+              ready=true
+              echo "proxy ready after ${i}s"
+              break
+            fi
+            sleep 1
+          done
+          if [ "$ready" != "true" ]; then
+            echo "::error::dario proxy never reached /health within 30s"
+            echo "=== proxy.log ==="
+            cat proxy.log
+            exit 1
+          fi
+
+      - name: Run compat tests
+        id: compat
+        run: |
+          set +e
+          node test/compat.mjs | tee compat-output.txt
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Stop dario proxy
+        if: always()
+        run: |
+          if [ -f proxy.pid ]; then
+            pid=$(cat proxy.pid)
+            kill "$pid" 2>/dev/null || true
+            # Give it 2s for graceful shutdown, then SIGKILL.
+            for i in 1 2; do
+              sleep 1
+              kill -0 "$pid" 2>/dev/null || break
+            done
+            kill -9 "$pid" 2>/dev/null || true
+            rm -f proxy.pid
+          fi
+          echo "=== proxy.log tail ==="
+          tail -80 proxy.log 2>/dev/null || true
+
+      - name: Comment on PR with result
+        if: github.event_name == 'pull_request' && always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # De-dup: replace previous compat-test comment from this bot on
+          # the same PR rather than stacking comments per push. Marker
+          # comment is recognized by the `<!-- dario-compat-test -->`
+          # HTML comment baked into the body.
+          pr=${{ github.event.pull_request.number }}
+          marker='<!-- dario-compat-test -->'
+          existing=$(gh api "repos/${{ github.repository }}/issues/$pr/comments" --jq ".[] | select(.body | startswith(\"$marker\")) | .id" | head -1)
+
+          status_emoji="❌"
+          status_text="FAILED"
+          if [ "${{ steps.compat.outputs.exit_code }}" = "0" ]; then
+            status_emoji="✅"
+            status_text="PASSED"
+          fi
+
+          body_file=$(mktemp)
+          {
+            echo "$marker"
+            echo "## Compat test: $status_emoji $status_text"
+            echo ""
+            echo "Ran \`node test/compat.mjs\` against \`dario proxy --passthrough\` on the [self-hosted runner](.github/workflows/compat-test-self-hosted.yml) for commit \`${{ github.event.pull_request.head.sha }}\`."
+            echo ""
+            echo "<details><summary>Output</summary>"
+            echo ""
+            echo '```'
+            cat compat-output.txt 2>/dev/null | tail -80 || echo "(no output captured)"
+            echo '```'
+            echo ""
+            echo "</details>"
+            echo ""
+            echo "[Full workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+          } > "$body_file"
+
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/${{ github.repository }}/issues/comments/$existing" -f body="$(cat "$body_file")" > /dev/null
+            echo "updated existing compat comment $existing"
+          else
+            gh pr comment "$pr" --body-file "$body_file"
+            echo "posted new compat comment"
+          fi
+
+      - name: Set job status
+        if: always()
+        run: |
+          # The job's pass/fail is the compat suite's exit code, regardless
+          # of whether the comment step succeeded.
+          exit ${{ steps.compat.outputs.exit_code }}

--- a/.github/workflows/compat-test-self-hosted.yml
+++ b/.github/workflows/compat-test-self-hosted.yml
@@ -153,7 +153,7 @@ jobs:
             echo "<details><summary>Output</summary>"
             echo ""
             echo '```'
-            cat compat-output.txt 2>/dev/null | tail -80 || echo "(no output captured)"
+            tail -80 compat-output.txt 2>/dev/null || echo "(no output captured)"
             echo '```'
             echo ""
             echo "</details>"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,52 @@ checklist.
 
 ## [Unreleased]
 
+## [4.3.0] - 2026-05-17
+
+### Added — PR-time compat test on the self-hosted runner
+
+v4.2.2 added the [self-hosted drift watcher](.github/workflows/cc-drift-template-watch.yml) that catches wire-shape divergences **after** release. v4.3.0 catches them **before** merge.
+
+`.github/workflows/compat-test-self-hosted.yml` runs `node test/compat.mjs` against a live `dario proxy --passthrough` on the same `[self-hosted, dario-drift]` runner the watcher uses. The test sends ~11 small subscription requests through the proxy and verifies: streaming framing (event/data pair correctness, message_start/_stop ordering), tool use (sync + streaming), OpenAI-compat path, header pass-through (request-id, ratelimit-*), no thinking-injection in passthrough mode, and client-beta preservation.
+
+Github-hosted runners can't host this — no Pro/Max subscription session, no OAuth credential. Until v4.3.0 the suite existed in the repo (`test/compat.mjs`) but never ran in CI, which meant wire-shape regressions surfaced only after merge (and often only after the drift watcher pinged them, often days later for subtle ones). Now they surface as a failing PR check before merge.
+
+**Trigger surface — path-filtered to keep runner cycles cheap.** Runs only on PRs that touch:
+
+- `src/proxy.ts` — the proxy entrypoint
+- `src/cc-template.ts` — the wire-shape builder
+- `src/cc-template-data.json` — the bundled template fallback
+- `src/streaming/**` / `src/sse/**` — streaming code paths
+- `src/shim/runtime.cjs` — shim deprecation period
+- `test/compat.mjs` — the test itself
+- the workflow file itself
+
+PRs touching only docs, README, unrelated tests, or other CI skip the job entirely. Maintainer-triggered `workflow_dispatch` is always available regardless of paths.
+
+**Fork-PR guard.** A self-hosted runner with credentials must never execute arbitrary code from forks. The job guards `if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository`. Fork PRs are visible but don't run on the runner; maintainers can manually dispatch after review.
+
+**Concurrency cancellation.** New commits to a PR cancel the previous in-flight run on the same ref. Saves runner time and subscription requests during rapid push iterations.
+
+**PR comment de-dup.** The workflow posts a single status comment per PR (✅/❌ + tail of compat output + run URL), then updates that comment on subsequent runs rather than stacking. Recognized by a `<!-- dario-compat-test -->` HTML marker.
+
+### Cost
+
+~11 small subscription requests per qualifying PR run, ~10–20s of runner wall time. The path filter is the cost lever: the wire-shape surface is the file set that benefits from the test, and only those PRs incur the spend.
+
+### Tests
+
+74/74 default suite green. No new tests added — the value is running an *existing* test (`test/compat.mjs`) in CI where it couldn't run before.
+
+### Why a minor bump (not patch)
+
+v4.2.2 was a patch because the drift watcher infrastructure was purely additive — no PR-gate behavior change. v4.3.0 introduces a **new PR check that can block merges**: a developer's PR can now fail compat. That's a behavioral change to the contribution flow, even though the runtime code is untouched. Semver-wise: minor.
+
+### Internal
+
+- No runtime code changes
+- No `src/` edits
+- Workflow file `.github/workflows/compat-test-self-hosted.yml` is the entire surface
+
 ## [4.2.2] - 2026-05-17
 
 ### Added — automated drift detection for same-binary remote-config drift

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.2.2",
+  "version": "4.3.0",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What does this PR do?

Catches wire-shape regressions **before** merge, on the same [self-hosted, dario-drift] runner v4.2.2 introduced for the post-release [drift watcher](.github/workflows/cc-drift-template-watch.yml).

`.github/workflows/compat-test-self-hosted.yml` runs `node test/compat.mjs` against a live `dario proxy --passthrough` instance and verifies — across ~11 small subscription requests:

- Anthropic Messages API (sync + streaming) — message_start first, message_stop last, event/data SSE framing
- Passthrough integrity — no thinking-block injection, client `anthropic-beta` headers preserved
- Tool use (sync + streaming, OpenClaw shape)
- OpenAI compat path (`/v1/chat/completions`)
- Header visibility (request-id, ratelimit-*)

Github-hosted runners cannot run this — no Pro/Max session, no OAuth credential. The suite has existed in the repo since v3.x but never ran in CI. v4.3.0 is the first release where every PR touching the wire-shape surface gets it as a gate.

**Trigger paths** (other PRs skip the job):
- \`src/proxy.ts\`, \`src/cc-template.ts\`, \`src/cc-template-data.json\`
- \`src/streaming/**\`, \`src/sse/**\`, \`src/shim/runtime.cjs\`
- \`test/compat.mjs\`, the workflow file itself
- Manual \`workflow_dispatch\` always available

**Safety**:
- Fork-PR guard — only same-repo PRs run on the self-hosted runner
- Concurrency cancellation on rapid pushes
- Single de-duped PR comment (\`<!-- dario-compat-test -->\` marker), updated rather than stacked

**Cost**: ~11 small subscription requests per qualifying run, ~10–20s wall time.

## How to test

```bash
git fetch origin feat/v4.3.0-compat-self-hosted
git checkout feat/v4.3.0-compat-self-hosted

# Local — already covered by the existing test suite (no src/ changes):
npm test          # 74/74

# End-to-end — dispatch the new workflow from the Actions tab once this
# PR is merged. The workflow's path filter means it does NOT fire on
# THIS PR (no src/proxy/template files touched). Manual dispatch on
# master after merge is the validation path.
```

## Checklist
- [x] \`npm run build\` passes
- [x] \`npm test\` passes (offline regression test, no credentials required) — 74/74
- [x] For changes that touch \`proxy.ts\`, \`cc-template.ts\`, or streaming behavior: tested with \`dario proxy --verbose\` + \`node test/compat.mjs\` (requires credentials) — *N/A: no src/ changes in this PR. The compat test IS what this PR wires up*
- [x] No new runtime dependencies added
- [x] No tokens/secrets in code or logs