### PR TITLE
fix(proxy): prefer IPv4 for the Anthropic upstream (default dns-result-order=ipv4first)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.35] - 2026-06-06
+
+- **Prefer IPv4 for the Anthropic upstream (`dns.setDefaultResultOrder('ipv4first')` at proxy startup)** — `api.anthropic.com` publishes both A and AAAA records; in a container with no IPv6 egress (e.g. a default Docker bridge network) Node's default `verbatim` order tries the AAAA address first → `ENETUNREACH`/hang → every upstream `fetch` times out (`Proxy error: The operation timed out`) while `/health` still returns 200. This silently took down a self-hosted SDK fleet routing all LLM calls through dario. `startProxy()` now defaults the DNS result order to `ipv4first` (Node built-in fetch/undici honors it). Override with `DARIO_DNS_RESULT_ORDER=verbatim|ipv6first` on IPv6-only / dual-stack hosts; the active order is logged under `--verbose`.
+
 ## [4.8.34] - 2026-06-06
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.165` → `2.1.167` for CC v2.1.167. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.34",
+  "version": "4.8.35",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,6 +4,7 @@ import { execSync } from 'node:child_process';
 import { readFileSync, readdirSync, createWriteStream, type WriteStream } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { setDefaultResultOrder } from 'node:dns';
 import { arch, platform } from 'node:process';
 import { getAccessToken, getStatus } from './oauth.js';
 import { buildCCRequest, parseEffortSuffix, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, CC_TEMPLATE, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
@@ -670,6 +671,28 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
   const host = opts.host ?? process.env.DARIO_HOST ?? DEFAULT_HOST;
   const verbose = opts.verbose ?? false;
   const passthrough = opts.passthrough ?? false;
+
+  // DNS result order — prefer IPv4 for the Anthropic upstream by default.
+  // api.anthropic.com publishes both A and AAAA records. In a container with
+  // no IPv6 egress (e.g. a default Docker bridge network), Node's `verbatim`
+  // order tries the AAAA address first → ENETUNREACH/hang → every upstream
+  // fetch times out ("Proxy error: The operation timed out") and the proxy is
+  // effectively dead while /health still returns 200. Defaulting to ipv4first
+  // makes Node resolve to the reachable A record (IPv4 to api.anthropic.com is
+  // universally routable). Override with DARIO_DNS_RESULT_ORDER=verbatim or
+  // ipv6first on IPv6-only / dual-stack hosts. (Node built-in fetch/undici
+  // honors dns.setDefaultResultOrder.)
+  const dnsOrder = (process.env.DARIO_DNS_RESULT_ORDER ?? 'ipv4first').trim();
+  if (dnsOrder === 'ipv4first' || dnsOrder === 'ipv6first' || dnsOrder === 'verbatim') {
+    try {
+      setDefaultResultOrder(dnsOrder);
+      if (verbose) console.error(`[dario] dns result order: ${dnsOrder}`);
+    } catch (e) {
+      console.error(`[dario] could not set dns result order (${dnsOrder}): ${e instanceof Error ? e.message : String(e)}`);
+    }
+  } else {
+    console.error(`[dario] ignoring invalid DARIO_DNS_RESULT_ORDER='${dnsOrder}' (use ipv4first | ipv6first | verbatim)`);
+  }
 
   // TLS-fingerprint axis (v3.23, direction #3). Proxy mode terminates TLS
   // to api.anthropic.com from this process; if we're not on Bun, the


### PR DESCRIPTION
## What
At `startProxy()` startup, call `dns.setDefaultResultOrder('ipv4first')` (overridable via `DARIO_DNS_RESULT_ORDER=verbatim|ipv6first`) so Node resolves `api.anthropic.com` to its reachable IPv4 A record.

## Why (production outage)
dario reaches `api.anthropic.com` via Node's built-in `fetch` (undici). The host publishes **both A and AAAA**, and Node's default DNS order is `verbatim`. In a container with **no IPv6 egress** (e.g. a default Docker bridge network), Node tries the AAAA address first → `ENETUNREACH` → every upstream request hangs until timeout. The proxy goes effectively dead — logs flood with `Proxy error: The operation timed out` — while `/health` still returns 200 (it only probes localhost, never the upstream). This took down an entire self-hosted SDK fleet routing its LLM calls through dario.

Confirmed from inside the affected container:
```
IPv4 (160.79.104.10): CONNECT 10ms
IPv6 (2607:6bc0::10): ERR ENETUNREACH
dns.getDefaultResultOrder(): verbatim
```

## Fix + verification
`ipv4first` makes Node use the A record (IPv4 to api.anthropic.com is universally routable; undici honors `setDefaultResultOrder`). Verified the equivalent (`NODE_OPTIONS=--dns-result-order=ipv4first`) live: a real call to `api.anthropic.com` returns **401 in ~280ms**, and the end-to-end proxy path returns in **~1.4s** (was 893s → 502). `tsc` clean.

Default chosen as `ipv4first` because dario's entire job is reaching `api.anthropic.com` and IPv4-broken-but-IPv6-only environments are rare; IPv6-only/dual-stack operators can set `DARIO_DNS_RESULT_ORDER=verbatim`. A logged line surfaces the active order under `--verbose`.

## Note
The downstream deploy already mitigated this via the compose env var (askalf/platform); this bakes the safe default into dario so any IPv6-broken container is robust without per-deploy config. No version bump here — leaving release to the maintainer.
