### PR TITLE
fix(auto-merge): pass --repo flag so gh doesn't need a git checkout

### DIFF
--- a/.github/workflows/auto-merge-bot-prs.yml
+++ b/.github/workflows/auto-merge-bot-prs.yml
@@ -79,5 +79,9 @@ jobs:
           # soon as all required status checks pass. If they're already
           # passing, it merges immediately. If a check fails, the PR
           # stays open and operator can intervene.
-          gh pr merge "$PR" --auto --squash --delete-branch
+          #
+          # --repo is required: the runner has no checkout, so gh can't
+          # infer the repo from a git remote and bails with "not a git
+          # repository". Pass it explicitly.
+          gh pr merge "$PR" --repo "${{ github.repository }}" --auto --squash --delete-branch
           echo "Auto-merge armed."


### PR DESCRIPTION
Follow-up to #376. The auto-merge job has no `actions/checkout` step, so `gh pr merge` was failing with `fatal: not a git repository` because gh tries to infer the repo from a git remote.

Pre-existing latent bug — masked for months because the substring-skip filter in #368 was rejecting grouped non-major Dependabot PRs before they ever reached this step. #376 fixed the filter; this surfaced the next failure.

Drift-bot PRs (`bot/cc-drift-*`) have probably been hitting this same failure silently. Operator's been merging them by hand.

## Fix

One-line addition: `gh pr merge "$PR" --repo "${{ github.repository }}" --auto --squash --delete-branch`. Uses GitHub API directly instead of git remote inference.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: re-trigger auto-merge on PR #374 (close + reopen) and confirm `gh pr merge` succeeds + native auto-merge arms