### PR TITLE
ci: add npm test job (gate against unit-test rot)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,27 @@ jobs:
       - run: node dist/cli.js help
       - run: node dist/cli.js status
 
+  # Unit suite. `npm test` (test/all.test.mjs) fans out every test/*.mjs as
+  # a node:test subtest EXCEPT the live-integration files (e2e / compat /
+  # stress / stealth — they need a running proxy, a real key, or a
+  # subscription). Build first: the tests import compiled code from dist/.
+  # Guards against silent unit-test rot — the build job above only runs
+  # `cli help`/`status`, so a stale assertion (an alias bump, a prompt
+  # rename) used to sit red on master unnoticed. The one binary-dependent
+  # test (oauth-detector) skips itself when no `claude` is on PATH, which
+  # is the case on a GitHub-hosted runner.
+  test:
+    needs: validate-package-json
+    runs-on: ubuntu-latest
+    steps:
+      - uses: askalf/checkout-with-retry@744195501c3e2b794c50370b753a7b8c93d084f5  # v1.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+
   # Docker smoke test under cap_drop: ALL — catches the class of regression
   # that shipped twice on 2026-05-14 (v3.37.16 + v3.37.17) where a Dockerfile
   # change introduced a privilege flow (chown / su-exec) that requires

--- a/test/oauth-detector.mjs
+++ b/test/oauth-detector.mjs
@@ -22,6 +22,7 @@
  */
 
 import { detectCCOAuthConfig, _resetDetectorCache } from '../dist/cc-oauth-detect.js';
+import { findInstalledCC } from '../dist/live-fingerprint.js';
 import { readFile, unlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir, tmpdir } from 'node:os';
@@ -77,6 +78,17 @@ async function main() {
   console.log('═══════════════════════════════════════════════════════════');
   console.log('  DARIO — CC OAuth AUTO-DETECTOR E2E TEST');
   console.log('═══════════════════════════════════════════════════════════\n');
+
+  // This is an E2E test: it scans the installed CC binary's prod OAuth
+  // config block, so it needs a real `claude` on disk. GitHub-hosted CI
+  // has none — skip cleanly there rather than fail. The detector's job
+  // (catch CC OAuth client_id / scope drift) is also covered by the
+  // self-hosted drift watchers; this test runs fully on any machine with
+  // CC installed (maintainer's box, the self-hosted dario-drift runner).
+  if (!findInstalledCC().path) {
+    console.log('SKIP: no `claude` binary on PATH — oauth-detector needs a real CC install to scan. Hermetic on CI; runs fully where CC exists.');
+    return;
+  }
 
   const savedEnv = captureOverrideEnv();
   const overridePath = join(tmpdir(), `dario-oauth-override-${process.pid}.json`);


### PR DESCRIPTION
## Why

CI gated only on `build` + `cli help`/`status` + docker-cap-drop + compat — **it never ran `npm test`**. So unit-test rot accumulated silently on master: the `provider-prefix` opus-alias staleness and the `system-prompt-modes` strip decay (both fixed in #439) had been red on `npm test` for weeks without blocking a single merge.

## What

A `test` job on hosted `ubuntu-latest`: `npm ci` → `npm run build` (the tests import compiled code from `dist/`) → `npm test`. `npm test` is `test/all.test.mjs`, which fans out every `test/*.mjs` as a `node:test` subtest except the live-integration files already excluded by the runner (`e2e` / `compat` / `stress` / `stealth` / `infra-probe` / `overage-guard-e2e-live`).

## The one snag: oauth-detector

`oauth-detector.mjs` is an E2E test that scans the **installed CC binary's** prod OAuth config block — a GitHub-hosted runner has no `claude`. I confirmed it's the *only* binary-dependent test by running the suite on a Linux box with `claude` stripped from `PATH` and an empty `HOME` (true hosted-CI simulation): **76/77, only `oauth-detector` failed.**

Rather than exclude it, it now **skips cleanly** when `findInstalledCC()` finds no binary — so it still runs fully on the maintainer's machine and the self-hosted `dario-drift` runner, where it's meaningful. Its purpose (catch CC OAuth `client_id` / scope drift) is independently covered by the drift watchers anyway.

## Validation

- Local (claude present): `oauth-detector` runs fully (23/23), `npm test` 77/77.
- No-claude + empty-HOME sim: was 76/77 (only oauth-detector); with the skip-guard it's 77/77.
- This PR's own `test` job is the authoritative hosted-CI proof.

Hosted, not self-hosted: keeps this an every-PR gate without depending on the `dario-drift` box being online, and avoids installing a moving `@latest` CC into CI (which would make oauth-detector's scope assertions fragile to unrelated Anthropic releases). No `src/` change, no version bump, no release.