### PR TITLE
fix(sdk-drift): tolerate empty npm view output (don't crash on absent field)

### DIFF
--- a/scripts/check-sdk-drift.mjs
+++ b/scripts/check-sdk-drift.mjs
@@ -29,7 +29,12 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
 
 function npmView(pkg, field) {
-  const out = execSync(`npm view ${pkg} ${field} --json`, { encoding: 'utf-8' });
+  // `npm view <pkg> <field> --json` prints NOTHING (empty stdout) when the
+  // field is absent — e.g. @anthropic-ai/claude-agent-sdk@0.3.x bundles its
+  // deps and exposes no top-level `dependencies`. JSON.parse('') would throw
+  // "Unexpected end of JSON input", so treat empty as "field not present".
+  const out = execSync(`npm view ${pkg} ${field} --json`, { encoding: 'utf-8' }).trim();
+  if (!out) return undefined;
   return JSON.parse(out);
 }
 


### PR DESCRIPTION
## Problem

The smoke-test of the new daily SDK-drift watcher (#385) immediately failed — surfacing a latent crash in `check-sdk-drift.mjs` that never showed while the script was orphaned:

```
SyntaxError: Unexpected end of JSON input
    at npmView (scripts/check-sdk-drift.mjs:33)
```

`npm view <pkg> <field> --json` prints **empty stdout** for an absent field, and `JSON.parse('')` throws. `@anthropic-ai/claude-agent-sdk@0.3.x` now bundles its deps and exposes no top-level `dependencies`, so the dependencies lookup hit exactly this.

## Fix

`npmView()` treats empty output as "field not present" (returns `undefined`); the existing optional chaining downstream already handles it. Verified locally — the script runs clean and emits its JSON report (currently reports `cc_version` 2.1.143→2.1.153 drift, exit 1).

## Follow-up (NOT in this PR — flagging for a decision)

- **Stainless signal is dark.** With agent-sdk bundling deps, `stainless_dep` reads `null` — that arm of the detector can't read the version from npm metadata anymore.
- **cc_version overlaps `cc-drift-watch.yml`.** The only remaining live signal duplicates the existing CC watcher. Worth deciding whether the SDK watcher earns its daily run as-is, or should be reworked (source Stainless another way) / reverted pending that.

## Test plan
- [x] `node --check` passes
- [x] `node scripts/check-sdk-drift.mjs` runs clean, emits valid JSON
- [ ] Post-merge: re-dispatch "SDK drift watch" and confirm it now reaches the issue step instead of hard-failing