### PR TITLE
readme: drop claude-sync — repo archived and made private

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,6 @@ Ordered by relevance to a dario reader — projects that route through dario fir
 | [arnie](https://github.com/askalf/arnie) | Portable IT troubleshooting agent — networking, AD, package managers, log triage. Routes through dario for subscription billing. |
 | [hands](https://github.com/askalf/hands) | Cross-platform computer-use agent — your LLM on your mouse, keyboard, and screen. Windows + macOS + Linux. Routes through dario or any Anthropic-compat. |
 | [deepdive](https://github.com/askalf/deepdive) | Local research agent. One command, cited answer. Plan → search → headless fetch → extract → synthesize. Every LLM call through your own router. |
-| [claude-sync](https://github.com/askalf/claude-sync) | Sync Claude Code sessions across machines. Pack a CC session into a portable `.ccsync` file, ship it via Dropbox / iCloud / USB, unpack on the other side. |
 | [browser-bridge](https://github.com/askalf/browser-bridge) | Stealth headless Chromium in a container, CDP on 9222. Connect from Playwright, Puppeteer, MCP browser tools, any agent that wants a remote browser. |
 | [install-kit](https://github.com/askalf/install-kit) | curl-pipe-bash template for self-hosted Docker apps — banner, prereq probes, `.env` scaffolding with crypto-rand secrets, healthcheck wait loop. |
 | [pgflex](https://github.com/askalf/pgflex) | One Postgres API, two modes — real PostgreSQL for production, PGlite (in-process WASM) for standalone / dev. Same SQL, drop the server when you don't need it. |


### PR DESCRIPTION
## What does this PR do?

Removes the `claude-sync` row from the README's Related Projects table — the repo is being made private + archived.

## How to test

Visual scan of README.md Related Projects section; the `claude-sync` row is gone, the surrounding rows are intact.

## Checklist
- [x] \`npm run build\` passes (no source changes; README-only)
- [x] \`npm test\` passes (README-only change, no test surface touched)
- [x] For changes that touch \`proxy.ts\`, \`cc-template.ts\`, or streaming behavior: N/A — README only
- [x] No new runtime dependencies added
- [x] No tokens/secrets in code or logs