### PR TITLE
feat(proxy): optional effort suffix on the model name (#419)

### DIFF
--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -968,6 +968,28 @@ export type EffortValue = 'low' | 'medium' | 'high' | 'xhigh' | 'ultracode' | 'm
 export const VALID_EFFORT_VALUES: ReadonlyArray<EffortValue> = ['low', 'medium', 'high', 'xhigh', 'ultracode', 'max', 'client'];
 
 /**
+ * dario#419 — strip an optional effort suffix off a model name, so OpenAI-compat
+ * clients that can't set `output_config.effort` (e.g. Cursor) can choose effort
+ * by model name: `opus-4-8:high` (colon) or Cursor-style `claude-opus-4-8-high`
+ * (hyphen). Only the wire-valid effort levels are recognized as a suffix — any
+ * other trailing token is left as part of the model name, and a bare model that
+ * IS an effort word (e.g. just "high") is left alone. Returns the model with the
+ * suffix removed plus the parsed effort (undefined when none). Exported for tests.
+ */
+const SUFFIX_EFFORTS: ReadonlyArray<EffortValue> = ['ultracode', 'medium', 'xhigh', 'high', 'low', 'max'];
+export function parseEffortSuffix(model: string): { model: string; effort?: EffortValue } {
+  for (const e of SUFFIX_EFFORTS) {
+    for (const sep of [':', '-']) {
+      const tag = sep + e;
+      if (model.length > tag.length && model.endsWith(tag)) {
+        return { model: model.slice(0, -tag.length), effort: e };
+      }
+    }
+  }
+  return { model };
+}
+
+/**
  * Normalize an effort value to a wire-valid `output_config.effort`. The
  * Messages API accepts only low|medium|high|xhigh|max. CC's `ultracode` is a
  * client mode (xhigh effort + dynamic workflow orchestration), NOT a wire

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { arch, platform } from 'node:process';
 import { getAccessToken, getStatus } from './oauth.js';
-import { buildCCRequest, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, CC_TEMPLATE, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
+import { buildCCRequest, parseEffortSuffix, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, CC_TEMPLATE, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
 import { describeTemplate, detectDrift, checkCCCompat } from './live-fingerprint.js';
 import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCooldown, authCooldownMs, type PoolAccount } from './pool.js';
 import { Analytics, billingBucketFromClaim, type RequestRecord } from './analytics.js';
@@ -1463,6 +1463,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
       // built-in `claude-*` name collision (Cursor reroutes any name it
       // recognizes through its own Anthropic gateway, bypassing localhost).
       let forcedProvider: 'openai' | 'claude' | null = cliProviderOverride;
+      let requestEffort: EffortValue | undefined; // dario#419 — per-request effort parsed from a model-name suffix (model:high / model-high)
       if (body.length > 0) {
         try {
           const parsed = JSON.parse(body.toString()) as Record<string, unknown>;
@@ -1470,14 +1471,23 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           const prefix = parseProviderPrefix(rawModel);
           if (prefix) {
             forcedProvider = prefix.provider;
+            // dario#419 — optional effort suffix (model:high / model-high). Claude
+            // path ONLY: OpenAI backends keep their own -high/-low suffixes, so we
+            // strip it before the alias lookup only when routing to the subscription.
+            let providerModel = prefix.model;
+            if (prefix.provider === 'claude') {
+              const eff = parseEffortSuffix(providerModel);
+              if (eff.effort) { requestEffort = eff.effort; providerModel = eff.model; }
+            }
             const resolvedModel = prefix.provider === 'claude'
-              ? resolveClaudeAlias(prefix.model)
-              : prefix.model;
+              ? resolveClaudeAlias(providerModel)
+              : providerModel;
             parsed.model = resolvedModel;
             body = Buffer.from(JSON.stringify(parsed));
             if (verbose) {
-              const aliasNote = resolvedModel !== prefix.model ? ` (alias: ${prefix.model} → ${resolvedModel})` : '';
-              console.log(`[dario] provider prefix: ${rawModel} → ${prefix.provider} backend with model ${resolvedModel}${aliasNote}`);
+              const aliasNote = resolvedModel !== providerModel ? ` (alias: ${providerModel} → ${resolvedModel})` : '';
+              const effNote = requestEffort ? ` (effort: ${requestEffort})` : '';
+              console.log(`[dario] provider prefix: ${rawModel} → ${prefix.provider} backend with model ${resolvedModel}${aliasNote}${effNote}`);
             }
           } else if (cliProviderOverride === 'openai' && cliModelRaw) {
             // --model=openai:<name> forces the openai backend and replaces
@@ -1485,6 +1495,17 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
             // route below sees the CLI-chosen model.
             parsed.model = cliModelRaw;
             body = Buffer.from(JSON.stringify(parsed));
+          } else if (!isOpenAIModel(rawModel) && forcedProvider !== 'openai') {
+            // dario#419 — bare Claude model name carrying an effort suffix with no
+            // provider prefix (e.g. Cursor's `claude-opus-4-8-high`). OpenAI-bound
+            // models are excluded so their own suffixes pass through untouched.
+            const eff = parseEffortSuffix(rawModel);
+            if (eff.effort) {
+              requestEffort = eff.effort;
+              parsed.model = eff.model;
+              body = Buffer.from(JSON.stringify(parsed));
+              if (verbose) console.log(`[dario] effort suffix: ${rawModel} → model ${eff.model} (effort: ${eff.effort})`);
+            }
           }
         } catch { /* not JSON — fall through */ }
       }
@@ -1616,7 +1637,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
                 hybridTools: opts.hybridTools ?? false,
                 mergeTools: opts.mergeTools ?? false,
                 noAutoDetect: opts.noAutoDetect ?? false,
-                effort: opts.effort,
+                effort: requestEffort ?? opts.effort,
                 maxTokens: opts.maxTokens,
                 systemPrompt: opts.systemPrompt,
                 skipFields,

--- a/test/effort-flag.mjs
+++ b/test/effort-flag.mjs
@@ -4,7 +4,7 @@
 // the outbound body), the CLI parser + env mirror + validation path, and
 // the haiku carve-out (no output_config on haiku regardless of flag).
 
-import { resolveEffort, VALID_EFFORT_VALUES, buildCCRequest } from '../dist/cc-template.js';
+import { resolveEffort, VALID_EFFORT_VALUES, parseEffortSuffix, buildCCRequest } from '../dist/cc-template.js';
 import { resolveEffortFlag } from '../dist/cli.js';
 
 let pass = 0, fail = 0;
@@ -23,7 +23,8 @@ header('VALID_EFFORT_VALUES — the allowed set');
   check('includes xhigh', VALID_EFFORT_VALUES.includes('xhigh'));
   check('includes max', VALID_EFFORT_VALUES.includes('max'));
   check('includes client', VALID_EFFORT_VALUES.includes('client'));
-  check('length === 6', VALID_EFFORT_VALUES.length === 6);
+  check('includes ultracode', VALID_EFFORT_VALUES.includes('ultracode'));
+  check('length === 7', VALID_EFFORT_VALUES.length === 7);
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -142,7 +143,30 @@ header('resolveEffortFlag — invalid value exits non-zero');
     `import('./dist/cli.js').then(({ resolveEffortFlag }) => { resolveEffortFlag(['--effort=ultra'], undefined); });`,
   ], { cwd: process.cwd(), encoding: 'utf-8', timeout: 5_000 });
   check('invalid value → non-zero exit', result.status !== 0);
-  check('stderr names valid values', /low, medium, high, xhigh, max, client/.test(result.stderr));
+  check('stderr names valid values', /low, medium, high, xhigh, ultracode, max, client/.test(result.stderr));
+}
+
+// ─────────────────────────────────────────────────────────────
+header('parseEffortSuffix — dario#419 effort-via-model-name');
+{
+  const cases = [
+    ['opus-4-8:high',         'opus-4-8',        'high'],    // colon form
+    ['claude-opus-4-8-high',  'claude-opus-4-8', 'high'],    // Cursor-style hyphen form
+    ['claude-opus-4-8-xhigh', 'claude-opus-4-8', 'xhigh'],   // xhigh not mis-split into -high
+    ['sonnet-4-6:max',        'sonnet-4-6',      'max'],
+    ['opus-4-8-low',          'opus-4-8',        'low'],
+    ['opus-4-8:medium',       'opus-4-8',        'medium'],
+  ];
+  for (const [input, model, effort] of cases) {
+    const r = parseEffortSuffix(input);
+    check(`${input} → model=${model}, effort=${effort}`, r.model === model && r.effort === effort);
+  }
+  check('no suffix: claude-opus-4-8 left untouched',
+    (() => { const r = parseEffortSuffix('claude-opus-4-8'); return r.model === 'claude-opus-4-8' && r.effort === undefined; })());
+  check('unknown trailing token (-turbo) left alone',
+    (() => { const r = parseEffortSuffix('claude-opus-4-8-turbo'); return r.model === 'claude-opus-4-8-turbo' && r.effort === undefined; })());
+  check('bare effort word "high" not stripped to empty',
+    (() => { const r = parseEffortSuffix('high'); return r.model === 'high' && r.effort === undefined; })());
 }
 
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #419 (thanks @pnewell).

OpenAI-compatible IDEs like Cursor expose no way to set reasoning effort except via the model name. This adds an optional effort suffix:
- `opus-4-8:high` (colon) or Cursor-style `claude-opus-4-8-high` (hyphen)
- levels: `low | medium | high | xhigh | max` (also `ultracode`)
- parsed per-request, applied over the global `--effort` flag; suffix stripped before alias resolution + the upstream call
- **Claude-path only** — OpenAI-bound models keep their own `-high`/`-low` suffixes for the OpenAI backend

New `parseEffortSuffix()` + unit tests (all green). Also refreshed two `effort-flag.mjs` assertions that were stale since `ultracode` was added. `tsc --noEmit` clean.