### PR TITLE
fix(liveness): tolerate transient gh CLI auth errors on healthy path

### DIFF
--- a/.github/workflows/cc-drift-watcher-liveness.yml
+++ b/.github/workflows/cc-drift-watcher-liveness.yml
@@ -94,13 +94,28 @@ jobs:
 
           echo "Last successful watcher run: $last_success ($hours_since hours ago, threshold ${THRESHOLD_HOURS}h)"
 
-          existing=$(gh issue list --label cc-watcher-liveness --state open --json number --jq '.[0].number')
+          # Look up any existing open alert issue so we can close it on the
+          # healthy path. This lookup is non-blocking — a transient API
+          # failure (e.g. HTTP 401 during GH-Actions token provisioning race,
+          # observed 2026-05-23 at 11:36 UTC despite same workflow passing
+          # 90 min earlier) must NOT fail the whole liveness check, because
+          # the watcher's actual liveness was already verified above. We
+          # tolerate auth + transient errors and treat them as "no existing
+          # issue" — worst case is we don't close a stale alert this cycle
+          # (next cycle will retry).
+          existing=$(gh issue list --label cc-watcher-liveness --state open --json number --jq '.[0].number' 2>/dev/null) || existing=""
 
           if [ "$hours_since" -lt "$THRESHOLD_HOURS" ]; then
             echo "Watcher healthy."
             if [ -n "$existing" ] && [ "$existing" != "null" ]; then
-              gh issue close "$existing" --comment "Watcher recovered: last successful run ${hours_since} hours ago (${last_success}). Closing this alert."
-              echo "Closed stale alert #$existing"
+              # Same tolerance on the close — if it fails for any transient
+              # reason, log a warning + continue. The issue will get closed
+              # on the next cycle.
+              if gh issue close "$existing" --comment "Watcher recovered: last successful run ${hours_since} hours ago (${last_success}). Closing this alert." 2>/dev/null; then
+                echo "Closed stale alert #$existing"
+              else
+                echo "::warning::Failed to close stale alert #$existing (transient API error); will retry next cycle"
+              fi
             fi
             exit 0
           fi


### PR DESCRIPTION
Surgical fix for the 2026-05-23T11:36 liveness failure. Root cause was `gh issue list` returning HTTP 401 from GitHub's GraphQL endpoint — a transient auth race that doesn't recur on retries (same workflow passed 90 min earlier with the same token).

## Symptom

Liveness job failed under `set -euo pipefail` after the actual healthiness check (`hours_since < THRESHOLD_HOURS`) had already passed:

```
Last successful watcher run: 2026-05-23T10:10:04Z (1 hours ago, threshold 8h)
HTTP 401: Bad credentials (https://api.github.com/graphql)
Try authenticating with: gh auth login
##[error]Process completed with exit code 1.
```

The failing `gh issue list` was looking for an existing alert issue to close — purely cosmetic side work. Real liveness signal was already determined positive.

## Fix

- Wrap `gh issue list` with `2>/dev/null) || existing=""` so transient failure → empty result rather than job exit.
- Same tolerance on the `gh issue close` call: log a warning if it fails, continue. Next cycle (2h) will retry.

Comment block documents the 2026-05-23 incident inline so future maintainers don't re-tighten the script.

## Risk

Negligible. The change only affects HOUSEKEEPING of alert issues, not the actual liveness signal. Worst case: a stale alert issue stays open one cycle longer than it should.

Per `project_dario_maintenance_mode`: this is critical-fix-only territory (false alarms on a watcher → operator noise), not feature work.