### PR TITLE
fix(template): prefer the newer of live-cache and bundled snapshot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.14",
+  "version": "4.8.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "4.8.14",
+      "version": "4.8.15",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.14",
+  "version": "4.8.15",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/live-fingerprint.ts
+++ b/src/live-fingerprint.ts
@@ -179,10 +179,19 @@ export function loadTemplate(_options?: { silent?: boolean }): TemplateData {
     if (age < LIVE_TTL_MS) {
       return cached;
     }
-    // Stale cache — still better than bundled if bundled is older.
-    // We return the stale live cache and let the background refresh
-    // update it for next startup.
-    return cached;
+    // Stale cache: prefer whichever of the live cache and the bundled
+    // snapshot was captured more recently — do NOT blindly keep the cache.
+    // A frozen live cache must not shadow a newer bundled template, which is
+    // exactly what happens in a no-CC deployment (e.g. the Hetzner container):
+    // the async refresh can never run there, so the cache stays pinned at its
+    // last capture while shipped releases move the bundle ahead. Without this
+    // comparison, every bundled-template update is silently ignored until the
+    // cache file is removed by hand. A fresh live capture (age < TTL) still
+    // wins above; a stale cache only wins if it is still newer than the bundle.
+    const bundled = loadBundledTemplate(_options);
+    const cachedAt = new Date(cached._captured).getTime();
+    const bundledAt = new Date(bundled._captured).getTime();
+    return Number.isFinite(bundledAt) && bundledAt > cachedAt ? bundled : cached;
   }
   return loadBundledTemplate(_options);
 }


### PR DESCRIPTION
## The bug
`loadTemplate()` returns the live cache (`~/.dario/cc-template.live.json`) whenever it exists — **at any age**. Both the fresh and the stale branch just `return cached`, on the assumption that a live capture is always at least as fresh as the bundled snapshot.

That assumption inverts in a **no-CC deployment** (the Hetzner `askalf-dario` container, which has no `claude` binary): the async `refreshLiveFingerprintAsync()` can never run, so the volume's live cache **freezes at its last capture** while shipped releases advance the bundled template. The stale cache then **shadows every bundled-template update** until the cache file is removed by hand.

## Observed
2026-05-28: a **May-10 CC 2.1.138** live cache shadowed the freshly baked **2.1.154** bundle in dario **4.8.14**. `dario doctor` read `Template: live capture, CC v2.1.138 (18d old)` despite the new image — the re-bake + release + container pull had **zero effect** on the served fingerprint. It only updated after the cache file was moved aside and dario restarted.

## The fix
On a **stale** cache (age ≥ TTL), prefer whichever of the live cache and the bundled snapshot was **captured more recently**, instead of blindly keeping the cache:
- Fresh cache (age < TTL) → still always wins (unchanged dev-machine behavior).
- Stale cache **newer** than the bundle → cache wins (preserves the original intent).
- Stale cache **older** than the bundle → **bundle wins** (fixes the no-CC container case — a shipped template update now takes effect on the next start, no manual cache removal).

`Number.isFinite` guards a malformed bundle date (falls back to the cache). No infra change, no CC required in the container. `tsc --noEmit` clean.