### PR TITLE
chore(release): v4.8.7 — maxTested → v2.1.148

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.7] - 2026-05-22
+
+- **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.147` → `2.1.148` for CC v2.1.148. Supersedes the blocked bot PR #359 (CI doesn't run on bot-opened branches due to GITHUB_TOKEN-attributed event suppression — same blocker that affected #352 / #356). Closes cc-drift issue #358.
+
 ## [4.8.6] - 2026-05-21
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.145` → `2.1.147` for CC v2.1.146 + v2.1.147 (rolled together; v2.1.147 is a strict superset of v2.1.146). Rolls up cc-drift issues #351 + #355 and supersedes the conflicted bot PRs #352 + #356. Bundled template was last re-captured at v2.1.143 (2026-05-17, 4d old); doctor's background live-fingerprint refresh handles the live-side drift, no template bake needed.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.6",
+  "version": "4.8.7",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/live-fingerprint.ts
+++ b/src/live-fingerprint.ts
@@ -876,7 +876,7 @@ export function _resetInstalledVersionProbeForTest(): void {
  */
 export const SUPPORTED_CC_RANGE = {
   min: '1.0.0',
-  maxTested: '2.1.147',
+  maxTested: '2.1.148',
 } as const;
 
 /**


### PR DESCRIPTION
Replaces blocked bot PR #359 with the same one-line `maxTested` bump on a branch that triggers CI.

## Why this PR vs #359

PR #359 (bot/cc-drift-v2.1.148) was MERGEABLE but `BLOCKED` because no CI ran on the branch — same suppression that hit #352 and #356. GitHub deliberately suppresses downstream workflows from GITHUB_TOKEN-attributed events to prevent loops. Bot PRs are stuck unmergeable as a result.

## Diff

- `src/live-fingerprint.ts` — `SUPPORTED_CC_RANGE.maxTested` `2.1.147` → `2.1.148`
- `package.json` — `4.8.6` → `4.8.7`
- `CHANGELOG.md` — new `## [4.8.7]` section

## Closes

- #358 — auto-closed by `cc-drift-auto-release.yml`'s "Close matching cc-drift issues" step on merge

## Risk

Minimal. One config-constant bump. Bundled template still v2.1.143 (background fingerprint refresh handles live-side drift). compat-range test passes 28/28.