### PR TITLE
docs(readme): reorder + refresh "Also by askalf" by reader-value

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,13 +503,17 @@ MIT — see [LICENSE](LICENSE) and [DISCLAIMER.md](DISCLAIMER.md).
 
 ## Also by askalf
 
+Ordered by relevance to a dario reader — projects that route through dario first, Claude Code ecosystem second, supporting infrastructure last.
+
 | Project | What it does |
 |---|---|
-| [arnie](https://github.com/askalf/arnie) | Portable IT troubleshooting companion — networking, AD, package managers, log triage |
-| [browser-bridge](https://github.com/askalf/browser-bridge) | Stealth headless Chromium in a container, CDP on 9222 |
-| [claude-bridge](https://github.com/askalf/claude-bridge) | Bridge Claude Code sessions to Discord |
-| [deepdive](https://github.com/askalf/deepdive) | Local research agent — plan → search → fetch → synthesize, cited answers |
-| [git-providers](https://github.com/askalf/git-providers) | Unified GitHub + GitLab + Bitbucket Cloud clients behind one interface |
-| [hands](https://github.com/askalf/hands) | Cross-platform computer-use agent — mouse, keyboard, screen |
-| [install-kit](https://github.com/askalf/install-kit) | curl-pipe-bash template for self-hosted Docker apps |
-| [pgflex](https://github.com/askalf/pgflex) | One Postgres API, two modes (real PG ↔ PGlite WASM) |
+| [arnie](https://github.com/askalf/arnie) | Portable IT troubleshooting agent — networking, AD, package managers, log triage. Routes through dario for subscription billing. |
+| [hands](https://github.com/askalf/hands) | Cross-platform computer-use agent — your LLM on your mouse, keyboard, and screen. Windows + macOS + Linux. Routes through dario or any Anthropic-compat. |
+| [deepdive](https://github.com/askalf/deepdive) | Local research agent. One command, cited answer. Plan → search → headless fetch → extract → synthesize. Every LLM call through your own router. |
+| [claude-sync](https://github.com/askalf/claude-sync) | Sync Claude Code sessions across machines. Pack a CC session into a portable `.ccsync` file, ship it via Dropbox / iCloud / USB, unpack on the other side. |
+| [claude-bridge](https://github.com/askalf/claude-bridge) | Bridge Claude Code sessions to Discord. Stay in sync with your CC instances from your phone. |
+| [browser-bridge](https://github.com/askalf/browser-bridge) | Stealth headless Chromium in a container, CDP on 9222. Connect from Playwright, Puppeteer, MCP browser tools, any agent that wants a remote browser. |
+| [install-kit](https://github.com/askalf/install-kit) | curl-pipe-bash template for self-hosted Docker apps — banner, prereq probes, `.env` scaffolding with crypto-rand secrets, healthcheck wait loop. |
+| [pgflex](https://github.com/askalf/pgflex) | One Postgres API, two modes — real PostgreSQL for production, PGlite (in-process WASM) for standalone / dev. Same SQL, drop the server when you don't need it. |
+| [redisflex](https://github.com/askalf/redisflex) | One Redis API, two modes — ioredis for production, in-process Map+EventEmitter for dev. Includes a BullMQ-shaped in-memory queue. |
+| [git-providers](https://github.com/askalf/git-providers) | One `GitProvider` interface for GitHub + GitLab + Bitbucket Cloud, plus a 44-entry api-key-provider taxonomy (cloud / CI / monitoring / analytics / ...). |


### PR DESCRIPTION
## What does this PR do?

Two issues with the previous \"Also by askalf\" table:

1. **Order was alphabetical**, not by relevance to a dario reader. Buried the projects most aligned with this README's audience.
2. **Two repos were missing** from the list — \`claude-sync\` and \`redisflex\` exist on the askalf org but weren't surfaced here.

New ordering, three tiers descending from \"directly extends what this reader is here for\":

- **Tier 1 — explicit dario integration:** arnie, hands, deepdive (each description says \"routes through dario\" or equivalent)
- **Tier 2 — Claude Code ecosystem:** claude-sync, claude-bridge
- **Tier 3 — supporting infra:** browser-bridge, install-kit, pgflex, redisflex, git-providers

Descriptions also trimmed to lead with the value prop instead of starting with taxonomy / domain category.

## How to test

\`\`\`bash
gh pr view <this-PR-number> --web
# Skim the \"Also by askalf\" table — order goes dario-integration → CC-ecosystem → infra.
\`\`\`

## Checklist
- [x] \`npm run build\` passes — no code change, vacuously
- [x] \`npm test\` passes — docs-only, no code touched
- [x] For changes that touch \`proxy.ts\`, \`cc-template.ts\`, or streaming behavior: tested with \`dario proxy --verbose\` + \`node test/compat.mjs\` (requires credentials) — *N/A: docs-only*
- [x] No new runtime dependencies added
- [x] No tokens/secrets in code or logs