### PR TITLE
feat: --honor-client-thinking — pass through client's thinking shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ checklist.
 
 ## [Unreleased]
 
+### Added — `--honor-client-thinking` for non-CC SDK clients
+
+New flag (env: `DARIO_HONOR_CLIENT_THINKING=1`) makes dario pass the client body's `thinking` field through to upstream instead of overwriting it with the default CC-style `{type:"adaptive"}`. SDK clients (apps calling dario via the Anthropic SDK) can now explicitly enable extended thinking with their own budget:
+
+```js
+fetch('http://dario:3456/v1/messages', {
+  method: 'POST',
+  body: JSON.stringify({
+    model: 'claude-opus-4-7',
+    thinking: { type: 'enabled', budget_tokens: 8000 },
+    messages: [...],
+  }),
+});
+```
+
+Without the flag, CC's `{type:"adaptive"}` shape is forced (correct for CC clients, but doesn't expose the budget knob to non-CC clients and forces newer 4.6-era models even when older Opus/Sonnet 4-5 endpoints would accept the public-API `{type:"enabled"}` shape).
+
+When honored, dario suppresses its paired `context_management.clear_thinking_20251015` edit — that edit is tuned for `type:"adaptive"` and pairing it with `type:"enabled"` 400s upstream (`"clear_thinking_* strategy requires thinking to be enabled or adaptive"`). The client takes responsibility for the request shape as a whole. Output `effort` injection is unchanged.
+
+No effect on Haiku (skips thinking by construction) or when the client omits `thinking`. CC clients are unaffected. Headers, beta flags, metadata, OAuth identity, billing pool routing all intact.
+
 ## [4.8.2] - 2026-05-19
 
 - **Fix — streaming token capture on single-account installs (#335).** The streaming SSE token parser in `proxy.ts` was gated on `poolAccount` being non-null. In single-account mode `poolAccount` is always null, so the parser never ran. Every streaming request landed in `/analytics` with `inputTokens=0 outputTokens=0 estimatedCost=0` — broke per-model and per-window token totals on every single-account install whose clients stream (Claude Code, Anthropic SDK, OpenAI-shim path). Drop the pool gate so token accumulators are filled in single-account mode too. Also capture thinking tokens from streaming `content_block_delta` events with `delta.type === 'thinking_delta'` (was hardcoded to 0).

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -1044,7 +1044,7 @@ export function buildCCRequest(
   billingTag: string,
   cacheControl: { type: 'ephemeral' },
   identity: { deviceId: string; accountUuid: string; sessionId: string },
-  opts: { preserveTools?: boolean; hybridTools?: boolean; mergeTools?: boolean; noAutoDetect?: boolean; effort?: EffortValue; maxTokens?: number | 'client'; systemPrompt?: string; skipFields?: ReadonlySet<string> } = {},
+  opts: { preserveTools?: boolean; hybridTools?: boolean; mergeTools?: boolean; noAutoDetect?: boolean; effort?: EffortValue; maxTokens?: number | 'client'; systemPrompt?: string; skipFields?: ReadonlySet<string>; honorClientThinking?: boolean } = {},
 ): { body: Record<string, unknown>; toolMap: Map<string, ToolMapping>; unmappedTools: string[]; detectedClient?: string } {
 
   const model = clientBody.model as string || 'claude-sonnet-4-6';
@@ -1395,7 +1395,31 @@ export function buildCCRequest(
   // absent). See dario#87.
   if (!isHaiku) {
     const skip = opts.skipFields;
-    if (supportsAdaptiveThinking(model)) {
+    // Client-supplied thinking shape takes precedence when honorClientThinking
+    // is enabled. SDK clients (vs CC) sometimes need explicit control over
+    // budget_tokens or the type='enabled' vs type='adaptive' choice — e.g.
+    // an agent that wants 8k thinking tokens for hard problems, or a model
+    // that supports thinking but not the 4.6-era adaptive variant. dario's
+    // default builds the CC-style adaptive shape, which is fine for CC
+    // clients but doesn't expose the budget knob to others.
+    //
+    // When honored, we also suppress dario's clear_thinking_* context-edit
+    // pair — that edit is tuned for type='adaptive' and the client's shape
+    // takes responsibility for the request as a whole. Effort still ships.
+    const clientThinking = (clientBody.thinking ?? null) as Record<string, unknown> | null;
+    const honoredClientThinking = Boolean(
+      opts.honorClientThinking
+      && clientThinking
+      && typeof clientThinking === 'object'
+      && typeof clientThinking['type'] === 'string',
+    );
+    if (honoredClientThinking) {
+      if (!skip || !skip.has('thinking')) {
+        ccRequest.thinking = clientThinking;
+      }
+      // Intentionally do NOT inject context_management.clear_thinking_*
+      // when honoring client thinking — the pairing is shape-specific.
+    } else if (supportsAdaptiveThinking(model)) {
       if (!skip || !skip.has('thinking')) {
         ccRequest.thinking = { type: 'adaptive' };
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -547,6 +547,12 @@ async function proxy() {
   // for rationale.
   const skipFields = parseSkipFieldsFlag(args, process.env['DARIO_SKIP_FIELDS']);
 
+  // --honor-client-thinking — pass through the client body's `thinking`
+  // field instead of dario's default CC-style `{type:'adaptive'}`. See
+  // ProxyOptions.honorClientThinking for rationale.
+  const honorClientThinking = args.includes('--honor-client-thinking')
+    || ['1', 'true', 'yes', 'on'].includes((process.env['DARIO_HONOR_CLIENT_THINKING'] ?? '').toLowerCase());
+
   // Non-loopback bind without DARIO_API_KEY turns dario into an open
   // OAuth-subscription relay for anyone on the reachable network. Refuse
   // to start rather than rely on the operator to read the startup banner.
@@ -567,7 +573,7 @@ async function proxy() {
     process.exit(1);
   }
 
-  await startProxy({ port, host, verbose, verboseBodies, model, passthrough, preserveTools, hybridTools, mergeTools, noAutoDetect, strictTls, pacingMinMs, pacingJitterMs, thinkTimeBaseMs, thinkTimePerTokenMs, thinkTimeJitterMs, thinkTimeMaxMs, sessionStartMinMs, sessionStartJitterMs, stealth, drainOnClose, sessionIdleRotateMs, sessionRotateJitterMs, sessionMaxAgeMs, sessionPerClient, preserveOrchestrationTags, noLiveCapture, strictTemplate, maxConcurrent, maxQueued, queueTimeoutMs, effort, maxTokens, logFile, passthroughBetas, skipFields, systemPrompt, overageGuardEnabled, overageGuardBehavior, overageGuardCooldownMs, overageGuardNotifyOs });
+  await startProxy({ port, host, verbose, verboseBodies, model, passthrough, preserveTools, hybridTools, mergeTools, noAutoDetect, strictTls, pacingMinMs, pacingJitterMs, thinkTimeBaseMs, thinkTimePerTokenMs, thinkTimeJitterMs, thinkTimeMaxMs, sessionStartMinMs, sessionStartJitterMs, stealth, drainOnClose, sessionIdleRotateMs, sessionRotateJitterMs, sessionMaxAgeMs, sessionPerClient, preserveOrchestrationTags, noLiveCapture, strictTemplate, maxConcurrent, maxQueued, queueTimeoutMs, effort, maxTokens, logFile, passthroughBetas, skipFields, systemPrompt, overageGuardEnabled, overageGuardBehavior, overageGuardCooldownMs, overageGuardNotifyOs, honorClientThinking });
 }
 
 /**
@@ -1422,6 +1428,19 @@ async function help() {
                              client routed through dario to a model
                              that rejects the field despite the beta
                              header. Env: DARIO_SKIP_FIELDS.
+
+    --honor-client-thinking  Pass the client body's \`thinking\` field
+                             through to upstream instead of dario's
+                             default \`{type:"adaptive"}\`. Lets SDK
+                             clients explicitly enable extended
+                             thinking with their own budget (e.g.
+                             \`{type:"enabled", budget_tokens:8000}\`).
+                             When honored, the paired
+                             \`context_management.clear_thinking_*\`
+                             edit is suppressed (shape-specific).
+                             No effect on Haiku or when client omits
+                             \`thinking\`. Env:
+                             DARIO_HONOR_CLIENT_THINKING.
 
     --upstream-proxy=URL / --via=URL
                              Route all of dario's outbound fetch

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -498,6 +498,25 @@ interface ProxyOptions {
    */
   skipFields?: string[];
   /**
+   * When set, an inbound client body's `thinking` field (e.g.
+   * `{type:"enabled", budget_tokens:N}` or `{type:"adaptive"}`) is passed
+   * through to the upstream INSTEAD of dario's default CC-style
+   * `{type:"adaptive"}`. SDK clients hitting dario can therefore explicitly
+   * enable extended thinking with their own budget, rather than being
+   * locked to CC's default adaptive shape.
+   *
+   * Side effect: when honored, dario also suppresses its
+   * `context_management.clear_thinking_*` edit — that edit is tuned for
+   * `type:"adaptive"` and pairing it with `type:"enabled"` 400s upstream.
+   * The client takes responsibility for the request shape as a whole.
+   *
+   * No effect on Haiku (which skips thinking by construction) or when the
+   * client doesn't supply a `thinking` field. CC clients are unaffected.
+   *
+   * Env: DARIO_HONOR_CLIENT_THINKING=1.
+   */
+  honorClientThinking?: boolean;
+  /**
    * System-prompt mode for the Claude backend. Empirically validated as
    * unfingerprinted by the billing classifier in docs/research/system-prompt-classifier-study.md.
    *
@@ -1600,6 +1619,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
                 maxTokens: opts.maxTokens,
                 systemPrompt: opts.systemPrompt,
                 skipFields,
+                honorClientThinking: opts.honorClientThinking ?? false,
               },
             );
             detectedClientForLog = detectedClient;


### PR DESCRIPTION
## Summary
Opt-in flag that lets SDK clients (apps hitting dario via the Anthropic SDK) explicitly enable extended thinking with their own budget. Without it, dario's CC-template rebuild overwrites any client-supplied `thinking` field with `{type:"adaptive"}` — correct for CC mimic but blocks SDK use cases.

## Use case
```js
fetch('http://dario:3456/v1/messages', {
  method: 'POST',
  headers: { 'x-api-key': DARIO_API_KEY, 'anthropic-version': '2023-06-01' },
  body: JSON.stringify({
    model: 'claude-opus-4-7',
    max_tokens: 4096,
    thinking: { type: 'enabled', budget_tokens: 8000 },
    messages: [...],
  }),
});
```
Today: thinking field gets dropped. Anthropic gets `{type:"adaptive"}` instead. Client never sees `thinking_delta` events; can't tune budget.

With `--honor-client-thinking`: the client's `thinking` shape is forwarded verbatim. Caller chooses `enabled` vs `adaptive`, picks the budget.

## Behavior
- **Default off.** CC clients unaffected; nothing changes for the captured wire fingerprint case.
- **On + client supplies `thinking` with a string `type`:** dario forwards `clientBody.thinking` verbatim. Suppresses the paired `context_management.clear_thinking_20251015` edit (shape-specific to `type:"adaptive"`; pairing with `type:"enabled"` 400s upstream).
- **On + client omits `thinking`:** dario falls back to its default `{type:"adaptive"}` (and the paired `clear_thinking_*` edit) for non-Haiku, `supportsAdaptiveThinking`-eligible models. So mixed clients work.
- **Haiku:** unchanged. Haiku skips thinking by construction.
- **Output `effort` injection:** unchanged (independent of thinking).
- **Headers, beta flags, metadata, OAuth identity, billing pool routing:** all unchanged.

## Files
- `src/cc-template.ts` — `buildCCRequest` opts gain `honorClientThinking?`; thinking-injection block checks for client-supplied thinking when honored
- `src/proxy.ts` — `ProxyOptions.honorClientThinking?` with doc comment; threaded into the `buildCCRequest` call
- `src/cli.ts` — parse `--honor-client-thinking` + `DARIO_HONOR_CLIENT_THINKING`; pass to `startProxy()`; --help entry
- `CHANGELOG.md` — Unreleased entry

## Test plan
- [ ] CI green (compat may still 429 against the runner credential; non-blocking)
- [ ] Local: start dario with `--honor-client-thinking`, send `thinking:{type:"enabled", budget_tokens:512}` against `claude-opus-4-7` → SSE stream contains `content_block_delta:thinking_delta` events
- [ ] Same proxy without the flag: same request → no `thinking_delta` events (dario's `{type:"adaptive"}` shape applied instead)