### PR TITLE
release: v4.7.2 — workflow_dispatch overrides for canary + liveness validation

### DIFF
--- a/.github/workflows/cc-billing-classifier-canary.yml
+++ b/.github/workflows/cc-billing-classifier-canary.yml
@@ -38,12 +38,12 @@ on:
   workflow_dispatch:
     inputs:
       force_status:
-        description: 'Override verdict for this run (validation only — leave blank for real probe)'
+        description: 'Override verdict for this run (validation only — pick "none" for real probe)'
         required: false
         type: choice
-        default: ''
+        default: none
         options:
-          - ''
+          - none
           - pass
           - fail
           - warn
@@ -162,7 +162,7 @@ jobs:
           # (force_status=pass) on demand. force_status is ignored
           # on scheduled runs (input only populated on dispatch).
           FORCE_STATUS='${{ github.event.inputs.force_status }}'
-          if [ -n "$FORCE_STATUS" ]; then
+          if [ -n "$FORCE_STATUS" ] && [ "$FORCE_STATUS" != "none" ]; then
             echo "::warning::force_status=${FORCE_STATUS} — overriding real verdict (was: claim=${claim} bucket=${bucket} status=${status})"
             claim="forced-${FORCE_STATUS}"
             case "$FORCE_STATUS" in

--- a/.github/workflows/cc-billing-classifier-canary.yml
+++ b/.github/workflows/cc-billing-classifier-canary.yml
@@ -36,6 +36,17 @@ on:
   schedule:
     - cron: '30 6 * * *'
   workflow_dispatch:
+    inputs:
+      force_status:
+        description: 'Override verdict for this run (validation only — leave blank for real probe)'
+        required: false
+        type: choice
+        default: ''
+        options:
+          - ''
+          - pass
+          - fail
+          - warn
 
 permissions:
   contents: read
@@ -144,6 +155,23 @@ jobs:
               status="warn"
               ;;
           esac
+
+          # v4.7.2: workflow_dispatch can override the verdict for
+          # validation runs. Lets us exercise the alert-open path
+          # (force_status=fail or warn) and the recovery-close path
+          # (force_status=pass) on demand. force_status is ignored
+          # on scheduled runs (input only populated on dispatch).
+          FORCE_STATUS='${{ github.event.inputs.force_status }}'
+          if [ -n "$FORCE_STATUS" ]; then
+            echo "::warning::force_status=${FORCE_STATUS} — overriding real verdict (was: claim=${claim} bucket=${bucket} status=${status})"
+            claim="forced-${FORCE_STATUS}"
+            case "$FORCE_STATUS" in
+              pass) bucket="subscription" ;;
+              fail) bucket="extra_usage" ;;
+              warn) bucket="unknown" ;;
+            esac
+            status="$FORCE_STATUS"
+          fi
 
           {
             echo "claim=${claim}"

--- a/.github/workflows/cc-drift-watcher-liveness.yml
+++ b/.github/workflows/cc-drift-watcher-liveness.yml
@@ -23,6 +23,12 @@ on:
   schedule:
     - cron: '15 */2 * * *'
   workflow_dispatch:
+    inputs:
+      force_threshold_hours:
+        description: 'Override THRESHOLD_HOURS for this run (validation only — leave blank for default 8h)'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -52,7 +58,13 @@ jobs:
           # every 2-4 hours in practice. 8h still catches real outages
           # (anything > a day-shift of silence is signal, not noise)
           # while absorbing the scheduler skew.
-          THRESHOLD_HOURS: '8'
+          #
+          # v4.7.2: workflow_dispatch can override THRESHOLD_HOURS for
+          # validation runs. Lets us exercise the alert-open path on
+          # demand (set inputs.force_threshold_hours=1, dispatch, watch
+          # the issue open) without waiting for or synthesizing a real
+          # outage. Default empty means "use the hardcoded 8".
+          THRESHOLD_HOURS: ${{ github.event.inputs.force_threshold_hours != '' && github.event.inputs.force_threshold_hours || '8' }}
         run: |
           set -euo pipefail
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,43 @@ checklist.
 
 ## [Unreleased]
 
+## [4.7.2] - 2026-05-18
+
+### Added — workflow_dispatch override inputs for canary + liveness validation
+
+Three joints in the drift-detection loop have working code but had not been observed firing in production: the PAT-equipped auto-rebake → compat-test gate, the canary alert-open path, and the liveness alert-open path. The PAT joint validates naturally on the next real Class B drift event. The other two would otherwise require either synthesizing a real failure (pollutes the issue tracker) or waiting for an 8h watcher outage (operationally costly). v4.7.2 adds dispatch-time override inputs so we can exercise both alert paths on demand without production state pollution.
+
+**`cc-billing-classifier-canary.yml`** — new `workflow_dispatch.inputs.force_status` (choice: `''` | `pass` | `fail` | `warn`). When set, the verdict is overridden to the chosen value with a synthetic `claim` value (`forced-fail` etc.) so it's clear in the issue body this was a validation run. Real probe still runs but its result is replaced. The override is only readable on `workflow_dispatch`; scheduled runs see an empty string and ignore it.
+
+**`cc-drift-watcher-liveness.yml`** — new `workflow_dispatch.inputs.force_threshold_hours` (string). When set, overrides the hardcoded 8h threshold. Dispatching with `force_threshold_hours=1` against a watcher that last ran 2h ago will trip the threshold and exercise the alert-open path. Scheduled runs see empty string → 8h.
+
+### Validation procedure
+
+```bash
+# Exercise canary alert-open path:
+gh workflow run cc-billing-classifier-canary.yml --ref master -f force_status=fail
+# → opens labeled `cc-billing-canary` alert. Next scheduled run with real
+#   subscription verdict auto-closes it.
+
+# Exercise liveness alert-open path:
+gh workflow run cc-drift-watcher-liveness.yml --ref master -f force_threshold_hours=1
+# → opens labeled `cc-watcher-liveness` alert. Next scheduled run with
+#   default 8h threshold auto-closes (watcher's been within 2-4h all session).
+```
+
+Both forced runs leave behind a brief auto-closed alert in the closed-issues list — these are the receipts that the alert paths work end-to-end. The validation runs themselves are marked with `::warning::force_status=…` in the workflow log so they're distinguishable from real fires later.
+
+### Why a patch
+
+Pure additive validation capability. No behavior change on scheduled runs (the inputs are only populated on `workflow_dispatch`). No `src/` changes. No new tests (the override paths are exercised by their own existence — dispatching them is the test).
+
+### Internal
+
+- Two workflow files modified (`cc-billing-classifier-canary.yml`, `cc-drift-watcher-liveness.yml`)
+- ~10 added lines per workflow (input declaration + conditional read)
+- No `src/` edits
+- 75/75 default suite green
+
 ## [4.7.1] - 2026-05-18
 
 ### Fixed — liveness alarm now actually alerts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What does this PR do?

Adds dispatch-time override inputs to two workflows so the alert-open paths can be exercised on demand. Three loop joints had working code but had not been observed firing in production; v4.7.2 enables two of them without polluting state or waiting for real failures.

### Canary force_status

\`cc-billing-classifier-canary.yml\` gets a new \`workflow_dispatch.inputs.force_status\` (choice: \`''\` | \`pass\` | \`fail\` | \`warn\`). When set, the real probe still runs but its verdict is overridden with a synthetic \`claim\` value (e.g. \`forced-fail\`) so the resulting issue body is clearly tagged as a validation run, not a real classifier flip.

### Liveness force_threshold_hours

\`cc-drift-watcher-liveness.yml\` gets \`workflow_dispatch.inputs.force_threshold_hours\` (string). When set, overrides the hardcoded 8h threshold. Dispatching with \`force_threshold_hours=1\` against a watcher that last ran 2h ago will trip the alarm and exercise the alert-open path.

### Both inputs are dispatch-only

Scheduled runs see an empty string and ignore. No behavior change on the normal cron path.

### Validation procedure (after merge)

\`\`\`bash
gh workflow run cc-billing-classifier-canary.yml --ref master -f force_status=fail
# → opens cc-billing-canary alert. Next scheduled (real) run auto-closes it.

gh workflow run cc-drift-watcher-liveness.yml --ref master -f force_threshold_hours=1
# → opens cc-watcher-liveness alert. Next scheduled run with default 8h auto-closes.
\`\`\`

Both leave behind a brief auto-closed alert in the closed-issues list — receipts that the alert paths work end-to-end. The validation runs are tagged with \`::warning::force_status=…\` in the workflow log so they're distinguishable from real fires.

## How to test

\`\`\`bash
git fetch origin feat/v4.7.2-dispatch-overrides
git checkout feat/v4.7.2-dispatch-overrides
npm run build && npm test    # 75/75 (no src/ changes)

# After merge: run the two dispatch commands above and verify alert
# open + recovery close behave as designed.
\`\`\`

## Checklist
- [x] \`npm run build\` passes
- [x] \`npm test\` passes (offline regression test, no credentials required) — 75/75
- [x] For changes that touch \`proxy.ts\`, \`cc-template.ts\`, or streaming behavior: tested with \`dario proxy --verbose\` + \`node test/compat.mjs\` (requires credentials) — *N/A: workflow only*
- [x] No new runtime dependencies added
- [x] No tokens/secrets in code or logs