### PR TITLE
docs: fix stale workflow refs, liveness threshold (3h→8h), and counts

### DIFF
--- a/.github/workflows/cc-drift-auto-release.yml
+++ b/.github/workflows/cc-drift-auto-release.yml
@@ -31,13 +31,13 @@ name: Auto release on version bump
 # path ships a release and the schedule path fires later, the second
 # run sees the tag and skips cleanly (no failure email).
 #
-# Inline-publish (vs relying on publish.yml's release:published trigger):
-# `gh release create` from this workflow uses GITHUB_TOKEN, which means
-# `release: published` ALSO doesn't fire downstream workflows here. So
-# the build/smoke/tag/release/npm-publish chain runs as one workflow
-# run. publish.yml stays in place for the manual release case (a
-# maintainer running `gh release create` locally as a real user, which
-# DOES fire release:published).
+# Inline-publish: `gh release create` from this workflow uses
+# GITHUB_TOKEN, so `release: published` doesn't fire downstream
+# workflows here. The build/smoke/tag/release/npm-publish chain
+# therefore runs as one workflow run. (The standalone publish.yml that
+# listened for release:published was removed in #369 — this inline chain
+# is now the ONLY release path, so a manual `gh release create` will
+# NOT publish to npm.)
 #
 # Filename retains `cc-drift-` prefix for git-blame continuity with the
 # originally-named workflow; the scope was generalized on 2026-04-23
@@ -84,8 +84,9 @@ permissions:
   # packages: write is required for the inline docker build/push to
   # ghcr.io/askalf/dario at the end of the release pipeline. Same loop-
   # protection reasoning as the inline npm publish — `gh release create`
-  # via GITHUB_TOKEN doesn't fire `release: published`, so we can't
-  # delegate to docker-publish.yml from this path.
+  # via GITHUB_TOKEN doesn't fire `release: published`, so the docker
+  # build/push runs inline here (the standalone docker-publish.yml was
+  # removed in #369).
   packages: write
 
 jobs:
@@ -257,7 +258,7 @@ jobs:
             echo "head_ref=$PR_HEAD_REF"
           } >> "$GITHUB_OUTPUT"
 
-      # ─── Build + smoke pipeline (mirrors publish.yml) ──────────────
+      # ─── Build + smoke pipeline (was publish.yml, removed in #369) ──
       # We do this BEFORE cutting the GitHub release, so a failing
       # build/smoke aborts everything — no release, no npm publish, no
       # half-shipped state.
@@ -346,8 +347,8 @@ jobs:
       # ─── Inline Docker publish to GHCR ─────────────────────────────
       # Same loop-protection reason as the inline npm publish above:
       # `gh release create` via GITHUB_TOKEN doesn't fire
-      # `release: published`, so docker-publish.yml never gets the chance
-      # to run from this path. Mirror its build/push steps inline.
+      # `release: published`. The standalone docker-publish.yml was
+      # removed in #369; its build/push steps live inline here.
       - name: Set up QEMU
         if: steps.gate.outputs.proceed == 'true'
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0

--- a/.github/workflows/cc-drift-watch.yml
+++ b/.github/workflows/cc-drift-watch.yml
@@ -188,7 +188,7 @@ jobs:
         # bumps), applies the patch, pushes to a bot branch, opens a PR,
         # and turns on auto-merge. Once required CI checks pass, GitHub
         # squash-merges the PR; cc-drift-auto-release.yml then tags the
-        # release and publish.yml ships to npm. Other drift classes still
+        # release and ships to npm inline. Other drift classes still
         # just open the plain issue via the earlier step.
         #
         # GH_TOKEN uses DARIO_DRIFT_BOT_PAT (not GITHUB_TOKEN): GitHub

--- a/.github/workflows/cc-drift-watcher-liveness.yml
+++ b/.github/workflows/cc-drift-watcher-liveness.yml
@@ -9,7 +9,7 @@ name: CC drift watcher liveness
 # Runs every 2 hours on a github-hosted runner (no auth, no self-hosted
 # dependency — so it survives the exact failure modes it's meant to catch).
 # Checks the most recent `success` run of cc-drift-template-watch.yml; if
-# the latest success is more than 3 hours old (≥ 6 missed 30-min cycles),
+# the latest success is more than 8 hours old (≥ 16 missed 30-min cycles),
 # opens a `cc-watcher-liveness`-labeled issue. Auto-closes the issue when
 # the watcher recovers.
 #

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <!-- <a href="https://discord.gg/fENVZpdYcX"><img src="https://img.shields.io/badge/discord-join-5865f2?style=flat-square&logo=discord&logoColor=white" alt="Join Discord"></a> -->
 </p>
 
-<p align="center"><em>Zero runtime dependencies · <a href="https://www.npmjs.com/package/@askalf/dario">SLSA-attested</a> every release · nothing phones home · ~17.5k lines you can read in a weekend · independent, unofficial, third-party (<a href="DISCLAIMER.md">DISCLAIMER.md</a>)</em></p>
+<p align="center"><em>Zero runtime dependencies · <a href="https://www.npmjs.com/package/@askalf/dario">SLSA-attested</a> every release · nothing phones home · ~18.5k lines you can read in a weekend · independent, unofficial, third-party (<a href="DISCLAIMER.md">DISCLAIMER.md</a>)</em></p>
 
 ---
 
@@ -153,7 +153,7 @@ The 2026-06-15 split is announced. The wire-shape changes that arrive between re
 - **Class B — same-binary remote-config drift** *(v4.2.2)*. [`cc-drift-template-watch.yml`](./.github/workflows/cc-drift-template-watch.yml) (cron `*/30 * * * *`) runs on a self-hosted runner with an authenticated CC install, captures live every 30 min. On detection, **opens an auto-rebake PR** *(v4.4.0)* with the freshly-baked template and a unified-line diff inline *(v4.5.0)* — a reviewer sees ship-or-investigate in one screen. This is the only way to catch the class — github-hosted has no Pro/Max session, no OAuth credential, no way to capture from real CC. Setup: [`docs/drift-monitor.md`](./docs/drift-monitor.md).
 - **Class C — classifier-rule drift** *(v4.6.0)*. [`cc-billing-classifier-canary.yml`](./.github/workflows/cc-billing-classifier-canary.yml) sends one live request through dario's canonical-rebuild mode daily, asserts the `representative-claim` response header still maps to a subscription bucket. Catches the orthogonal failure mode where CC's wire shape is unchanged but Anthropic's classifier rules shifted underneath.
 - **PR-time compat gate** *(v4.3.0)*. [`compat-test-self-hosted.yml`](./.github/workflows/compat-test-self-hosted.yml) runs the full compat suite against a live `dario proxy` on every PR that touches the wire-shape surface — regressions fail the merge check **before** they ship.
-- **Liveness alarm** *(v4.4.2)*. [`cc-drift-watcher-liveness.yml`](./.github/workflows/cc-drift-watcher-liveness.yml) runs on github-hosted infra every 2 hours, alerts if the self-hosted class-B watcher hasn't had a successful run in 3 hours. Watches the watcher; survives the exact failure modes it's designed to detect.
+- **Liveness alarm** *(v4.4.2)*. [`cc-drift-watcher-liveness.yml`](./.github/workflows/cc-drift-watcher-liveness.yml) runs on github-hosted infra every 2 hours, alerts if the self-hosted class-B watcher hasn't had a successful run in 8 hours. Watches the watcher; survives the exact failure modes it's designed to detect.
 
 **Anthropic doesn't publish a wire-level changelog for subscribers. dario is one.**
 
@@ -366,7 +366,7 @@ The tool doesn't know. The backend doesn't know. Dario is the seam.
 | Dependencies | **0 runtime.** Verify: `npm ls --production` |
 | Provenance | Every release [SLSA-attested](https://www.npmjs.com/package/@askalf/dario) via GitHub Actions + Sigstore. v4.1.0 published 2026-05-16T15:13:24Z |
 | Scanning | [CodeQL](https://github.com/askalf/dario/actions/workflows/codeql.yml) on every push and weekly |
-| Tests | **80 test files**, **74 in default `npm test` suite** — green on every release |
+| Tests | **84 test files**, **77 in the default `npm test` suite** (`test/all.test.mjs`) — green on every release |
 | Drift response | [`cc-drift-watch.yml`](./.github/workflows/cc-drift-watch.yml) hourly cron, [`cc-drift-auto-release.yml`](./.github/workflows/cc-drift-auto-release.yml) auto-publish on merge — median CC-release → dario-release under one hour |
 | Credentials | Never logged, redacted from errors, `0600` on disk in `0700` dirs; MCP server redacts at the tool boundary |
 | Network | Binds `127.0.0.1` by default; upstream only to configured backends over HTTPS; hardcoded SSRF allowlist |
@@ -466,7 +466,7 @@ PRs welcome. Small TypeScript codebase, zero runtime deps. Architecture + file-b
 git clone https://github.com/askalf/dario && cd dario
 npm install
 npm run dev    # tsx, no build step
-npm test       # 2,080 assertions, 71 suites
+npm test       # 77 test files via test/all.test.mjs, green on every release
 npm run e2e    # live proxy + OAuth (needs a working Claude backend)
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,16 +4,16 @@ How a release actually ships and what to verify post-publish. Process exists bec
 
 ## How releases ship
 
-Dario uses **inline auto-release**: bumping `package.json.version` on master fires `.github/workflows/auto-release.yml`, which tags `vX.Y.Z`, generates a GitHub Release from the matching `## [X.Y.Z]` CHANGELOG section, and runs `npm publish --access public --provenance` in the same job.
+Dario uses **inline auto-release**: bumping `package.json.version` on master fires `.github/workflows/cc-drift-auto-release.yml` (display name "Auto release on version bump"), which tags `vX.Y.Z`, generates a GitHub Release from the matching `## [X.Y.Z]` CHANGELOG section, and runs `npm publish --access public --provenance` + the inline GHCR docker push in the same job.
 
 No manual `git tag` / `npm publish` step. The version bump on master is the release.
 
-The flow chosen because `GITHUB_TOKEN`-created releases don't fire `release:published`, so a separate `publish.yml` listening for that event would never trigger. Cost: lost the v0.3.0-equivalent of [deepdive#3.0](https://github.com/askalf/deepdive) once via that mistake; not making it twice.
+The flow chosen because `GITHUB_TOKEN`-created releases don't fire `release:published`, so a separate workflow listening for that event would never trigger — the standalone `publish.yml`/`docker-publish.yml` that did were removed in #369 and folded inline. Cost: lost the v0.3.0-equivalent of [deepdive#3.0](https://github.com/askalf/deepdive) once via that mistake; not making it twice. A manual `gh release create` will NOT publish — only the version-bump path does.
 
 ## Pre-merge checklist (PR author / reviewer)
 
 - [ ] `npm run build` — clean
-- [ ] `npm test` — all green (currently 54+ assertions)
+- [ ] `npm test` — all green (77 test files via `test/all.test.mjs`)
 - [ ] `package.json.version` bumped if and only if the PR is a release
 - [ ] `CHANGELOG.md` has a matching `## [X.Y.Z] - YYYY-MM-DD` heading above `## [Unreleased]`, populated with the release's user-visible changes
 - [ ] No `Co-Authored-By:` trailers in commits

--- a/docs/drift-monitor.md
+++ b/docs/drift-monitor.md
@@ -32,7 +32,7 @@ prompt). The npm watcher can't see this; the binary is unchanged.
 > Watched-by-the-watcher: `.github/workflows/cc-drift-watcher-liveness.yml`
 > runs every 2 hours on a github-hosted runner and opens a
 > `cc-watcher-liveness`-labeled alert if the class-B watcher has not had a
-> successful run within 3 hours (≥ 6 missed cycles). Catches "runner went
+> successful run within 8 hours (≥ 16 missed cycles). Catches "runner went
 > offline silently" — the failure mode where class-B drift goes uncaught
 > because the watcher itself is down. The liveness watcher lives on
 > github-hosted infrastructure deliberately so it survives the exact failure
@@ -217,7 +217,7 @@ Workflows that exercise live `dario proxy` paths (compat-test, billing canary, f
 | `cc-billing-classifier-canary.yml` | daily 06:30 UTC | daily | 1 small haiku request |
 | `compat-test-self-hosted.yml` | per qualifying PR | per qualifying PR | ~11 small requests |
 
-**Cron scheduler reality.** GitHub Actions' free-tier cron scheduler is best-effort, not guaranteed. The class-B watcher declares `*/30 * * * *` but in practice GitHub honors it every 2-4 hours on this repo. The v4.4.2 liveness alarm's threshold is set to 8h to absorb this skew — anything past that is signal, not scheduler noise. If you need a tighter SLA (sub-hour), self-host the runner *and* the cron driver (e.g. a cron entry on the same Hetzner box invoking `gh workflow run` directly).
+**Cron scheduler reality.** GitHub Actions' free-tier cron scheduler is best-effort, not guaranteed. The class-B watcher declares `*/30 * * * *` but in practice GitHub honors it every 2-4 hours on this repo. The liveness alarm (added v4.4.2) has its threshold set to 8h (raised from 3h in v4.7.1) to absorb this skew — anything past that is signal, not scheduler noise. If you need a tighter SLA (sub-hour), self-host the runner *and* the cron driver (e.g. a cron entry on the same Hetzner box invoking `gh workflow run` directly).
 
 At steady state, this is comfortably inside Pro/Max headroom. The failure mode to watch for is **batched firing** — manually re-triggering the same workflow several times in a single hour, or PRs landing in rapid succession that each fire compat-test. We tripped this during the v4.6.x rollout: a half-dozen manual re-runs in a 2-hour window 429'd the runner credential. Pro/Max accounts have per-hour rate caps as well as per-5h / per-7d pools, and the per-hour cap is what surfaces first.
 

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -172,7 +172,7 @@ Get a fresh runner registration token from: github.com → askalf/dario → Sett
 **Fix** — Hetzner side:
 1. Hetzner Cloud Console → askalf-platform-1 → check VM state (running / stopped / hung)
 2. If hung: console-reset or hard-reboot from the console
-3. If filesystem corruption: snapshot restore (R2 nightly backups via age-encrypted offsite, recovery via `restic` — see `reference_r2_backup` in operator memory)
+3. If filesystem corruption: snapshot restore (R2 nightly age-encrypted offsite backups, recovery via `restic`)
 
 Recovery time: typically minutes for a console-reboot. Snapshot restore is hours.
 
@@ -180,6 +180,6 @@ Recovery time: typically minutes for a console-reboot. Snapshot restore is hours
 
 ## What I do NOT cover here
 
-- Building new dario features (we're in maintenance mode — see `project_dario_maintenance_mode` operator memory)
+- Building new dario features (we're in maintenance mode)
 - Tuning compat-suite coverage (Anthropic-wire-shape correctness is captured by the existing tests; expanding it is out of maintenance scope)
 - Migrating off the OAuth proxy pattern entirely (dario is the OAuth proxy; if Anthropic blocks it permanently, that's a strategic decision, not a runbook recovery)

--- a/scripts/auto-draft-drift-fix.mjs
+++ b/scripts/auto-draft-drift-fix.mjs
@@ -237,7 +237,7 @@ function buildPrBody(ccVersion, before, after, newDarioVersion, report) {
     '',
     '### What happens when you merge this',
     '',
-    `A separate workflow (\`cc-drift-auto-release.yml\`) fires on merge of any PR whose head branch starts with \`bot/cc-drift-\`. It reads \`package.json\` from master, tags \`v${newDarioVersion}\`, and creates the GitHub release. The existing \`publish.yml\` workflow triggers on release publication and runs \`npm publish --provenance\`. Net: merging this PR ships \`@askalf/dario@${newDarioVersion}\` to npm within ~3 minutes, no further maintainer action.`,
+    `A separate workflow (\`cc-drift-auto-release.yml\`) fires on merge of any version-bumping PR to \`master\`. It reads \`package.json\` from master, tags \`v${newDarioVersion}\`, creates the GitHub release, and runs \`npm publish --provenance\` + the GHCR docker push inline — all in one run (the old separate \`publish.yml\` was removed in #369). Net: merging this PR ships \`@askalf/dario@${newDarioVersion}\` to npm within ~3 minutes, no further maintainer action.`,
     '',
     '### Maintainer checklist before merging',
     '',

--- a/scripts/drift-report.mjs
+++ b/scripts/drift-report.mjs
@@ -4,7 +4,7 @@
 // kicks off captureLiveTemplateAsync at import time, which is not what
 // unit tests want).
 //
-// dario#XXX (v4.5.0 — unified-diff snippets in drift reports).
+// Added in v4.5.0 — unified-diff snippets in drift reports.
 
 /**
  * Generate a line-level unified diff between two text blobs. Bounded


### PR DESCRIPTION
Audit-driven cleanup. No behavior change — comments, docs, and counts only.

## Dead-workflow references
`publish.yml` + `docker-publish.yml` were removed in #369; `cc-drift-auto-release.yml` now does npm publish + GHCR push **inline**. Fixed everything that still described them as the live/fallback path:
- `cc-drift-auto-release.yml` — 3 comments (no longer claim publish.yml "stays in place for the manual case" / that we "delegate to docker-publish.yml")
- `cc-drift-watch.yml` — "publish.yml ships to npm" → "ships to npm inline"
- `auto-draft-drift-fix.mjs` — PR-body "what happens on merge" no longer cites publish.yml (leftover from #382)
- `RELEASING.md` — named a **nonexistent** `auto-release.yml` → corrected to `cc-drift-auto-release.yml`; reworded the rationale and noted a manual `gh release create` will NOT ship

## Liveness threshold (3h → 8h)
Code default is `THRESHOLD_HOURS=8` (raised from 3h in v4.7.1), but three docs still said "3 hours / 6 missed cycles":
- `cc-drift-watcher-liveness.yml` header, `README:156`, `docs/drift-monitor.md:35` → 8h / 16 missed cycles
- reconciled drift-monitor.md's self-contradiction (line 35 said 3h, line 220 said 8h) and its version attribution

## Stale counts (verified)
- `README`: `~17.5k`→`~18.5k` lines (actual `find src -name '*.ts'` = 18,800 across 44 files; also reconciles the sibling `~18.5k` claim), `80`→`84` test files / `77` in the default suite, replaced the unreproducible "2,080 assertions, 71 suites" with the verifiable file count (`npm test` runs `test/all.test.mjs` → 77 files, confirmed green locally)
- `RELEASING.md`: dropped the wildly-stale "54+ assertions"

## Minor
- `drift-report.mjs`: filled-in placeholder `dario#XXX` → plain version note
- `recovery.md`: dropped two operator-private memory-key references meaningless to a public reader

## Test plan
- [x] `node --check` passes on both edited scripts
- [x] `npm test` green locally (77 files)
- [ ] CI green (actionlint validates the 3 workflow comment edits didn't break YAML)