### PR TITLE
release: v4.5.0 — unified-diff snippets in drift reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,47 @@ checklist.
 
 ## [Unreleased]
 
+## [4.5.0] - 2026-05-17
+
+### Added — drift reports embed unified-diff snippets
+
+Pre-v4.5.0, a class-B drift report read like `system_prompt content changed (12716 → 12719 chars, delta +3)`. Useful as a tripwire; useless for triage. A reviewer had to fetch the bot's auto-rebake PR, inspect the diff, then come back to decide ship-or-investigate. v4.5.0 shortens that to "read the issue, decide" by embedding the actual content delta.
+
+### Mechanism
+
+Drift detection moved from inline in `scripts/capture-and-bake.mjs` to a dedicated `scripts/drift-report.mjs` module (testable without spawning live CC). Each drift entry now has a `summary` plus an optional `detail` array — rendered as a bullet with indented sub-lines. New helpers:
+
+- **`unifiedDiff(prev, now, opts)`** — line-level diff between two text blobs. LCS-table backtrack, `contextLines`/`maxLines` bounded for issue/PR embedding. Empty array when inputs are identical. Used for `system_prompt` and `agent_identity` slots.
+- **`describeTool(tool)`** — for `tools added`/`tools removed`, returns the tool's name + first-line description (capped) + `input_schema.properties` keys, so a reviewer can see *what the tool does* without leaving the issue.
+- **`formatDriftReport(diff)`** — renders the rich entries as indented bullets for `--check` log output.
+
+### Detail coverage by slot
+
+| Drift slot | Detail format |
+|---|---|
+| `tools added` / `tools removed` | per-tool: name, first-line description, input-schema property keys |
+| `system_prompt` content | bounded unified-line diff with ±2 context lines |
+| `agent_identity` content | bounded unified-line diff with ±2 context lines |
+| `body_field_order` | before / after JSON arrays |
+| `header_order` | before / after JSON arrays |
+| `anthropic_beta` added/removed | (no detail — summary names the betas) |
+
+### Tests
+
+- **New file `test/bake-drift-report.mjs`** — 19 headers, 42 assertions covering: identical/empty inputs returning empty diff, single-line / insertion / deletion / multi-hunk cases, `maxLines` cap, `describeTool` graceful on missing fields, per-slot drift detection, multi-axis aggregation, `formatDriftReport` indentation contract.
+- 75/75 default suite green (74 + the new file).
+
+### Why a minor bump
+
+`--check` output and drift-issue body shape are externally observable surfaces — they're embedded verbatim in workflow issue bodies and PR descriptions. Anyone scraping those (or hand-pasting them into a ticket) sees a new shape. Internal-only refactor would be a patch; user-visible-text-shape change is a minor.
+
+### Internal
+
+- Two new files: `scripts/drift-report.mjs`, `test/bake-drift-report.mjs`
+- `scripts/capture-and-bake.mjs` slimmed down — inline drift helpers removed, imports from `./drift-report.mjs` instead
+- No `src/` changes
+- No runtime dependencies added
+
 ## [4.4.2] - 2026-05-17
 
 ### Added — drift watcher liveness alarm

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.4.2",
+  "version": "4.5.0",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/scripts/capture-and-bake.mjs
+++ b/scripts/capture-and-bake.mjs
@@ -33,6 +33,7 @@ import { fileURLToPath } from 'node:url';
 import { captureLiveTemplateAsync, findInstalledCC } from '../dist/live-fingerprint.js';
 import { scrubTemplate, findUserPathHits } from '../dist/scrub-template.js';
 import { PLATFORM_ONLY_TOOLS } from '../dist/cc-template.js';
+import { computeDrift, formatDriftReport } from './drift-report.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, '..');
@@ -110,7 +111,7 @@ if (CHECK_MODE) {
     process.exit(0);
   }
   log(`check: drift detected — ${diff.length} differing slot${diff.length === 1 ? '' : 's'}:`);
-  for (const item of diff) log(`  • ${item}`);
+  for (const line of formatDriftReport(diff)) log(line);
   log('check: bundled template is stale relative to live CC. Run `node scripts/capture-and-bake.mjs` to re-bake.');
   process.exit(2);
 }
@@ -121,70 +122,7 @@ log(`wrote ${OUT}`);
 log(`summary: CC v${prev._version} → v${scrubbed._version}, tools ${prev.tools.length} → ${scrubbed.tools.length}, system_prompt ${prev.system_prompt.length} → ${scrubbed.system_prompt.length} chars`);
 
 
-/**
- * Compute the meaningful template drift between `prev` (current bundled)
- * and `now` (freshly captured + scrubbed). Returns an array of human-
- * readable diff strings; empty array = no drift.
- *
- * Intentionally ignores transient fields that always differ between runs:
- *   - `_captured` (timestamp)
- *   - `header_values['user-agent']` (varies by CC version string; replayed at runtime anyway)
- *   - `_version`, `_supportedMaxTested` (these are the version markers; the
- *     point of --check is to catch drift WITHIN the same version, so a
- *     version-string diff isn't itself drift — the wire shape changing IS)
- *
- * Catches drift in:
- *   - tools (added / removed by name)
- *   - anthropic_beta header value
- *   - system_prompt content (any character delta)
- *   - body_field_order
- *   - header_order
- *   - agent_identity content
- *
- * dario#XXX (v4.2.2 — same-binary remote-config drift detection).
- */
-function computeDrift(prev, now) {
-  const out = [];
-
-  // tools — by name set
-  const prevTools = new Set((prev.tools || []).map((t) => t.name));
-  const nowTools = new Set((now.tools || []).map((t) => t.name));
-  const addedTools = [...nowTools].filter((n) => !prevTools.has(n));
-  const removedTools = [...prevTools].filter((n) => !nowTools.has(n));
-  if (addedTools.length > 0) out.push(`tools added: ${addedTools.join(', ')}`);
-  if (removedTools.length > 0) out.push(`tools removed: ${removedTools.join(', ')}`);
-
-  // anthropic_beta — exact string match
-  if ((prev.anthropic_beta || '') !== (now.anthropic_beta || '')) {
-    const prevBetas = new Set((prev.anthropic_beta || '').split(',').filter(Boolean));
-    const nowBetas = new Set((now.anthropic_beta || '').split(',').filter(Boolean));
-    const addedB = [...nowBetas].filter((b) => !prevBetas.has(b));
-    const removedB = [...prevBetas].filter((b) => !nowBetas.has(b));
-    if (addedB.length > 0) out.push(`anthropic_beta added: ${addedB.join(', ')}`);
-    if (removedB.length > 0) out.push(`anthropic_beta removed: ${removedB.join(', ')}`);
-  }
-
-  // system_prompt — content (length is a proxy for cheaper signal; full
-  // string compare for definitive)
-  if ((prev.system_prompt || '') !== (now.system_prompt || '')) {
-    const delta = (now.system_prompt || '').length - (prev.system_prompt || '').length;
-    out.push(`system_prompt content changed (${prev.system_prompt.length} → ${now.system_prompt.length} chars, delta ${delta >= 0 ? '+' : ''}${delta})`);
-  }
-
-  // body_field_order — array deep-equal
-  if (JSON.stringify(prev.body_field_order || []) !== JSON.stringify(now.body_field_order || [])) {
-    out.push(`body_field_order changed: ${JSON.stringify(prev.body_field_order)} → ${JSON.stringify(now.body_field_order)}`);
-  }
-
-  // header_order — array deep-equal
-  if (JSON.stringify(prev.header_order || []) !== JSON.stringify(now.header_order || [])) {
-    out.push(`header_order changed`);
-  }
-
-  // agent_identity — exact string
-  if ((prev.agent_identity || '') !== (now.agent_identity || '')) {
-    out.push(`agent_identity content changed (${prev.agent_identity?.length || 0} → ${now.agent_identity?.length || 0} chars)`);
-  }
-
-  return out;
-}
+// `computeDrift` + `unifiedDiff` + `formatDriftReport` live in
+// `./drift-report.mjs` so they can be unit-tested without importing this
+// file (top-level `await captureLiveTemplateAsync` would block the test
+// runner on a live CC capture). Imported above.

--- a/scripts/drift-report.mjs
+++ b/scripts/drift-report.mjs
@@ -1,0 +1,228 @@
+// Pure functions for the --check drift detector in `capture-and-bake.mjs`.
+// Lives in its own module so the test suite can exercise drift detection
+// without spawning a live CC capture (the top of capture-and-bake.mjs
+// kicks off captureLiveTemplateAsync at import time, which is not what
+// unit tests want).
+//
+// dario#XXX (v4.5.0 — unified-diff snippets in drift reports).
+
+/**
+ * Generate a line-level unified diff between two text blobs. Bounded
+ * output for issue / PR embedding. Each line is prefixed with
+ * ` ` (context), `-` (removed), `+` (added), or `  …` (truncation /
+ * hunk separator).
+ *
+ * Algorithm: LCS-table backtrack — O(mn) time/space, fine for scrubbed-
+ * system-prompt-sized inputs (~12 KB / ~200 lines in current bakes).
+ *
+ * Returns an empty array when the two inputs are identical.
+ */
+export function unifiedDiff(prev, now, opts = {}) {
+  const { contextLines = 2, maxLines = 60 } = opts;
+  const a = (prev || '').split('\n');
+  const b = (now || '').split('\n');
+  const m = a.length;
+  const n = b.length;
+
+  // Length of LCS for prefixes a[0..i-1] and b[0..j-1].
+  const dp = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] = a[i - 1] === b[j - 1]
+        ? dp[i - 1][j - 1] + 1
+        : Math.max(dp[i - 1][j], dp[i][j - 1]);
+    }
+  }
+
+  // Backtrack to produce ops, then reverse.
+  const ops = [];
+  let i = m;
+  let j = n;
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && a[i - 1] === b[j - 1]) {
+      ops.push({ k: ' ', s: a[i - 1] });
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      ops.push({ k: '+', s: b[j - 1] });
+      j--;
+    } else {
+      ops.push({ k: '-', s: a[i - 1] });
+      i--;
+    }
+  }
+  ops.reverse();
+
+  // Find indices of changed ops; expand context around each.
+  const changed = [];
+  for (let k = 0; k < ops.length; k++) {
+    if (ops[k].k !== ' ') changed.push(k);
+  }
+  if (changed.length === 0) return [];
+
+  const keep = new Set();
+  for (const idx of changed) {
+    keep.add(idx);
+    for (let c = 1; c <= contextLines; c++) {
+      if (idx - c >= 0) keep.add(idx - c);
+      if (idx + c < ops.length) keep.add(idx + c);
+    }
+  }
+  const sorted = [...keep].sort((x, y) => x - y);
+
+  const out = [];
+  let lastIdx = -2;
+  for (let s = 0; s < sorted.length; s++) {
+    const idx = sorted[s];
+    if (idx > lastIdx + 1) out.push('  …');
+    out.push(ops[idx].k + ops[idx].s);
+    lastIdx = idx;
+    if (out.length >= maxLines) {
+      const remaining = sorted.length - s - 1;
+      if (remaining > 0) {
+        out.push(`  … (${remaining} more changed/context line${remaining === 1 ? '' : 's'} truncated)`);
+      }
+      break;
+    }
+  }
+  return out;
+}
+
+/**
+ * Describe a tool for the drift report — first 100 chars of description,
+ * + input_schema property keys. Used to give a reviewer context on what
+ * a newly-added (or removed) tool actually does.
+ */
+export function describeTool(tool) {
+  if (!tool) return [];
+  const lines = [];
+  const desc = (tool.description || '').split('\n')[0];
+  if (desc) {
+    lines.push(`${tool.name}: ${desc.slice(0, 100)}${desc.length > 100 ? '…' : ''}`);
+  } else {
+    lines.push(tool.name);
+  }
+  const props = tool.input_schema?.properties;
+  if (props && typeof props === 'object') {
+    const keys = Object.keys(props);
+    if (keys.length > 0) lines.push(`  input keys: ${keys.join(', ')}`);
+  }
+  return lines;
+}
+
+/**
+ * Compute the meaningful template drift between `prev` (current bundled)
+ * and `now` (freshly captured + scrubbed). Returns an array of entries —
+ * each with a `summary` line and an optional `detail` array of lines that
+ * the caller renders indented under the summary.
+ *
+ * Intentionally ignores transient fields that always differ between runs:
+ *   - `_captured` (timestamp)
+ *   - `header_values['user-agent']` (varies by CC version; replayed)
+ *   - `_version`, `_supportedMaxTested` (the point of --check is to catch
+ *     drift WITHIN the same version, so a version-string diff isn't drift)
+ *
+ * Catches drift in:
+ *   - tools (added / removed by name; detail shows description + schema keys)
+ *   - anthropic_beta header value (added / removed lists)
+ *   - system_prompt content (any character delta; detail is a unified diff)
+ *   - body_field_order (detail shows the before / after JSON)
+ *   - header_order (detail shows the before / after JSON)
+ *   - agent_identity content (detail is a unified diff)
+ *
+ * v4.5.0 added the rich `{ summary, detail }` entry format; previously each
+ * entry was a single summary string.
+ */
+export function computeDrift(prev, now) {
+  const out = [];
+
+  // tools — by name set, detail = description + schema keys
+  const prevTools = new Map((prev.tools || []).map((t) => [t.name, t]));
+  const nowTools = new Map((now.tools || []).map((t) => [t.name, t]));
+  const addedTools = [...nowTools.keys()].filter((n) => !prevTools.has(n));
+  const removedTools = [...prevTools.keys()].filter((n) => !nowTools.has(n));
+  if (addedTools.length > 0) {
+    out.push({
+      summary: `tools added: ${addedTools.join(', ')}`,
+      detail: addedTools.flatMap((n) => describeTool(nowTools.get(n))),
+    });
+  }
+  if (removedTools.length > 0) {
+    out.push({
+      summary: `tools removed: ${removedTools.join(', ')}`,
+      detail: removedTools.flatMap((n) => describeTool(prevTools.get(n))),
+    });
+  }
+
+  // anthropic_beta — exact string match
+  if ((prev.anthropic_beta || '') !== (now.anthropic_beta || '')) {
+    const prevBetas = new Set((prev.anthropic_beta || '').split(',').filter(Boolean));
+    const nowBetas = new Set((now.anthropic_beta || '').split(',').filter(Boolean));
+    const addedB = [...nowBetas].filter((b) => !prevBetas.has(b));
+    const removedB = [...prevBetas].filter((b) => !nowBetas.has(b));
+    if (addedB.length > 0) out.push({ summary: `anthropic_beta added: ${addedB.join(', ')}` });
+    if (removedB.length > 0) out.push({ summary: `anthropic_beta removed: ${removedB.join(', ')}` });
+  }
+
+  // system_prompt — content (detail = unified diff)
+  if ((prev.system_prompt || '') !== (now.system_prompt || '')) {
+    const prevLen = (prev.system_prompt || '').length;
+    const nowLen = (now.system_prompt || '').length;
+    const delta = nowLen - prevLen;
+    out.push({
+      summary: `system_prompt content changed (${prevLen} → ${nowLen} chars, delta ${delta >= 0 ? '+' : ''}${delta})`,
+      detail: unifiedDiff(prev.system_prompt || '', now.system_prompt || ''),
+    });
+  }
+
+  // body_field_order — array deep-equal
+  if (JSON.stringify(prev.body_field_order || []) !== JSON.stringify(now.body_field_order || [])) {
+    out.push({
+      summary: 'body_field_order changed',
+      detail: [
+        `- ${JSON.stringify(prev.body_field_order)}`,
+        `+ ${JSON.stringify(now.body_field_order)}`,
+      ],
+    });
+  }
+
+  // header_order — array deep-equal
+  if (JSON.stringify(prev.header_order || []) !== JSON.stringify(now.header_order || [])) {
+    out.push({
+      summary: 'header_order changed',
+      detail: [
+        `- ${JSON.stringify(prev.header_order)}`,
+        `+ ${JSON.stringify(now.header_order)}`,
+      ],
+    });
+  }
+
+  // agent_identity — exact string, detail = unified diff
+  if ((prev.agent_identity || '') !== (now.agent_identity || '')) {
+    const prevLen = (prev.agent_identity || '').length;
+    const nowLen = (now.agent_identity || '').length;
+    out.push({
+      summary: `agent_identity content changed (${prevLen} → ${nowLen} chars)`,
+      detail: unifiedDiff(prev.agent_identity || '', now.agent_identity || ''),
+    });
+  }
+
+  return out;
+}
+
+/**
+ * Render a drift report (from `computeDrift`) into the line list that
+ * `capture-and-bake.mjs --check` logs through `log()`. Each summary
+ * appears as a bullet; each detail line is indented under its bullet so
+ * the [bake] prefix doesn't break the visual hierarchy.
+ */
+export function formatDriftReport(diff) {
+  const lines = [];
+  for (const item of diff) {
+    lines.push(`  • ${item.summary}`);
+    if (item.detail && item.detail.length > 0) {
+      for (const d of item.detail) lines.push(`      ${d}`);
+    }
+  }
+  return lines;
+}

--- a/test/bake-drift-report.mjs
+++ b/test/bake-drift-report.mjs
@@ -1,0 +1,235 @@
+// Unit tests for the drift-report helpers in scripts/drift-report.mjs.
+// Lives in the test:serial set because it imports from .mjs (the parallel
+// test runner spawns each file via node:test which is fine for imports
+// too, but the existing pattern groups script-imports in serial).
+
+import { unifiedDiff, computeDrift, describeTool, formatDriftReport } from '../scripts/drift-report.mjs';
+
+let pass = 0;
+let fail = 0;
+
+function check(label, cond) {
+  if (cond) { console.log(`  ✅ ${label}`); pass++; }
+  else { console.log(`  ❌ ${label}`); fail++; }
+}
+
+function header(label) {
+  console.log(`\n======================================================================`);
+  console.log(`  ${label}`);
+  console.log(`======================================================================`);
+}
+
+// ──────────────────────────────────────────────────────────────────────
+header('1. unifiedDiff — identical inputs return empty');
+{
+  check('identical strings → []', unifiedDiff('foo\nbar', 'foo\nbar').length === 0);
+  check('both empty → []', unifiedDiff('', '').length === 0);
+}
+
+// ──────────────────────────────────────────────────────────────────────
+header('2. unifiedDiff — single-line change');
+{
+  const a = 'line one\nline two\nline three';
+  const b = 'line one\nline two CHANGED\nline three';
+  const diff = unifiedDiff(a, b);
+  check('contains the removed line', diff.some((l) => l === '-line two'));
+  check('contains the added line', diff.some((l) => l === '+line two CHANGED'));
+  check('contains context (unchanged neighbors)', diff.some((l) => l === ' line one') && diff.some((l) => l === ' line three'));
+}
+
+// ──────────────────────────────────────────────────────────────────────
+header('3. unifiedDiff — line insertion');
+{
+  const a = 'a\nb\nc';
+  const b = 'a\nb\nNEW\nc';
+  const diff = unifiedDiff(a, b);
+  check('shows the inserted line as +', diff.some((l) => l === '+NEW'));
+  check('no false deletes', !diff.some((l) => l.startsWith('-')));
+}
+
+// ──────────────────────────────────────────────────────────────────────
+header('4. unifiedDiff — line deletion');
+{
+  const a = 'a\nb\nGONE\nc';
+  const b = 'a\nb\nc';
+  const diff = unifiedDiff(a, b);
+  check('shows the deleted line as -', diff.some((l) => l === '-GONE'));
+  check('no false adds', !diff.some((l) => l.startsWith('+')));
+}
+
+// ──────────────────────────────────────────────────────────────────────
+header('5. unifiedDiff — maxLines cap');
+{
+  // 200 changed lines vs maxLines=10
+  const a = Array.from({ length: 200 }, (_, i) => `prev-${i}`).join('\n');
+  const b = Array.from({ length: 200 }, (_, i) => `now-${i}`).join('\n');
+  const diff = unifiedDiff(a, b, { maxLines: 10, contextLines: 0 });
+  check('output is bounded at maxLines (+ optional truncation marker)', diff.length <= 11);
+  check('truncation marker mentions "more"', diff.some((l) => /more/.test(l)));
+}
+
+// ──────────────────────────────────────────────────────────────────────
+header('6. unifiedDiff — empty input on one side');
+{
+  const a = '';
+  const b = 'just one line';
+  const diff = unifiedDiff(a, b);
+  check('non-empty side shows as +', diff.some((l) => l === '+just one line'));
+}
+
+// ──────────────────────────────────────────────────────────────────────
+header('7. unifiedDiff — preserves order of multiple hunks');
+{
+  const a = 'a\nb\nc\nd\ne\nf\ng\nh\ni\nj';
+  const b = 'a\nb\nc\nX\ne\nf\ng\nh\nY\nj';   // d→X, i→Y; far enough apart for separate hunks
+  const diff = unifiedDiff(a, b, { contextLines: 1 });
+  // hunks are separated by " … " markers when there are unchanged lines
+  // between them that aren't in context
+  check('first hunk delete appears before second hunk delete', diff.indexOf('-d') < diff.indexOf('-i'));
+  check('first hunk add appears before second hunk add', diff.indexOf('+X') < diff.indexOf('+Y'));
+}
+
+// ──────────────────────────────────────────────────────────────────────
+header('8. describeTool — name + description + input keys');
+{
+  const tool = {
+    name: 'SearchTool',
+    description: 'Search the web for the given query.',
+    input_schema: { type: 'object', properties: { query: { type: 'string' }, limit: { type: 'number' } } },
+  };
+  const lines = describeTool(tool);
+  check('first line includes name + description prefix', lines[0].startsWith('SearchTool: Search the web'));
+  check('input keys line lists property names', lines.some((l) => /input keys:.*query/.test(l) && /limit/.test(l)));
+}
+
+header('9. describeTool — missing description / schema graceful');
+{
+  const tool = { name: 'Bare' };
+  const lines = describeTool(tool);
+  check('returns at least one line', lines.length >= 1);
+  check('first line is just the name when no description', lines[0] === 'Bare');
+}
+
+header('10. describeTool — null tool returns empty array');
+{
+  check('null → []', describeTool(null).length === 0);
+  check('undefined → []', describeTool(undefined).length === 0);
+}
+
+// ──────────────────────────────────────────────────────────────────────
+function makeTemplate(overrides = {}) {
+  return {
+    _version: '2.1.143',
+    _captured: '2026-05-17T00:00:00Z',
+    agent_identity: 'You are Claude Code.',
+    system_prompt: 'You are an assistant.\nFollow instructions.',
+    tools: [
+      { name: 'Read', description: 'Read a file', input_schema: { type: 'object', properties: { path: { type: 'string' } } } },
+      { name: 'Bash', description: 'Run a shell command', input_schema: { type: 'object', properties: { cmd: { type: 'string' } } } },
+    ],
+    anthropic_beta: 'claude-code-20250219',
+    body_field_order: ['model', 'system', 'messages'],
+    header_order: ['accept', 'anthropic-version'],
+    ...overrides,
+  };
+}
+
+header('11. computeDrift — no differences → empty');
+{
+  const t = makeTemplate();
+  check('identical templates → no drift', computeDrift(t, t).length === 0);
+}
+
+header('12. computeDrift — tools added carries detail');
+{
+  const prev = makeTemplate();
+  const now = makeTemplate({
+    tools: [
+      ...prev.tools,
+      { name: 'NewTool', description: 'A newly added tool', input_schema: { type: 'object', properties: { foo: { type: 'string' } } } },
+    ],
+  });
+  const d = computeDrift(prev, now);
+  check('one entry produced', d.length === 1);
+  check('summary names the added tool', /tools added.*NewTool/.test(d[0].summary));
+  check('detail describes the tool', d[0].detail?.some((l) => /NewTool:.*newly added/.test(l)));
+  check('detail lists schema keys', d[0].detail?.some((l) => /input keys:.*foo/.test(l)));
+}
+
+header('13. computeDrift — tools removed carries detail');
+{
+  const prev = makeTemplate();
+  const now = makeTemplate({ tools: prev.tools.filter((t) => t.name !== 'Bash') });
+  const d = computeDrift(prev, now);
+  check('summary names removed tool', /tools removed.*Bash/.test(d[0].summary));
+  check('detail describes the removed tool', d[0].detail?.some((l) => /Bash:.*shell command/.test(l)));
+}
+
+header('14. computeDrift — system_prompt change carries unified diff');
+{
+  const prev = makeTemplate({ system_prompt: 'line one\nline two\nline three' });
+  const now = makeTemplate({ system_prompt: 'line one\nline TWO\nline three' });
+  const d = computeDrift(prev, now);
+  check('one entry produced', d.length === 1);
+  check('summary mentions char delta', /system_prompt content changed/.test(d[0].summary));
+  check('detail contains the - line', d[0].detail?.some((l) => l === '-line two'));
+  check('detail contains the + line', d[0].detail?.some((l) => l === '+line TWO'));
+}
+
+header('15. computeDrift — anthropic_beta added/removed are separate entries');
+{
+  const prev = makeTemplate({ anthropic_beta: 'a,b' });
+  const now = makeTemplate({ anthropic_beta: 'b,c' });
+  const d = computeDrift(prev, now);
+  const summaries = d.map((e) => e.summary);
+  check('beta added entry present', summaries.some((s) => /anthropic_beta added: c/.test(s)));
+  check('beta removed entry present', summaries.some((s) => /anthropic_beta removed: a/.test(s)));
+}
+
+header('16. computeDrift — body_field_order detail shows before/after JSON');
+{
+  const prev = makeTemplate();
+  const now = makeTemplate({ body_field_order: ['model', 'messages', 'system'] });
+  const d = computeDrift(prev, now);
+  check('one entry produced', d.length === 1);
+  check('summary names the slot', d[0].summary === 'body_field_order changed');
+  check('detail shows - and + lines with JSON arrays', d[0].detail?.length === 2 && d[0].detail[0].startsWith('-') && d[0].detail[1].startsWith('+'));
+}
+
+header('17. computeDrift — agent_identity change carries diff');
+{
+  const prev = makeTemplate({ agent_identity: 'You are Claude.' });
+  const now = makeTemplate({ agent_identity: 'You are Claude Code.' });
+  const d = computeDrift(prev, now);
+  check('summary names the slot', /agent_identity content changed/.test(d[0].summary));
+  check('detail produced (unified diff)', Array.isArray(d[0].detail) && d[0].detail.length > 0);
+}
+
+header('18. computeDrift — multi-axis drift returns multiple entries');
+{
+  const prev = makeTemplate();
+  const now = makeTemplate({
+    system_prompt: 'changed',
+    anthropic_beta: 'claude-code-20250219,new-beta-2026-01-01',
+    tools: [...prev.tools, { name: 'X', description: 'x', input_schema: { type: 'object' } }],
+  });
+  const d = computeDrift(prev, now);
+  check('three entries produced (tools added + beta added + system_prompt changed)', d.length === 3);
+}
+
+// ──────────────────────────────────────────────────────────────────────
+header('19. formatDriftReport — bullets summaries, indents details');
+{
+  const diff = [
+    { summary: 'A changed', detail: ['-old', '+new'] },
+    { summary: 'B changed' },
+  ];
+  const lines = formatDriftReport(diff);
+  check('summary A appears as a bullet', lines.some((l) => l === '  • A changed'));
+  check('detail lines indented under A', lines.some((l) => l === '      -old') && lines.some((l) => l === '      +new'));
+  check('summary B has no detail lines', lines.includes('  • B changed') && lines.filter((l) => /^      /.test(l)).length === 2);
+}
+
+// ──────────────────────────────────────────────────────────────────────
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## What does this PR do?

Replaces \"a tripwire that says \`system_prompt content changed (12716 → 12719 chars)\`\" with \"a tripwire that includes a unified diff of *what changed*\". Faster triage of class-B drift events without leaving the issue / PR body.

### Mechanism

Drift detection extracted into a new \`scripts/drift-report.mjs\` module — testable without spawning live CC. Three helpers:

- **\`unifiedDiff(prev, now, opts)\`** — line-level diff (LCS-table backtrack), \`contextLines\` / \`maxLines\` bounded for issue/PR embedding. Used for \`system_prompt\` and \`agent_identity\`.
- **\`describeTool(tool)\`** — for \`tools added\`/\`removed\`, renders name + first-line description (capped) + \`input_schema.properties\` keys. A reviewer sees *what the tool does* without checking out the branch.
- **\`formatDriftReport(diff)\`** — renders rich entries as indented bullets for \`--check\` log output.

\`computeDrift\` now returns \`{ summary, detail? }\` entries (was plain strings). The workflow's drift-output.txt already gets embedded verbatim in the issue + auto-rebake PR bodies, so the richer output flows through without any workflow change.

### Detail coverage by slot

| Drift slot | Detail format |
|---|---|
| \`tools added\` / \`tools removed\` | per-tool: name, first-line description (cap 100 chars), input-schema property keys |
| \`system_prompt\` content | bounded unified-line diff (default ±2 context, 60 line cap) |
| \`agent_identity\` content | same |
| \`body_field_order\` | before / after JSON arrays |
| \`header_order\` | before / after JSON arrays |
| \`anthropic_beta\` added/removed | summary already names the betas — no detail |

### Tests

**New file \`test/bake-drift-report.mjs\`** — 19 headers, 42 assertions covering: identical/empty inputs, single-line / insertion / deletion / multi-hunk cases, maxLines cap, describeTool graceful on missing fields, per-slot drift detection, multi-axis aggregation, formatDriftReport indentation contract.

\`npm test\` → **75/75 green** (74 + the new file).

## How to test

\`\`\`bash
git fetch origin feat/v4.5.0-diff-fidelity
git checkout feat/v4.5.0-diff-fidelity
npm run build && npm test     # 75/75

# Optional: simulate a drift report against a modified template:
node -e \"
import('./scripts/drift-report.mjs').then(({ computeDrift, formatDriftReport }) => {
  const t = (sp) => ({ tools: [], system_prompt: sp, agent_identity: '', anthropic_beta: '', body_field_order: [], header_order: [] });
  const diff = computeDrift(t('hello\nworld'), t('hello\nWORLD\nnew line'));
  console.log(formatDriftReport(diff).join('\n'));
});
\"
\`\`\`

## Checklist
- [x] \`npm run build\` passes
- [x] \`npm test\` passes (offline regression test, no credentials required) — 75/75
- [x] For changes that touch \`proxy.ts\`, \`cc-template.ts\`, or streaming behavior: tested with \`dario proxy --verbose\` + \`node test/compat.mjs\` (requires credentials) — *N/A: scripts + tests only, no src/ changes*
- [x] No new runtime dependencies added
- [x] No tokens/secrets in code or logs