### PR TITLE
fix(scrub): stop corrupting user code/data in message content (the `continue;` bug)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.39] - 2026-06-07
+
+- **Content scrub no longer corrupts the user's code/data (the `continue;` → `;` bug).** `scrubFrameworkIdentifiers` masks framework/product identifiers (Cursor, Cline, Aider, Continue, Cody, …) so non-CC clients aren't fingerprinted upstream — but it was applied to **message content** with the full `FRAMEWORK_PATTERNS` set, including bare words that double as code tokens. The JavaScript keyword **`continue`** (also Continue.dev) was stripped from source code, turning `continue;` into a bare `;`; downstream code analysis then reported a bare-semicolon "no-op" bug that **the proxy itself had introduced** (it also corrupts `cursor`, `gateway`, `openai`, `hermes`, etc.). Message content now scrubs with a **content-safe subset** (`scrubFrameworkIdentifiersInContent`) — only distinctive multi-token product names that never occur verbatim in real code; `powered by …` / `gateway` and other content-corrupting patterns are no longer applied to content. The **system-prompt** identity scrub keeps the full set unchanged. A proxy must not mutate the user's payload. Regression + live-verified integration coverage in `test/scrub-content-keywords.mjs`.
+
 ## [4.8.38] - 2026-06-07
 
 - **sdk-drift label-only autofix** — `cc-drift-template-watch.yml` now self-closes the `sdk-drift` loop for the common "patch release, identical wire shape" case. `capture-and-bake.mjs --check` gains exit code `3` (label-only drift: `computeDrift` empty but bundled `_version` lags live CC); the workflow runs the new `scripts/label-sync.mjs` to bump only the version-label fields (`_version`, `_supportedMaxTested`, the `user-agent` version token — never the wire shape), then opens a `bot/template-label-*` PR with **auto-merge** enabled. Safe to auto-merge because the empty `computeDrift` proves the shape is byte-identical at the live version — the same deterministic-bump class `cc-drift-watch.yml` already auto-merges for `maxTested`. Replaces the recurring hand PR (#418 / #427 / #451). Pure `bumpTemplateLabels` helper unit-tested in `test/label-sync.mjs`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.38",
+  "version": "4.8.39",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -276,9 +276,32 @@ const FRAMEWORK_PATTERNS: RegExp[] = [
   /\bsessions_[a-z_]+\b/gi,
 ];
 
-export function scrubFrameworkIdentifiers(text: string): string {
+// Patterns SAFE to apply to message *content* (user data: source code, docs,
+// tool output). This is the small subset of FRAMEWORK_PATTERNS that consists
+// only of distinctive, multi-word / unambiguous product identifiers which
+// effectively never appear verbatim in real code or prose. It deliberately
+// EXCLUDES every bare single-word pattern (`continue`, `cursor`, `gateway`,
+// `openai`, `hermes`, `zed`, `tabby`, `cody`, `aider`, `cline`, `copilot`,
+// `windsurf`, …) because those collide with ordinary code tokens and English.
+// Stripping those from a user's payload silently CORRUPTS it: the JS keyword
+// `continue;` became `;` (because Continue.dev is on the list), which made a
+// code auditor report a bare-semicolon "no-op" that THIS PROXY had introduced.
+// A proxy must never mutate the user's content — identity-masking of the
+// *client's framing* is the job of the system-prompt scrub, which still uses
+// the full FRAMEWORK_PATTERNS set.
+const CONTENT_FRAMEWORK_PATTERNS: RegExp[] = [
+  /\b(roo[- ]?cline|roo[- ]?code|big[- ]?agi|claude[- ]?bridge)\b/gi,
+  /\b(librechat|typingmind)\b/gi,
+  // NOTE: deliberately omits `/powered by [a-z]+/` and `/\bgateway\b/` etc.
+  // from FRAMEWORK_PATTERNS — those would strip legitimate user content like
+  // a "Powered by Stripe" footer or a `gateway` variable. Only distinctive,
+  // multi-token product names that never occur verbatim in real code/data are
+  // safe to mask in the user's payload.
+];
+
+function scrubWithPatterns(text: string, patterns: readonly RegExp[]): string {
   let result = text;
-  for (const pattern of FRAMEWORK_PATTERNS) {
+  for (const pattern of patterns) {
     pattern.lastIndex = 0;
     result = result.replace(pattern, (match, ...args) => {
       const offset = args[args.length - 2] as number;
@@ -297,6 +320,17 @@ export function scrubFrameworkIdentifiers(text: string): string {
     });
   }
   return result;
+}
+
+// Scrub the CLIENT'S system prompt / identity fields — full pattern set.
+export function scrubFrameworkIdentifiers(text: string): string {
+  return scrubWithPatterns(text, FRAMEWORK_PATTERNS);
+}
+
+// Scrub message CONTENT (the user's code/data) — content-safe subset only, so
+// a user's payload is never corrupted. See CONTENT_FRAMEWORK_PATTERNS.
+export function scrubFrameworkIdentifiersInContent(text: string): string {
+  return scrubWithPatterns(text, CONTENT_FRAMEWORK_PATTERNS);
 }
 
 /**
@@ -1328,24 +1362,28 @@ export function buildCCRequest(
   // point so framework identifiers don't leak upstream.
   let systemText = scrubFrameworkIdentifiers(rawSystemForDetection);
 
-  // Also scrub framework identifiers from message content text blocks.
-  // Clients often inject their product name into user/tool messages as well,
-  // and the system-prompt-only scrub used to miss those.
+  // Also scrub framework identifiers from message content text blocks —
+  // clients can leak their product name in user/tool messages too. This uses
+  // the CONTENT-SAFE subset (scrubFrameworkIdentifiersInContent), NOT the full
+  // pattern set: message content is the user's own code/data and must never be
+  // mutated. The full set ran here previously and corrupted source — the JS
+  // keyword `continue;` became `;` (Continue.dev is a scrubbed name), so a code
+  // auditor "found" a bare-semicolon no-op the proxy itself had introduced.
   for (const msg of messages) {
     if (typeof msg.content === 'string') {
-      msg.content = scrubFrameworkIdentifiers(msg.content as string);
+      msg.content = scrubFrameworkIdentifiersInContent(msg.content as string);
     } else if (Array.isArray(msg.content)) {
       for (const block of msg.content as Array<Record<string, unknown>>) {
         if (block.type === 'text' && typeof block.text === 'string') {
-          block.text = scrubFrameworkIdentifiers(block.text);
+          block.text = scrubFrameworkIdentifiersInContent(block.text);
         }
         if (block.type === 'tool_result' && typeof block.content === 'string') {
-          block.content = scrubFrameworkIdentifiers(block.content);
+          block.content = scrubFrameworkIdentifiersInContent(block.content);
         }
         if (block.type === 'tool_result' && Array.isArray(block.content)) {
           for (const sub of block.content as Array<Record<string, unknown>>) {
             if (sub.type === 'text' && typeof sub.text === 'string') {
-              sub.text = scrubFrameworkIdentifiers(sub.text);
+              sub.text = scrubFrameworkIdentifiersInContent(sub.text);
             }
           }
         }

--- a/test/scrub-content-keywords.mjs
+++ b/test/scrub-content-keywords.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// Regression test: dario's content scrubber must NOT corrupt the user's
+// source code / data. The framework-identifier patterns include bare words
+// that double as code tokens — most notably `continue` (the JS keyword AND
+// Continue.dev). Running the full pattern set over message content turned
+// `continue;` into `;`, so a code auditor downstream reported a bare-semicolon
+// "no-op" that the proxy itself had introduced. Message content now uses a
+// content-safe subset (scrubFrameworkIdentifiersInContent); the system-prompt
+// scrub (scrubFrameworkIdentifiers) keeps the full set.
+
+import { scrubFrameworkIdentifiers, scrubFrameworkIdentifiersInContent, buildCCRequest } from '../dist/cc-template.js';
+
+let pass = 0, fail = 0;
+function assertEq(actual, expected, label) {
+  if (actual === expected) { console.log(`  ✅ ${label}`); pass++; }
+  else {
+    console.log(`  ❌ ${label}`);
+    console.log(`     expected: ${JSON.stringify(expected)}`);
+    console.log(`     actual:   ${JSON.stringify(actual)}`);
+    fail++;
+  }
+}
+function assertHas(haystack, needle, label) { assertEq(haystack.includes(needle), true, label); }
+function assertMissing(haystack, needle, label) { assertEq(haystack.includes(needle), false, label); }
+
+console.log('\n======================================================================');
+console.log('  content scrub must not corrupt user code/data (the `continue` bug)');
+console.log('======================================================================');
+
+// ── The exact regression: a guard clause survives intact ──────────────────
+const guard = '    if (!rawKey) {\n      skipped++;\n      continue;\n    }';
+assertEq(
+  scrubFrameworkIdentifiersInContent(guard),
+  guard,
+  'cmdPull-style guard with `continue;` survives content scrub byte-for-byte',
+);
+assertHas(scrubFrameworkIdentifiersInContent(guard), 'continue;', 'the `continue;` keyword is preserved (not stripped to `;`)');
+
+// ── Bare code tokens / common words preserved in content ──────────────────
+for (const code of [
+  'for (const x of xs) continue;',
+  'const cursor = await db.cursor();',
+  'import { Hermes } from "react-native";',
+  'const gateway = new ApiGateway();',
+  'const client = new OpenAI();',
+  'let cody = users.find(u => u.name === "cody");',
+  'while (true) { if (done) break; else continue; }',
+]) {
+  assertEq(scrubFrameworkIdentifiersInContent(code), code, `content preserved verbatim: ${code.slice(0, 42)}…`);
+}
+
+// ── Distinctive product identifiers ARE still masked in content ───────────
+assertMissing(scrubFrameworkIdentifiersInContent('this came from roo-cline today'), 'roo-cline', 'distinctive `roo-cline` still scrubbed from content');
+assertMissing(scrubFrameworkIdentifiersInContent('relayed via claude-bridge'), 'claude-bridge', 'distinctive `claude-bridge` still scrubbed from content');
+assertMissing(scrubFrameworkIdentifiersInContent('we use librechat internally'), 'librechat', 'distinctive `librechat` still scrubbed from content');
+// `powered by X` and other content-corrupting patterns are NOT applied to content:
+assertEq(scrubFrameworkIdentifiersInContent('footer: "Powered by Stripe"'), 'footer: "Powered by Stripe"', 'legit "Powered by Stripe" in content is NOT corrupted');
+
+// ── The system-prompt scrub (full set) is UNCHANGED ───────────────────────
+// (It masks the client's framing — the intended target — and keeps the full
+//  pattern set incl. the bare words.)
+assertMissing(scrubFrameworkIdentifiers('You are Cursor, an AI editor.'), 'Cursor', 'system-prompt scrub still strips bare `Cursor`');
+assertMissing(scrubFrameworkIdentifiers('You are Continue.'), 'Continue', 'system-prompt scrub still strips bare `Continue`');
+// path preservation in the full scrub is unaffected (dario#35)
+assertEq(scrubFrameworkIdentifiers('/Users/foo/.openclaw/workspace/'), '/Users/foo/.openclaw/workspace/', 'system-prompt scrub still preserves paths (dario#35)');
+
+// ── Integration: `continue;` survives the full buildCCRequest path ────────
+// (the actual outbound-request builder, not just the scrub helper)
+{
+  const code = 'function cmdPull() {\n  for (const k of keys) {\n    if (!ok) { skipped++; continue; }\n    const cursor = db.cursor();\n  }\n}';
+  const clientBody = { model: 'claude-sonnet-4-6', stream: false, messages: [{ role: 'user', content: code }] };
+  const built = buildCCRequest(clientBody, 'billing', { type: 'ephemeral' }, { deviceId: 'D', accountUuid: 'A', sessionId: 'S' });
+  const out = built.body.messages[built.body.messages.length - 1].content;
+  assertHas(out, 'continue;', 'INTEGRATION: buildCCRequest preserves `continue;` in the outbound user message');
+  assertHas(out, 'db.cursor()', 'INTEGRATION: buildCCRequest preserves `cursor` in the outbound user message');
+  assertMissing(out, '\n      ;\n', 'INTEGRATION: no bare-`;` no-op introduced by the proxy');
+}
+
+console.log(`\n  ${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## What
dario's identity scrubber (`scrubFrameworkIdentifiers`) was applied to **message content** with the full pattern set, corrupting the user's code/data. The JS keyword **`continue`** (also Continue.dev, on the scrub list) was stripped from source — `continue;` → bare `;`. Message content now uses a **content-safe subset** (`scrubFrameworkIdentifiersInContent`); the system-prompt scrub is unchanged.

## Why it matters
A proxy must never mutate the user's payload. This silently corrupted any code containing `continue`, `cursor`, `gateway`, `openai`, `hermes`, `cody`, etc. routed through dario — a downstream code auditor "found" a bare-`;` no-op bug **the proxy itself introduced**. It looked like LLM hallucination; it was content corruption in transit.

## How
- New `CONTENT_FRAMEWORK_PATTERNS` (distinctive multi-token names only) + `scrubFrameworkIdentifiersInContent`; the message-content scrub uses it.
- `scrubFrameworkIdentifiers` (system prompt) keeps the full `FRAMEWORK_PATTERNS` set — masking the client's framing is its intended job.
- `powered by …` / `gateway` etc. are no longer applied to content (they'd corrupt a "Powered by Stripe" footer or a `gateway` variable).

## Verification
- Full suite **79/79** green.
- New `test/scrub-content-keywords.mjs`: code keywords preserved, distinctive names still masked, system-prompt scrub unchanged, **integration** check that `buildCCRequest` preserves `continue;`/`cursor`.
- **Live Max traffic A/B:** the same `cmdPull` audit fabricated **3/3** through the unfixed proxy and **0/4** through the fixed one.
