### PR TITLE
release: v4.7.1 — liveness alarm actually opens issues (checkout + threshold)

### DIFF
--- a/.github/workflows/cc-drift-watcher-liveness.yml
+++ b/.github/workflows/cc-drift-watcher-liveness.yml
@@ -14,7 +14,10 @@ name: CC drift watcher liveness
 # the watcher recovers.
 #
 # Cron offset to the :15 mark so it never overlaps with the 30-min cron
-# of the watcher itself (:00 and :30).
+# of the watcher itself (:00 and :30) — though in practice GitHub Actions
+# only fires the watcher's `*/30` schedule every ~4h on this repo (public
+# free-tier scheduler is best-effort, not guaranteed). See the threshold
+# rationale below.
 
 on:
   schedule:
@@ -30,14 +33,26 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
+      # v4.7.1: gh CLI commands below need a git context to resolve the
+      # repo (otherwise `gh issue list` exits with "fatal: not a git
+      # repository"). actions/checkout supplies it; we don't actually
+      # need any files from the checkout, just the .git directory.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 1
+
       - name: Check watcher last-successful-run age
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Hours-since-last-success threshold for alarming. 3 hours = 6
-          # missed 30-min cycles. Strict enough to catch real outages,
-          # loose enough to absorb a single transient infra hiccup +
-          # cron skew on hot start.
-          THRESHOLD_HOURS: '3'
+          # Hours-since-last-success threshold for alarming. Originally
+          # 3h (= 6 missed 30-min cycles per the declared schedule), but
+          # v4.7.1 bumped to 8h after observing real-world cadence on
+          # this repo: GitHub Actions' free-tier cron scheduler is
+          # best-effort, and the watcher's `*/30 * * * *` typically fires
+          # every 2-4 hours in practice. 8h still catches real outages
+          # (anything > a day-shift of silence is signal, not noise)
+          # while absorbing the scheduler skew.
+          THRESHOLD_HOURS: '8'
         run: |
           set -euo pipefail
 
@@ -89,7 +104,7 @@ jobs:
             echo ""
             echo "**Last successful run of [\`cc-drift-template-watch.yml\`](.github/workflows/cc-drift-template-watch.yml): ${hours_since} hours ago** (\`${last_success}\`)."
             echo ""
-            echo "Expected cadence: every 30 minutes. Threshold for this alarm: ${THRESHOLD_HOURS} hours of failures (${THRESHOLD_HOURS}× 2 = ${THRESHOLD_HOURS} missed pairs of cycles)."
+            echo "Declared cadence: every 30 minutes (\`*/30 * * * *\`). Observed cadence on this repo: typically every 2-4 hours (GitHub Actions' free-tier cron scheduler is best-effort). Threshold for this alarm: ${THRESHOLD_HOURS} hours of silence."
             echo ""
             echo "### Likely causes"
             echo ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,37 @@ checklist.
 
 ## [Unreleased]
 
+## [4.7.1] - 2026-05-18
+
+### Fixed — liveness alarm now actually alerts
+
+Overnight observation surfaced two latent bugs in the v4.4.2 liveness alarm. The workflow had been "firing" successfully (running every 2h on schedule) and **correctly detecting that the class-B watcher was lagging behind threshold** — but failing before it could open a `cc-watcher-liveness` issue. So the alarm was silently broken: the watcher could have actually been offline and no alert would have surfaced.
+
+**Bug 1 — Missing `actions/checkout`.** The workflow shelled out to `gh issue list` / `gh issue create` without first checking out the repo. `gh` resolves the target repository by reading `.git/config` from the working directory; without a git context, it fails with `fatal: not a git repository`. The workflow exited 1 immediately after correctly logging `Last successful watcher run: ... (4 hours ago, threshold 3h)`.
+
+**Bug 2 — Threshold set against fictional cadence.** I sized the 3h threshold against the *declared* `*/30 * * * *` cron (= 6 missed cycles), but GitHub Actions' free-tier cron scheduler is best-effort, not guaranteed. The observed cadence of the class-B watcher on this repo is every 2-4 hours, not 30 min. So even *healthy* watcher state would trip the 3h threshold ~half the time.
+
+### Fix
+
+- Add `actions/checkout@v6.0.2` to the start of the job. Provides the `.git` directory `gh` needs.
+- Bump `THRESHOLD_HOURS` from `3` to `8`. Absorbs the observed 2-4h scheduler skew while still catching real outages (anything past 8h of silence is signal, not noise).
+- Update alert-body text to describe both the declared and observed cadence so an investigator reading the alert understands the threshold rationale.
+
+### Documented — scheduler reality
+
+`docs/drift-monitor.md`'s "Runner credential rate-limit headroom" section gains an explicit *Observed cadence* column distinguishing declared cron from real-world cron. Plus a paragraph stating: GitHub Actions free-tier cron is best-effort; if you need sub-hour SLA, self-host both the runner and the cron driver.
+
+### Why a patch
+
+Operational hardening — same shape as v4.4.1 / v4.6.1 / v4.6.2 / v4.6.3 / v4.6.5. Workflow + docs only, no `src/` change. The previous behavior wasn't producing false alarms (the workflow exited 1 before opening any issue), but it also wasn't producing real ones; the alarm was effectively a no-op for the entire window from v4.4.2 (2026-05-17) through v4.7.0.
+
+### Internal
+
+- One workflow file (`cc-drift-watcher-liveness.yml`): adds checkout step + threshold bump + body-text refinement
+- `docs/drift-monitor.md`: explicit declared-vs-observed cadence column + scheduler-reality paragraph
+- No `src/` edits, no test changes
+- 75/75 default suite green
+
 ## [4.7.0] - 2026-05-18
 
 ### Added — auto-rebake PRs and drift issues lead with a structured verdict

--- a/docs/drift-monitor.md
+++ b/docs/drift-monitor.md
@@ -213,11 +213,13 @@ The watcher workflow uses `GH_TOKEN: ${{ secrets.DARIO_DRIFT_BOT_PAT || secrets.
 
 Workflows that exercise live `dario proxy` paths (compat-test, billing canary, future end-to-end probes) all consume against the runner credential's subscription pool. The cadence assumptions are:
 
-| Workflow | Cadence | Requests per fire |
-|---|---|---|
-| `cc-drift-template-watch.yml` (`--check`) | every 30 min | 1 capture (no /v1/messages traffic — MITM-only) |
-| `cc-billing-classifier-canary.yml` | daily 06:30 UTC | 1 small haiku request |
-| `compat-test-self-hosted.yml` | per qualifying PR | ~11 small requests |
+| Workflow | Declared cadence | Observed cadence | Requests per fire |
+|---|---|---|---|
+| `cc-drift-template-watch.yml` (`--check`) | every 30 min (`*/30 * * * *`) | typically every 2-4h | 1 capture (no /v1/messages traffic — MITM-only) |
+| `cc-billing-classifier-canary.yml` | daily 06:30 UTC | daily | 1 small haiku request |
+| `compat-test-self-hosted.yml` | per qualifying PR | per qualifying PR | ~11 small requests |
+
+**Cron scheduler reality.** GitHub Actions' free-tier cron scheduler is best-effort, not guaranteed. The class-B watcher declares `*/30 * * * *` but in practice GitHub honors it every 2-4 hours on this repo. The v4.4.2 liveness alarm's threshold is set to 8h to absorb this skew — anything past that is signal, not scheduler noise. If you need a tighter SLA (sub-hour), self-host the runner *and* the cron driver (e.g. a cron entry on the same Hetzner box invoking `gh workflow run` directly).
 
 At steady state, this is comfortably inside Pro/Max headroom. The failure mode to watch for is **batched firing** — manually re-triggering the same workflow several times in a single hour, or PRs landing in rapid succession that each fire compat-test. We tripped this during the v4.6.x rollout: a half-dozen manual re-runs in a 2-hour window 429'd the runner credential. Pro/Max accounts have per-hour rate caps as well as per-5h / per-7d pools, and the per-hour cap is what surfaces first.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What does this PR do?

Closes two latent bugs in the v4.4.2 liveness alarm that overnight observation exposed. The alarm had been firing every 2 hours **and correctly detecting that the class-B watcher was past threshold** — but failing before it could open the \`cc-watcher-liveness\` issue. Net result: the watcher-of-the-watcher was a no-op for the entire window from v4.4.2 (2026-05-17) through v4.7.0. If the class-B watcher had actually gone offline, no alert would have surfaced.

### Bug 1 — missing \`actions/checkout\`

The workflow shelled out to \`gh issue list\` / \`gh issue create\` without first checking out the repo. \`gh\` resolves the target repository by reading \`.git/config\` from the working directory; without a git context, it exits with \`fatal: not a git repository\`. The workflow logged \`Last successful watcher run: 2026-05-18T06:35:47Z (4 hours ago, threshold 3h)\` and then crashed.

**Fix:** \`actions/checkout@v6.0.2\` at the top of the job. We don't actually need any files — just the \`.git\` directory \`gh\` needs.

### Bug 2 — threshold set against fictional cadence

I sized the v4.4.2 threshold (3h) against the *declared* \`*/30 * * * *\` cron (= 6 missed cycles). But GitHub Actions' free-tier cron scheduler is best-effort, not guaranteed. The observed cadence of the class-B watcher on this repo overnight was every 2-4 hours:

\`\`\`
23:46:53 → 02:08:34   (2h22m)
02:08:34 → 06:35:47   (4h27m)
06:35:47 → 10:56:08   (4h21m)
\`\`\`

So *healthy* watcher state would trip the 3h threshold ~half the time — but never actually surface as an alert because of Bug 1 above. Two bugs masking each other.

**Fix:** \`THRESHOLD_HOURS\` 3 → 8. Absorbs the observed skew while still catching real outages (anything past 8h of silence is signal, not noise).

### Alert body text updated

The alert body now describes both the *declared* and *observed* cadence so an investigator reading the issue understands the threshold rationale instead of asking "why 8 hours?"

### Documented

\`docs/drift-monitor.md\` gains an explicit \"Observed cadence\" column distinguishing declared from real-world cron. Plus a paragraph stating: GitHub Actions free-tier cron is best-effort; if you need sub-hour SLA, self-host the runner *and* the cron driver (e.g. a cron entry on the same Hetzner box calling \`gh workflow run cc-drift-template-watch.yml --ref master\`).

## How to test

\`\`\`bash
git fetch origin fix/v4.7.1-liveness-alarm
git checkout fix/v4.7.1-liveness-alarm
npm run build && npm test    # 75/75 (no src/ changes)

# Manual trigger after merge — should now exit 0 if watcher last
# succeeded within 8h, or actually open a labeled issue if past:
gh workflow run cc-drift-watcher-liveness.yml --ref master
\`\`\`

## Checklist
- [x] \`npm run build\` passes
- [x] \`npm test\` passes (offline regression test, no credentials required) — 75/75
- [x] For changes that touch \`proxy.ts\`, \`cc-template.ts\`, or streaming behavior: tested with \`dario proxy --verbose\` + \`node test/compat.mjs\` (requires credentials) — *N/A: workflow + docs only*
- [x] No new runtime dependencies added
- [x] No tokens/secrets in code or logs