### PR TITLE
docs: correct stale effort value in classifier-signals table

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ dario doesn't *guess* Claude Code's request shape — it captures it live from y
 
 | Signal | Claude Code value | Non-CC value |
 |---|---|---|
-| `output_config.effort` | `medium` (CC default) | other → reclassified |
+| `output_config.effort` | CC-scale level — CC default `xhigh`; dario sends `max` (both subscription-verified) | omitted / off-scale → reclassified |
 | `max_tokens` | `64000` | other → reclassified |
 | `thinking` shape | `{type: "adaptive"}` *(per-model)* | `{enabled, budget_tokens: N}` → reclassified |
 | System prompt block count | exactly 3 | other → reclassified |


### PR DESCRIPTION
The **What the classifier reads** table listed `output_config.effort` as `medium (CC default)` / `other → reclassified`. That's stale and now self-contradicting:

- CC's wire default evolved `medium → high → xhigh` (`xhigh` since CC 2.1.143, May 17 — tracked in `src/cc-template.ts`).
- dario sends `max` as of **4.8.20**, and `max` is **verified** routing to the subscription pool (`representative-claim=five_hour`) on both **Opus 4.8 and Sonnet 4.6**.

So the old row implied "any non-`medium` effort reclassifies" while the tool itself ships `max` and stays subscription — exactly the kind of contradiction a skeptical reader would flag. Updated to the current CC default + dario's actual value, both subscription-verified.

Docs-only; no code change.
