### PR TITLE
ci(cc-drift): wire DARIO_DRIFT_BOT_PAT so bot PRs trigger CI + auto-merge

### DIFF
--- a/.github/workflows/cc-drift-watch.yml
+++ b/.github/workflows/cc-drift-watch.yml
@@ -100,6 +100,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Persist the drift-bot PAT so the later `git push origin bot/cc-drift-*`
+          # and `gh pr create` are attributed to a real user identity rather than
+          # GITHUB_TOKEN. GitHub deliberately suppresses downstream workflow runs
+          # (CI on pull_request) when the triggering event is attributed to
+          # GITHUB_TOKEN — that suppression is what stranded #352 / #356 / #359
+          # with no checks and made `gh pr merge --auto` wait forever. Pushing +
+          # opening the PR under the PAT identity restores normal CI firing.
+          token: ${{ secrets.DARIO_DRIFT_BOT_PAT }}
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -181,10 +190,17 @@ jobs:
         # squash-merges the PR; cc-drift-auto-release.yml then tags the
         # release and publish.yml ships to npm. Other drift classes still
         # just open the plain issue via the earlier step.
+        #
+        # GH_TOKEN uses DARIO_DRIFT_BOT_PAT (not GITHUB_TOKEN): GitHub
+        # suppresses downstream workflow runs for events attributed to
+        # GITHUB_TOKEN, so a PR opened with GITHUB_TOKEN never gets CI
+        # checks, and `gh pr merge --auto` then waits forever for checks
+        # that won't appear (this stranded #352, #356, #359 — each one
+        # required a manual chore/release-* rollup PR to ship).
         if: steps.drift.outputs.exit_code != '0'
         id: auto_draft
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DARIO_DRIFT_BOT_PAT }}
         run: |
           set -eo pipefail
 


### PR DESCRIPTION
## Summary

Wires the already-provisioned `DARIO_DRIFT_BOT_PAT` (created 2026-05-18 but never plumbed in) into `cc-drift-watch.yml` so the bot's auto-drafted drift PRs actually merge end-to-end instead of stranding.

## Why this is needed

PRs opened by a workflow authenticated with `GITHUB_TOKEN` do **not** trigger downstream `pull_request` workflow runs — GitHub's documented anti-recursion behavior. That meant:

- bot opens `bot/cc-drift-v2.1.X` PR ✓
- CI doesn't fire (no checks appear) ✗
- branch protection requires checks → `gh pr merge --auto` hangs ✗
- maintainer closes unmerged + opens manual `chore/release-*` rollup ✗

This pattern stranded **#352, #356, #359** over the last 36 hours, each requiring a manual rollup to ship v4.8.5, v4.8.6, v4.8.7 to npm.

## Fix (two lines)

1. `actions/checkout` -> `with: token: secrets.DARIO_DRIFT_BOT_PAT` so subsequent `git push origin bot/cc-drift-*` is attributed to the PAT identity.
2. Auto-draft step -> `env: GH_TOKEN: secrets.DARIO_DRIFT_BOT_PAT` so `gh pr create` opens the PR under the PAT identity.

Both attributions matter; the second is what GitHub keys the `pull_request` event suppression on.

## Test plan

- [ ] After merge, force a drift watcher run: `gh workflow run cc-drift-watch.yml -R askalf/dario -f force=true`
- [ ] Confirm the new `bot/cc-drift-vX.Y.Z` PR shows CI checks running (build x 3 node versions, validate-package-json, docker-cap-drop-smoke, actionlint, codeql)
- [ ] Confirm `gh pr merge --auto --squash` consummates on green CI
- [ ] Confirm `cc-drift-auto-release.yml` fires on the merge and ships to npm + ghcr
- [ ] Branches list stays clean (auto-delete on merge)