### PR TITLE
ci: add workflow_dispatch to maintainer-fallback publish workflows

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,6 +19,13 @@ name: Publish Docker image to GHCR
 on:
   release:
     types: [published]
+  # Maintainer-fallback dispatch. Run on a tag ref to publish that tag's
+  # image: `gh workflow run docker-publish.yml -R askalf/dario --ref v4.8.4`.
+  # The docker/metadata-action below derives semver tags from `github.ref`,
+  # so dispatch on master is effectively a no-op (no version tag derived;
+  # would push only `latest`). Useful for verifying the workflow's wiring
+  # without cutting a real release.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,13 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  # Maintainer-fallback dispatch. Run on a tag ref to publish that tag's
+  # version to npm: `gh workflow run publish.yml -R askalf/dario --ref v4.8.4`.
+  # `npm publish` uses package.json's version from the checked-out ref;
+  # dispatching on master against an already-published version 403s
+  # cleanly (npm rejects re-publish). Useful for verifying wiring
+  # without cutting a real release.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

`publish.yml` + `docker-publish.yml` fire only on `release: published`, which the bot's auto-release deliberately suppresses. The two workflows have never been testable without cutting a real maintainer release.

Adds `workflow_dispatch:` to both:
- Run on a tag ref (`gh workflow run … --ref v4.8.4`) to publish that tag's artifacts
- Run on master for a wiring-check no-op (npm 403s on existing version; docker re-tags `latest` only)

## Closes the last gap from today's GitHub Actions audit

12/14 workflows already verified green in this session; the dormant fallback pair is the only thing left without a dispatch path.

## Test plan

- [ ] After merge: `gh workflow run publish.yml -R askalf/dario --ref v4.8.4` → expect 403 from npm (version already published), confirms auth + build wiring
- [ ] After merge: `gh workflow run docker-publish.yml -R askalf/dario --ref v4.8.4` → expect successful re-tag of `latest`, confirms ghcr + build wiring