### PR TITLE
release: v4.4.0 — auto-rebake on class-B drift + widen compat-test paths

### DIFF
--- a/.github/workflows/cc-drift-template-watch.yml
+++ b/.github/workflows/cc-drift-template-watch.yml
@@ -2,8 +2,8 @@ name: CC template drift watch (self-hosted)
 
 # Watches for "same-binary remote-config drift" — the class of CC wire-shape
 # change documented in v4.2.1's CHANGELOG entry. Runs `capture-and-bake.mjs
-# --check` against a live CC install on a self-hosted runner; opens an issue
-# when the captured template differs from the committed bundled template.
+# --check` against a live CC install on a self-hosted runner; on detection,
+# auto-rebakes the template, pushes to a bot branch, and opens a PR (v4.4.0).
 #
 # Pairs with `cc-drift-watch.yml` (catches npm-release-level drift, runs on
 # github-hosted runner, no auth needed). This workflow catches everything
@@ -16,8 +16,16 @@ name: CC template drift watch (self-hosted)
 # Hetzner / DO / EC2 / etc — anything dedicated. Setup: docs/drift-monitor.md.
 #
 # Runs every 30 min when the runner is online. Idempotent: if drift persists
-# across cycles, the issue stays open (de-duped by label). When the template
-# is re-baked + merged, the issue auto-closes on the next clean cycle.
+# across cycles AND a bot rebake PR is already open, no new PR is opened
+# (the existing one stays current). When the template is re-baked + merged,
+# the issue auto-closes on the next clean cycle.
+#
+# v4.4.0 — auto-rebake closes the manual-remediation step in the loop.
+# Previously: drift detected → issue opened → maintainer SSHes to a CC-
+# installed machine → runs capture-and-bake → commits + opens PR. Now:
+# drift detected → issue opened → bot opens PR with the re-bake → maintainer
+# reviews compat-test result + diff and clicks merge. NOT auto-merged —
+# template content is the wire-shape contract; a human approves the bake.
 
 on:
   schedule:
@@ -25,8 +33,9 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write       # v4.4.0: push the auto-rebake commit to bot/* branches
   issues: write
+  pull-requests: write  # v4.4.0: open the auto-rebake PR
 
 jobs:
   template-drift-check:
@@ -34,7 +43,7 @@ jobs:
     # runners don't have CC + OAuth, so this job effectively gates on whether
     # a maintainer has registered a runner with that label.
     runs-on: [self-hosted, dario-drift]
-    timeout-minutes: 5
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -54,9 +63,10 @@ jobs:
         #   0 — no drift, template matches live capture
         #   1 — infrastructure failure (CC not on PATH, capture timeout)
         #   2 — drift detected vs current bundled template
-        # We want the workflow to keep running through exit 2 so the next step
-        # can capture and report; `continue-on-error: true` does that without
-        # failing the whole job.
+        # We want the workflow to keep running through exit 2 so the
+        # auto-rebake + issue steps can run; the final `Set job status`
+        # step recovers the failure code so the workflow run reflects the
+        # actual drift outcome.
         run: |
           set +e
           node scripts/capture-and-bake.mjs --check 2> drift-output.txt
@@ -74,10 +84,97 @@ jobs:
             exit $code
           fi
 
+      - name: Auto-rebake + open PR
+        # On drift detection (exit 2), re-bake the template (real write, not
+        # --check), commit to a bot/template-rebake-* branch, push, and open
+        # a PR. Skip if a bot rebake PR is already open — the existing one
+        # will eventually be reviewed or rejected, and the next clean cycle
+        # closes the drift issue if the existing PR resolves things.
+        if: steps.check.outputs.exit_code == '2'
+        id: rebake
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eo pipefail
+
+          # De-dup: skip if a bot rebake PR is already open. Match on the
+          # branch-name prefix that this workflow exclusively writes to.
+          existing_pr=$(gh pr list --state open --search "head:bot/template-rebake-" --json number,headRefName,url --jq '.[0]' || echo "")
+          if [ -n "$existing_pr" ] && [ "$existing_pr" != "null" ]; then
+            pr_url=$(echo "$existing_pr" | node -pe "JSON.parse(require('fs').readFileSync(0,'utf8')).url")
+            pr_number=$(echo "$existing_pr" | node -pe "JSON.parse(require('fs').readFileSync(0,'utf8')).number")
+            echo "existing auto-rebake PR is still open: $pr_url"
+            echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
+            echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Run the real bake. Writes src/cc-template-data.json.
+          node scripts/capture-and-bake.mjs
+
+          # Sanity: did the bake actually change the bundle?
+          if git diff --quiet -- src/cc-template-data.json; then
+            echo "::warning::--check reported drift but bake produced no diff vs HEAD — likely a transient capture; skipping PR"
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          branch="bot/template-rebake-$(date -u +%Y%m%d-%H%M%S)"
+          git config user.email "actions@github.com"
+          git config user.name "cc-drift-template-watch[bot]"
+          git checkout -b "$branch"
+          git add src/cc-template-data.json
+          git commit -m "auto-rebake: template drift detected $(date -u +%Y-%m-%dT%H:%MZ)"
+          git push origin "$branch"
+
+          # PR body uses the same drift-output.txt the issue does, so the
+          # reviewer can decide ship-or-investigate from inside the PR alone.
+          pr_body_file=$(mktemp)
+          {
+            echo "## Auto-rebake from class-B drift detection"
+            echo ""
+            echo "Generated by [\`cc-drift-template-watch.yml\`](.github/workflows/cc-drift-template-watch.yml) on $(date -Iseconds)."
+            echo ""
+            echo "The watcher's \`--check\` exited 2 against a live capture from the self-hosted runner. This PR contains the freshly-baked \`src/cc-template-data.json\` from that capture, with the v4.2.2 platform-superset preservation already applied."
+            echo ""
+            echo "### Drift report"
+            echo ""
+            echo '```'
+            cat drift-output.txt
+            echo '```'
+            echo ""
+            echo "### Validation"
+            echo ""
+            echo "Compat-test (\`compat-test-self-hosted.yml\`) will auto-fire on this PR because it touches \`src/cc-template-data.json\`. If it goes green, this is mergeable as-is. If it fails, the rebake captured something Anthropic isn't ready to ship — close the PR, investigate manually."
+            echo ""
+            echo "### Why not auto-merged"
+            echo ""
+            echo "The bundled template is the wire-shape contract for non-CC clients. compat-test exercises passthrough mode; it cannot validate the rebuild-from-canonical path. A human approves the bake."
+            echo ""
+            echo "Background: [v4.2.1 CHANGELOG entry](https://github.com/askalf/dario/blob/master/CHANGELOG.md#421---2026-05-17) documents this drift class — same CC binary, different runtime wire shape via remote configuration."
+          } > "$pr_body_file"
+
+          pr_url=$(gh pr create \
+            --head "$branch" \
+            --base master \
+            --title "auto-rebake: template drift detected $(date +%Y-%m-%d)" \
+            --body-file "$pr_body_file" \
+            --label cc-drift-template)
+
+          pr_number=$(echo "$pr_url" | grep -oE '[0-9]+$')
+          echo "opened $pr_url"
+          echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
+
       - name: Open / update drift issue
         if: steps.check.outputs.exit_code == '2'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ steps.rebake.outputs.pr_url }}
+          PR_NUMBER: ${{ steps.rebake.outputs.pr_number }}
+          REBAKE_SKIPPED: ${{ steps.rebake.outputs.skipped }}
         run: |
           # De-dup: if there's already an open issue labeled cc-drift-template,
           # update it with a new comment instead of opening a duplicate.
@@ -88,21 +185,21 @@ jobs:
             echo ""
             echo "Generated by \`.github/workflows/cc-drift-template-watch.yml\` on $(date -Iseconds)."
             echo ""
+            if [ -n "$PR_URL" ]; then
+              if [ "$REBAKE_SKIPPED" = "true" ]; then
+                echo "**Existing auto-rebake PR still open:** $PR_URL — review + merge to resolve."
+              else
+                echo "**Auto-rebake PR opened:** $PR_URL — compat-test will run, then a human reviews + merges."
+              fi
+              echo ""
+            else
+              echo "**Auto-rebake skipped** (capture matched HEAD despite --check signal — likely a transient). Investigate manually if this recurs."
+              echo ""
+            fi
             echo "### Drift report"
             echo ""
             echo '```'
             cat drift-output.txt
-            echo '```'
-            echo ""
-            echo "### What to do"
-            echo ""
-            echo "From a maintainer machine with CC installed:"
-            echo ""
-            echo '```'
-            echo "npm run build"
-            echo "node scripts/capture-and-bake.mjs"
-            echo "# review the diff in src/cc-template-data.json"
-            echo "# commit + open a PR to re-bake the template"
             echo '```'
             echo ""
             echo "Background: [v4.2.1 CHANGELOG entry](https://github.com/askalf/dario/blob/master/CHANGELOG.md#421---2026-05-17) documents this drift class — same CC binary, different runtime wire shape via remote configuration."

--- a/.github/workflows/cc-drift-template-watch.yml
+++ b/.github/workflows/cc-drift-template-watch.yml
@@ -104,9 +104,11 @@ jobs:
             pr_url=$(echo "$existing_pr" | node -pe "JSON.parse(require('fs').readFileSync(0,'utf8')).url")
             pr_number=$(echo "$existing_pr" | node -pe "JSON.parse(require('fs').readFileSync(0,'utf8')).number")
             echo "existing auto-rebake PR is still open: $pr_url"
-            echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
-            echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
-            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "pr_url=$pr_url"
+              echo "pr_number=$pr_number"
+              echo "skipped=true"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -164,9 +166,11 @@ jobs:
 
           pr_number=$(echo "$pr_url" | grep -oE '[0-9]+$')
           echo "opened $pr_url"
-          echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
-          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
-          echo "skipped=false" >> "$GITHUB_OUTPUT"
+          {
+            echo "pr_url=$pr_url"
+            echo "pr_number=$pr_number"
+            echo "skipped=false"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Open / update drift issue
         if: steps.check.outputs.exit_code == '2'

--- a/.github/workflows/compat-test-self-hosted.yml
+++ b/.github/workflows/compat-test-self-hosted.yml
@@ -33,9 +33,11 @@ on:
       - 'src/proxy.ts'
       - 'src/cc-template.ts'
       - 'src/cc-template-data.json'
+      - 'src/scrub-template.ts'
       - 'src/streaming/**'
       - 'src/sse/**'
       - 'src/shim/runtime.cjs'
+      - 'scripts/capture-and-bake.mjs'
       - 'test/compat.mjs'
       - '.github/workflows/compat-test-self-hosted.yml'
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,42 @@ checklist.
 
 ## [Unreleased]
 
+## [4.4.0] - 2026-05-17
+
+### Added — auto-rebake on class-B drift detection
+
+Closes the manual-remediation step in the drift loop. The pre-v4.4.0 cycle was: detection → issue opened → **maintainer SSHes into a CC-installed machine** → runs `capture-and-bake.mjs` → reviews diff → commits → opens PR → merges → issue auto-closes. v4.4.0 replaces the three middle steps with a bot, mirroring [`cc-drift-watch.yml`](.github/workflows/cc-drift-watch.yml)'s class-A auto-PR pattern.
+
+The updated [`cc-drift-template-watch.yml`](.github/workflows/cc-drift-template-watch.yml) workflow now, on exit-2 from `--check`:
+
+1. Skips if a `bot/template-rebake-*` PR is already open (de-dup by branch-name prefix).
+2. Runs `node scripts/capture-and-bake.mjs` (real write, not `--check`). Bake already preserves Windows-only tools from the previous bundle (v4.2.2 platform-superset preservation) and re-sorts alphabetically.
+3. Bails with a workflow warning if the bake produced no diff vs HEAD (catches the rare transient where `--check` and the real bake disagree — e.g. classifier-sensitive content that scrubs differently between runs).
+4. Commits to `bot/template-rebake-YYYYMMDD-HHMMSS` as `cc-drift-template-watch[bot]`, pushes, opens a PR labeled `cc-drift-template`.
+5. The drift issue body is then expanded with a link to the open PR (or a "rebake skipped" note if step 3 short-circuited).
+
+**Not auto-merged.** The bundled template is the wire-shape contract for non-CC clients (Cursor, Aider, Cline — anything dario rebuilds-from-canonical for). [`compat-test-self-hosted.yml`](.github/workflows/compat-test-self-hosted.yml) auto-fires on the PR because the path filter includes `src/cc-template-data.json`, validating the **passthrough** plane. The rebuild-from-canonical plane isn't currently exercised by an end-to-end test, so a human eyes the diff and clicks merge. Once merged, the next watcher cycle exits 0 and auto-closes the drift issue.
+
+**Workflow permission bump.** `contents: write` (was `read`) so the bot can push to `bot/*` branches; `pull-requests: write` (added) so it can open the PR. Master is still protected — the bot cannot push there directly; only the PR path is open.
+
+### Added — compat-test path filter widened
+
+[`compat-test-self-hosted.yml`](.github/workflows/compat-test-self-hosted.yml) now also fires on PRs touching `src/scrub-template.ts` and `scripts/capture-and-bake.mjs`. The v4.3.1 scrubber fix would not have triggered the compat gate under the old filter — exactly the regression class the gate is supposed to catch.
+
+### Tests
+
+- 74/74 default suite green (no src/ changes)
+
+### Why a minor bump
+
+The bot now opens PRs autonomously and pushes to repo branches it didn't push to before. Behavioral change to the bot surface, even though end-user runtime code is unchanged.
+
+### Internal
+
+- No runtime code changes
+- No `src/` edits
+- Two workflow files modified: `cc-drift-template-watch.yml` (auto-rebake), `compat-test-self-hosted.yml` (path filter)
+
 ## [4.3.1] - 2026-05-17
 
 ### Fixed — scrubber strips CC's gitStatus block

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.3.1",
+  "version": "4.4.0",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What does this PR do?

Closes the manual-remediation step in the drift loop. Pre-v4.4.0: detection ✓ → issue opened ✓ → **maintainer SSHes into a CC-installed machine** → \`capture-and-bake\` → review diff → commit → PR → merge → issue auto-closes. v4.4.0 replaces the three middle steps with a bot, mirroring [\`cc-drift-watch.yml\`](.github/workflows/cc-drift-watch.yml)'s class-A auto-PR pattern.

### Auto-rebake workflow change

\`.github/workflows/cc-drift-template-watch.yml\` gets a new \"Auto-rebake + open PR\" step that fires on \`--check\` exit 2:

1. Skip if a \`bot/template-rebake-*\` PR is already open (de-dup by branch-name prefix)
2. Run \`node scripts/capture-and-bake.mjs\` (real write — not \`--check\`)
3. Bail with workflow warning if bake produced no diff vs HEAD (catches the rare transient where \`--check\` and the real bake disagree)
4. Commit as \`cc-drift-template-watch[bot]\`, push to \`bot/template-rebake-YYYYMMDD-HHMMSS\`, open a labeled PR with the drift report inline
5. The existing drift-issue step references the open PR (or a \"rebake skipped\" note)

**Not auto-merged.** The bundled template is the wire-shape contract for non-CC clients. compat-test exercises only the passthrough plane; the rebuild-from-canonical plane is not currently covered by an end-to-end test, so a human approves the bake. Compat-test still fires automatically on the bot's PR because the path filter includes \`src/cc-template-data.json\`.

### Permission bump

\`contents: write\` (was \`read\`) for \`bot/*\` push, \`pull-requests: write\` (added) for PR open. Master branch protection still gates the actual merge.

### Compat-test path filter widened

\`.github/workflows/compat-test-self-hosted.yml\` now also fires on PRs touching \`src/scrub-template.ts\` and \`scripts/capture-and-bake.mjs\`. The v4.3.1 scrubber fix would not have triggered the compat gate under the old filter — exactly the regression class the gate is designed to catch.

## How to test

\`\`\`bash
git fetch origin feat/v4.4.0-auto-rebake
git checkout feat/v4.4.0-auto-rebake

npm run build && npm test     # 74/74 green (no src/ changes)

# End-to-end test happens organically: once merged, the next 30-min cron
# tick runs --check on master. If it detects drift, the auto-rebake step
# will fire and we'll see a bot/template-rebake-* PR open in the repo.
# That's the real validation. Workflow dispatch on master is also available
# for immediate trigger.
\`\`\`

## Checklist
- [x] \`npm run build\` passes
- [x] \`npm test\` passes (offline regression test, no credentials required) — 74/74
- [x] For changes that touch \`proxy.ts\`, \`cc-template.ts\`, or streaming behavior: tested with \`dario proxy --verbose\` + \`node test/compat.mjs\` (requires credentials) — *N/A: workflow + CHANGELOG only, no src/ changes*
- [x] No new runtime dependencies added
- [x] No tokens/secrets in code or logs