### PR TITLE
chore(template): bump _version + user-agent to 2.1.159 (clears sdk-drift #411)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.22] - 2026-05-31
+
+- **Template version-label bump** — `_version` + the `user-agent` header value → `2.1.159` to track `@anthropic-ai/claude-code@latest`. The wire shape is unchanged (`cc-drift-template-watch` reports zero shape drift vs live CC), so this is a label refresh, not a re-capture — `_captured` is intentionally left at the last real capture. Clears the `sdk-drift` signal ([#411](https://github.com/askalf/dario/issues/411)).
+
 ## [4.8.21] - 2026-05-31
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.158` → `2.1.159` for CC v2.1.159. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.21",
+  "version": "4.8.22",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template-data.json
+++ b/src/cc-template-data.json
@@ -1,5 +1,5 @@
 {
-  "_version": "2.1.156",
+  "_version": "2.1.159",
   "_captured": "2026-05-29T16:58:06.219Z",
   "_source": "bundled",
   "_schemaVersion": 3,
@@ -1073,7 +1073,7 @@
   "anthropic_beta": "claude-code-20250219,context-1m-2025-08-07,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24",
   "header_values": {
     "accept": "application/json",
-    "user-agent": "claude-cli/2.1.156 (external, sdk-cli)",
+    "user-agent": "claude-cli/2.1.159 (external, sdk-cli)",
     "x-stainless-arch": "x64",
     "x-stainless-lang": "js",
     "x-stainless-os": "Linux",


### PR DESCRIPTION
## What
Bumps the bundled CC template's `_version` + `user-agent` header `2.1.156` → `2.1.159` to track `@anthropic-ai/claude-code@latest`; dario `4.8.21` → `4.8.22`.

## Why
`sdk-drift-watch.yml` flagged #411 (bundled `_version` trails npm). The **wire shape is unchanged** — `cc-drift-template-watch.yml` has captured live CC every ~hour with zero shape drift and opened no rebake PR — so this is a **label refresh, not a re-capture**. `_captured` is intentionally left at the last real capture; the PR does not fake a capture timestamp. Keeps dario presenting as a current CLI and clears the drift signal.

## Validation
- JSON re-parses; only `_version` + `user-agent` changed in the template.
- Template wire-shape currency is independently confirmed by `cc-drift-template-watch`.
- `compat-test-self-hosted` runs on this PR (touches `src/cc-template-data.json`).

Closes #411.