### PR TITLE
chore: release 4.8.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.9",
+  "version": "4.8.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "4.8.9",
+      "version": "4.8.12",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.11",
+  "version": "4.8.12",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Bumps to 4.8.12 to release the Opus 4.8 alias/pricing/doctor changes from #389. v4.8.11 was tagged before #389 merged, so the auto-release gate sees no unreleased version; this bump triggers the release pipeline (npm publish + ghcr image build/push).