### PR TITLE
chore(cc-drift): v4.8.8 — maxTested → v2.1.149

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.8] - 2026-05-22
+
+- **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.148` → `2.1.149` for CC v2.1.149. Auto-drafted by `cc-drift-watch.yml`; maintainer confirm the bundled template doesn't also need a re-capture (run `node scripts/capture-and-bake.mjs` locally, amend this PR).
 ## [4.8.7] - 2026-05-22
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.147` → `2.1.148` for CC v2.1.148. Supersedes the blocked bot PR #359 (CI doesn't run on bot-opened branches due to GITHUB_TOKEN-attributed event suppression — same blocker that affected #352 / #356). Closes cc-drift issue #358.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.7",
+  "version": "4.8.8",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/live-fingerprint.ts
+++ b/src/live-fingerprint.ts
@@ -876,7 +876,7 @@ export function _resetInstalledVersionProbeForTest(): void {
  */
 export const SUPPORTED_CC_RANGE = {
   min: '1.0.0',
-  maxTested: '2.1.148',
+  maxTested: '2.1.149',
 } as const;
 
 /**


### PR DESCRIPTION
## Auto-drafted by cc-drift-watch.yml

The drift watcher flagged CC v2.1.149 as outside the current supported range. This PR:

1. Bumps `SUPPORTED_CC_RANGE.maxTested` from `2.1.148` → `2.1.149` in `src/live-fingerprint.ts`
2. Bumps `package.json` version → `4.8.8`
3. Promotes `## [Unreleased]` in `CHANGELOG.md` to `## [4.8.8] - 2026-05-22` and appends the drift-fix bullet

### Items in the drift report

- **compat.range** (medium) — CC v2.1.149 is beyond SUPPORTED_CC_RANGE.maxTested (v2.1.148). Run the e2e suite against the new CC and bump maxTested in src/live-fingerprint.ts — users on the new CC currently get a soft "untested-above" warning from dario doctor.
- **template.version** (low) — baked cc-template-data.json is v2.1.143; npm latest is v2.1.149. Re-capture the template (MITM a real CC v2.1.149 request) if any fingerprint-sensitive field (system prompt, header order, metadata shape, beta flags) changed.

### What happens when you merge this

A separate workflow (`cc-drift-auto-release.yml`) fires on merge of any PR whose head branch starts with `bot/cc-drift-`. It reads `package.json` from master, tags `v4.8.8`, and creates the GitHub release. The existing `publish.yml` workflow triggers on release publication and runs `npm publish --provenance`. Net: merging this PR ships `@askalf/dario@4.8.8` to npm within ~3 minutes, no further maintainer action.

### Maintainer checklist before merging

- [ ] Install the new CC locally: `npm install -g @anthropic-ai/claude-code@2.1.149`
- [ ] Run `dario doctor` and confirm it comes back clean against v2.1.149
- [ ] **If any fingerprint-sensitive fields changed**, re-capture the bundled template locally (`npm run build && node scripts/capture-and-bake.mjs`) and amend this PR with the updated `src/cc-template-data.json`. The bot cannot re-capture from CI because the bake requires an authenticated CC session.
- [ ] Confirm the CHANGELOG entry under `## [4.8.8]` reads cleanly. The bot wrote a short factual line; feel free to rewrite with more context.
- [ ] Mark as ready for review + merge. Auto-merge will ship it through CI, and the auto-release workflow handles the tag + release + npm publish.

### About this auto-draft

Only `compat.range` items are auto-patched. Other drift categories (template re-capture, scope rotations, URL / clientId / tokenUrl changes) require judgment and stay manual — the bot opens the plain drift-issue for those as before.

---

_Generated by `scripts/auto-draft-drift-fix.mjs`. Closes the detection-latency arc: [#112](https://github.com/askalf/dario/pull/112) (CF bypass), [#113](https://github.com/askalf/dario/pull/113) (hourly cadence), [#114](https://github.com/askalf/dario/pull/114) (auto-draft PR)._
