### PR TITLE
ci(canary): pass force_status via env, not inline interpolation

### DIFF
--- a/.github/workflows/cc-billing-classifier-canary.yml
+++ b/.github/workflows/cc-billing-classifier-canary.yml
@@ -108,6 +108,10 @@ jobs:
 
       - name: Send canary request + capture representative-claim header
         id: probe
+        env:
+          # workflow_dispatch-only override (maintainer-set). Passed via env, not
+          # inline ${{ }}, so the value can't break shell quoting or inject into the runner.
+          FORCE_STATUS: ${{ github.event.inputs.force_status }}
         run: |
           set -eo pipefail
 
@@ -162,7 +166,6 @@ jobs:
           # (force_status=fail or warn) and the recovery-close path
           # (force_status=pass) on demand. force_status is ignored
           # on scheduled runs (input only populated on dispatch).
-          FORCE_STATUS='${{ github.event.inputs.force_status }}'
           if [ -n "$FORCE_STATUS" ] && [ "$FORCE_STATUS" != "none" ]; then
             echo "::warning::force_status=${FORCE_STATUS} — overriding real verdict (was: claim=${claim} bucket=${bucket} status=${status})"
             claim="forced-${FORCE_STATUS}"


### PR DESCRIPTION
Defense-in-depth from the self-hosted-workflow injection sweep. The classifier canary assigned `FORCE_STATUS='${{ github.event.inputs.force_status }}'` inside its `run:` block.

It's **not exploitable** — `force_status` is a maintainer-only `workflow_dispatch` input (no `pull_request` trigger, so not attacker-reachable) and it was single-quoted. But it's the same *class* as the `deploy.yml` commit-message bug fixed today, so moving it to a step-level `env:` var removes the interpolation-into-shell entirely. No behavior change (empty/unset input still skips the override on scheduled runs).