### PR TITLE
fix(template): scope Glob/Grep to win32 so POSIX bakes don't drop them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.29] - 2026-06-04
+
+- **Glob/Grep are platform-scoped** — `Glob` and `Grep` join `PowerShell` in `PLATFORM_ONLY_TOOLS` (win32). CC v2.1.162 advertises them on Windows CC but drops them on POSIX (steering the agent to shell `find`/`grep`), so the v4.8.28 re-bake on the Linux runner silently culled them from the bundled union — degrading the Windows fallback to a 28-tool POSIX shape. They are now preserved across bakes and filtered to win32 clients, restoring the 30-tool Windows wire shape. A POSIX `capture-and-bake --check` once again reports no drift.
 ## [4.8.28] - 2026-06-04
 
 - **Template rebake** — re-captured `src/cc-template-data.json` after cc-drift-template-watch detected wire-fingerprint drift against a live CC capture. Bundled fallback template now matches the current CC wire shape.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.28",
+  "version": "4.8.29",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template-data.json
+++ b/src/cc-template-data.json
@@ -386,6 +386,107 @@
       }
     },
     {
+      "name": "Glob",
+      "description": "Fast file pattern matching. Supports glob patterns like \"**/*.js\" or \"src/**/*.ts\". Returns matching file paths sorted by modification time.",
+      "input_schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "pattern": {
+            "description": "The glob pattern to match files against",
+            "type": "string"
+          },
+          "path": {
+            "description": "The directory to search in. If not specified, the current working directory will be used. IMPORTANT: Omit this field to use the default directory. DO NOT enter \"undefined\" or \"null\" - simply omit it for the default behavior. Must be a valid directory path if provided.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "pattern"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "Grep",
+      "description": "Content search built on ripgrep. Prefer this over `grep`/`rg` via Bash — results integrate with the permission UI and file links.\n\n- Full regex syntax (e.g. \"log.*Error\", \"function\\s+\\w+\"). Ripgrep, not grep — escape literal braces (`interface\\{\\}`).\n- Filter with `glob` (e.g. \"**/*.tsx\") or `type` (e.g. \"js\", \"py\", \"rust\").\n- `output_mode`: \"content\" (matching lines), \"files_with_matches\" (paths only, default), or \"count\".\n- `multiline: true` for patterns that span lines.",
+      "input_schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "pattern": {
+            "description": "The regular expression pattern to search for in file contents",
+            "type": "string"
+          },
+          "path": {
+            "description": "File or directory to search in (rg PATH). Defaults to current working directory.",
+            "type": "string"
+          },
+          "glob": {
+            "description": "Glob pattern to filter files (e.g. \"*.js\", \"*.{ts,tsx}\") - maps to rg --glob",
+            "type": "string"
+          },
+          "output_mode": {
+            "description": "Output mode: \"content\" shows matching lines (supports -A/-B/-C context, -n line numbers, head_limit), \"files_with_matches\" shows file paths (supports head_limit), \"count\" shows match counts (supports head_limit). Defaults to \"files_with_matches\".",
+            "type": "string",
+            "enum": [
+              "content",
+              "files_with_matches",
+              "count"
+            ]
+          },
+          "-B": {
+            "description": "Number of lines to show before each match (rg -B). Requires output_mode: \"content\", ignored otherwise.",
+            "type": "number"
+          },
+          "-A": {
+            "description": "Number of lines to show after each match (rg -A). Requires output_mode: \"content\", ignored otherwise.",
+            "type": "number"
+          },
+          "-C": {
+            "description": "Alias for context.",
+            "type": "number"
+          },
+          "context": {
+            "description": "Number of lines to show before and after each match (rg -C). Requires output_mode: \"content\", ignored otherwise.",
+            "type": "number"
+          },
+          "-n": {
+            "description": "Show line numbers in output (rg -n). Requires output_mode: \"content\", ignored otherwise. Defaults to true.",
+            "type": "boolean"
+          },
+          "-i": {
+            "description": "Case insensitive search (rg -i)",
+            "type": "boolean"
+          },
+          "-o": {
+            "description": "Print only the matched (non-empty) parts of each matching line, one match per output line (rg -o / --only-matching). Requires output_mode: \"content\", ignored otherwise. Defaults to false.",
+            "type": "boolean"
+          },
+          "type": {
+            "description": "File type to search (rg --type). Common types: js, py, rust, go, java, etc. More efficient than include for standard file types.",
+            "type": "string"
+          },
+          "head_limit": {
+            "description": "Limit output to first N lines/entries, equivalent to \"| head -N\". Works across all output modes: content (limits output lines), files_with_matches (limits file paths), count (limits count entries). Defaults to 250 when unspecified. Pass 0 for unlimited (use sparingly — large result sets waste context).",
+            "type": "number"
+          },
+          "offset": {
+            "description": "Skip first N lines/entries before applying head_limit, equivalent to \"| tail -n +N | head -N\". Works across all output modes. Defaults to 0.",
+            "type": "number"
+          },
+          "multiline": {
+            "description": "Enable multiline mode where . matches newlines and patterns can span lines (rg -U --multiline-dotall). Default: false.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "pattern"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
       "name": "Monitor",
       "description": "Start a background monitor that streams events from a long-running script. Each stdout line is an event — you keep working and notifications arrive in the chat. Events arrive on their own schedule and are not replies from the user, even if one lands while you're waiting for the user to answer a question.\n\nPick by how many notifications you need:\n- **One** (\"tell me when the server is ready / the build finishes\") → use **Bash with `run_in_background`** and a command that exits when the condition is true, e.g. `until grep -q \"Ready in\" dev.log; do sleep 0.5; done`. You get a single completion notification when it exits.\n- **One per occurrence, indefinitely** (\"tell me every time an ERROR line appears\") → Monitor with an unbounded command (`tail -f`, `inotifywait -m`, `while true`).\n- **One per occurrence, until a known end** (\"emit each CI step result, stop when the run completes\") → Monitor with a command that emits lines and then exits.\n\nYour script's stdout is the event stream. Each line becomes a notification. Exit ends the watch.\n\n  # Each matching log line is an event\n  tail -f /var/log/app.log | grep --line-buffered \"ERROR\"\n\n  # Each file change is an event\n  inotifywait -m --format '%e %f' /watched/dir\n\n  # Poll GitHub for new PR comments and emit one line per new comment\n  last=$(date -u +%Y-%m-%dT%H:%M:%SZ)\n  while true; do\n    now=$(date -u +%Y-%m-%dT%H:%M:%SZ)\n    gh api \"repos/owner/repo/issues/123/comments?since=$last\" --jq '.[] | \"\\(.user.login): \\(.body)\"'\n    last=$now; sleep 30\n  done\n\n  # Node script that emits events as they arrive (e.g. WebSocket listener)\n  node watch-for-events.js\n\n  # Per-occurrence with a natural end: emit each CI check as it lands, exit when the run completes\n  prev=\"\"\n  while true; do\n    s=$(gh pr checks 123 --json name,bucket)\n    cur=$(jq -r '.[] | select(.bucket!=\"pending\") | \"\\(.name): \\(.bucket)\"' <<<\"$s\" | sort)\n    comm -13 <(echo \"$prev\") <(echo \"$cur\")\n    prev=$cur\n    jq -e 'all(.bucket!=\"pending\")' <<<\"$s\" >/dev/null && break\n    sleep 30\n  done\n\n**Don't use an unbounded command for a single notification.** `tail -f`, `inotifywait -m`, and `while true` never exit on their own, so the monitor stays armed until timeout even after the event has fired. For \"tell me when X is ready,\" use Bash `run_in_background` with an `until` loop instead (one notification, ends in seconds). Note that `tail -f log | grep -m 1 ...` does *not* fix this: if the log goes quiet after the match, `tail` never receives SIGPIPE and the pipeline hangs anyway.\n\n**Script quality:**\n- Every pipe stage must flush per line or matches sit in its buffer unseen: `grep` needs `--line-buffered`, `awk` needs `fflush()`. `head` cannot flush at all — `| head -N` delivers nothing until N matches accumulate, then ends the stream.\n- In poll loops, handle transient failures (`curl ... || true`) — one failed request shouldn't kill the monitor.\n- Poll intervals: 30s+ for remote APIs (rate limits), 0.5-1s for local checks.\n- Write a specific `description` — it appears in every notification (\"errors in deploy.log\" not \"watching logs\").\n- Only stdout is the event stream. Stderr goes to the output file (readable via Read) but does not trigger notifications — for a command you run directly (e.g. `python train.py 2>&1 | grep --line-buffered ...`), merge stderr with `2>&1` so its failures reach your filter. (No effect on `tail -f` of an existing log — that file only contains what its writer redirected.)\n\n**Coverage — silence is not success.** When watching a job or process for an outcome, your filter must match every terminal state, not just the happy path. A monitor that greps only for the success marker stays silent through a crashloop, a hung process, or an unexpected exit — and silence looks identical to \"still running.\" Before arming, ask: *if this process crashed right now, would my filter emit anything?* If not, widen it.\n\n  # Wrong — silent on crash, hang, or any non-success exit\n  tail -f run.log | grep --line-buffered \"elapsed_steps=\"\n\n  # Right — one alternation covering progress + the failure signatures you'd act on\n  tail -f run.log | grep -E --line-buffered \"elapsed_steps=|Traceback|Error|FAILED|assert|Killed|OOM\"\n\nFor poll loops checking job state, emit on every terminal status (`succeeded|failed|cancelled|timeout`), not just success. If you cannot confidently enumerate the failure signatures, broaden the grep alternation rather than narrow it — some extra noise is better than missing a crashloop.\n\n**Output volume**: Every stdout line is a conversation message, so the filter should be selective — but selective means \"the lines you'd act on,\" not \"only good news.\" Never pipe raw logs; filter to exactly the success and failure signals you care about. Monitors that produce too many events are automatically stopped; restart with a tighter filter if this happens.\n\nStdout lines within 200ms are batched into a single notification, so multiline output from a single event groups naturally.\n\nThe script runs in the same shell environment as Bash. Exit ends the watch (exit code is reported). Timeout → killed. Set `persistent: true` for session-length watches (PR monitoring, log tails) — the monitor runs until you call TaskStop or the session ends. Use TaskStop to cancel early.",
       "input_schema": {

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -26,10 +26,16 @@ export const CC_TEMPLATE: TemplateData = TEMPLATE;
  * coming back for a tool the client has no handler for.
  *
  * PowerShell shipped in CC v2.1.116 on Windows; POSIX CC installs do not
- * advertise it. Add new platform-scoped tools here as CC adds them.
+ * advertise it. As of CC v2.1.162 the Glob/Grep tools are the same shape:
+ * Windows CC advertises them, POSIX CC drops them and steers the agent to
+ * shell `find`/`grep` instead (which PowerShell has no native equivalent
+ * for). Registering them here filters them to win32 clients AND keeps a
+ * POSIX auto-bake from dropping them out of the union — the v4.8.28
+ * regression, where a Linux runner re-baked the bundle down to 28 tools.
+ * Add new platform-scoped tools here as CC adds them.
  */
 export const PLATFORM_ONLY_TOOLS: Record<string, Set<string>> = {
-  win32: new Set(['PowerShell']),
+  win32: new Set(['PowerShell', 'Glob', 'Grep']),
 };
 
 /** Keep tool `t` unless its name is listed under a platform other than the current one. */

--- a/src/shim/runtime.cjs
+++ b/src/shim/runtime.cjs
@@ -156,7 +156,7 @@ function rewriteBody(bodyText, tmpl) {
 // step with the proxy's filter so shim-rewritten and proxy-rewritten bodies
 // carry the same outbound tool set on the same host.
 const PLATFORM_ONLY_TOOLS = {
-  win32: new Set(['PowerShell']),
+  win32: new Set(['PowerShell', 'Glob', 'Grep']),
 };
 function filterToolsForPlatform(tools, platform) {
   return tools.filter((tool) => {

--- a/test/platform-tools.mjs
+++ b/test/platform-tools.mjs
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 // Unit tests for platform-scoped tool filtering.
 //
-// CC's tool set is platform-dependent — PowerShell ships on Windows CC only,
-// POSIX CC installs do not advertise it. dario's bundled template is a union
-// capture (whichever platform the maintainer baked from), and `cc-template.ts`
-// filters it down to the running platform at module load so outbound requests
-// match what real CC on that host would declare.
+// CC's tool set is platform-dependent. Windows CC advertises PowerShell and,
+// as of v2.1.162, the Glob/Grep tools; POSIX CC installs advertise none of
+// them (they steer the agent to shell `find`/`grep` instead). dario's bundled
+// template is a union capture (whichever platform the maintainer baked from),
+// and `cc-template.ts` filters it down to the running platform at module load
+// so outbound requests match what real CC on that host would declare.
 
 import { filterToolsForPlatform } from '../dist/cc-template.js';
 
@@ -16,30 +17,37 @@ function check(name, cond) {
 }
 function header(n) { console.log(`\n=== ${n} ===`); }
 
+// Bash/Read/Write are cross-platform; PowerShell/Glob/Grep are win32-only.
 const UNION_TOOLS = [
-  { name: 'Bash',       description: 'POSIX shell', input_schema: {} },
-  { name: 'PowerShell', description: 'Windows shell', input_schema: {} },
-  { name: 'Read',       description: 'read a file', input_schema: {} },
-  { name: 'Write',      description: 'write a file', input_schema: {} },
+  { name: 'Bash',       description: 'POSIX shell',   input_schema: {} },
+  { name: 'PowerShell', description: 'Windows shell',  input_schema: {} },
+  { name: 'Glob',       description: 'glob search',    input_schema: {} },
+  { name: 'Grep',       description: 'content search', input_schema: {} },
+  { name: 'Read',       description: 'read a file',    input_schema: {} },
+  { name: 'Write',      description: 'write a file',   input_schema: {} },
 ];
 
 // ─────────────────────────────────────────────────────────────
-header('Windows keeps PowerShell');
+header('Windows keeps PowerShell + Glob + Grep');
 {
   const filtered = filterToolsForPlatform(UNION_TOOLS, 'win32');
   const names = filtered.map(t => t.name);
-  check('all four tools retained', filtered.length === 4);
+  check('all six tools retained', filtered.length === 6);
   check('PowerShell kept on win32', names.includes('PowerShell'));
+  check('Glob kept on win32', names.includes('Glob'));
+  check('Grep kept on win32', names.includes('Grep'));
   check('Bash kept on win32', names.includes('Bash'));
 }
 
 // ─────────────────────────────────────────────────────────────
-header('POSIX drops PowerShell');
+header('POSIX drops PowerShell + Glob + Grep');
 {
   for (const plat of ['linux', 'darwin', 'freebsd', 'openbsd']) {
     const filtered = filterToolsForPlatform(UNION_TOOLS, plat);
     const names = filtered.map(t => t.name);
     check(`PowerShell dropped on ${plat}`, !names.includes('PowerShell'));
+    check(`Glob dropped on ${plat}`, !names.includes('Glob'));
+    check(`Grep dropped on ${plat}`, !names.includes('Grep'));
     check(`Bash kept on ${plat}`, names.includes('Bash'));
     check(`Read kept on ${plat}`, names.includes('Read'));
     check(`Write kept on ${plat}`, names.includes('Write'));
@@ -53,7 +61,7 @@ header('Array with no platform-scoped tools passes through unchanged');
   const noScoped = [
     { name: 'Read',  input_schema: {} },
     { name: 'Write', input_schema: {} },
-    { name: 'Grep',  input_schema: {} },
+    { name: 'Edit',  input_schema: {} },
   ];
   const filtered = filterToolsForPlatform(noScoped, 'linux');
   check('length unchanged', filtered.length === 3);
@@ -72,7 +80,10 @@ header('Empty array is a no-op');
 header('Unknown platform string behaves like POSIX (drops win32-only)');
 {
   const filtered = filterToolsForPlatform(UNION_TOOLS, 'unknown_platform');
-  check('PowerShell dropped on unknown platform', !filtered.some(t => t.name === 'PowerShell'));
+  const names = filtered.map(t => t.name);
+  check('PowerShell dropped on unknown platform', !names.includes('PowerShell'));
+  check('Glob dropped on unknown platform', !names.includes('Glob'));
+  check('Grep dropped on unknown platform', !names.includes('Grep'));
   check('other tools retained', filtered.length === 3);
 }
 


### PR DESCRIPTION
## Root cause

CC v2.1.162's tool set is **platform-divergent**, confirmed by capturing the same binary version on both OSes:

| | Windows | Linux/macOS |
|---|---|---|
| tools | 30 (incl. `Glob`, `Grep`, `PowerShell`) | 27 |
| explore prose | "use Glob, Grep" | "use `find`/`grep`" |

On POSIX, CC drops the `Glob`/`Grep` tools and steers the agent to shell `find`/`grep`; on Windows it keeps them (PowerShell has no native equivalent). 100% stable across runs on each OS — not an account cohort, not a rollout.

The bundle is a cross-platform union filtered per-client by `filterToolsForPlatform` against `PLATFORM_ONLY_TOOLS`, which only listed `PowerShell`. So when v4.8.28 re-baked **on the Linux runner**, the preservation step didn't recognize `Glob`/`Grep` as another platform's tools and **culled them from the union** — degrading the Windows fallback to a 28-tool POSIX shape. The drift watcher can't catch this (it doesn't diff tool descriptions), and each platform's capture disagrees with the other, so the auto-rebake would ping-pong indefinitely.

## Fix

- Add `Glob`, `Grep` to `PLATFORM_ONLY_TOOLS.win32` in `src/cc-template.ts` **and** the `src/shim/runtime.cjs` copy.
- Restore the `Glob`/`Grep` tool defs to `src/cc-template-data.json` from a live 2.1.162 capture (re-sorted to CC's alphabetical wire order). `+101/-0` — surgical, nothing else in the bundle changes.
- Extend `test/platform-tools.mjs` to cover `Glob`/`Grep` as win32-only (it previously used `Grep` as a *non*-scoped example).

## Validation

- Focused suite green: `platform-tools` (41), `template-invariants` (228), `drift-detection`, `scrub-template`, `live-fingerprint`, `compat-range`, `effort-flag`, `tool-schema-contract`, `hybrid-tools`, `issue-29-tool-translation`.
- A POSIX `capture-and-bake --check` now preserves `Glob`/`Grep` and reports **no drift** (verified the logic; will confirm live on the runner post-merge).
- `lint:pkg`, `cli help`, `cli status`, build all pass.

## Out of scope (follow-ups)

Two other platform divergences observed but deliberately not bundled here, since they don't affect the POSIX-runner CI gate or routing:
- `afk-mode-2026-01-31` beta is present on Windows, absent on POSIX (betas aren't platform-filtered).
- The Linux bake left the runner's memory path (`actions-runner--work-dario-dario/...`) in the bundled system prompt — the scrubber normalizes Windows user-paths but not the POSIX runner path. Minor host-path leak + a perpetual system_prompt drift-noise source; worth a separate scrubber fix.

Note: pre-existing `npm test` failures (`provider-prefix` opus→4-7, `system-prompt-modes` stale headers) exist on master independent of this change and aren't in CI's gating path.