### PR TITLE
chore: add Opus 4.8 to aliases, pricing, and doctor probe

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -83,6 +83,8 @@ export function billingBucketFromClaim(claim: string | null | undefined): Billin
 // Anthropic pricing (per 1M tokens, USD). Not authoritative — used for
 // rough burn-rate display in the /analytics summary.
 const PRICING: Record<string, { input: number; output: number; cacheRead: number; cacheCreate: number }> = {
+  'claude-opus-4-8': { input: 5, output: 25, cacheRead: 0.5, cacheCreate: 6.25 },
+  'claude-opus-4-7': { input: 5, output: 25, cacheRead: 0.5, cacheCreate: 6.25 },
   'claude-opus-4-6': { input: 15, output: 75, cacheRead: 1.5, cacheCreate: 18.75 },
   'claude-sonnet-4-6': { input: 3, output: 15, cacheRead: 0.3, cacheCreate: 3.75 },
   'claude-haiku-4-5': { input: 0.8, output: 4, cacheRead: 0.08, cacheCreate: 1 },

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -998,6 +998,7 @@ export function resolveEffort(flag: EffortValue | undefined, clientBody: Record<
  *
  * Empirical results (2026-05-15, live OAuth-subscription probes against
  * api.anthropic.com — see dario#NNN for the probe matrix):
+ *   claude-opus-4-8    ✓ accepts adaptive (verified 2026-05-28)
  *   claude-opus-4-7    ✓ accepts adaptive
  *   claude-opus-4-6    ✓ accepts adaptive
  *   claude-sonnet-4-6  ✓ accepts adaptive

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -571,7 +571,7 @@ export async function runChecks(opts: RunChecksOptions = {}): Promise<Check[]> {
       const families: Array<{ family: string; model: string }> = [
         { family: 'haiku',  model: 'claude-haiku-4-5' },
         { family: 'sonnet', model: 'claude-sonnet-4-6' },
-        { family: 'opus',   model: 'claude-opus-4-7' },
+        { family: 'opus',   model: 'claude-opus-4-8' },
       ];
       const probe = async (model: string) => {
         const res = await fetch(probeEndpoint, {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -131,7 +131,8 @@ function loadClaudeIdentity(): { deviceId: string; accountUuid: string } {
 
 // Model shortcuts — users can pass short names
 const MODEL_ALIASES: Record<string, string> = {
-  'opus': 'claude-opus-4-7',
+  'opus': 'claude-opus-4-8',
+  'opus47': 'claude-opus-4-7',
   'opus46': 'claude-opus-4-6',
   'opus1m': 'claude-opus-4-7[1m]',
   'sonnet': 'claude-sonnet-4-6',
@@ -283,7 +284,7 @@ export function sanitizeMessages(body: Record<string, unknown>, preserveTags?: S
 
 // OpenAI model names → Anthropic (fallback if client sends GPT names)
 const OPENAI_MODEL_MAP: Record<string, string> = {
-  'gpt-5.4': 'claude-opus-4-6',
+  'gpt-5.4': 'claude-opus-4-8',
   'gpt-5.4-mini': 'claude-sonnet-4-6',
   'gpt-5.4-nano': 'claude-haiku-4-5',
   'gpt-5.3': 'claude-opus-4-6',
@@ -371,7 +372,7 @@ function translateStreamChunk(line: string): string | null {
   return null;
 }
 
-const OPENAI_MODELS_LIST = { object: 'list', data: ['claude-opus-4-7', 'claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5'].map(id => ({ id, object: 'model', created: 1700000000, owned_by: 'anthropic' })) };
+const OPENAI_MODELS_LIST = { object: 'list', data: ['claude-opus-4-8', 'claude-opus-4-7', 'claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5'].map(id => ({ id, object: 'model', created: 1700000000, owned_by: 'anthropic' })) };
 
 interface ProxyOptions {
   port?: number;


### PR DESCRIPTION
Opus 4.8 shipped 2026-05-28. Routing already works (the `pool.ts` family matcher and the `supportsAdaptiveThinking` version regex both admit `claude-opus-4-8` with no change), but the hardcoded model references still named 4.7.

## Changes
- **`MODEL_ALIASES`**: `opus` → `claude-opus-4-8`; added `opus47` so the prior shorthand still resolves. `opus1m` deliberately stays `claude-opus-4-7[1m]` — Anthropic has not shipped a 4-8 1M SKU (`claude-opus-4-8[1m]` returns 404).
- **OpenAI compat**: `/models` list advertises `claude-opus-4-8`; `gpt-5.4` (flagship) maps to it.
- **`analytics.ts` PRICING**: added `claude-opus-4-8` and `claude-opus-4-7` at \$5/\$25. Both were absent, so `estimateCost` fell back to sonnet rates for every opus request — the burn-rate display under-counted opus ~40%.
- **`doctor.ts`**: opus-family 7d-bucket probe now targets 4-8.
- **`cc-template.ts`**: adaptive-thinking doc note records 4-8 (comment only).

## Scope / trade-offs
- Left `gpt-5.3` / `gpt-4` and the `openaiToAnthropic` unknown-model fallback at `claude-opus-4-6` — those are intentional lower-tier/back-compat anchors, not "latest flagship" pointers.
- Did **not** touch `SUPPORTED_CC_RANGE.maxTested` (the cc-drift bot owns that).
- Local `tsc --noEmit` clean. No unit tests reference these maps.