### PR TITLE
fix(runner): share OAuth credential with platform dario — drop HOME isolation

### DIFF
--- a/.github/workflows/cc-billing-classifier-canary.yml
+++ b/.github/workflows/cc-billing-classifier-canary.yml
@@ -70,10 +70,13 @@ jobs:
           npm run build
 
       - name: Start dario proxy (canonical-rebuild — NOT passthrough)
-        # HOME pinned to /root/.claude-runner (v4.4.1) — uses the isolated
-        # runner credential. NO --passthrough flag here: the canary is
-        # specifically validating dario's rebuild-from-canonical mode, the
-        # mode every non-CC dario user runs in.
+        # OAuth credential: shares /root/.claude/.credentials.json with the
+        # platform dario, same rationale as compat-test-self-hosted.yml —
+        # the isolated /root/.claude-runner credential had no refresh
+        # authority between sparse workflow fires, repeatedly died of disuse.
+        # NO --passthrough flag: the canary specifically validates dario's
+        # rebuild-from-canonical mode, the mode every non-CC dario user
+        # runs in.
         #
         # --port=3457 (v4.6.1) — see compat-test-self-hosted.yml for the
         # rationale. The platform runs its own dario at :3456 via docker;
@@ -82,8 +85,6 @@ jobs:
         # using PLATFORM credentials, producing 401s that look like
         # classifier flips. Use :3457 so the workflow's own dist actually
         # runs.
-        env:
-          HOME: /root/.claude-runner
         run: |
           node dist/cli.js proxy --port=3457 > proxy.log 2>&1 &
           echo $! > proxy.pid

--- a/.github/workflows/cc-drift-template-watch.yml
+++ b/.github/workflows/cc-drift-template-watch.yml
@@ -68,14 +68,16 @@ jobs:
         # step recovers the failure code so the workflow run reflects the
         # actual drift outcome.
         #
-        # HOME is pinned to /root/.claude-runner (v4.4.1) so this workflow
-        # uses a dedicated CC OAuth credential isolated from any other CC
-        # client sharing /root/.claude/ on this box (e.g. docker services
-        # that mount the host's /root/.claude/ — see docs/drift-monitor.md
-        # for setup). Lets the runner's token refresh on its own cycle
-        # with no race vs operator machines that share the account.
-        env:
-          HOME: /root/.claude-runner
+        # OAuth credential: shares /root/.claude/.credentials.json with the
+        # platform dario container instead of the isolated /root/.claude-runner
+        # path the v4.4.1 design used. Reason: the isolated credential
+        # had no refresh authority — workflow fires were too sparse to
+        # rotate the token before Anthropic's idle-refresh limit kicked
+        # in, and recovery required interactive `dario login --manual`.
+        # Sharing with the platform credential file lets platform dario's
+        # 24/7 auto-refresh loop keep the token fresh; this workflow just
+        # reads whatever's current, no refresh from this side. See
+        # docs/drift-monitor.md.
         run: |
           set +e
           node scripts/capture-and-bake.mjs --check 2> drift-output.txt
@@ -116,10 +118,6 @@ jobs:
           # v4.6.4). Setup: docs/drift-monitor.md "Optional: PAT for
           # downstream workflow triggers".
           GH_TOKEN: ${{ secrets.DARIO_DRIFT_BOT_PAT || secrets.GITHUB_TOKEN }}
-          # v4.4.1: dedicated runner credential isolated at
-          # /root/.claude-runner/.claude/.credentials.json. Same rationale
-          # as the Run drift check step above.
-          HOME: /root/.claude-runner
         run: |
           set -eo pipefail
 

--- a/.github/workflows/cc-drift-watcher-liveness.yml
+++ b/.github/workflows/cc-drift-watcher-liveness.yml
@@ -129,7 +129,7 @@ jobs:
             echo ""
             echo "1. Check runner status: [Settings → Actions → Runners](../../settings/actions/runners) — is \`askalf-platform-1\` showing **Online**?"
             echo "2. Check recent runs: [Actions → CC template drift watch (self-hosted)](../../actions/workflows/cc-drift-template-watch.yml) — read the latest failure log"
-            echo "3. SSH to the box and probe auth: \`HOME=/root/.claude-runner claude --print < /dev/null\`"
+            echo "3. SSH to the box and probe auth: \`claude --print < /dev/null\` (shares /root/.claude/.credentials.json with the platform dario; platform dario container's /health should show \`oauth: healthy\`)"
             echo "4. Re-run manually after fixing: \`gh workflow run cc-drift-template-watch.yml --ref master\`"
             echo ""
             echo "This alert auto-closes when the watcher next reports a successful run."

--- a/.github/workflows/compat-test-self-hosted.yml
+++ b/.github/workflows/compat-test-self-hosted.yml
@@ -73,11 +73,22 @@ jobs:
           npm run build
 
       - name: Start dario proxy (passthrough mode)
-        # HOME is pinned to /root/.claude-runner (v4.4.1) so the proxy
-        # authenticates with the runner-isolated credential, not whatever
-        # /root/.claude/.credentials.json the box's other CC clients use
-        # (e.g. docker services that mount /root/.claude/). Setup:
-        # docs/drift-monitor.md.
+        # OAuth credential: the previous v4.4.1 design pinned HOME to
+        # /root/.claude-runner to isolate this workflow's OAuth from any
+        # other CC client sharing /root/.claude/. In practice that meant
+        # nothing kept the isolated token fresh between workflow fires
+        # (each run lasts <10 min; the credential idled for hours);
+        # access tokens expired, then refresh tokens also died of disuse
+        # (Anthropic invalidates a refresh token if it sits unused too
+        # long). Symptom: `invalid_grant` on every workflow run, with no
+        # path to recovery short of an interactive `dario login --manual`.
+        #
+        # New design: share /root/.claude/.credentials.json with the
+        # platform dario. The platform dario auto-refreshes the access
+        # token on its own ~1h cycle, so the file is always fresh when
+        # this workflow fires. The runner just READS the current token
+        # — no refresh attempted from this side, no rotation race.
+        # docs/drift-monitor.md updated to match.
         #
         # --port=3457 (v4.6.1) avoids the platform's existing dario at
         # :3456 (askalf-dario docker container). Without this, dario's
@@ -86,7 +97,6 @@ jobs:
         # platform's, not the PR's freshly-built one. DARIO_TEST_URL
         # is read by test/compat.mjs.
         env:
-          HOME: /root/.claude-runner
           DARIO_TEST_URL: http://127.0.0.1:3457
         run: |
           # Background-start the proxy, capture PID for the always-run

--- a/docs/drift-monitor.md
+++ b/docs/drift-monitor.md
@@ -103,31 +103,29 @@ sudo npm i -g @anthropic-ai/claude-code @askalf/dario
 #    follow the printed URL in any browser, paste the post-login callback
 #    URL back into the SSH session.
 #
-#    v4.4.1: if this host runs OTHER CC clients sharing /root/.claude/
-#    (e.g. docker services mounting the host's /root/.claude/ as a
-#    credentials volume, an operator's own SSH-based CC sessions, etc.),
-#    use an isolated home for the runner so its OAuth refresh cycle
-#    does not race with theirs:
+#    SHARE the credential with any other CC clients that auto-refresh
+#    (e.g. a platform dario container running 24/7). Just run the standard
+#    `dario login --manual` against /root/.claude/.credentials.json and let
+#    that long-running refresh authority keep the token fresh. The workflows
+#    read whatever's current at fire time and never attempt a refresh from
+#    the runner side.
 #
-#      mkdir -p /root/.claude-runner/.claude
-#      chmod 700 /root/.claude-runner
-#      HOME=/root/.claude-runner dario login --manual
-#      # dario writes its credentials to /root/.claude-runner/.dario/credentials.json
-#      # CC reads from $HOME/.claude/.credentials.json — same JSON format, mirror it:
-#      cp /root/.claude-runner/.dario/credentials.json \
-#         /root/.claude-runner/.claude/.credentials.json
-#      chmod 600 /root/.claude-runner/.claude/.credentials.json
+#    History: v4.4.1 isolated the runner's credential at /root/.claude-runner
+#    to avoid OAuth refresh-token rotation races between the runner and other
+#    CC clients on the host. The isolation worked for races but introduced a
+#    different failure: the isolated token had no refresh authority between
+#    workflow fires (each <10 min, often hours apart), and Anthropic invalidates
+#    refresh tokens that idle too long. Result: `invalid_grant` on every
+#    workflow fire, recoverable only via interactive `dario login --manual`.
 #
-#    The drift-watch + compat-test workflows pin `HOME: /root/.claude-runner`
-#    on every step that spawns CC, so the isolated credential is what the
-#    runner actually uses at workflow time.
-#
-#    If no other CC clients are sharing the box, the simpler default flow
-#    works: just run `dario login --manual` and CC will find the
-#    credentials under ~/.claude/.credentials.json.
+#    Sharing with a 24/7 refresh authority (typical setup: the docker-stack
+#    dario container) fixes that. The race the isolation was protecting
+#    against is rare in practice — platform dario refreshes proactively
+#    when the access token has ~1h life remaining, so workflow runs hit a
+#    fresh token and don't need to refresh themselves.
 dario login --manual
 
-# 5. Smoke test (replace HOME with /root/.claude-runner if isolated):
+# 5. Smoke test:
 echo "Reply with PONG" | claude --print     # should print PONG
 ```
 
@@ -223,9 +221,9 @@ Workflows that exercise live `dario proxy` paths (compat-test, billing canary, f
 
 At steady state, this is comfortably inside Pro/Max headroom. The failure mode to watch for is **batched firing** — manually re-triggering the same workflow several times in a single hour, or PRs landing in rapid succession that each fire compat-test. We tripped this during the v4.6.x rollout: a half-dozen manual re-runs in a 2-hour window 429'd the runner credential. Pro/Max accounts have per-hour rate caps as well as per-5h / per-7d pools, and the per-hour cap is what surfaces first.
 
-If the runner credential is rate-limited and a workflow run reports 429s across the board, the right diagnosis order is: (a) check `claude --print` with the runner HOME directly — if it 429s, the credential pool is dry, just wait an hour; (b) check the credential is still on a subscription account (`dario doctor`); (c) check workflow cadence assumptions haven't changed.
+If the runner credential is rate-limited and a workflow run reports 429s across the board, the right diagnosis order is: (a) check `claude --print` directly — if it 429s, the credential pool is dry, just wait an hour; (b) check the credential is still on a subscription account (`dario doctor`); (c) check workflow cadence assumptions haven't changed.
 
-The runner credential should run a real Pro/Max subscription with no other workload on it. Sharing the credential with manual `claude` sessions or other CC clients eats the headroom the watchers need. v4.4.1's `HOME=/root/.claude-runner` isolation gives the runner its own token pair within the same Pro/Max account; if you also need its own subscription account, log into a different one when running `dario login --manual` against the isolated HOME.
+The runner shares its OAuth credential with any other long-running CC client on the box (typically the platform dario container, which auto-refreshes 24/7). Sharing is intentional: a workflow that fires sparsely cannot keep its own refresh token alive — Anthropic invalidates idle refresh tokens, and `invalid_grant` then breaks every subsequent run. Letting a 24/7 refresh authority own the token rotation eliminates that failure mode at the cost of competing for the same Pro/Max headroom. With current cadence (drift-template-watch every 30 min + compat per PR + canary daily), runner-side burn on the shared account is a manageable fraction of the headroom available on a Max plan; reducing cadence further is a knob if a particular workload needs more of it.
 
 ## Why a self-hosted runner
 


### PR DESCRIPTION
## Summary
Re-do of #341 (closed earlier — wrong premise). Now correct: the companion platform PR (askalf/platform#173, merged + deployed) bind-mounts platform dario's credential storage to `/var/lib/askalf-dario` and symlinks both `/root/.dario/credentials.json` and `/root/.claude/.credentials.json` to it. Single 24/7-refreshed credential, two runner-readable paths.

This PR drops `HOME=/root/.claude-runner` from the three runner workflows so they read from the default `/root/.claude/` and `/root/.dario/` — which now point at the shared, fresh credential.

## Why this works now
| State | Before | After today's platform migration |
|---|---|---|
| Platform dario credential | docker named volume `dario-config` (isolated) | host bind-mount `/var/lib/askalf-dario/credentials.json` |
| `/root/.claude/.credentials.json` | orphan, expired 50h ago | symlink → bind-mount, fresh (7.5h life) |
| `/root/.dario/credentials.json` | doesn't exist | symlink → bind-mount, fresh |
| `/root/.claude-runner/.claude/.credentials.json` | orphan, expired 3h ago | moved to `.pre-bindmount.bak`, gone |

Workflows now have a real shared 24/7-refreshed credential to read, no refresh required from their side.

## Changes
- `.github/workflows/compat-test-self-hosted.yml` — drop HOME env, comment-document the new policy
- `.github/workflows/cc-drift-template-watch.yml` — same, on both `--check` step and auto-rebake step
- `.github/workflows/cc-billing-classifier-canary.yml` — same
- `.github/workflows/cc-drift-watcher-liveness.yml` — alert-body diagnostic command uses default HOME
- `docs/drift-monitor.md` — drop isolated-HOME setup section; document shared-credential approach + history

## Test plan
- [ ] CI green (compat will run on the SHARED credential this time — should pass now)
- [ ] After merge, manually dispatch `cc-drift-template-watch` and confirm successful run
- [ ] Confirm `cc-billing-classifier-canary` next daily run goes green