### PR TITLE
fix(release): gate also checks npm — retry-publish when GH release exists but npm doesn't

### DIFF
--- a/.github/workflows/cc-drift-auto-release.yml
+++ b/.github/workflows/cc-drift-auto-release.yml
@@ -149,31 +149,59 @@ jobs:
           echo "version=$CURRENT" >> "$GITHUB_OUTPUT"
           echo "needs_release=true" >> "$GITHUB_OUTPUT"
 
-      - name: Idempotency gate (release-exists check)
+      - name: Idempotency gate (release + npm-publish + ghcr check)
         id: gate
         if: steps.ver.outputs.needs_release == 'true'
-        # When a release for the current version already exists, the
-        # ship has already happened — skip cleanly. This is the
-        # expected steady state for the hourly schedule trigger; we do
-        # NOT exit non-zero, because that would generate an hourly
-        # failure email forever.
+        # Two-axis check: a release ships when BOTH the GitHub release tag
+        # exists AND the npm registry has the version. Previous design only
+        # checked the GitHub tag — when an earlier run created the tag but
+        # failed at npm publish (transient registry 5xx, expired NPM_TOKEN,
+        # etc.), the schedule fallback then saw the tag and skipped
+        # everything, leaving npm permanently behind. v4.8.2 and v4.8.3
+        # both landed in that state on 2026-05-19 — github releases exist,
+        # npm latest stayed pinned at 4.8.1.
         #
-        # Queries the GitHub API directly (`gh release view`) rather
-        # than `git rev-parse` against the local checkout. The checkout
-        # uses `fetch-depth: 2` for the HEAD^1 version-diff and does
-        # not fetch tags, so a local `git rev-parse v3.32.2` returns
-        # false for an existing remote tag and the gate would
-        # incorrectly set proceed=true. The `gh release view` query
-        # hits the GitHub API and is decoupled from local fetch state.
+        # Now: emit fine-grained outputs so downstream steps can skip the
+        # work that's already done and retry the work that isn't:
+        #   - gh_release_exists  → "Create GitHub release" skips
+        #   - npm_published      → "npm publish" skips
+        #   - proceed            → false ONLY when both are true (fully shipped)
+        #
+        # Queries the GitHub API directly (`gh release view`) rather than
+        # `git rev-parse` against the local checkout — the checkout uses
+        # `fetch-depth: 2` for HEAD^1 version-diff and does not fetch tags.
+        # npm check uses `npm view`; tolerates 404 (treats package-not-found
+        # as not-published, fresh release case).
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="v${{ steps.ver.outputs.version }}"
+          VERSION="${{ steps.ver.outputs.version }}"
+          PKG_NAME="$(node -p 'require("./package.json").name')"
+
           if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Release $TAG already exists — already shipped (idempotent skip)."
+            gh_exists=true
+          else
+            gh_exists=false
+          fi
+
+          # `npm view <name>@<version> version` prints the version if
+          # published, exits non-zero with an empty stdout otherwise.
+          # Wrap with `|| true` so missing packages don't fail the step.
+          if [ -n "$(npm view "$PKG_NAME@$VERSION" version 2>/dev/null || true)" ]; then
+            npm_exists=true
+          else
+            npm_exists=false
+          fi
+
+          echo "gh_release_exists=$gh_exists" >> "$GITHUB_OUTPUT"
+          echo "npm_published=$npm_exists" >> "$GITHUB_OUTPUT"
+
+          if [ "$gh_exists" = "true" ] && [ "$npm_exists" = "true" ]; then
+            echo "Release $TAG fully shipped (GitHub + npm) — idempotent skip."
             echo "proceed=false" >> "$GITHUB_OUTPUT"
           else
-            echo "Release $TAG does not exist — proceeding."
+            echo "Release $TAG incomplete (gh=$gh_exists, npm=$npm_exists) — proceeding to fill the gaps."
             echo "proceed=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -277,7 +305,10 @@ jobs:
           cat release-notes.md
 
       - name: Create GitHub release
-        if: steps.gate.outputs.proceed == 'true'
+        # Skip if the GH release tag already exists — a prior run created
+        # it but failed downstream (npm or ghcr). The gate left proceed=true
+        # so the remaining publish steps retry; this one is already done.
+        if: steps.gate.outputs.proceed == 'true' && steps.gate.outputs.gh_release_exists != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
@@ -304,7 +335,10 @@ jobs:
             --notes-file body.md
 
       - name: npm publish
-        if: steps.gate.outputs.proceed == 'true'
+        # Skip if npm already has this version. Lets a re-run target only
+        # the missing publish (e.g. retrying after a transient npm 5xx)
+        # without re-publishing what's already on the registry.
+        if: steps.gate.outputs.proceed == 'true' && steps.gate.outputs.npm_published != 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public --provenance


### PR DESCRIPTION
## Summary
The auto-release pipeline's idempotency gate only checked whether the GitHub release tag existed. When an earlier run created the tag but failed at npm publish (transient 5xx, expired NPM_TOKEN, etc.), the hourly-schedule fallback then saw the tag and skipped everything — leaving npm permanently behind.

Both **v4.8.2 and v4.8.3 landed in that state on 2026-05-19**: GitHub release tags exist, `npm view @askalf/dario` still reports `latest: 4.8.1`.

## Fix
Gate now checks both axes and emits fine-grained outputs:
- `gh_release_exists` — `gh release view v$VERSION` exits 0
- `npm_published` — `npm view @askalf/dario@$VERSION version` returns non-empty
- `proceed=false` only when BOTH are true; otherwise `proceed=true` and downstream steps fill the gaps.

Downstream skip-if-done:
- **Create GitHub release** — `if: ... && gh_release_exists != 'true'`
- **npm publish** — `if: ... && npm_published != 'true'`
- **Docker push steps** — unchanged (re-pushing the same tag to ghcr is idempotent, no per-step skip needed)

## Failure scenario this fixes
```
T0:        PR merge fires auto-release. Creates v4.8.2 tag + GH release.
           npm publish hits transient 5xx. Workflow exits 1.
           Docker step skipped (failure short-circuit).
T0+18min:  Schedule fallback fires.
           OLD gate: sees v4.8.2 release exists, sets proceed=false, exits.
           npm stays at 4.8.1 forever.
NEW gate:  sees v4.8.2 release exists BUT npm doesn't have 4.8.2.
           Sets proceed=true, gh_release_exists=true, npm_published=false.
           'Create GitHub release' step: skipped (already done).
           'npm publish' step: runs.
           Docker push: re-runs (idempotent).
           npm catches up.
```

## Manual recovery for v4.8.3 (this PR doesn't auto-fix existing gaps)
After this lands + you rotate the NPM_TOKEN tonight:
```bash
gh workflow run cc-drift-auto-release.yml -R askalf/dario
# Hits the new gate, sees v4.8.3 GH release exists + npm doesn't,
# proceeds to npm publish + docker push only. Backfills cleanly.
```

## Files
- `.github/workflows/cc-drift-auto-release.yml` — gate step query expanded to npm; output schema gains `gh_release_exists`, `npm_published`; the GH-release and npm-publish step `if:` conditions add the per-step skip-if-already-done check (+51, -17 lines)

## Test plan
- [ ] CI green (the workflow file change doesn't trigger compat; only Build + actionlint will run)
- [ ] After merge + NPM_TOKEN rotation, dispatch `gh workflow run cc-drift-auto-release.yml` and confirm:
  - Gate detects v4.8.3 GH release exists + npm doesn't
  - 'Create GitHub release' step skips (logs "already done")
  - 'npm publish' runs and succeeds
  - npm latest shows 4.8.3