### PR TITLE
release: v4.6.2 — --port=3457 not --port 3457 in runner workflows

### DIFF
--- a/.github/workflows/cc-billing-classifier-canary.yml
+++ b/.github/workflows/cc-billing-classifier-canary.yml
@@ -64,7 +64,7 @@ jobs:
         # specifically validating dario's rebuild-from-canonical mode, the
         # mode every non-CC dario user runs in.
         #
-        # --port 3457 (v4.6.1) — see compat-test-self-hosted.yml for the
+        # --port=3457 (v4.6.1) — see compat-test-self-hosted.yml for the
         # rationale. The platform runs its own dario at :3456 via docker;
         # without --port the canary's `dario proxy` exits 0 ("already
         # running") and the curl below silently hits the platform dario
@@ -74,7 +74,7 @@ jobs:
         env:
           HOME: /root/.claude-runner
         run: |
-          node dist/cli.js proxy --port 3457 > proxy.log 2>&1 &
+          node dist/cli.js proxy --port=3457 > proxy.log 2>&1 &
           echo $! > proxy.pid
           echo "started dario proxy with PID $(cat proxy.pid)"
 

--- a/.github/workflows/compat-test-self-hosted.yml
+++ b/.github/workflows/compat-test-self-hosted.yml
@@ -79,7 +79,7 @@ jobs:
         # (e.g. docker services that mount /root/.claude/). Setup:
         # docs/drift-monitor.md.
         #
-        # --port 3457 (v4.6.1) avoids the platform's existing dario at
+        # --port=3457 (v4.6.1) avoids the platform's existing dario at
         # :3456 (askalf-dario docker container). Without this, dario's
         # "already running" detection short-circuits the workflow's own
         # startup and the test runs against the WRONG dario — the
@@ -94,7 +94,7 @@ jobs:
           # rebuild path so compat.mjs can verify dario forwards the
           # client's exact request shape (the explicit guarantee
           # passthrough mode makes).
-          node dist/cli.js proxy --passthrough --port 3457 > proxy.log 2>&1 &
+          node dist/cli.js proxy --passthrough --port=3457 > proxy.log 2>&1 &
           echo $! > proxy.pid
           echo "started dario proxy with PID $(cat proxy.pid)"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ checklist.
 
 ## [Unreleased]
 
+## [4.6.2] - 2026-05-17
+
+### Fixed — runner workflows actually use port 3457 now
+
+v4.6.1 declared `--port 3457` (space-separated) for both runner workflows to avoid the platform's existing dario at `:3456`. dario's CLI only accepts `--port=3457` (equals-separated) — the space-separated form silently falls through to the default 3456. Result: v4.6.1's compat-test on PR #313 still bound to :3456, still short-circuited to the platform's dario.
+
+We caught the bug because v4.6.1's compat-test on PR #313 failed with the same `dario — already running on http://localhost:3456` proxy.log output v4.6.1 claimed to fix. That's actually the system working as designed — the runner is now testing the right binary frequently enough that bugs in the harness can't hide.
+
+**Fix.** Six `--port 3457` → `--port=3457` substitutions across the two workflow files. Same change in spirit as v4.6.1; same change in code as a one-character typo.
+
+### Why a patch
+
+Same shape as v4.4.1 and v4.6.1 — operational hardening. The previous behavior wasn't *wrong* in any user-visible way; the workflows just weren't binding the port they claimed to. No `src/` changes.
+
+### Internal
+
+- Two workflow files updated (`compat-test-self-hosted.yml`, `cc-billing-classifier-canary.yml`)
+- No `src/` edits, no tests changed
+- 75/75 default suite green
+
 ## [4.6.1] - 2026-05-17
 
 ### Fixed — runner workflows now actually test the PR's dist

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What does this PR do?

v4.6.1's port fix was a one-character regression. Declared \`--port 3457\` (space-separated) but dario's CLI only parses \`--port=3457\` (equals-separated). Space-separated form silently falls through to the default 3456 — which is exactly the port v4.6.1 was meant to avoid (the platform's askalf-dario docker container).

**How we caught it:** v4.6.1's own compat-test on PR #313 failed with the exact \`dario — already running on http://localhost:3456\` proxy.log output that v4.6.1 was supposed to fix. That's the system catching itself — the runner is now testing the right binary frequently enough that harness bugs can't hide. (Previous PRs short-circuited so quickly that this bug looked like a green test.)

### Fix

Six \`--port 3457\` → \`--port=3457\` substitutions across:
- \`.github/workflows/compat-test-self-hosted.yml\` (Start step + 3 comment refs)
- \`.github/workflows/cc-billing-classifier-canary.yml\` (Start step + 1 comment ref)

## How to test

The PR's own compat-test will fire (touches \`compat-test-self-hosted.yml\` path filter). If it goes green, the workflow is now binding :3457 properly and exercising the freshly-built dist. If it fails, the failure is real (no more \"silent platform-dario shadow\").

\`\`\`bash
git fetch origin fix/v4.6.2-port-syntax
git checkout fix/v4.6.2-port-syntax
npm run build && npm test       # 75/75 (no src/ changes)

# Verify locally (won't run actions — show the dist binary's parsing):
node dist/cli.js proxy --port 3457 --help 2>&1 | head -2   # ignores
node dist/cli.js proxy --port=3457 --help 2>&1 | head -2   # respected
\`\`\`

## Checklist
- [x] \`npm run build\` passes
- [x] \`npm test\` passes (offline regression test, no credentials required) — 75/75
- [x] For changes that touch \`proxy.ts\`, \`cc-template.ts\`, or streaming behavior: tested with \`dario proxy --verbose\` + \`node test/compat.mjs\` (requires credentials) — *N/A: workflow + docs only, no src/ changes*
- [x] No new runtime dependencies added
- [x] No tokens/secrets in code or logs