### PR TITLE
docs: add Sprayberry Labs studio footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,3 +364,12 @@ MIT — see [LICENSE](LICENSE) and [DISCLAIMER.md](DISCLAIMER.md).
 | [claude-sync](https://github.com/askalf/claude-sync) | Sync Claude Code sessions across machines via a portable `.ccsync` file. |
 | [pgflex](https://github.com/askalf/pgflex) | One Postgres API, two modes — real PostgreSQL for production, PGlite (WASM) for dev. |
 | [redisflex](https://github.com/askalf/redisflex) | One Redis API, two modes — ioredis for production, in-process for dev. Includes a BullMQ-shaped in-memory queue. |
+
+
+---
+
+## Built by Sprayberry Labs
+
+This is one of the open-source building blocks from **[Sprayberry Labs](https://sprayberrylabs.com)** — an independent studio (Atlanta, GA) that ships bespoke software and **fixed-price code & security audits**, delivered with the AI workforce these tools are part of.
+
+**Got a codebase that needs an expert read?** → **[Scan a repo — free mini-audit](https://sprayberrylabs.com)**, or see the **$1,500 fixed-price Audit** and build Sprints. · [sprayberrylabs.com](https://sprayberrylabs.com) · hello@sprayberrylabs.com


### PR DESCRIPTION
Adds a short 'Built by Sprayberry Labs' footer at the end of the README, linking the free repo mini-audit and the $1,500 fixed-price Audit — funnels OSS traffic to the studio's paid services. Matches the org-profile README + sprayberrylabs.com framing. README-only.