### PR TITLE
chore(template): bump _version + user-agent to 2.1.168 (clears sdk-drift #445)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.37] - 2026-06-07
+
+- **Template version-label bump** — `_version`, `_supportedMaxTested`, and the `user-agent` header value → `2.1.168` to track `@anthropic-ai/claude-code@latest`. The wire shape is unchanged (`cc-drift-template-watch` reported zero shape drift capturing live CC v2.1.168 on 2026-06-07), so this is a label refresh, not a re-capture — `_captured` is intentionally left at the last real capture. `_supportedMaxTested` rides along so the startup "newer CC than tested" warning no longer false-fires for 2.1.168 users. Clears the `sdk-drift` signal ([#445](https://github.com/askalf/dario/issues/445)).
+
 ## [4.8.36] - 2026-06-07
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.167` → `2.1.168` for CC v2.1.168. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.36",
+  "version": "4.8.37",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template-data.json
+++ b/src/cc-template-data.json
@@ -1,5 +1,5 @@
 {
-  "_version": "2.1.162",
+  "_version": "2.1.168",
   "_captured": "2026-06-04T12:25:00.361Z",
   "_source": "bundled",
   "_schemaVersion": 3,
@@ -1071,7 +1071,7 @@
   "anthropic_beta": "claude-code-20250219,context-1m-2025-08-07,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24",
   "header_values": {
     "accept": "application/json",
-    "user-agent": "claude-cli/2.1.162 (external, sdk-cli)",
+    "user-agent": "claude-cli/2.1.168 (external, sdk-cli)",
     "x-stainless-arch": "x64",
     "x-stainless-lang": "js",
     "x-stainless-os": "Linux",
@@ -1096,5 +1096,5 @@
     "output_config",
     "stream"
   ],
-  "_supportedMaxTested": "2.1.162"
+  "_supportedMaxTested": "2.1.168"
 }


### PR DESCRIPTION
## Label-only template bump — clears `sdk-drift` #445

`sdk-drift-watch.yml` has flagged drift for 3 daily runs (#445): bundled `_version` `2.1.162` vs `@anthropic-ai/claude-code@latest` `2.1.168`.

### Why this is a label refresh, not a re-capture

The self-hosted `cc-drift-template-watch` runs `capture-and-bake.mjs --check` against a **live CC 2.1.168** binary on every cycle. The 2026-06-07 run ([27091604113](https://github.com/askalf/dario/actions/runs/27091604113)) captured CC v2.1.168 and reported:

```
[bake] using CC at /usr/bin/claude (version 2.1.168) [--check mode: dry-run]
[bake] captured: CC v2.1.168, 27 tools, 5781 char system prompt
[bake] check: no drift detected. Bundled template matches live capture.
```

So the **wire shape (tools + system prompt + beta headers) is already byte-identical at 2.1.168** — there is no content drift to re-bake, and the auto-rebake path (gated on `--check` exit 2) correctly never fires. The only thing stale is the cosmetic `_version` label that `check-sdk-drift.mjs` compares against npm. This is the same situation #427 (→2.1.160) and #418 (→2.1.159) resolved with a hand bump.

### Changes

- `src/cc-template-data.json`: `_version`, `_supportedMaxTested`, and the `user-agent` header → `2.1.168`. `_captured` left at the last real capture (`2026-06-04T12:25`); `x-stainless-package-version` left at `0.94.0` (stable since 2.1.159; npm exposes no readable dep for the bundled SDK, and the drift watcher does not flag it).
- `_supportedMaxTested` rides along so `loadBundledTemplate`'s "installed CC newer than tested" startup warning (`live-fingerprint.ts`) no longer false-fires for 2.1.168 users — today's `--check` is exactly that verification.
- `package.json` `4.8.36` → `4.8.37` + CHANGELOG entry, so merging ships the label refresh to npm.

### Validation

`node scripts/check-sdk-drift.mjs` against this branch → `"status": "clean"`, `"drift": []`. compat-test will auto-fire (touches `src/cc-template-data.json`); the wire shape is unchanged so it should stay green.
