### PR TITLE
ci(sdk-drift): retry npm + treat registry failure as infra error, not a red run

### DIFF
--- a/.github/workflows/sdk-drift-watch.yml
+++ b/.github/workflows/sdk-drift-watch.yml
@@ -11,11 +11,13 @@ name: SDK drift watch
 # interactive-CC billing split, where SDK-side wire changes are the thing
 # most likely to move first.
 #
-# scripts/check-sdk-drift.mjs exits 1 on drift (with a JSON report on
-# stdout) and 0 when aligned. On drift we open/refresh a single
-# `sdk-drift`-labeled issue; on a clean run we auto-close any open one. A
-# real crash (non-zero exit with NO valid JSON report — e.g. npm registry
-# down) fails the run so it surfaces red rather than as a false drift issue.
+# scripts/check-sdk-drift.mjs exits 0 = aligned, 1 = drift (with a JSON
+# report on stdout), 2 = infra error (npm registry/network failed after the
+# script's own retries). On drift (1) we open/refresh a single
+# `sdk-drift`-labeled issue; on a clean run (0) we auto-close any open one;
+# on an infra error (2) we log a warning and pass — a flaky registry must not
+# page or churn the issue. A genuine crash (exit 1 with NO valid JSON report)
+# still fails the run so it surfaces red rather than as a false drift issue.
 #
 # Metadata-only: no `npm ci`, no build. check-sdk-drift.mjs imports only
 # node builtins, reads src/cc-template-data.json directly, and shells out to
@@ -60,8 +62,14 @@ jobs:
             cat sdk-drift.json
             exit 0
           fi
-          # Non-zero: distinguish real drift (valid JSON report on stdout)
-          # from a crash (no parseable report — registry/network error).
+          if [ "$code" -eq 2 ]; then
+            echo "::warning::SDK drift check could not complete (npm registry/infra error after retries) — skipping this run, not treating as drift."
+            cat sdk-drift.json 2>/dev/null || true
+            cat sdk-drift.err 2>/dev/null || true
+            exit 0
+          fi
+          # code is 1: real drift if a valid JSON report landed on stdout,
+          # else a genuine crash (no parseable report — registry/network error).
           if node -e "JSON.parse(require('fs').readFileSync('sdk-drift.json','utf8'))" 2>/dev/null; then
             echo "SDK DRIFT detected:"
             cat sdk-drift.json
@@ -72,7 +80,7 @@ jobs:
           fi
 
       - name: Open / refresh sdk-drift issue
-        if: steps.check.outputs.exit_code != '0'
+        if: steps.check.outputs.exit_code == '1'
         run: |
           set -eo pipefail
 

--- a/scripts/check-sdk-drift.mjs
+++ b/scripts/check-sdk-drift.mjs
@@ -16,8 +16,11 @@
  * suitable for high-frequency signals or pre-release gating where downloading
  * the full CC binary is too heavy.
  *
- * Exits 1 on any drift (stale pinned constants) and 0 when everything aligns.
- * JSON report to stdout.
+ * Exit codes: 0 = aligned, 1 = drift (stale pinned constants), 2 = infra
+ * error — npm registry/network failed after retries, so drift could not be
+ * determined. The workflow treats exit 2 as a skipped run (warn + pass),
+ * never as drift, so a flaky registry doesn't page or churn the drift issue.
+ * JSON report to stdout in all cases.
  */
 
 import { execSync } from 'node:child_process';
@@ -28,14 +31,44 @@ import { dirname, join } from 'node:path';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
 
+/** Raised when npm metadata can't be fetched or parsed after retries — an
+ *  infra/registry problem, NOT drift. Caught in run() → exit 2. */
+class InfraError extends Error {}
+
+/** Synchronous sleep — we're in a sync execSync flow, no event loop to await. */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/** Shell out with a few retries to ride out transient npm-registry blips
+ *  (5xx, rate-limit, DNS). Throws InfraError only after every attempt fails. */
+function sh(cmd, attempts = 3) {
+  let lastErr;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return execSync(cmd, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+    } catch (err) {
+      lastErr = err;
+      if (i < attempts - 1) sleepSync(400 * (i + 1));
+    }
+  }
+  throw new InfraError(`\`${cmd}\` failed after ${attempts} attempts: ${(lastErr && (lastErr.stderr || lastErr.message)) || lastErr}`);
+}
+
 function npmView(pkg, field) {
   // `npm view <pkg> <field> --json` prints NOTHING (empty stdout) when the
   // field is absent — e.g. @anthropic-ai/claude-agent-sdk@0.3.x bundles its
   // deps and exposes no top-level `dependencies`. JSON.parse('') would throw
   // "Unexpected end of JSON input", so treat empty as "field not present".
-  const out = execSync(`npm view ${pkg} ${field} --json`, { encoding: 'utf-8' }).trim();
+  const out = sh(`npm view ${pkg} ${field} --json`);
   if (!out) return undefined;
-  return JSON.parse(out);
+  try {
+    return JSON.parse(out);
+  } catch {
+    // Non-empty but unparseable = npm returned garbage (a proxy's partial/HTML
+    // error page, say). That's infra, not drift.
+    throw new InfraError(`npm view ${pkg} ${field} returned non-JSON output`);
+  }
 }
 
 function loadBundled() {
@@ -48,11 +81,27 @@ function run() {
   const bundledUa = bundled.header_values?.['user-agent'];
   const bundledCcVersion = bundled._version;
 
-  const agentSdkVersion = npmView('@anthropic-ai/claude-agent-sdk', 'version');
-  const agentSdkDeps = npmView('@anthropic-ai/claude-agent-sdk', 'dependencies');
+  let agentSdkVersion, agentSdkDeps, ccVersion;
+  try {
+    agentSdkVersion = npmView('@anthropic-ai/claude-agent-sdk', 'version');
+    agentSdkDeps = npmView('@anthropic-ai/claude-agent-sdk', 'dependencies');
+    ccVersion = npmView('@anthropic-ai/claude-code', 'version');
+  } catch (err) {
+    if (err instanceof InfraError) {
+      // Registry/network problem — emit a valid JSON report and exit 2 so the
+      // workflow skips this run (warn + pass) instead of paging or churning
+      // the drift issue. See the exit-code contract in the header.
+      console.log(JSON.stringify({
+        checkedAt: new Date().toISOString(),
+        status: 'infra_error',
+        error: String(err.message),
+      }, null, 2));
+      process.exit(2);
+    }
+    throw err;
+  }
   const stainlessRange = agentSdkDeps?.['@anthropic-ai/sdk'];
   const upstreamStainless = stainlessRange ? String(stainlessRange).replace(/^[\^~>=\s]+/, '') : null;
-  const ccVersion = npmView('@anthropic-ai/claude-code', 'version');
 
   const drift = [];
 


### PR DESCRIPTION
## What

Harden the SDK drift watcher so a flaky npm registry can't produce a red run / false-alarm notification.

## Why

The 5/28 manual run ([26578972981](https://github.com/askalf/dario/actions/runs/26578972981)) failed with `SyntaxError: Unexpected end of JSON input` at `check-sdk-drift.mjs:33`: `npm view @anthropic-ai/claude-agent-sdk version --json` returned an empty/erroring response (a transient registry blip), `execSync`/`JSON.parse` threw, and the run went red — firing a GitHub failure notification even though there was **no actual drift**.

The empty-*output* case was already guarded; the remaining vector is `npm view` itself throwing on a registry 5xx / rate-limit / DNS hiccup. The workflow's own comment already says "treat as infra/registry error, not drift" — but it then still `exit`s non-zero and fails the run. This PR makes that intent real.

## What changed

**`scripts/check-sdk-drift.mjs`**
- `npm view` calls now go through `sh()` with a **3× retry + backoff** to ride out transient registry blips.
- On persistent failure (or non-JSON output) it raises a tagged `InfraError`; `run()` catches it, prints a valid `{status:"infra_error"}` JSON report, and **exits 2**.
- New exit-code contract: `0` aligned · `1` drift · `2` infra error.

**`.github/workflows/sdk-drift-watch.yml`**
- `exit 2` → log a `::warning::` and **pass** (skip the run) — no page, no issue churn.
- Only `exit 1` opens/refreshes the `sdk-drift` issue (gate tightened from `!= '0'` to `== '1'`).
- Clean (`0`) still auto-closes; a **genuine** crash (`exit 1` with no valid JSON report) still surfaces red.

## Behavior matrix

| Script exit | Run result | `sdk-drift` issue |
|---|---|---|
| 0 (aligned) | green | auto-close if open |
| 1 (drift) | green | open / refresh |
| 2 (infra error) | green + `::warning::` | untouched |
| crash (1, no JSON) | **red** | untouched |

## Test

- `node --check` clean.
- Live run produces a valid report and exits 1 on the real drift currently present (bundled CC `2.1.156` vs `2.1.158` upstream) — confirming the retry wrapper is transparent on the happy path and the existing empty-field guard still works (`stainless_dep: null`).

The same pattern is propagatable to the sibling watchers (`cc-drift-watch.yml`, etc.) if we want uniform infra-error handling across the drift fleet.
