### PR TITLE
fix(runner): share OAuth credential with platform dario — drop HOME isolation

### DIFF
--- a/.github/workflows/cc-billing-classifier-canary.yml
+++ b/.github/workflows/cc-billing-classifier-canary.yml
@@ -70,10 +70,13 @@ jobs:
           npm run build
 
       - name: Start dario proxy (canonical-rebuild — NOT passthrough)
-        # HOME pinned to /root/.claude-runner (v4.4.1) — uses the isolated
-        # runner credential. NO --passthrough flag here: the canary is
-        # specifically validating dario's rebuild-from-canonical mode, the
-        # mode every non-CC dario user runs in.
+        # OAuth credential: shares /root/.claude/.credentials.json with the
+        # platform dario, same rationale as compat-test-self-hosted.yml —
+        # the isolated /root/.claude-runner credential had no refresh
+        # authority between sparse workflow fires, repeatedly died of disuse.
+        # NO --passthrough flag: the canary specifically validates dario's
+        # rebuild-from-canonical mode, the mode every non-CC dario user
+        # runs in.
         #
         # --port=3457 (v4.6.1) — see compat-test-self-hosted.yml for the
         # rationale. The platform runs its own dario at :3456 via docker;
@@ -82,8 +85,6 @@ jobs:
         # using PLATFORM credentials, producing 401s that look like
         # classifier flips. Use :3457 so the workflow's own dist actually
         # runs.
-        env:
-          HOME: /root/.claude-runner
         run: |
           node dist/cli.js proxy --port=3457 > proxy.log 2>&1 &
           echo $! > proxy.pid

--- a/.github/workflows/cc-drift-template-watch.yml
+++ b/.github/workflows/cc-drift-template-watch.yml
@@ -68,14 +68,16 @@ jobs:
         # step recovers the failure code so the workflow run reflects the
         # actual drift outcome.
         #
-        # HOME is pinned to /root/.claude-runner (v4.4.1) so this workflow
-        # uses a dedicated CC OAuth credential isolated from any other CC
-        # client sharing /root/.claude/ on this box (e.g. docker services
-        # that mount the host's /root/.claude/ — see docs/drift-monitor.md
-        # for setup). Lets the runner's token refresh on its own cycle
-        # with no race vs operator machines that share the account.
-        env:
-          HOME: /root/.claude-runner
+        # OAuth credential: shares /root/.claude/.credentials.json with the
+        # platform dario container instead of the isolated /root/.claude-runner
+        # path the v4.4.1 design used. Reason: the isolated credential
+        # had no refresh authority — workflow fires were too sparse to
+        # rotate the token before Anthropic's idle-refresh limit kicked
+        # in, and recovery required interactive `dario login --manual`.
+        # Sharing with the platform credential file lets platform dario's
+        # 24/7 auto-refresh loop keep the token fresh; this workflow just
+        # reads whatever's current, no refresh from this side. See
+        # docs/drift-monitor.md.
         run: |
           set +e
           node scripts/capture-and-bake.mjs --check 2> drift-output.txt
@@ -116,10 +118,6 @@ jobs:
           # v4.6.4). Setup: docs/drift-monitor.md "Optional: PAT for
           # downstream workflow triggers".
           GH_TOKEN: ${{ secrets.DARIO_DRIFT_BOT_PAT || secrets.GITHUB_TOKEN }}
-          # v4.4.1: dedicated runner credential isolated at
-          # /root/.claude-runner/.claude/.credentials.json. Same rationale
-          # as the Run drift check step above.
-          HOME: /root/.claude-runner
         run: |
           set -eo pipefail
 

--- a/.github/workflows/cc-drift-watcher-liveness.yml
+++ b/.github/workflows/cc-drift-watcher-liveness.yml
@@ -129,7 +129,7 @@ jobs:
             echo ""
             echo "1. Check runner status: [Settings → Actions → Runners](../../settings/actions/runners) — is \`askalf-platform-1\` showing **Online**?"
             echo "2. Check recent runs: [Actions → CC template drift watch (self-hosted)](../../actions/workflows/cc-drift-template-watch.yml) — read the latest failure log"
-            echo "3. SSH to the box and probe auth: \`HOME=/root/.claude-runner claude --print < /dev/null\`"
+            echo "3. SSH to the box and probe auth: \`claude --print < /dev/null\` (shares /root/.claude/.credentials.json with the platform dario; platform dario container's /health should show \`oauth: healthy\`)"
             echo "4. Re-run manually after fixing: \`gh workflow run cc-drift-template-watch.yml --ref master\`"
             echo ""
             echo "This alert auto-closes when the watcher next reports a successful run."

--- a/.github/workflows/compat-test-self-hosted.yml
+++ b/.github/workflows/compat-test-self-hosted.yml
@@ -73,11 +73,22 @@ jobs:
           npm run build
 
       - name: Start dario proxy (passthrough mode)
-        # HOME is pinned to /root/.claude-runner (v4.4.1) so the proxy
-        # authenticates with the runner-isolated credential, not whatever
-        # /root/.claude/.credentials.json the box's other CC clients use
-        # (e.g. docker services that mount /root/.claude/). Setup:
-        # docs/drift-monitor.md.
+        # OAuth credential: the previous v4.4.1 design pinned HOME to
+        # /root/.claude-runner to isolate this workflow's OAuth from any
+        # other CC client sharing /root/.claude/. In practice that meant
+        # nothing kept the isolated token fresh between workflow fires
+        # (each run lasts <10 min; the credential idled for hours);
+        # access tokens expired, then refresh tokens also died of disuse
+        # (Anthropic invalidates a refresh token if it sits unused too
+        # long). Symptom: `invalid_grant` on every workflow run, with no
+        # path to recovery short of an interactive `dario login --manual`.
+        #
+        # New design: share /root/.claude/.credentials.json with the
+        # platform dario. The platform dario auto-refreshes the access
+        # token on its own ~1h cycle, so the file is always fresh when
+        # this workflow fires. The runner just READS the current token
+        # — no refresh attempted from this side, no rotation race.
+        # docs/drift-monitor.md updated to match.
         #
         # --port=3457 (v4.6.1) avoids the platform's existing dario at
         # :3456 (askalf-dario docker container). Without this, dario's
@@ -86,7 +97,6 @@ jobs:
         # platform's, not the PR's freshly-built one. DARIO_TEST_URL
         # is read by test/compat.mjs.
         env:
-          HOME: /root/.claude-runner
           DARIO_TEST_URL: http://127.0.0.1:3457
         run: |
           # Background-start the proxy, capture PID for the always-run

--- a/docs/drift-monitor.md
+++ b/docs/drift-monitor.md
@@ -103,31 +103,29 @@ sudo npm i -g @anthropic-ai/claude-code @askalf/dario
 #    follow the printed URL in any browser, paste the post-login callback
 #    URL back into the SSH session.
 #
-#    v4.4.1: if this host runs OTHER CC clients sharing /root/.claude/
-#    (e.g. docker services mounting the host's /root/.claude/ as a
-#    credentials volume, an operator's own SSH-based CC sessions, etc.),
-#    use an isolated home for the runner so its OAuth refresh cycle
-#    does not race with theirs:
+#    SHARE the credential with any other CC clients that auto-refresh
+#    (e.g. a platform dario container running 24/7). Just run the standard
+#    `dario login --manual` against /root/.claude/.credentials.json and let
+#    that long-running refresh authority keep the token fresh. The workflows
+#    read whatever's current at fire time and never attempt a refresh from
+#    the runner side.
 #
-#      mkdir -p /root/.claude-runner/.claude
-#      chmod 700 /root/.claude-runner
-#      HOME=/root/.claude-runner dario login --manual
-#      # dario writes its credentials to /root/.claude-runner/.dario/credentials.json
-#      # CC reads from $HOME/.claude/.credentials.json — same JSON format, mirror it:
-#      cp /root/.claude-runner/.dario/credentials.json \
-#         /root/.claude-runner/.claude/.credentials.json
-#      chmod 600 /root/.claude-runner/.claude/.credentials.json
+#    History: v4.4.1 isolated the runner's credential at /root/.claude-runner
+#    to avoid OAuth refresh-token rotation races between the runner and other
+#    CC clients on the host. The isolation worked for races but introduced a
+#    different failure: the isolated token had no refresh authority between
+#    workflow fires (each <10 min, often hours apart), and Anthropic invalidates
+#    refresh tokens that idle too long. Result: `invalid_grant` on every
+#    workflow fire, recoverable only via interactive `dario login --manual`.
 #
-#    The drift-watch + compat-test workflows pin `HOME: /root/.claude-runner`
-#    on every step that spawns CC, so the isolated credential is what the
-#    runner actually uses at workflow time.
-#
-#    If no other CC clients are sharing the box, the simpler default flow
-#    works: just run `dario login --manual` and CC will find the
-#    credentials under ~/.claude/.credentials.json.
+#    Sharing with a 24/7 refresh authority (typical setup: the docker-stack
+#    dario container) fixes that. The race the isolation was protecting
+#    against is rare in practice — platform dario refreshes proactively
+#    when the access token has ~1h life remaining, so workflow runs hit a
+#    fresh token and don't need to refresh themselves.
 dario login --manual
 
-# 5. Smoke test (replace HOME with /root/.claude-runner if isolated):
+# 5. Smoke test:
 echo "Reply with PONG" | claude --print     # should print PONG
 ```
 
@@ -223,9 +221,9 @@ Workflows that exercise live `dario proxy` paths (compat-test, billing canary, f
 
 At steady state, this is comfortably inside Pro/Max headroom. The failure mode to watch for is **batched firing** — manually re-triggering the same workflow several times in a single hour, or PRs landing in rapid succession that each fire compat-test. We tripped this during the v4.6.x rollout: a half-dozen manual re-runs in a 2-hour window 429'd the runner credential. Pro/Max accounts have per-hour rate caps as well as per-5h / per-7d pools, and the per-hour cap is what surfaces first.
 
-If the runner credential is rate-limited and a workflow run reports 429s across the board, the right diagnosis order is: (a) check `claude --print` with the runner HOME directly — if it 429s, the credential pool is dry, just wait an hour; (b) check the credential is still on a subscription account (`dario doctor`); (c) check workflow cadence assumptions haven't changed.
+If the runner credential is rate-limited and a workflow run reports 429s across the board, the right diagnosis order is: (a) check `claude --print` directly — if it 429s, the credential pool is dry, just wait an hour; (b) check the credential is still on a subscription account (`dario doctor`); (c) check workflow cadence assumptions haven't changed.
 
-The runner credential should run a real Pro/Max subscription with no other workload on it. Sharing the credential with manual `claude` sessions or other CC clients eats the headroom the watchers need. v4.4.1's `HOME=/root/.claude-runner` isolation gives the runner its own token pair within the same Pro/Max account; if you also need its own subscription account, log into a different one when running `dario login --manual` against the isolated HOME.
+The runner shares its OAuth credential with any other long-running CC client on the box (typically the platform dario container, which auto-refreshes 24/7). Sharing is intentional: a workflow that fires sparsely cannot keep its own refresh token alive — Anthropic invalidates idle refresh tokens, and `invalid_grant` then breaks every subsequent run. Letting a 24/7 refresh authority own the token rotation eliminates that failure mode at the cost of competing for the same Pro/Max headroom. With current cadence (drift-template-watch every 30 min + compat per PR + canary daily), runner-side burn on the shared account is a manageable fraction of the headroom available on a Max plan; reducing cadence further is a knob if a particular workload needs more of it.
 
 ## Why a self-hosted runner
 


### PR DESCRIPTION
## Summary
v4.4.1 pinned `HOME=/root/.claude-runner` across the three runner workflows (compat-test, drift-template-watch, billing-classifier-canary) to give the runner its own OAuth credential separate from `/root/.claude/.credentials.json`. Intent was to avoid refresh-token rotation races with other long-running CC clients on the host.

The isolation prevented races but introduced a worse failure: the isolated token had **no refresh authority between workflow fires**. Each workflow run lasts <10 minutes; runs are hours apart at typical cadence. Anthropic invalidates refresh tokens that sit unused too long, so within a few weeks the runner's refresh token died of disuse → every subsequent fire returned `invalid_grant` with no path to recovery short of interactive `dario login --manual`.

We hit this today: the runner credential expired at 22:33 UTC, refresh attempted at 23:30 UTC, `invalid_grant`. Same pattern almost certainly responsible for every prior \"runner-credential died\" incident.

## Fix
Drop the `HOME` override. Workflows now read `/root/.claude/.credentials.json`, which is typically owned by a 24/7 platform dario container that auto-refreshes when the access token has ~1h life remaining. Workflows fire → find a fresh token → do their <10 min job → never attempt a refresh from their side.

The race the isolation protected against is rare in practice: it only matters if a workflow's CC/dario inside it decides to refresh simultaneously with the platform dario. With the platform dario refreshing pre-emptively while ~1h life remains, workflow runs hit a fresh token and don't need to refresh themselves.

## Tradeoff acknowledged
Runner workflows now compete for the same Max-account 5h-window quota as the rest of the platform fleet. At typical cadence (drift-watch every 30 min + compat per PR + canary daily), this is a single-digit % of the headroom available on a Max plan also running an agent fleet. If a workload genuinely needs more isolation, the cadence knob is the lever — not credential isolation.

## Files
- `.github/workflows/compat-test-self-hosted.yml` — drop HOME env; explain new policy in step comment
- `.github/workflows/cc-drift-template-watch.yml` — same, on both the `--check` step and the auto-rebake step
- `.github/workflows/cc-billing-classifier-canary.yml` — same
- `.github/workflows/cc-drift-watcher-liveness.yml` — update the alert-body diagnostic command (no more `HOME=/root/.claude-runner claude --print`)
- `docs/drift-monitor.md` — drop the isolated-HOME setup section; document the shared-credential approach + history of why it changed

## Operator action (one-time) after merge
\`\`\`bash
# On the Hetzner runner host, after this PR ships:
rm -rf /root/.claude-runner  # delete the dead isolated credential dir
# /root/.claude/.credentials.json is already in place (platform dario uses it)
# Next workflow fire will pick it up; no further action needed.
\`\`\`

## Test plan
- [ ] CI green (compat will likely still 429 on the dead runner credential until the operator deletes /root/.claude-runner AND the next workflow fire reads /root/.claude/, which platform dario has been keeping fresh; that's expected — first post-merge run validates the new path)
- [ ] After cleanup, manually dispatch `cc-drift-template-watch` and confirm successful run on the shared credential
- [ ] Confirm no token-rotation race over 24h (platform dario keeps refreshing; workflows keep reading)