### PR TITLE
chore(release): v4.8.6 — maxTested → v2.1.147

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.6] - 2026-05-21
+
+- **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.145` → `2.1.147` for CC v2.1.146 + v2.1.147 (rolled together; v2.1.147 is a strict superset of v2.1.146). Rolls up cc-drift issues #351 + #355 and supersedes the conflicted bot PRs #352 + #356. Bundled template was last re-captured at v2.1.143 (2026-05-17, 4d old); doctor's background live-fingerprint refresh handles the live-side drift, no template bake needed.
+
 ## [4.8.5] - 2026-05-21
 
 ### Added — `dario doctor` Identity drift check (#353)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.5",
+  "version": "4.8.6",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/live-fingerprint.ts
+++ b/src/live-fingerprint.ts
@@ -876,7 +876,7 @@ export function _resetInstalledVersionProbeForTest(): void {
  */
 export const SUPPORTED_CC_RANGE = {
   min: '1.0.0',
-  maxTested: '2.1.145',
+  maxTested: '2.1.147',
 } as const;
 
 /**


### PR DESCRIPTION
## What

Rolls up two stale cc-drift bot PRs (#352 v2.1.146 + #356 v2.1.147) into a single clean release. v2.1.147 is a strict superset of v2.1.146, so one bump covers both detection issues.

## Changes

- `src/live-fingerprint.ts` — `SUPPORTED_CC_RANGE.maxTested` `2.1.145` → `2.1.147`
- `package.json` — `4.8.5` → `4.8.6`
- `CHANGELOG.md` — adds `## [4.8.6]` section

## Why this isn't the bot PRs

Both #352 and #356 were `mergeable: CONFLICTING` because they were opened pre-v4.8.5 (#354) and both wanted the `## [4.8.5]` CHANGELOG heading + `package.json` 4.8.4 → 4.8.5 — but v4.8.5 already shipped (with the doctor Identity check from #353). Their *useful* change was a single `maxTested` line; this PR carries that one line into a v4.8.6 release.

## Closes

- #351 (auto-closed by `cc-drift-auto-release.yml` "Close matching cc-drift issues" step on merge)
- #355 (same — v2.1.147 ≥ both)

## Risk

Minimal. One config-constant bump + CHANGELOG note. Bundled template unchanged (still v2.1.143 from 2026-05-17 — doctor's background fingerprint refresh handles the local-CC drift). compat-range test passes 28/28 locally.