### PR TITLE
fix(effort): default to 'max' not 'xhigh' so fresh installs don't 400 on Sonnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.20] - 2026-05-31
+
+- **Default effort → `max` (was `xhigh`)** — the unset `output_config.effort` default is now `max`, the highest *universally-supported* level. `xhigh` is Opus-only, so a fresh `npx @askalf/dario` on Sonnet/Haiku-class models 400'd ("does not support effort level 'xhigh'"). `max` is accepted by every model and still routes to the subscription pool (verified `representative-claim=five_hour` on Opus + Sonnet). Power users wanting Opus's extra tier set `--effort=xhigh` / `DARIO_EFFORT=xhigh`. (`resolveEffort` default + client-mode fallback.)
+
 ## [4.8.19] - 2026-05-30
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.157` → `2.1.158` for CC v2.1.158. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.19",
+  "version": "4.8.20",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -985,21 +985,26 @@ function normalizeEffortForWire(effort: string): string {
  *   - mid-May 2026:            effort = 'high'    (dario#87 pinned to match)
  *   - May 17 2026, CC 2.1.143: effort = 'xhigh'   (verified by capture-full-body.mjs)
  *
- *   undefined → 'xhigh' (current CC wire default)
+ *   undefined → 'max' (highest *universally*-supported level. CC's own wire
+ *               default is 'xhigh', but that's Opus-only — Sonnet/Haiku-class
+ *               400 on 'xhigh' ("supported: high|low|max|medium"). 'max' is
+ *               accepted by all and still routes to the subscription pool
+ *               (verified: representative-claim=five_hour on Opus + Sonnet).
+ *               Set --effort=xhigh / DARIO_EFFORT=xhigh for Opus's extra tier.)
  *   'low' / 'medium' / 'high' / 'xhigh' / 'max' → pin to that value
  *   'ultracode' → 'xhigh' (CC's ultracode mode; xhigh on the wire)
  *   'client' → extract from `clientBody.output_config.effort` (normalized
- *              for the wire); fall back to 'xhigh' if absent/non-string
+ *              for the wire); fall back to 'max' if absent/non-string
  *
  * Exported for tests.
  */
 export function resolveEffort(flag: EffortValue | undefined, clientBody: Record<string, unknown>): string {
-  if (flag === undefined) return 'xhigh';
+  if (flag === undefined) return 'max';
   if (flag === 'client') {
     const clientOC = clientBody.output_config as { effort?: unknown } | undefined;
     const clientEffort = clientOC?.effort;
     if (typeof clientEffort === 'string' && clientEffort.length > 0) return normalizeEffortForWire(clientEffort);
-    return 'xhigh';
+    return 'max';
   }
   return normalizeEffortForWire(flag);
 }

--- a/test/effort-flag.mjs
+++ b/test/effort-flag.mjs
@@ -29,9 +29,9 @@ header('VALID_EFFORT_VALUES — the allowed set');
 // ─────────────────────────────────────────────────────────────
 header('resolveEffort — explicit values pin');
 {
-  // v4.2.1 (2026-05-17): default tracks CC's evolving wire value.
-  // medium (Apr) → high (mid-May) → xhigh (May 17, CC 2.1.143).
-  check('undefined → xhigh (default)', resolveEffort(undefined, {}) === 'xhigh');
+  // Unset default is 'max' — the highest universally-supported level (Opus +
+  // Sonnet both accept it; 'xhigh' is Opus-only and 400s Sonnet-class).
+  check('undefined → max (default)', resolveEffort(undefined, {}) === 'max');
   check('low → low', resolveEffort('low', {}) === 'low');
   check('medium → medium', resolveEffort('medium', {}) === 'medium');
   check('high → high', resolveEffort('high', {}) === 'high');
@@ -41,20 +41,20 @@ header('resolveEffort — explicit values pin');
 
 header('resolveEffort — client passthrough');
 {
-  check('client, no output_config → xhigh fallback',
-    resolveEffort('client', {}) === 'xhigh');
-  check('client, output_config without effort → xhigh fallback',
-    resolveEffort('client', { output_config: {} }) === 'xhigh');
+  check('client, no output_config → max fallback',
+    resolveEffort('client', {}) === 'max');
+  check('client, output_config without effort → max fallback',
+    resolveEffort('client', { output_config: {} }) === 'max');
   check('client, output_config.effort = "low" → low',
     resolveEffort('client', { output_config: { effort: 'low' } }) === 'low');
   check('client, output_config.effort = "xhigh" → xhigh',
     resolveEffort('client', { output_config: { effort: 'xhigh' } }) === 'xhigh');
   check('client, output_config.effort = "max" → max',
     resolveEffort('client', { output_config: { effort: 'max' } }) === 'max');
-  check('client, non-string effort ignored → xhigh',
-    resolveEffort('client', { output_config: { effort: 42 } }) === 'xhigh');
-  check('client, empty string effort ignored → xhigh',
-    resolveEffort('client', { output_config: { effort: '' } }) === 'xhigh');
+  check('client, non-string effort ignored → max',
+    resolveEffort('client', { output_config: { effort: 42 } }) === 'max');
+  check('client, empty string effort ignored → max',
+    resolveEffort('client', { output_config: { effort: '' } }) === 'max');
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -66,7 +66,7 @@ header('buildCCRequest — effort reaches outbound body');
   const clientBody = { model: 'claude-sonnet-4-6', messages: [{ role: 'user', content: 'hi' }], stream: false };
 
   const defaultBuild = buildCCRequest(clientBody, billingTag, cacheControl, identity);
-  check('default outbound effort = xhigh', defaultBuild.body.output_config?.effort === 'xhigh');
+  check('default outbound effort = max', defaultBuild.body.output_config?.effort === 'max');
 
   const lowBuild = buildCCRequest(clientBody, billingTag, cacheControl, identity, { effort: 'low' });
   check('effort=low → outbound low', lowBuild.body.output_config?.effort === 'low');
@@ -83,7 +83,7 @@ header('buildCCRequest — effort reaches outbound body');
   check('effort=client + client body.output_config.effort=xhigh → xhigh', passthroughBuild.body.output_config?.effort === 'xhigh');
 
   const passthroughNoneBuild = buildCCRequest(clientBody, billingTag, cacheControl, identity, { effort: 'client' });
-  check('effort=client + no client output_config → xhigh fallback', passthroughNoneBuild.body.output_config?.effort === 'xhigh');
+  check('effort=client + no client output_config → max fallback', passthroughNoneBuild.body.output_config?.effort === 'max');
 }
 
 header('buildCCRequest — haiku carve-out: no output_config regardless of flag');


### PR DESCRIPTION
Fixes a fresh-install 400 for Sonnet-class models.

## Problem
A fresh `npx @askalf/dario` (no `DARIO_EFFORT`) defaults `output_config.effort` to `xhigh`. `xhigh` is **Opus-only** — Sonnet/Haiku-class models reject it:
> This model does not support effort level 'xhigh'. Supported levels: high, low, max, medium.

So a new user pointing any tool at dario on a Sonnet model 400s on their first request. (Opus works — it accepts `xhigh`.)

## Fix
Default the unset effort to **`max`** — the highest *universally-supported* level. Verified end-to-end (fresh `npm i -g`, plain node:22, no Bun): both **Opus 4.8 and Sonnet 4.6** route to the **subscription** pool (`representative-claim=five_hour`, 0% overage) with `max`. Power users wanting Opus's extra tier set `--effort=xhigh` / `DARIO_EFFORT=xhigh`.

- `resolveEffort`: unset default + `client`-mode fallback → `max`
- `test/effort-flag.mjs`: default/fallback assertions updated (explicit-value pins unchanged)
- v4.8.20 + CHANGELOG

No change to explicit `--effort` values or wire-shape fidelity for any pinned level.
