### PR TITLE
release: v4.6.5 — optional PAT for auto-rebake → compat-test triggers fire

### DIFF
--- a/.github/workflows/cc-drift-template-watch.yml
+++ b/.github/workflows/cc-drift-template-watch.yml
@@ -102,7 +102,20 @@ jobs:
         if: steps.check.outputs.exit_code == '2'
         id: rebake
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # v4.6.5: prefer DARIO_DRIFT_BOT_PAT (a fine-grained PAT) over
+          # the default GITHUB_TOKEN for the gh CLI ops below. PRs created
+          # by GITHUB_TOKEN don't trigger downstream workflows by design —
+          # so compat-test never observed auto-rebake PRs and the
+          # validation gate the v4.4.0 design promised was effectively
+          # bypassed. With a PAT, GitHub treats PR creation as a regular
+          # user action and `pull_request:` workflows fire normally.
+          #
+          # The `||` fallback to GITHUB_TOKEN means the workflow keeps
+          # working pre-PAT setup — you just don't get the compat-test
+          # gate on auto-rebake PRs (the same behavior as v4.4.0 through
+          # v4.6.4). Setup: docs/drift-monitor.md "Optional: PAT for
+          # downstream workflow triggers".
+          GH_TOKEN: ${{ secrets.DARIO_DRIFT_BOT_PAT || secrets.GITHUB_TOKEN }}
           # v4.4.1: dedicated runner credential isolated at
           # /root/.claude-runner/.claude/.credentials.json. Same rationale
           # as the Run drift check step above.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,39 @@ checklist.
 
 ## [Unreleased]
 
+## [4.6.5] - 2026-05-17
+
+### Fixed — auto-rebake PRs now eligible for compat-test gating (optional PAT)
+
+The first real-world class-B drift event today exposed a gap in the v4.4.0 design. When the watcher fired at 23:47 UTC, opened [PR #317](https://github.com/askalf/dario/pull/317) via `gh pr create`, and we went to merge it — branch protection blocked the merge because the **required compat-test check had never fired**. Compat-test (which lives in `pull_request:`) didn't observe the bot's PR at all.
+
+**Cause.** GitHub Actions has a deliberate security restriction: workflows authenticated by the default `GITHUB_TOKEN` cannot trigger downstream workflow runs ([docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)). The auto-rebake PR was therefore invisible to compat-test, and the validation gate the v4.4.0 CHANGELOG promised was effectively bypassed for every auto-rebake PR.
+
+**Fix.** [`cc-drift-template-watch.yml`](.github/workflows/cc-drift-template-watch.yml)'s `Auto-rebake + open PR` step now reads `GH_TOKEN: ${{ secrets.DARIO_DRIFT_BOT_PAT || secrets.GITHUB_TOKEN }}` — preferring a maintainer-supplied PAT if present, falling back to GITHUB_TOKEN if not. PRs created with a PAT are treated as a regular user action by Actions, so `pull_request:` triggers fire normally and compat-test gets to run.
+
+**Setup** (one-time, [`docs/drift-monitor.md`](docs/drift-monitor.md)):
+
+1. Generate a fine-grained PAT at `github.com/settings/personal-access-tokens/new` scoped to this repo with `Contents: write`, `Pull requests: write`, `Issues: write`.
+2. Add it as repo secret `DARIO_DRIFT_BOT_PAT`.
+3. Next drift event proves it: the bot PR will have a `compat` check alongside the others.
+
+The fallback to `GITHUB_TOKEN` exists so the watcher keeps working pre-PAT setup — operators can defer this without breaking the loop. The cost of deferring is "auto-rebake PRs need human-only review" (which is how PR #317 was actually merged tonight, with `--admin` to bypass the blocking required-check policy).
+
+### What PR #317 proved
+
+This was the first real-world execution of the v4.4.0 → v4.5.0 → v4.6.4 chain in production. Cycle: 23:47:27 UTC drift detected → bot opens [PR #317](https://github.com/askalf/dario/pull/317) with unified-line diff inline → human reviews (substantively non-trivial change: AskUserQuestion gained a new "Preview feature" section, "Executing actions with care" condensed from 4 paragraphs to 1 sentence, "clarifying question has a cost" guidance added) → human merges (admin override due to the gap fixed here) → 23:55:36 UTC watcher cycle confirms exit 0 → auto-closes [issue #318](https://github.com/askalf/dario/issues/318). Full receipt: 8 minutes from drift to fix to closure.
+
+### Why a patch
+
+Same shape as v4.4.1 / v4.6.1 / v4.6.2 / v4.6.3 — operational hardening on the workflow surface. No code change, no test change, just the workflow env line + docs. The fallback preserves the pre-v4.6.5 behavior for operators who haven't set up the PAT yet.
+
+### Internal
+
+- One workflow line changed (`cc-drift-template-watch.yml` GH_TOKEN env on the Auto-rebake step)
+- `docs/drift-monitor.md`: new section "Optional: PAT for downstream workflow triggers"
+- No `src/` edits
+- 75/75 default suite green
+
 ## [4.6.4] - 2026-05-17
 
 ### Updated — README + GitHub repo description reflect three-class drift

--- a/docs/drift-monitor.md
+++ b/docs/drift-monitor.md
@@ -189,6 +189,26 @@ git diff src/cc-template-data.json  # review
 # version. The next clean --check cycle auto-closes the drift issue.
 ```
 
+## Optional: PAT for downstream workflow triggers
+
+Since v4.4.0, the watcher auto-opens a `bot/template-rebake-*` PR on detection. Since v4.3.0, `compat-test-self-hosted.yml` is supposed to run on PRs touching `src/cc-template-data.json`. **Without the setup below, it doesn't.** GitHub Actions has a deliberate restriction: workflows authenticated by the default `GITHUB_TOKEN` cannot trigger downstream workflow runs ([docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)). The auto-rebake PR is therefore invisible to compat-test, and the validation gate the v4.4.0 design promised is effectively bypassed.
+
+To close the gap, create a fine-grained personal access token (PAT) scoped to this repo and expose it to the watcher as `DARIO_DRIFT_BOT_PAT`:
+
+1. **Generate** at `https://github.com/settings/personal-access-tokens/new`:
+   - Resource owner: your user (or org)
+   - Repository access: select `dario` only
+   - Permissions: **Contents: read & write**, **Pull requests: read & write**, **Issues: read & write**
+   - Expiration: whatever your security policy mandates (90 days / 1 year)
+
+2. **Store** at `Settings → Secrets and variables → Actions → New repository secret`:
+   - Name: `DARIO_DRIFT_BOT_PAT`
+   - Value: the PAT from step 1
+
+3. **Verify** on the next watcher cycle that detects drift. The auto-rebake PR's "Checks" tab should now include the `compat` job (which it didn't pre-v4.6.5).
+
+The watcher workflow uses `GH_TOKEN: ${{ secrets.DARIO_DRIFT_BOT_PAT || secrets.GITHUB_TOKEN }}` for `gh` CLI ops, so the PAT is **optional** — the watcher keeps working without it, you just don't get compat-test gating on auto-rebake PRs (same behavior as v4.4.0 through v4.6.4). The fallback exists so a maintainer can defer the PAT setup without breaking the loop.
+
 ## Runner credential rate-limit headroom
 
 Workflows that exercise live `dario proxy` paths (compat-test, billing canary, future end-to-end probes) all consume against the runner credential's subscription pool. The cadence assumptions are:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.6.4",
+  "version": "4.6.5",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What does this PR do?

Closes the gate-evasion gap that tonight's [PR #317](https://github.com/askalf/dario/pull/317) (first real-world class-B auto-rebake) exposed: compat-test never fired on the bot's PR, branch protection blocked the merge as a result, and the v4.4.0 design's "compat-test gates the rebake" promise was bypassed for every auto-rebake since the feature shipped.

### Why the gate didn't fire

GitHub Actions [deliberately doesn't trigger downstream workflow runs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) from events authenticated by the default \`GITHUB_TOKEN\`. The watcher used GITHUB_TOKEN to call \`gh pr create\`, so the resulting PR's \`pull_request:opened\` event was invisible to compat-test.

### Fix

\`cc-drift-template-watch.yml\`'s \`Auto-rebake + open PR\` step now reads:

\`\`\`yaml
env:
  GH_TOKEN: \${{ secrets.DARIO_DRIFT_BOT_PAT || secrets.GITHUB_TOKEN }}
\`\`\`

If the maintainer has set up a fine-grained PAT as \`DARIO_DRIFT_BOT_PAT\`, the PR is created by the PAT's owner (a regular user) and downstream workflows fire normally. If not, it falls back to GITHUB_TOKEN and behavior is identical to v4.6.4 (auto-rebake still works, just no compat-test gate).

The fallback exists so the watcher keeps working pre-PAT setup. The cost of deferring is \"auto-rebake PRs need human-only review\" — same as the manual admin-merge path tonight.

### Setup (one-time, in repo settings)

\`docs/drift-monitor.md\` adds a new section. Three steps:
1. Generate fine-grained PAT scoped to the repo (Contents/PR/Issues: write)
2. Add as repo secret \`DARIO_DRIFT_BOT_PAT\`
3. Next drift event proves it (\`compat\` check appears on the bot's PR)

### Tonight's receipt (the bug we caught with this fix in mind)

23:47:27 UTC: drift detected, bot opens [PR #317](https://github.com/askalf/dario/pull/317) with unified-diff inline (real Anthropic change: AskUserQuestion gained a Preview feature section, \"Executing actions with care\" condensed). 23:54 UTC: human reviewed, confirmed benign, merged via \`--admin\` to bypass blocking required-check policy. 23:55:36 UTC: watcher cycle exit 0, auto-closed [issue #318](https://github.com/askalf/dario/issues/318). 8 minutes from drift detection to fix-to-closure — the cycle works, just needed the admin override tonight. v4.6.5 removes that need.

## How to test

\`\`\`bash
git fetch origin fix/v4.6.5-pat-for-downstream-triggers
git checkout fix/v4.6.5-pat-for-downstream-triggers
npm run build && npm test     # 75/75 (no src/ changes)

# End-to-end: after merge, set up the PAT per docs/drift-monitor.md, then
# wait for the next class-B drift event (or force one via the workflow's
# workflow_dispatch). The bot PR should have a `compat` check alongside
# the standard set this time.
\`\`\`

## Checklist
- [x] \`npm run build\` passes
- [x] \`npm test\` passes (offline regression test, no credentials required) — 75/75
- [x] For changes that touch \`proxy.ts\`, \`cc-template.ts\`, or streaming behavior: tested with \`dario proxy --verbose\` + \`node test/compat.mjs\` (requires credentials) — *N/A: workflow + docs only*
- [x] No new runtime dependencies added
- [x] No tokens/secrets in code or logs