### PR TITLE
fix(test): refresh two stale npm-test cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.31] - 2026-06-04
+
+- **Restore `--system-prompt` strip on the compact CC prompt + refresh a stale alias test** — `system-prompt-modes` exposed that `resolveSystemPrompt('partial'/'aggressive')` had silently degraded to verbatim: its strip targeted the old verbose prompt (`# Tone and style`, `# Doing tasks` bullets, `# Executing actions with care`), none of which exist in CC 2.1.x's compact prompt. `stripBehavioralConstraints` now also targets the compact prompt — `partial` swaps the comment-density / match-surrounding-style line for the positive "be thorough" instruction; `aggressive` additionally removes the `IMPORTANT:` RLHF line and the hard-to-reverse caution paragraph. Legacy patterns stay as no-op fallbacks. Separately, `provider-prefix` expected `opus → claude-opus-4-7`, stale since the opus 4.8 release (the alias resolves to `claude-opus-4-8`); fixed and `opus47` legacy-pin coverage added. `npm test` is green again (77/77).
 ## [4.8.30] - 2026-06-04
 
 - **Scrub the POSIX `~/.claude/projects` path slug** — the template scrubber normalized Windows / `C--Users-` home paths but not the POSIX flattened project slug, so the self-hosted-runner bake left `/root/.claude/projects/-root-actions-runner--work-dario-dario/memory/` in the bundled `# Memory` section: a host-path leak on every fresh install's first request, and a source of benign per-working-directory `--check` drift. `scrubText` now collapses the slug to `.claude/projects/project/` under any home (incl. `/root`), `findUserPathHits` gains a matching detector, and the shipped bundle is re-scrubbed. Forward-slash anchored, so the Windows backslash form is untouched.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.30",
+  "version": "4.8.31",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -72,18 +72,20 @@ export const CC_AGENT_IDENTITY = TEMPLATE.agent_identity;
  * Modes:
  *   - undefined / 'verbatim' — CC's prompt unchanged (default; existing
  *     setups don't regress).
- *   - 'partial' — strip purely behavioral constraints (Tone-and-style +
- *     Text-output sections, scope-discipline / verbosity / commenting
- *     bullets in Doing-tasks). Recovers most of the 1.2-2.8x output
- *     capability seen in the constraint-removal test while leaving
- *     every IMPORTANT: refusal reminder and every tool description
- *     intact.
- *   - 'aggressive' — partial + remove prompt-level RLHF reminders (the
- *     IMPORTANT: lines that re-state refusal categories) and the
- *     Executing-actions-with-care overcaution language. Adds <3%
- *     practical difference vs partial because alignment is RLHF-trained,
- *     not prompt-trained — RLHF refusals on harmful content survive
- *     prompt removal.
+ *   - 'partial' — strip purely behavioral constraints, leaving every
+ *     refusal reminder and tool description intact. On the compact CC
+ *     prompt (2.1.x+) the lone behavioral constraint is the comment-
+ *     density / match-surrounding-style line, swapped for a positive
+ *     "be thorough" instruction; on older verbose prompts the
+ *     Tone-and-style + Text-output sections and the Doing-tasks bullets
+ *     are removed as well. Recovers the output capability the
+ *     constraint-removal research test measured.
+ *   - 'aggressive' — partial + remove the prompt-level RLHF reminder (the
+ *     IMPORTANT: line re-stating refusal categories) and the caution
+ *     guidance about hard-to-reverse / outward-facing actions (the
+ *     "Executing actions with care" section on older prompts). Adds
+ *     little practical difference vs partial — alignment is RLHF-trained,
+ *     not prompt-trained, so refusals survive prompt removal.
  *   - any other string — used as the literal system prompt text. The
  *     CLI resolves file paths to file contents up-front so this layer
  *     stays filesystem-pure.
@@ -97,13 +99,16 @@ export function resolveSystemPrompt(arg: string | undefined): string {
 
 /**
  * Port of scripts/research/test-constraint-removal.mjs:stripConstraints. Pure over
- * its input; returns the input unchanged if section headers don't match
- * (so a future CC bump that renames sections degrades to verbatim rather
- * than producing an unpredictable strip).
+ * its input; returns the input unchanged if no target matches (so a CC
+ * bump that renames sections degrades to verbatim rather than producing
+ * an unpredictable strip). Handles both the verbose pre-2.1 prompt
+ * (`# Tone and style` etc.) and the compact 2.1.x+ prompt; the patterns
+ * for the era not in play are simply no-ops.
  */
 function stripBehavioralConstraints(input: string, level: 'partial' | 'aggressive'): string {
   let s = input;
 
+  // ── Legacy (pre-2.1 verbose prompt): no-ops on the compact prompt ──
   s = s.replace(/# Tone and style[\s\S]*?(?=\n# |\n$|$)/m, '');
   s = s.replace(/# Text output[^\n]*\n[\s\S]*?(?=\n# |\n$|$)/m, '');
 
@@ -124,10 +129,20 @@ function stripBehavioralConstraints(input: string, level: 'partial' | 'aggressiv
     '# Doing tasks\n\nBe thorough. Show your reasoning. Provide the context and explanations the user is likely to find useful. Use as many tokens as the task warrants.\n\n',
   );
 
+  // ── Compact prompt (2.1.x+): its one behavioral constraint is the
+  // comment-density / match-surrounding-style line. Swap it for the same
+  // positive instruction the legacy Doing-tasks rewrite inserts. ──
+  s = s.replace(
+    /^Write code that reads like the surrounding code:[^\n]*\n/m,
+    'Be thorough. Show your reasoning. Provide the context and explanations the user is likely to find useful. Use as many tokens as the task warrants.\n',
+  );
+
   if (level === 'aggressive') {
     s = s.replace(/^IMPORTANT: Assist with authorized security testing[^\n]*\n/m, '');
     s = s.replace(/^IMPORTANT: You must NEVER generate or guess URLs[^\n]*\n/m, '');
     s = s.replace(/# Executing actions with care[\s\S]*?(?=\n# |\n$|$)/m, '');
+    // Compact prompt: the caution guidance is a single unheaded paragraph.
+    s = s.replace(/^For actions that are hard to reverse or outward-facing,[^\n]*\n/m, '');
   }
 
   return s;

--- a/test/provider-prefix.mjs
+++ b/test/provider-prefix.mjs
@@ -64,7 +64,8 @@ console.log('\n=================================================================
 console.log('  resolveClaudeAlias — request-time alias resolution (dario#190)');
 console.log('======================================================================');
 
-assert(resolveClaudeAlias('opus') === 'claude-opus-4-7', 'opus → claude-opus-4-7');
+assert(resolveClaudeAlias('opus') === 'claude-opus-4-8', 'opus → claude-opus-4-8 (latest)');
+assert(resolveClaudeAlias('opus47') === 'claude-opus-4-7', 'opus47 → claude-opus-4-7 (legacy-pin alias)');
 assert(resolveClaudeAlias('opus46') === 'claude-opus-4-6', 'opus46 → claude-opus-4-6 (legacy-pin alias)');
 assert(resolveClaudeAlias('sonnet') === 'claude-sonnet-4-6', 'sonnet → claude-sonnet-4-6');
 assert(resolveClaudeAlias('haiku') === 'claude-haiku-4-5', 'haiku → claude-haiku-4-5');

--- a/test/system-prompt-modes.mjs
+++ b/test/system-prompt-modes.mjs
@@ -1,21 +1,23 @@
 // Unit tests for resolveSystemPrompt + the constraint-stripping helper
-// behind it (cc-template.ts, v3.34.0).
+// behind it (cc-template.ts).
 //
 // Pure decision function over its input — no I/O, no upstream calls. We
 // import the real CC system prompt from the shipped template and assert
-// that:
+// that, against the current compact CC prompt (2.1.x+):
 //   - undefined / 'verbatim' returns CC unchanged
-//   - 'partial' removes "# Tone and style" + "# Text output" sections
-//     and the scope/verbosity/comment bullets in "# Doing tasks", AND
-//     leaves IMPORTANT: refusal lines + tool descriptions intact
-//   - 'aggressive' additionally removes the prompt-level RLHF
-//     restatements + the "# Executing actions with care" section
+//   - 'partial' swaps the comment-density / match-surrounding-style
+//     constraint for a positive "be thorough" instruction, leaving the
+//     IMPORTANT: refusal line + the caution paragraph + tools intact
+//   - 'aggressive' additionally removes the IMPORTANT: RLHF restatement
+//     and the hard-to-reverse / outward-facing caution paragraph
 //   - any other string is used verbatim as the literal system prompt
 //     (the file-path escape hatch — CLI resolves the path; this layer
 //     just gets the loaded text)
 //
-// These regressions catch the case where a future CC bump renames
-// section headers and the strip silently degrades to verbatim.
+// These regressions catch the case the v4.8.x rebake hit: a CC prompt
+// rewrite the strip no longer matches, silently degrading to verbatim.
+// `partial !== CC` plus the explicit removal/insertion checks fail loud
+// rather than passing a no-op.
 
 import { resolveSystemPrompt, CC_SYSTEM_PROMPT } from '../dist/cc-template.js';
 
@@ -41,39 +43,30 @@ header('verbatim mode');
 }
 
 // ======================================================================
-//  partial — strip behavioral constraints, keep alignment & tools
+//  partial — swap the behavioral constraint, keep alignment & tools
 // ======================================================================
 header('partial mode');
 {
   const partial = resolveSystemPrompt('partial');
 
-  check('partial differs from CC', partial !== CC_SYSTEM_PROMPT);
-  check('partial is shorter than CC', partial.length < CC_SYSTEM_PROMPT.length);
-  check('partial removes "# Tone and style" section header',
-    !partial.includes('# Tone and style'));
-  check('partial removes "# Text output" section header',
-    !partial.includes('# Text output'));
-  check('partial replaces "Default to writing no comments." line',
-    !partial.includes('Default to writing no comments.'));
-  check('partial keeps "# Doing tasks" header',
-    partial.includes('# Doing tasks'));
-  check('partial keeps the IMPORTANT: refusal reminders intact (alignment-shaped lines)',
-    partial.includes('IMPORTANT: Assist with authorized security testing')
-      && partial.includes('IMPORTANT: You must NEVER generate or guess URLs'));
-  check('partial keeps "# Executing actions with care" intact',
-    partial.includes('# Executing actions with care'));
+  // partial !== CC is the load-bearing anti-degradation check: if a CC
+  // prompt rewrite stops matching the strip, partial collapses to
+  // verbatim and this fails loud rather than passing a silent no-op.
+  check('partial differs from CC (strip actually fired)', partial !== CC_SYSTEM_PROMPT);
+  check('partial removes the comment-density / match-style constraint',
+    !partial.includes('Write code that reads like the surrounding code'));
   check('partial inserts the positive replacement instruction',
     partial.includes('Be thorough. Show your reasoning.'));
-
-  // Sanity: partial output isn't a regex-misfire collapsed string. Any
-  // CC bump that loses these section headers should fail this loud
-  // rather than silently produce a verbatim-shaped output.
-  check('partial removed at least 500 chars vs CC',
-    CC_SYSTEM_PROMPT.length - partial.length >= 500);
+  check('partial keeps the IMPORTANT: refusal reminder intact (alignment-shaped line)',
+    partial.includes('IMPORTANT: Assist with authorized security testing'));
+  check('partial keeps the hard-to-reverse caution paragraph intact',
+    partial.includes('For actions that are hard to reverse or outward-facing'));
+  check('partial keeps the "# Harness" tool-usage section',
+    partial.includes('# Harness'));
 }
 
 // ======================================================================
-//  aggressive — partial + strip prompt-level RLHF restatements
+//  aggressive — partial + strip prompt-level RLHF restatement + caution
 // ======================================================================
 header('aggressive mode');
 {
@@ -81,15 +74,16 @@ header('aggressive mode');
   const aggressive = resolveSystemPrompt('aggressive');
 
   check('aggressive differs from CC', aggressive !== CC_SYSTEM_PROMPT);
-  check('aggressive is shorter than partial', aggressive.length < partial.length);
-  check('aggressive removes "IMPORTANT: Assist with authorized security testing"',
+  check('aggressive is shorter than partial (removes alignment + caution paragraphs)',
+    aggressive.length < partial.length);
+  check('aggressive removes the IMPORTANT: alignment line',
     !aggressive.includes('IMPORTANT: Assist with authorized security testing'));
-  check('aggressive removes "IMPORTANT: You must NEVER generate or guess URLs"',
-    !aggressive.includes('IMPORTANT: You must NEVER generate or guess URLs'));
-  check('aggressive removes "# Executing actions with care" section',
-    !aggressive.includes('# Executing actions with care'));
-  check('aggressive still keeps "# Doing tasks" header',
-    aggressive.includes('# Doing tasks'));
+  check('aggressive removes the hard-to-reverse caution paragraph',
+    !aggressive.includes('For actions that are hard to reverse or outward-facing'));
+  check('aggressive also applies the partial swap (no comment-density constraint)',
+    !aggressive.includes('Write code that reads like the surrounding code'));
+  check('aggressive still keeps the "# Harness" tool-usage section',
+    aggressive.includes('# Harness'));
 }
 
 // ======================================================================
@@ -114,24 +108,27 @@ header('custom literal text');
 }
 
 // ======================================================================
-//  invariant: 'aggressive' adds <3% practical reduction over 'partial'
+//  invariant: on the compact prompt, partial barely moves the needle
+//  and aggressive removes the bulk
 // ======================================================================
-//  This is the load-bearing claim from docs/research/system-prompt-classifier-study.md —
-//  the aggressive strip's RLHF-restatement removal is decorative because
-//  alignment is RLHF-trained, not prompt-trained. The size delta
-//  partial → aggressive should be small relative to verbatim → partial.
-header('partial → aggressive delta is small (alignment is in the weights)');
+//  The compact CC prompt (2.1.x+) carries a single behavioral-style line
+//  that partial swaps for a slightly longer positive instruction, so
+//  partial ≈ verbatim in length. Aggressive removes the IMPORTANT:
+//  alignment paragraph + the caution paragraph — most of the strippable
+//  surface. This matches docs/research/system-prompt-classifier-study.md:
+//  there is very little prompt-level alignment to strip; it lives in the
+//  weights, not the prompt. (On the older verbose prompt the ratio was
+//  the reverse — partial did the bulk — which is why the size delta is no
+//  longer the invariant; the content checks above are.)
+header('partial ≈ verbatim length; aggressive removes the bulk');
 {
   const partial = resolveSystemPrompt('partial');
   const aggressive = resolveSystemPrompt('aggressive');
   const verbatim = CC_SYSTEM_PROMPT;
-  const partialDrop = verbatim.length - partial.length;
-  const aggressiveDelta = partial.length - aggressive.length;
-  // Aggressive's delta over partial should be smaller than partial's
-  // delta over verbatim — the IMPORTANT: lines + Executing-actions
-  // section together are smaller than Tone + Text-output + bullets.
-  check('aggressive→partial delta < partial→verbatim drop',
-    aggressiveDelta < partialDrop);
+  check('partial stays within ~200 chars of verbatim (single-line swap)',
+    Math.abs(verbatim.length - partial.length) < 200);
+  check('aggressive removes more from verbatim than partial does',
+    (verbatim.length - aggressive.length) > Math.abs(verbatim.length - partial.length));
 }
 
 // ======================================================================


### PR DESCRIPTION
Two `npm test` cases were red on master (not in CI's gating path, so they never blocked a merge). Both are now green — and one turned out to be a silently-broken feature, not just a stale assertion.

## 1. `provider-prefix` — stale alias expectation (test-only)
Asserted `resolveClaudeAlias('opus') === 'claude-opus-4-7'`. The source alias (`MODEL_ALIASES`) correctly maps `opus → claude-opus-4-8` since the opus 4.8 release. Updated the assertion and added coverage for the `opus47` legacy-pin alias (the source has it; the test didn't).

## 2. `system-prompt-modes` — the strip had silently degraded to verbatim (source + test)
`resolveSystemPrompt('partial'/'aggressive')` (wired to `--system-prompt=` / `DARIO_SYSTEM_PROMPT`, surfaced in `doctor`) targeted the **old verbose** CC prompt: `# Tone and style`, `# Text output`, the `# Doing tasks` bullets, `# Executing actions with care`. CC 2.1.x's **compact** prompt has none of those, so the strip matched nothing and returned verbatim — i.e. `--system-prompt=partial` was a no-op. This is exactly the degradation the test was written to catch; it had been failing since the prompt rewrite.

`stripBehavioralConstraints` now also targets the compact prompt (legacy patterns kept as no-op fallbacks for older captures):
- **partial** — swaps the lone behavioral-style constraint (`Write code that reads like the surrounding code: match its comment density…`) for the same positive *"Be thorough. Show your reasoning…"* instruction the legacy `# Doing tasks` rewrite inserted. Keeps the `IMPORTANT:` alignment line, the caution paragraph, and all tools.
- **aggressive** — partial + removes the `IMPORTANT: Assist with authorized security testing…` RLHF line and the `For actions that are hard to reverse or outward-facing…` caution paragraph.

The test is rewritten to assert this against the real compact prompt. The old size-based invariant (`aggressive→partial delta < partial→verbatim drop`) is dropped — it inverted on the compact prompt (partial now ≈ verbatim; aggressive removes the bulk), consistent with `docs/research/system-prompt-classifier-study.md`'s finding that there's little prompt-level alignment to strip. The anti-degradation guard (`partial !== CC` + explicit removal/insertion checks) is kept so a future prompt rewrite fails loud instead of silently no-op'ing again.

**Note:** this is a behavior change to what `--system-prompt=partial/aggressive` strips (it was doing nothing on 2.1.x before). If you'd rather deprecate the modes than maintain them against an evolving compact prompt, say so and I'll swap this for a deprecation path instead.

## Validation
`npm test` → **77/77** (was 75/77). `provider-prefix` 28/0, `system-prompt-modes` 21/0. `lint:pkg`, `cli help`, `cli status`, build all pass. No bundle/template change (`cc-template-data.json` untouched).