### PR TITLE
release: v4.6.3 — PIPESTATUS in compat-test + rate-limit headroom docs

### DIFF
--- a/.github/workflows/compat-test-self-hosted.yml
+++ b/.github/workflows/compat-test-self-hosted.yml
@@ -124,8 +124,16 @@ jobs:
           DARIO_TEST_URL: http://127.0.0.1:3457
         run: |
           set +e
+          # `node test/compat.mjs | tee` — without pipefail, `$?` captures
+          # `tee`'s exit (always 0), NOT compat.mjs's. v4.6.3 fix: use
+          # ${PIPESTATUS[0]} (the leftmost command's exit code) so a
+          # failing compat suite actually surfaces as a non-zero exit.
+          # Pre-v4.6.3 this step always emitted `exit_code=0`, which let
+          # the workflow's job status finalizer mark the run SUCCESS even
+          # when 9/10 compat assertions failed. Caught by hand on the
+          # v4.6.2 follow-up run (#26003543366).
           node test/compat.mjs | tee compat-output.txt
-          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
       - name: Stop dario proxy
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ checklist.
 
 ## [Unreleased]
 
+## [4.6.3] - 2026-05-17
+
+### Fixed — compat-test no longer reports SUCCESS while tests fail
+
+A latent harness bug surfaced as soon as v4.6.2 made compat-test actually reach the PR's own dist. The "Run compat tests" step ran `node test/compat.mjs | tee compat-output.txt`, then captured `$?` into `GITHUB_OUTPUT`. Without `pipefail` set, `$?` is the exit code of `tee`, which is always 0 — so a 9-of-10-failing compat suite still emitted `exit_code=0`, and the workflow's job-status finalizer marked the run SUCCESS.
+
+We caught this in PR #314's compat-test run (#26003543366): the proxy.log proved :3457 was bound and the PR's own dist was being exercised; the test output showed `RESULTS: 1 passed, 9 failed`; the workflow check on the PR showed `compat: SUCCESS`. The bug hid itself for every prior compat run since v4.3.0 because v4.6.0/v4.6.1 had different bugs that caused the workflow to fail earlier — only v4.6.2 made compat-test reach this step cleanly enough to expose it.
+
+**Fix.** Capture `${PIPESTATUS[0]}` (the leftmost piped command's exit) instead of `$?`. Single line change in `.github/workflows/compat-test-self-hosted.yml`.
+
+### Documented — runner credential rate-limit headroom
+
+`docs/drift-monitor.md` gains a section on the runner credential's expected request budget across all the workflows that hit it. Pro/Max accounts have per-hour rate caps as well as the per-5h / per-7d pools, and the per-hour cap is what surfaces first when manually re-triggering workflows in rapid succession (we tripped this during the v4.6.x rollout with a half-dozen manual re-runs in 2 hours). The runner credential should run a real Pro/Max subscription with no other workload on it; v4.4.1's `HOME=/root/.claude-runner` isolation already gives it its own token pair within the same account, but if you want a fully separate subscription pool too, log into a different account during `dario login --manual` against that HOME.
+
+### Why a patch
+
+Same shape as v4.4.1 / v4.6.1 / v4.6.2 — operational hardening on the runner workflow surface. No `src/` changes. Docs + workflow only.
+
+### Internal
+
+- One workflow line changed (`compat-test-self-hosted.yml` Run compat tests step)
+- `docs/drift-monitor.md`: new section "Runner credential rate-limit headroom"
+- 75/75 default suite green
+
 ## [4.6.2] - 2026-05-17
 
 ### Fixed — runner workflows actually use port 3457 now

--- a/docs/drift-monitor.md
+++ b/docs/drift-monitor.md
@@ -189,6 +189,22 @@ git diff src/cc-template-data.json  # review
 # version. The next clean --check cycle auto-closes the drift issue.
 ```
 
+## Runner credential rate-limit headroom
+
+Workflows that exercise live `dario proxy` paths (compat-test, billing canary, future end-to-end probes) all consume against the runner credential's subscription pool. The cadence assumptions are:
+
+| Workflow | Cadence | Requests per fire |
+|---|---|---|
+| `cc-drift-template-watch.yml` (`--check`) | every 30 min | 1 capture (no /v1/messages traffic — MITM-only) |
+| `cc-billing-classifier-canary.yml` | daily 06:30 UTC | 1 small haiku request |
+| `compat-test-self-hosted.yml` | per qualifying PR | ~11 small requests |
+
+At steady state, this is comfortably inside Pro/Max headroom. The failure mode to watch for is **batched firing** — manually re-triggering the same workflow several times in a single hour, or PRs landing in rapid succession that each fire compat-test. We tripped this during the v4.6.x rollout: a half-dozen manual re-runs in a 2-hour window 429'd the runner credential. Pro/Max accounts have per-hour rate caps as well as per-5h / per-7d pools, and the per-hour cap is what surfaces first.
+
+If the runner credential is rate-limited and a workflow run reports 429s across the board, the right diagnosis order is: (a) check `claude --print` with the runner HOME directly — if it 429s, the credential pool is dry, just wait an hour; (b) check the credential is still on a subscription account (`dario doctor`); (c) check workflow cadence assumptions haven't changed.
+
+The runner credential should run a real Pro/Max subscription with no other workload on it. Sharing the credential with manual `claude` sessions or other CC clients eats the headroom the watchers need. v4.4.1's `HOME=/root/.claude-runner` isolation gives the runner its own token pair within the same Pro/Max account; if you also need its own subscription account, log into a different one when running `dario login --manual` against the isolated HOME.
+
 ## Why a self-hosted runner
 
 GitHub-hosted runners can't capture CC. They have no Pro/Max subscription

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.6.2",
+  "version": "4.6.3",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What does this PR do?

Catches a latent harness bug that v4.6.2 exposed, plus operational guidance on the runner credential's rate-limit budget.

### The silent green-when-failing bug

The compat-test workflow's \"Run compat tests\" step ran:

\`\`\`bash
set +e
node test/compat.mjs | tee compat-output.txt
echo \"exit_code=\$?\" >> \"\$GITHUB_OUTPUT\"
\`\`\`

Without \`pipefail\` set, \`\$?\` is **\`tee\`'s** exit code — always 0 — not \`node test/compat.mjs\`'s. A 9-of-10-failing compat run emitted \`exit_code=0\` to GITHUB_OUTPUT; the \`Set job status\` finalizer ran \`exit 0\`; the workflow reported \`compat: SUCCESS\`.

Confirmed on PR #314's compat-test (run [26003543366](https://github.com/askalf/dario/actions/runs/26003543366)):
- proxy.log proved :3457 was bound to the PR's dist ✓
- test output: \`RESULTS: 1 passed, 9 failed\` ✗
- workflow check: \`compat: SUCCESS\` ❌

Bug hid itself across every compat run since v4.3.0 because v4.6.0 / v4.6.1 had earlier-in-the-workflow bugs that caused the workflow to fail before this step. v4.6.2 was the first release that let compat-test reach this step cleanly enough to expose the issue.

### Fix

\`\${PIPESTATUS[0]}\` (the leftmost piped command's exit) instead of \`\$?\`. One-line change.

### Runner credential rate-limit headroom — new docs section

\`docs/drift-monitor.md\` gains operational guidance on the request budget across the workflows that hit the runner credential. Pro/Max accounts have a **per-hour rate cap** as well as the per-5h / per-7d pools, and the per-hour cap surfaces first when manually re-triggering workflows in rapid succession.

We tripped this during the v4.6.x rollout with ~6 manual re-runs in 2 hours. Recommendation: the runner credential should ideally run a real Pro/Max subscription with no other workload on it. v4.4.1's \`HOME=/root/.claude-runner\` isolation already gives it its own token pair within the same account; for fully separate pool headroom, log into a different account during \`dario login --manual\` against that HOME.

## How to test

The PR's own compat-test fires. Two expected outcomes:

- **If the runner credential pool has recovered:** compat-test passes for real (10/10) — meaning the workflow + the PR's dist + the runner credential are all in working order.
- **If the runner is still rate-limited:** compat-test reports \`9 failed\` and (this time) marks the workflow check as **FAIL**. That's the fix working — failure is no longer silent.

Either case proves the fix. The only \"wrong\" outcome would be \`compat: SUCCESS\` with non-zero test failures in the output, which was the pre-v4.6.3 behavior.

## Checklist
- [x] \`npm run build\` passes
- [x] \`npm test\` passes (offline regression test, no credentials required) — 75/75
- [x] For changes that touch \`proxy.ts\`, \`cc-template.ts\`, or streaming behavior: tested with \`dario proxy --verbose\` + \`node test/compat.mjs\` (requires credentials) — *N/A: workflow + docs only*
- [x] No new runtime dependencies added
- [x] No tokens/secrets in code or logs