### PR TITLE
release: v4.8.0 — --skip-fields flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ checklist.
 
 ## [Unreleased]
 
-### Added — `--skip-fields=<csv>` for opting out of CC body injections
+## [4.8.0] - 2026-05-18
+
+### Added — `--skip-fields=<csv>` for opting out of CC body injections (#325)
 
 New flag (env: `DARIO_SKIP_FIELDS`) suppresses specific CC body-field injections on outbound requests. Allowed values: `thinking`, `context_management`, `output_config`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.7.2",
+  "version": "4.8.0",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Promotes the Unreleased entry from #325 to v4.8.0. Minor bump (additive opt-in flag, default behavior unchanged).

Triggers `Auto release on version bump` workflow → docker image rebuild → unblocks askalf forge's SDK migration which relies on `DARIO_SKIP_FIELDS=context_management` to stop dario from injecting CC fields that `claude-sonnet-4-6` rejects.