### PR TITLE
release: v4.7.0 — auto-rebake PRs + drift issues lead with structured verdict

### DIFF
--- a/.github/workflows/cc-drift-template-watch.yml
+++ b/.github/workflows/cc-drift-template-watch.yml
@@ -158,6 +158,9 @@ jobs:
 
           # PR body uses the same drift-output.txt the issue does, so the
           # reviewer can decide ship-or-investigate from inside the PR alone.
+          # v4.7.0: lead with the structured drift-summary.md (one-line
+          # verdict + per-axis breakdown), keep the raw [bake] log for
+          # detail.
           pr_body_file=$(mktemp)
           {
             echo "## Auto-rebake from class-B drift detection"
@@ -166,6 +169,12 @@ jobs:
             echo ""
             echo "The watcher's \`--check\` exited 2 against a live capture from the self-hosted runner. This PR contains the freshly-baked \`src/cc-template-data.json\` from that capture, with the v4.2.2 platform-superset preservation already applied."
             echo ""
+            if [ -f drift-summary.md ]; then
+              echo "### Summary"
+              echo ""
+              cat drift-summary.md
+              echo ""
+            fi
             echo "### Drift report"
             echo ""
             echo '```'
@@ -224,6 +233,12 @@ jobs:
               echo ""
             else
               echo "**Auto-rebake skipped** (capture matched HEAD despite --check signal — likely a transient). Investigate manually if this recurs."
+              echo ""
+            fi
+            if [ -f drift-summary.md ]; then
+              echo "### Summary"
+              echo ""
+              cat drift-summary.md
               echo ""
             fi
             echo "### Drift report"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,55 @@ checklist.
 
 ## [Unreleased]
 
+## [4.7.0] - 2026-05-18
+
+### Added — auto-rebake PRs and drift issues lead with a structured verdict
+
+PR #317 (tonight's first real-world auto-rebake) demonstrated the v4.4.0 → v4.5.0 → v4.6.5 chain works end-to-end. It also surfaced an ergonomic gap: the PR body opened with raw `[bake]` log output, then a unified-line diff. A reviewer had to read ~60 lines of detail to decide ship-or-investigate. The common case (text-only system_prompt drift, ship it) was indistinguishable at a glance from the rare case (tools removed, body_field_order changed, investigate).
+
+v4.7.0 leads with a one-line verdict + per-axis bullet breakdown.
+
+### Mechanism
+
+`scripts/drift-report.mjs` gains two new exports:
+
+- **`interpretDrift(diff)`** — classifies the slot-level diff into a structured summary: `toolsAdded`, `toolsRemoved`, `betasAdded`, `betasRemoved`, `systemPromptDelta`, `agentIdentityChanged`, `bodyFieldOrderChanged`, `headerOrderChanged`, plus a single `verdict`:
+  - `'benign'` — text-only drift (system_prompt / agent_identity content), no structural shifts. The 90%+ case.
+  - `'moderate'` — tools added, betas changed, agent_identity changed. Probably ship, worth a closer read.
+  - `'substantive'` — **tools removed**, body_field_order or header_order changed. Don't auto-trust; these can break canonical-rebuild paths.
+  - Verdict ladder is conservative — substantive dominates moderate dominates benign — so when tool-removed and tool-added land in the same drift, the verdict is `substantive`.
+- **`formatDriftSummary(interpretation)`** — renders the structured summary as markdown for direct embedding in PR + issue bodies. Leads with `**Verdict:** ✅ Benign` / `🟡 Moderate` / `🔴 Substantive`, then per-axis bullets with brief context (e.g., "⚠ can break canonical-rebuild paths" next to tools-removed).
+
+### Wiring
+
+- `scripts/capture-and-bake.mjs --check`: prints the verdict-led summary before the unified-line detail. Also writes `drift-summary.md` to disk so the workflow can drop it into PR/issue bodies without grep-parsing the `[bake]`-prefixed log output.
+- `.github/workflows/cc-drift-template-watch.yml`: both the auto-rebake PR body and the drift tracking issue body lead with a "### Summary" section (the contents of `drift-summary.md`) before the existing "### Drift report" code block. Guarded by `[ -f drift-summary.md ]` so the workflow stays compatible with pre-v4.7.0 bakes.
+
+### Reviewer-ergonomics example
+
+What a reviewer sees on the next class-B drift PR, before reading any detail:
+
+> **Verdict:** ✅ Benign
+> - **system_prompt:** -2107 chars net (text-content drift — see unified diff below)
+
+That's enough for the common case. Click merge. The unified diff stays inline below for the unusual cases where the slot-level signal isn't enough.
+
+### Tests
+
+`test/bake-drift-report.mjs` gains 12 new headers (20-31) / 27 assertions covering empty-diff verdict, per-slot verdict promotions, multi-axis aggregation, comma-split parsing of tool/beta lists, `formatDriftSummary` emoji + label + bullet rendering across the three verdicts. **69/69 file tests pass; 75/75 full suite green.**
+
+### Why a minor bump
+
+New observable surface in workflow-embedded artifacts (auto-rebake PR bodies, drift issue bodies, `--check` log output) plus two new public exports from `scripts/drift-report.mjs`. Anyone monitoring repo activity sees a structurally different shape. The exit codes (`--check` 0/1/2) and existing detail format are unchanged — purely additive.
+
+### Internal
+
+- One new function + one new helper in `scripts/drift-report.mjs` (+114 lines)
+- `capture-and-bake.mjs --check`: writes `drift-summary.md` alongside `drift-output.txt`
+- Workflow body composition gains 5 lines of conditional `cat drift-summary.md`
+- `test/bake-drift-report.mjs`: 12 new headers, 27 new assertions
+- No `src/` edits
+
 ## [4.6.5] - 2026-05-17
 
 ### Fixed — auto-rebake PRs now eligible for compat-test gating (optional PAT)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.6.5",
+  "version": "4.7.0",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/scripts/capture-and-bake.mjs
+++ b/scripts/capture-and-bake.mjs
@@ -33,7 +33,7 @@ import { fileURLToPath } from 'node:url';
 import { captureLiveTemplateAsync, findInstalledCC } from '../dist/live-fingerprint.js';
 import { scrubTemplate, findUserPathHits } from '../dist/scrub-template.js';
 import { PLATFORM_ONLY_TOOLS } from '../dist/cc-template.js';
-import { computeDrift, formatDriftReport } from './drift-report.mjs';
+import { computeDrift, formatDriftReport, interpretDrift, formatDriftSummary } from './drift-report.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, '..');
@@ -110,9 +110,25 @@ if (CHECK_MODE) {
     log('check: no drift detected. Bundled template matches live capture.');
     process.exit(0);
   }
-  log(`check: drift detected — ${diff.length} differing slot${diff.length === 1 ? '' : 's'}:`);
+  // v4.7.0: lead with a one-line verdict + per-axis breakdown so the
+  // workflow embedding this output (and any human reading the log)
+  // sees the ship/investigate signal before the line-by-line detail.
+  const interp = interpretDrift(diff);
+  log(`check: drift detected — ${diff.length} differing slot${diff.length === 1 ? '' : 's'} (verdict: ${interp.verdict}):`);
+  for (const line of formatDriftSummary(interp)) log(line);
+  log('');
+  log('check: per-slot detail:');
   for (const line of formatDriftReport(diff)) log(line);
   log('check: bundled template is stale relative to live CC. Run `node scripts/capture-and-bake.mjs` to re-bake.');
+
+  // Also write a clean markdown summary file (v4.7.0) so the wrapping
+  // workflow can drop the verdict into a PR body without grep-parsing
+  // the [bake]-prefixed log output. Path is fixed and intentionally
+  // colocated with where the workflow runs the script.
+  const summaryPath = join(repoRoot, 'drift-summary.md');
+  writeFileSync(summaryPath, formatDriftSummary(interp).join('\n') + '\n');
+  log(`wrote drift-summary.md for workflow embedding`);
+
   process.exit(2);
 }
 

--- a/scripts/drift-report.mjs
+++ b/scripts/drift-report.mjs
@@ -226,3 +226,125 @@ export function formatDriftReport(diff) {
   }
   return lines;
 }
+
+/**
+ * Classify drift entries into a structured summary + a one-word
+ * verdict the reviewer can scan at a glance. v4.7.0 — built so the
+ * auto-rebake bot's PR body can lead with "ship this" or "investigate"
+ * instead of forcing the reviewer to skim a unified-line diff.
+ *
+ * Verdicts (in increasing severity):
+ *   - 'benign'       — only text content changed (system_prompt /
+ *                      agent_identity / tool descriptions). No tool
+ *                      added/removed, no structural shifts. The vast
+ *                      majority of class-B drift events.
+ *   - 'moderate'     — tools added (CC gained a capability), beta
+ *                      headers added/removed (CC opted into/out of
+ *                      a feature flag), agent_identity changed.
+ *                      Probably ship, but worth a closer read.
+ *   - 'substantive'  — tools REMOVED, body_field_order / header_order
+ *                      changed. These can break dario's canonical-
+ *                      rebuild path; don't auto-trust.
+ *
+ * The categorization is conservative — when in doubt, escalate. False
+ * positives (calling something substantive when it's actually fine) waste
+ * a reviewer's attention; false negatives (calling something benign when
+ * it can break clients) waste subscribers' money via reclassification.
+ */
+export function interpretDrift(diff) {
+  const summary = {
+    toolsAdded: [],
+    toolsRemoved: [],
+    betasAdded: [],
+    betasRemoved: [],
+    systemPromptDelta: 0,
+    agentIdentityChanged: false,
+    bodyFieldOrderChanged: false,
+    headerOrderChanged: false,
+  };
+
+  for (const entry of diff) {
+    const s = entry.summary;
+    if (s.startsWith('tools added:')) {
+      summary.toolsAdded = s.replace('tools added:', '').trim().split(',').map((t) => t.trim()).filter(Boolean);
+    } else if (s.startsWith('tools removed:')) {
+      summary.toolsRemoved = s.replace('tools removed:', '').trim().split(',').map((t) => t.trim()).filter(Boolean);
+    } else if (s.startsWith('anthropic_beta added:')) {
+      summary.betasAdded = s.replace('anthropic_beta added:', '').trim().split(',').map((t) => t.trim()).filter(Boolean);
+    } else if (s.startsWith('anthropic_beta removed:')) {
+      summary.betasRemoved = s.replace('anthropic_beta removed:', '').trim().split(',').map((t) => t.trim()).filter(Boolean);
+    } else if (s.startsWith('system_prompt content changed')) {
+      const m = s.match(/delta ([+-]?\d+)/);
+      if (m) summary.systemPromptDelta = parseInt(m[1], 10);
+    } else if (s.startsWith('agent_identity content changed')) {
+      summary.agentIdentityChanged = true;
+    } else if (s === 'body_field_order changed') {
+      summary.bodyFieldOrderChanged = true;
+    } else if (s === 'header_order changed') {
+      summary.headerOrderChanged = true;
+    }
+  }
+
+  // Verdict ladder. Each tier dominates the ones below it.
+  let verdict;
+  if (summary.toolsRemoved.length > 0 || summary.bodyFieldOrderChanged || summary.headerOrderChanged) {
+    verdict = 'substantive';
+  } else if (summary.toolsAdded.length > 0 || summary.betasAdded.length > 0 || summary.betasRemoved.length > 0 || summary.agentIdentityChanged) {
+    verdict = 'moderate';
+  } else {
+    verdict = 'benign';
+  }
+
+  return { ...summary, verdict };
+}
+
+/**
+ * Render the interpreted drift summary as a human-scannable markdown
+ * block — used at the top of the auto-rebake PR body and (in compact
+ * form) the --check log output. Each line is its own list item; the
+ * verdict gets a leading emoji + bold label.
+ */
+export function formatDriftSummary(interpretation) {
+  const lines = [];
+  const v = interpretation.verdict;
+  const verdictEmoji = v === 'benign' ? '✅' : v === 'moderate' ? '🟡' : '🔴';
+  const verdictLabel = v === 'benign' ? 'Benign'
+    : v === 'moderate' ? 'Moderate — worth a closer read'
+    : 'Substantive — investigate before merging';
+  lines.push(`**Verdict:** ${verdictEmoji} ${verdictLabel}`);
+  lines.push('');
+
+  if (interpretation.toolsAdded.length > 0) {
+    lines.push(`- **Tools added:** \`${interpretation.toolsAdded.join('`, `')}\` (CC gained a capability)`);
+  }
+  if (interpretation.toolsRemoved.length > 0) {
+    lines.push(`- **Tools removed:** \`${interpretation.toolsRemoved.join('`, `')}\` ⚠ (can break canonical-rebuild paths)`);
+  }
+  if (interpretation.betasAdded.length > 0) {
+    lines.push(`- **anthropic_beta added:** \`${interpretation.betasAdded.join('`, `')}\` (CC opted into a feature flag)`);
+  }
+  if (interpretation.betasRemoved.length > 0) {
+    lines.push(`- **anthropic_beta removed:** \`${interpretation.betasRemoved.join('`, `')}\` (CC opted out of a feature flag)`);
+  }
+  if (interpretation.systemPromptDelta !== 0) {
+    const sign = interpretation.systemPromptDelta > 0 ? '+' : '';
+    lines.push(`- **system_prompt:** ${sign}${interpretation.systemPromptDelta} chars net (text-content drift — see unified diff below)`);
+  }
+  if (interpretation.agentIdentityChanged) {
+    lines.push(`- **agent_identity:** changed (CC's "You are..." line shifted — affects classifier signal #4)`);
+  }
+  if (interpretation.bodyFieldOrderChanged) {
+    lines.push(`- **body_field_order:** changed ⚠ (classifier signal #7 — affects every request shape)`);
+  }
+  if (interpretation.headerOrderChanged) {
+    lines.push(`- **header_order:** changed (HTTP/2 header sequence — affects classifier signal)`);
+  }
+
+  if (lines.length === 2) {
+    // Verdict line + blank, no axis bullets — should not happen if the
+    // diff was non-empty, but defensive.
+    lines.push('- *(no specific axes flagged — drift detector returned an empty interpretation)*');
+  }
+
+  return lines;
+}

--- a/test/bake-drift-report.mjs
+++ b/test/bake-drift-report.mjs
@@ -3,7 +3,7 @@
 // test runner spawns each file via node:test which is fine for imports
 // too, but the existing pattern groups script-imports in serial).
 
-import { unifiedDiff, computeDrift, describeTool, formatDriftReport } from '../scripts/drift-report.mjs';
+import { unifiedDiff, computeDrift, describeTool, formatDriftReport, interpretDrift, formatDriftSummary } from '../scripts/drift-report.mjs';
 
 let pass = 0;
 let fail = 0;
@@ -228,6 +228,106 @@ header('19. formatDriftReport — bullets summaries, indents details');
   check('summary A appears as a bullet', lines.some((l) => l === '  • A changed'));
   check('detail lines indented under A', lines.some((l) => l === '      -old') && lines.some((l) => l === '      +new'));
   check('summary B has no detail lines', lines.includes('  • B changed') && lines.filter((l) => /^      /.test(l)).length === 2);
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// v4.7.0 — verdict + structured-summary helpers
+header('20. interpretDrift — empty diff → benign verdict, zero counts');
+{
+  const r = interpretDrift([]);
+  check('verdict = benign', r.verdict === 'benign');
+  check('no tools added', r.toolsAdded.length === 0);
+  check('no tools removed', r.toolsRemoved.length === 0);
+  check('systemPromptDelta = 0', r.systemPromptDelta === 0);
+}
+
+header('21. interpretDrift — only system_prompt change → benign');
+{
+  const r = interpretDrift([{ summary: 'system_prompt content changed (12000 → 12150 chars, delta +150)' }]);
+  check('verdict = benign', r.verdict === 'benign');
+  check('systemPromptDelta captured +150', r.systemPromptDelta === 150);
+}
+
+header('22. interpretDrift — tool added → moderate verdict');
+{
+  const r = interpretDrift([{ summary: 'tools added: NewTool' }]);
+  check('verdict = moderate', r.verdict === 'moderate');
+  check('toolsAdded includes NewTool', r.toolsAdded.includes('NewTool'));
+}
+
+header('23. interpretDrift — tool removed → substantive verdict');
+{
+  const r = interpretDrift([{ summary: 'tools removed: OldTool' }]);
+  check('verdict = substantive', r.verdict === 'substantive');
+  check('toolsRemoved includes OldTool', r.toolsRemoved.includes('OldTool'));
+}
+
+header('24. interpretDrift — body_field_order change → substantive');
+{
+  const r = interpretDrift([{ summary: 'body_field_order changed' }]);
+  check('verdict = substantive', r.verdict === 'substantive');
+  check('bodyFieldOrderChanged = true', r.bodyFieldOrderChanged === true);
+}
+
+header('25. interpretDrift — beta change without tool change → moderate');
+{
+  const r = interpretDrift([
+    { summary: 'anthropic_beta added: new-feature-2026-01-01' },
+    { summary: 'anthropic_beta removed: old-beta-2025-12-31' },
+  ]);
+  check('verdict = moderate', r.verdict === 'moderate');
+  check('betasAdded captured', r.betasAdded.includes('new-feature-2026-01-01'));
+  check('betasRemoved captured', r.betasRemoved.includes('old-beta-2025-12-31'));
+}
+
+header('26. interpretDrift — substantive dominates moderate');
+{
+  // tool added AND tool removed → substantive (the removed one wins)
+  const r = interpretDrift([
+    { summary: 'tools added: NewTool' },
+    { summary: 'tools removed: OldTool' },
+  ]);
+  check('verdict = substantive (tools removed wins)', r.verdict === 'substantive');
+}
+
+header('27. interpretDrift — agent_identity change → moderate');
+{
+  const r = interpretDrift([{ summary: 'agent_identity content changed (20 → 25 chars)' }]);
+  check('verdict = moderate', r.verdict === 'moderate');
+  check('agentIdentityChanged = true', r.agentIdentityChanged === true);
+}
+
+header('28. interpretDrift — multiple tools added, comma-split correctly');
+{
+  const r = interpretDrift([{ summary: 'tools added: ToolA, ToolB, ToolC' }]);
+  check('all three tools captured', r.toolsAdded.length === 3 && r.toolsAdded.includes('ToolA') && r.toolsAdded.includes('ToolB') && r.toolsAdded.includes('ToolC'));
+}
+
+// ──────────────────────────────────────────────────────────────────────
+header('29. formatDriftSummary — benign verdict with system_prompt only');
+{
+  const interp = { verdict: 'benign', toolsAdded: [], toolsRemoved: [], betasAdded: [], betasRemoved: [], systemPromptDelta: 50, agentIdentityChanged: false, bodyFieldOrderChanged: false, headerOrderChanged: false };
+  const lines = formatDriftSummary(interp);
+  check('verdict line has ✅ emoji + Benign label', lines[0].includes('✅') && /Benign/.test(lines[0]));
+  check('system_prompt line shows +50 chars', lines.some((l) => /system_prompt.*\+50 chars/.test(l)));
+  check('no tool bullets', !lines.some((l) => /Tools added/.test(l)));
+}
+
+header('30. formatDriftSummary — substantive verdict surfaces removed tools');
+{
+  const interp = { verdict: 'substantive', toolsAdded: [], toolsRemoved: ['DroppedTool'], betasAdded: [], betasRemoved: [], systemPromptDelta: 0, agentIdentityChanged: false, bodyFieldOrderChanged: false, headerOrderChanged: false };
+  const lines = formatDriftSummary(interp);
+  check('verdict line has 🔴 emoji + Substantive label', lines[0].includes('🔴') && /Substantive/.test(lines[0]));
+  check('tools removed line shows DroppedTool with warn marker', lines.some((l) => /Tools removed.*DroppedTool.*⚠/.test(l)));
+}
+
+header('31. formatDriftSummary — moderate verdict with tool add + beta change');
+{
+  const interp = { verdict: 'moderate', toolsAdded: ['NewTool'], toolsRemoved: [], betasAdded: ['new-beta'], betasRemoved: [], systemPromptDelta: 0, agentIdentityChanged: false, bodyFieldOrderChanged: false, headerOrderChanged: false };
+  const lines = formatDriftSummary(interp);
+  check('verdict line has 🟡 emoji + Moderate label', lines[0].includes('🟡') && /Moderate/.test(lines[0]));
+  check('tools added bullet present', lines.some((l) => /Tools added.*NewTool/.test(l)));
+  check('beta added bullet present', lines.some((l) => /anthropic_beta added.*new-beta/.test(l)));
 }
 
 // ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

Closes an ergonomic gap that PR #317 (tonight's first real-world auto-rebake) exposed: the PR body opened with raw \`[bake]\` log output, then a unified-line diff. A reviewer had to read ~60 lines of detail to decide ship-or-investigate. The common case (text-only drift, ship it) looked identical at a glance to the rare case (tools removed, body_field_order changed, investigate).

v4.7.0 leads with a one-line verdict + per-axis bullets.

### Two new exports in \`scripts/drift-report.mjs\`

**\`interpretDrift(diff)\`** — classifies the slot-level diff into a structured summary:

\`\`\`typescript
{
  toolsAdded: string[]
  toolsRemoved: string[]
  betasAdded: string[]
  betasRemoved: string[]
  systemPromptDelta: number       // chars added/removed, signed
  agentIdentityChanged: boolean
  bodyFieldOrderChanged: boolean
  headerOrderChanged: boolean
  verdict: 'benign' | 'moderate' | 'substantive'
}
\`\`\`

Verdict ladder (conservative — substantive dominates moderate dominates benign):

| Verdict | Triggers | Action |
|---|---|---|
| \`benign\` | only text-content drift (system_prompt / agent_identity / tool descriptions) | ship — the 90%+ case |
| \`moderate\` | tools added, betas added/removed, agent_identity changed | probably ship, closer read |
| \`substantive\` | **tools removed**, body_field_order or header_order changed | investigate; can break canonical-rebuild |

**\`formatDriftSummary(interpretation)\`** — renders the structured summary as markdown for embedding in PR + issue bodies. Lead line: \`**Verdict:** ✅ Benign\` / \`🟡 Moderate\` / \`🔴 Substantive\`, then per-axis bullets with brief context.

### Wiring

- \`scripts/capture-and-bake.mjs --check\`: prints the verdict-led summary before the unified-line detail. Also writes \`drift-summary.md\` to disk so the workflow can drop it verbatim into PR/issue bodies.
- \`.github/workflows/cc-drift-template-watch.yml\`: both the auto-rebake PR body and the drift tracking issue body lead with a \"### Summary\" section before the existing \"### Drift report\" code block.

### What a reviewer sees on the next drift PR (before reading any detail)

> **Verdict:** ✅ Benign
> - **system_prompt:** -2107 chars net (text-content drift — see unified diff below)

Click merge. Done. The unified diff stays inline for the rare case where slot-level signal isn't enough.

### Tests

\`test/bake-drift-report.mjs\` gains 12 headers (20-31) / 27 assertions covering:
- Empty diff returns benign verdict, zero counts
- Per-slot verdict promotions (benign → moderate → substantive)
- Substantive-dominates-moderate ordering
- Multi-tool comma-split parsing
- \`formatDriftSummary\` emoji + label + bullet rendering across the three verdicts

**69/69 file tests pass; 75/75 full suite green.**

## How to test

\`\`\`bash
git fetch origin feat/v4.7.0-drift-summary-header
git checkout feat/v4.7.0-drift-summary-header
npm run build && npm test    # 75/75 (no src/ changes; new tests in test/bake-drift-report.mjs)

# Optional: simulate the summary output:
node -e \"
import('./scripts/drift-report.mjs').then(({ interpretDrift, formatDriftSummary }) => {
  const interp = interpretDrift([
    { summary: 'tools added: NewTool' },
    { summary: 'system_prompt content changed (12000 → 12150 chars, delta +150)' },
  ]);
  console.log(formatDriftSummary(interp).join('\n'));
});
\"
\`\`\`

## Checklist
- [x] \`npm run build\` passes
- [x] \`npm test\` passes (offline regression test, no credentials required) — 75/75
- [x] For changes that touch \`proxy.ts\`, \`cc-template.ts\`, or streaming behavior: tested with \`dario proxy --verbose\` + \`node test/compat.mjs\` (requires credentials) — *N/A: scripts + workflow + tests only*
- [x] No new runtime dependencies added
- [x] No tokens/secrets in code or logs