### PR TITLE
release: v4.4.1 — isolate runner OAuth credential from shared /root/.claude/

### DIFF
--- a/.github/workflows/cc-drift-template-watch.yml
+++ b/.github/workflows/cc-drift-template-watch.yml
@@ -67,6 +67,15 @@ jobs:
         # auto-rebake + issue steps can run; the final `Set job status`
         # step recovers the failure code so the workflow run reflects the
         # actual drift outcome.
+        #
+        # HOME is pinned to /root/.claude-runner (v4.4.1) so this workflow
+        # uses a dedicated CC OAuth credential isolated from any other CC
+        # client sharing /root/.claude/ on this box (e.g. docker services
+        # that mount the host's /root/.claude/ — see docs/drift-monitor.md
+        # for setup). Lets the runner's token refresh on its own cycle
+        # with no race vs operator machines that share the account.
+        env:
+          HOME: /root/.claude-runner
         run: |
           set +e
           node scripts/capture-and-bake.mjs --check 2> drift-output.txt
@@ -94,6 +103,10 @@ jobs:
         id: rebake
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # v4.4.1: dedicated runner credential isolated at
+          # /root/.claude-runner/.claude/.credentials.json. Same rationale
+          # as the Run drift check step above.
+          HOME: /root/.claude-runner
         run: |
           set -eo pipefail
 

--- a/.github/workflows/compat-test-self-hosted.yml
+++ b/.github/workflows/compat-test-self-hosted.yml
@@ -73,6 +73,13 @@ jobs:
           npm run build
 
       - name: Start dario proxy (passthrough mode)
+        # HOME is pinned to /root/.claude-runner (v4.4.1) so the proxy
+        # authenticates with the runner-isolated credential, not whatever
+        # /root/.claude/.credentials.json the box's other CC clients use
+        # (e.g. docker services that mount /root/.claude/). Setup:
+        # docs/drift-monitor.md.
+        env:
+          HOME: /root/.claude-runner
         run: |
           # Background-start the proxy, capture PID for the always-run
           # teardown step. --passthrough disables the canonical wire-shape

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ checklist.
 
 ## [Unreleased]
 
+## [4.4.1] - 2026-05-17
+
+### Fixed — runner OAuth credential isolated from shared `/root/.claude/`
+
+The v4.2.2 walkthrough seeded the runner's CC credential at `/root/.claude/.credentials.json`. On a box that also hosts other CC clients sharing that path — e.g. docker services that mount the host's `/root/.claude/` as a credentials volume — both clients use the same access/refresh token pair. When either refreshes, the other's token can be silently invalidated until its next refresh attempt. We hit one such 401 during v4.2.2 setup; the 30-min cron cadence absorbed it, but it's a real failure mode for high-frequency setups.
+
+**Fix.** Both runner workflows now pin `HOME: /root/.claude-runner` on every step that spawns CC. Setup writes the runner's credential to `/root/.claude-runner/.claude/.credentials.json`, isolated from `/root/.claude/`. Refreshes on the two paths are now independent.
+
+- [`cc-drift-template-watch.yml`](.github/workflows/cc-drift-template-watch.yml): `Run drift check` and `Auto-rebake + open PR` steps both get `env: HOME: /root/.claude-runner`.
+- [`compat-test-self-hosted.yml`](.github/workflows/compat-test-self-hosted.yml): `Start dario proxy (passthrough mode)` step gets the same.
+- [`docs/drift-monitor.md`](docs/drift-monitor.md): updated to document the isolated-credential flow as the recommended pattern for boxes that share the host with other CC clients (the simpler `~/.claude/.credentials.json` default still works for runner-only boxes).
+
+**Verification.** Generated a fresh OAuth credential on the production runner via `HOME=/root/.claude-runner dario login --manual`. `dario` writes its credentials to `~/.dario/credentials.json` but CC reads from `~/.claude/.credentials.json` — same JSON format though (top-level `claudeAiOauth` key), so the setup mirrors the file. `claude --print` returns PONG against the isolated credential; full `--check` against the runner's clone reports `no drift detected. exit 0`. The platform's `/root/.claude/.credentials.json` is untouched.
+
+### Why a patch (not minor)
+
+Pure operational hardening. No user-visible API change, no end-user runtime behavior change, no code change in `src/`. Two workflow files and one docs file modified.
+
+### Internal
+
+- No `src/` edits
+- No new tests (the env var change is exercised end-to-end by the next watcher/compat-test cycle)
+- 74/74 default suite green
+
 ## [4.4.0] - 2026-05-17
 
 ### Added — auto-rebake on class-B drift detection

--- a/docs/drift-monitor.md
+++ b/docs/drift-monitor.md
@@ -76,11 +76,33 @@ sudo npm i -g @anthropic-ai/claude-code @askalf/dario
 
 # 4. OAuth — manual flow for headless boxes. Run from the host's shell,
 #    follow the printed URL in any browser, paste the post-login callback
-#    URL back into the SSH session. Drops a credentials file at
-#    ~/.claude/.credentials.json.
+#    URL back into the SSH session.
+#
+#    v4.4.1: if this host runs OTHER CC clients sharing /root/.claude/
+#    (e.g. docker services mounting the host's /root/.claude/ as a
+#    credentials volume, an operator's own SSH-based CC sessions, etc.),
+#    use an isolated home for the runner so its OAuth refresh cycle
+#    does not race with theirs:
+#
+#      mkdir -p /root/.claude-runner/.claude
+#      chmod 700 /root/.claude-runner
+#      HOME=/root/.claude-runner dario login --manual
+#      # dario writes its credentials to /root/.claude-runner/.dario/credentials.json
+#      # CC reads from $HOME/.claude/.credentials.json — same JSON format, mirror it:
+#      cp /root/.claude-runner/.dario/credentials.json \
+#         /root/.claude-runner/.claude/.credentials.json
+#      chmod 600 /root/.claude-runner/.claude/.credentials.json
+#
+#    The drift-watch + compat-test workflows pin `HOME: /root/.claude-runner`
+#    on every step that spawns CC, so the isolated credential is what the
+#    runner actually uses at workflow time.
+#
+#    If no other CC clients are sharing the box, the simpler default flow
+#    works: just run `dario login --manual` and CC will find the
+#    credentials under ~/.claude/.credentials.json.
 dario login --manual
 
-# 5. Smoke test
+# 5. Smoke test (replace HOME with /root/.claude-runner if isolated):
 echo "Reply with PONG" | claude --print     # should print PONG
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What does this PR do?

Operational hardening. The v4.2.2 walkthrough seeded the runner's CC credential at \`/root/.claude/.credentials.json\`. On boxes where that path is also mounted into other CC clients (docker services that mount the host's \`/root/.claude/\` as a credentials volume, operator SSH sessions, etc.), both clients use the same access/refresh tokens. When either refreshes, the other's bearer can be silently invalidated until its next refresh attempt. We hit one such 401 during v4.2.2 setup; the 30-min cron cadence absorbed it, but it's a real failure mode for higher-frequency setups (e.g. v4.4.0's auto-rebake firing during a cycle that happens to overlap a token refresh).

### Fix

Both runner workflows now pin \`HOME: /root/.claude-runner\` on every step that spawns CC. Runner's credential lives at \`/root/.claude-runner/.claude/.credentials.json\`, isolated from \`/root/.claude/\` — refreshes on the two paths are now independent.

- \`cc-drift-template-watch.yml\`: \`Run drift check\` and \`Auto-rebake + open PR\` steps both get \`env: HOME: /root/.claude-runner\`
- \`compat-test-self-hosted.yml\`: \`Start dario proxy (passthrough mode)\` step gets the same
- \`docs/drift-monitor.md\`: documents the isolated-credential flow as the recommended pattern for boxes that share with other CC clients; simpler default (\`~/.claude/\`) still works for runner-only hosts

### Verification

Generated a fresh OAuth credential on the production runner via \`HOME=/root/.claude-runner dario login --manual\`. dario writes its credentials to \`~/.dario/credentials.json\`; CC reads from \`~/.claude/.credentials.json\`. Same JSON format though (top-level \`claudeAiOauth\` key), so setup mirrors the file. Confirmed:

- \`HOME=/root/.claude-runner claude --print\` returns PONG (auth works)
- Full \`--check\` against the runner's clone with isolated HOME reports \`no drift detected. exit 0\`
- Platform's \`/root/.claude/.credentials.json\` (mtime 13:48 UTC, hours before the v4.4.1 work) untouched

## How to test

\`\`\`bash
git fetch origin fix/v4.4.1-runner-credential-isolation
git checkout fix/v4.4.1-runner-credential-isolation
npm run build && npm test     # 74/74

# End-to-end: once merged, the next 30-min watcher cron tick exercises
# the new HOME pinning. Manual workflow_dispatch on master also available.
\`\`\`

## Checklist
- [x] \`npm run build\` passes
- [x] \`npm test\` passes (offline regression test, no credentials required) — 74/74
- [x] For changes that touch \`proxy.ts\`, \`cc-template.ts\`, or streaming behavior: tested with \`dario proxy --verbose\` + \`node test/compat.mjs\` (requires credentials) — *N/A: workflow + docs only, no src/ changes; the compat-test workflow itself is one of the files modified though, which means this PR's path filter triggers compat-test on the bot's PR after the auto-release if any*
- [x] No new runtime dependencies added
- [x] No tokens/secrets in code or logs