### PR TITLE
fix(compat): slower inter-test pacing + single-flight across PRs

### DIFF
--- a/.github/workflows/compat-test-self-hosted.yml
+++ b/.github/workflows/compat-test-self-hosted.yml
@@ -46,11 +46,18 @@ permissions:
   contents: read
   pull-requests: write
 
-# Cancel previous in-flight runs on the same ref when a new commit lands.
-# Saves runner time + subscription requests when a PR is updated rapidly.
+# Single-flight across the whole repo, not per-ref. Two PRs landing in
+# the same hour both run compat, both make real Anthropic calls, and
+# the second one hits the rate-limit-window cap accumulated by the
+# first. The per-ref concurrency this replaced still let cross-PR runs
+# stack. Global group + queue (cancel-in-progress: false) serializes
+# them so the shared subscription window has time to recover between
+# runs. Tradeoff: a PR may wait a few minutes if another compat run is
+# in-flight. Acceptable for unattended bot-PR cycles which are the
+# main consumer of this workflow in maintenance mode.
 concurrency:
-  group: compat-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: compat-${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   compat:

--- a/test/compat.mjs
+++ b/test/compat.mjs
@@ -23,15 +23,24 @@ function log(label, status, details) {
 
 async function wait(ms) { return new Promise(r => setTimeout(r, ms)); }
 
-// Per-test pacing — Anthropic's per-minute / subscription-window rate caps
-// trip when 10 real calls land in <20s. The previous 1.5s spacing was the
-// fastest the suite could run cleanly on a fresh credential, but in
-// practice the runner credential's 5h window fills up across the day and
-// the burst pattern then exhausts what's left. 5s pacing stretches the
-// 10-test suite to ~70s end-to-end, gives the per-minute window time to
-// recover between calls. Overridable via DARIO_COMPAT_PACE_MS env for the
-// rare case a maintainer wants to run faster locally.
-const PACE_MS = parseInt(process.env.DARIO_COMPAT_PACE_MS ?? '5000', 10);
+// Per-test pacing. In passthrough mode (what compat tests), dario strips
+// the CC fingerprint from outbound requests and Anthropic's billing
+// classifier routes the calls to the Agent SDK / standard API pool —
+// which has a much stricter per-minute cap (~3–5/min on a subscription
+// OAuth credential) than the Max interactive pool. The CC-fingerprinted
+// platform dario handles tens of req/sec fine; compat under passthrough
+// trips the lower pool's cap at any pace under ~15s/req.
+//
+// 20s default stretches the 10-test suite to ~3.5min end-to-end but
+// stays under the passthrough-pool's per-minute cap. Overridable via
+// DARIO_COMPAT_PACE_MS env for the rare case a maintainer wants to run
+// faster locally (e.g., DARIO_COMPAT_PACE_MS=500 with a freshly minted
+// API key in the env).
+//
+// Longer-term fix is to point compat at a real sk-ant-... API key on
+// its own rate-limit pool (see docs/recovery.md "Compat suite 429s").
+// That's out of scope for the maintenance-mode trim.
+const PACE_MS = parseInt(process.env.DARIO_COMPAT_PACE_MS ?? '20000', 10);
 
 // --- Anthropic Messages API (Hermes path) ---
 

--- a/test/compat.mjs
+++ b/test/compat.mjs
@@ -23,6 +23,16 @@ function log(label, status, details) {
 
 async function wait(ms) { return new Promise(r => setTimeout(r, ms)); }
 
+// Per-test pacing — Anthropic's per-minute / subscription-window rate caps
+// trip when 10 real calls land in <20s. The previous 1.5s spacing was the
+// fastest the suite could run cleanly on a fresh credential, but in
+// practice the runner credential's 5h window fills up across the day and
+// the burst pattern then exhausts what's left. 5s pacing stretches the
+// 10-test suite to ~70s end-to-end, gives the per-minute window time to
+// recover between calls. Overridable via DARIO_COMPAT_PACE_MS env for the
+// rare case a maintainer wants to run faster locally.
+const PACE_MS = parseInt(process.env.DARIO_COMPAT_PACE_MS ?? '5000', 10);
+
 // --- Anthropic Messages API (Hermes path) ---
 
 async function testAnthropicNonStream() {
@@ -302,27 +312,27 @@ async function main() {
     console.log('   Re-run after 5h window resets for direct API results.\n');
   }
   await probe.text();
-  await wait(1500);
+  await wait(PACE_MS);
 
   console.log('--- Anthropic Messages API (Hermes) ---');
-  await testAnthropicNonStream(); await wait(1500);
-  await testAnthropicStream(); await wait(1500);
-  await testAnthropicStreamFraming(); await wait(1500);
+  await testAnthropicNonStream(); await wait(PACE_MS);
+  await testAnthropicStream(); await wait(PACE_MS);
+  await testAnthropicStreamFraming(); await wait(PACE_MS);
   console.log();
 
   console.log('--- Passthrough Verification ---');
-  await testNoInjection(); await wait(1500);
-  await testClientBetasPreserved(); await wait(1500);
+  await testNoInjection(); await wait(PACE_MS);
+  await testClientBetasPreserved(); await wait(PACE_MS);
   console.log();
 
   console.log('--- Tool Use (OpenClaw) ---');
-  await testToolUse(); await wait(1500);
-  await testToolUseStreaming(); await wait(1500);
+  await testToolUse(); await wait(PACE_MS);
+  await testToolUseStreaming(); await wait(PACE_MS);
   console.log();
 
   console.log('--- OpenAI Compat ---');
-  await testOpenAINonStream(); await wait(1500);
-  await testOpenAIStream(); await wait(1500);
+  await testOpenAINonStream(); await wait(PACE_MS);
+  await testOpenAIStream(); await wait(PACE_MS);
   console.log();
 
   console.log('--- Header Visibility ---');


### PR DESCRIPTION
## Summary
Compat suite has been failing 9/10 with Anthropic 429s on most PRs when multiple ran the same afternoon. Diagnosis: not pure burst-rate, not pure 5h cap — combination of the two. Per-test 1.5s pacing was tight enough to trip the per-minute window when the credential's already-warm, and the per-ref concurrency group meant cross-PR runs could stack on the shared subscription window.

## Two changes

**`test/compat.mjs`** — `PACE_MS` env var, default 5000ms (was hardcoded 1500ms). Suite goes from ~25s end-to-end to ~70s, but stays under Anthropic's per-minute window with headroom for the credential's existing usage. Maintainer can override via `DARIO_COMPAT_PACE_MS=500` for local iteration.

**`.github/workflows/compat-test-self-hosted.yml`** — concurrency group dropped the `${{ github.ref }}` suffix so it's repo-wide. Two PRs in flight now serialize through compat instead of running in parallel and both burning from the shared 5h Max window. `cancel-in-progress: false` so queued runs aren't dropped.

## Why this works
Steady state under maintenance mode:
- Drift-watch fires hourly (~1 Anthropic call per fire after the early-exit drop in dario#TBD — not yet shipped)
- Per-PR compat fires once on PR open / update, ~10 calls per run, paced 5s apart
- Single-flight: PR2 waits for PR1's compat run to finish before starting

Combined call rate stays well under the 5h Max window's headroom on the runner credential, with enough per-minute slack that bursts don't trip.

## Test plan
- [ ] CI green
- [ ] Self-flight: trigger this PR's compat, then open a quick second PR while it's running — second should queue, not fail
- [ ] After merge, monitor the next 3-5 bot-rebake auto-PRs or manual PRs to confirm compat goes consistently green without admin override

## Files
- `test/compat.mjs` (+12, -1) — `PACE_MS` constant, all `wait(1500)` → `wait(PACE_MS)`
- `.github/workflows/compat-test-self-hosted.yml` (+10, -3) — repo-wide concurrency group + `cancel-in-progress: false`