### PR TITLE
release: v4.6.1 — pin runner workflows to port 3457 (away from platform's :3456)

### DIFF
--- a/.github/workflows/cc-billing-classifier-canary.yml
+++ b/.github/workflows/cc-billing-classifier-canary.yml
@@ -63,17 +63,25 @@ jobs:
         # runner credential. NO --passthrough flag here: the canary is
         # specifically validating dario's rebuild-from-canonical mode, the
         # mode every non-CC dario user runs in.
+        #
+        # --port 3457 (v4.6.1) — see compat-test-self-hosted.yml for the
+        # rationale. The platform runs its own dario at :3456 via docker;
+        # without --port the canary's `dario proxy` exits 0 ("already
+        # running") and the curl below silently hits the platform dario
+        # using PLATFORM credentials, producing 401s that look like
+        # classifier flips. Use :3457 so the workflow's own dist actually
+        # runs.
         env:
           HOME: /root/.claude-runner
         run: |
-          node dist/cli.js proxy > proxy.log 2>&1 &
+          node dist/cli.js proxy --port 3457 > proxy.log 2>&1 &
           echo $! > proxy.pid
           echo "started dario proxy with PID $(cat proxy.pid)"
 
           # Wait up to 30s for /health to respond.
           ready=false
           for i in $(seq 1 30); do
-            if curl -sf -o /dev/null --max-time 2 http://127.0.0.1:3456/health; then
+            if curl -sf -o /dev/null --max-time 2 http://127.0.0.1:3457/health; then
               ready=true
               echo "proxy ready after ${i}s"
               break
@@ -93,10 +101,11 @@ jobs:
 
           # Send a tiny haiku request — cheapest model + tiny output budget.
           # The model: claude-haiku-4-5-20251001 is the same one the
-          # compat-test uses for its probe step.
+          # compat-test uses for its probe step. :3457 matches the proxy
+          # port set in the Start step (avoid the platform's :3456).
           response_headers=$(mktemp)
           curl -sS -D "$response_headers" -o /dev/null \
-            -X POST http://127.0.0.1:3456/v1/messages \
+            -X POST http://127.0.0.1:3457/v1/messages \
             -H "Content-Type: application/json" \
             -H "anthropic-version: 2023-06-01" \
             -H "x-api-key: dario" \

--- a/.github/workflows/compat-test-self-hosted.yml
+++ b/.github/workflows/compat-test-self-hosted.yml
@@ -78,15 +78,23 @@ jobs:
         # /root/.claude/.credentials.json the box's other CC clients use
         # (e.g. docker services that mount /root/.claude/). Setup:
         # docs/drift-monitor.md.
+        #
+        # --port 3457 (v4.6.1) avoids the platform's existing dario at
+        # :3456 (askalf-dario docker container). Without this, dario's
+        # "already running" detection short-circuits the workflow's own
+        # startup and the test runs against the WRONG dario — the
+        # platform's, not the PR's freshly-built one. DARIO_TEST_URL
+        # is read by test/compat.mjs.
         env:
           HOME: /root/.claude-runner
+          DARIO_TEST_URL: http://127.0.0.1:3457
         run: |
           # Background-start the proxy, capture PID for the always-run
           # teardown step. --passthrough disables the canonical wire-shape
           # rebuild path so compat.mjs can verify dario forwards the
           # client's exact request shape (the explicit guarantee
           # passthrough mode makes).
-          node dist/cli.js proxy --passthrough > proxy.log 2>&1 &
+          node dist/cli.js proxy --passthrough --port 3457 > proxy.log 2>&1 &
           echo $! > proxy.pid
           echo "started dario proxy with PID $(cat proxy.pid)"
 
@@ -94,7 +102,7 @@ jobs:
           # Bail with the proxy log if it never comes up.
           ready=false
           for i in $(seq 1 30); do
-            if curl -sf -o /dev/null --max-time 2 http://127.0.0.1:3456/health; then
+            if curl -sf -o /dev/null --max-time 2 http://127.0.0.1:3457/health; then
               ready=true
               echo "proxy ready after ${i}s"
               break
@@ -110,6 +118,10 @@ jobs:
 
       - name: Run compat tests
         id: compat
+        # DARIO_TEST_URL points test/compat.mjs at the workflow's :3457
+        # proxy, not the platform's :3456 one.
+        env:
+          DARIO_TEST_URL: http://127.0.0.1:3457
         run: |
           set +e
           node test/compat.mjs | tee compat-output.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ checklist.
 
 ## [Unreleased]
 
+## [4.6.1] - 2026-05-17
+
+### Fixed — runner workflows now actually test the PR's dist
+
+When v4.6.0's billing canary first ran on the production runner, it returned `representative-claim: ''` and a 401 — but the runner's `claude --print` smoke test passed cleanly. Investigation revealed both runner workflows had been silently piggybacking on the platform's existing dario instance (the `askalf-dario` docker container at port 3456), not the freshly-built `dist/` they were supposed to test.
+
+**Mechanism.** `dario proxy` has a friendly EADDRINUSE handler: when its target port is occupied, it probes `/health`, sees an existing dario, prints "dario — already running" and exits 0 (so users running `dario login` or `dario proxy` twice get a no-op instead of a crash). On the production runner, the platform's docker `askalf-dario` already binds :3456 — so the workflow's `dario proxy` short-circuits, the workflow's curls hit the platform's dario, and the platform's auth (`/root/.claude/.credentials.json`, not `/root/.claude-runner/.claude/.credentials.json`) services them. For the canary, that returned 401 because the platform's credential happens to be on a different account state right now. For compat-test, every PR check has been validating the platform's dario binary, not the PR's — which means several recent PRs (#303, #304, #306, #308, #310, #311) were never actually compat-tested.
+
+**Fix.** Both runner workflows now bind `--port 3457` and the test harnesses read `DARIO_TEST_URL=http://127.0.0.1:3457`. Eliminates the port collision with the platform dario.
+
+- [`compat-test-self-hosted.yml`](.github/workflows/compat-test-self-hosted.yml): `Start dario proxy` adds `--port 3457`, env adds `DARIO_TEST_URL=http://127.0.0.1:3457` for both Start + Run steps; readiness probe + comment fallback all point at :3457.
+- [`cc-billing-classifier-canary.yml`](.github/workflows/cc-billing-classifier-canary.yml): `Start dario proxy` adds `--port 3457`; canary curl posts to `:3457/v1/messages`.
+
+**Validation.** Local manual run on the production runner with these flags (`HOME=/root/.claude-runner dario proxy --port 3457`) — proxy started cleanly, `/health` responded, single tiny haiku request returned 200, `representative-claim` header was a subscription value. Confirms the workflow path will resolve to a subscription bucket once the fix lands.
+
+### Why a patch
+
+Pure operational hardening — same vintage as v4.4.1 (workflow env fix). The previous behavior wasn't "wrong" in any user-visible way; the workflows just weren't testing what they advertised. No `src/` changes.
+
+### Internal
+
+- Two workflow files updated
+- No `src/` edits, no new tests (the existing tests run unchanged; what changes is *which* dario binary they hit)
+- 75/75 default suite green
+
 ## [4.6.0] - 2026-05-17
 
 ### Added — daily billing classifier canary

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What does this PR do?

Fixes a silent test-of-the-wrong-binary problem that's been hiding since v4.3.0.

### What broke

When v4.6.0's billing canary first ran on the production runner, it returned \`representative-claim: ''\` and a 401 — but \`claude --print\` on the same box with the same \`HOME\` was returning PONG cleanly. Investigation:

1. \`dario proxy\` has a friendly EADDRINUSE handler. When its target port is occupied, it probes \`/health\`, sees an existing dario, prints \"dario — already running\" and exits 0. Intentional: makes \`dario login\` and \`dario proxy\` idempotent for users.
2. On the production runner, the askalf platform's own docker container (\`askalf-dario\`) already binds \`:3456\`.
3. So every \"Start dario proxy\" step in the runner workflows short-circuited, **exited 0**, and the subsequent curls in the workflow hit the platform's dario — using the platform's \`/root/.claude/.credentials.json\` (not the runner-isolated \`/root/.claude-runner/.claude/.credentials.json\` from v4.4.1).

For the canary that's an obvious 401 (platform credential in a different state). For **compat-test**, it's worse: every PR check on PRs **#303, #304, #306, #308, #310, #311** was validating the platform dario, not the PR's freshly-built dist. The PR-time gate was measuring the wrong thing.

### Fix

Both runner workflows now bind \`--port 3457\` (away from the platform's :3456) and the harnesses read \`DARIO_TEST_URL=http://127.0.0.1:3457\`. Eliminates the port collision.

- \`compat-test-self-hosted.yml\`: \`Start dario proxy\` adds \`--port 3457\`; both Start + Run Tests steps env-set \`DARIO_TEST_URL=http://127.0.0.1:3457\`; readiness probe + PR-comment fallback all point at :3457.
- \`cc-billing-classifier-canary.yml\`: \`Start dario proxy\` adds \`--port 3457\`; canary curl posts to \`:3457/v1/messages\`.

### Validation

Manual run on the production runner with these flags:

\`\`\`bash
HOME=/root/.claude-runner DARIO_QUIET_TLS=1 dario proxy --port 3457
# → starts clean, /health responds, single tiny haiku request returns 200
# → representative-claim is a subscription value
\`\`\`

The workflow path will produce the same result once landed — both gates will start actually validating the PR's dist instead of the platform's.

## How to test

\`\`\`bash
git fetch origin fix/v4.6.1-runner-port-isolation
git checkout fix/v4.6.1-runner-port-isolation
npm run build && npm test     # 75/75

# End-to-end: this PR touches a workflow file in compat-test-self-hosted.yml's
# path filter, so compat-test fires on the PR. THAT run is the validation:
# it should resolve to compat tests passing against THIS branch's freshly-
# built dist, not the platform dario at :3456.

# Also, manually dispatch the canary after merge:
gh workflow run cc-billing-classifier-canary.yml --ref master
# Expected: exit 0, no alert (canary healthy = subscription). If 4.6.0's
# fake-401 was misdiagnosing rather than an actual classifier issue, this
# will close out cleanly. If it was a real classifier flip, the canary
# now produces an honest signal.
\`\`\`

## Checklist
- [x] \`npm run build\` passes
- [x] \`npm test\` passes (offline regression test, no credentials required) — 75/75
- [x] For changes that touch \`proxy.ts\`, \`cc-template.ts\`, or streaming behavior: tested with \`dario proxy --verbose\` + \`node test/compat.mjs\` (requires credentials) — *N/A: workflow + CHANGELOG only, no src/ changes*
- [x] No new runtime dependencies added
- [x] No tokens/secrets in code or logs