### PR TITLE
docs: correct the compat ~3/min misdiagnosis across docs + comments

### DIFF
--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -75,22 +75,21 @@ docker exec askalf-dario sh -c "node -e 'fetch(\"http://localhost:3456/health\")
 
 ## Compat suite 429s on every PR
 
-**Symptom**: `compat-test-self-hosted` reports all tests failing with `HTTP 429: rate_limit_error`. Single isolated calls through platform dario succeed; only the compat burst fails.
+**Symptom**: `compat-test-self-hosted` reports tests failing with `HTTP 429: rate_limit_error: "Rate limited (rejected)"`. Single isolated calls through the *platform* dario succeed; only the compat suite fails.
 
-**Cause**: Anthropic severely rate-limits subscription-OAuth + passthrough (non-CC-fingerprinted) traffic — the per-minute cap is ~3/min on that pool. Pacing alone cannot fix this; any practical compat run takes more requests than the cap allows.
+**Cause** (corrected 2026-06-08 — the earlier "~3/min per-minute cap" was a misdiagnosis): it is **not a rate/volume cap**. The compat job runs dario in **`--passthrough`** (so it can verify the no-injection guarantee), which means its outbound requests are **not CC-shaped**. Anthropic's **Max OAuth pool rejects non-CC-shaped traffic by design** — returning `429 "Rate limited (rejected)"` (the billing classifier) for *any* such request, even a single one, regardless of pacing. The platform dario succeeds on the *same* OAuth path because it rebuilds requests as CC (canonical mode), which the classifier accepts. (Verified: routing the suite through dario→Max gives ~9/10 rejections immediately; separately, canonical CC-shaped traffic runs 25 req/min clean — so rate was never the issue.)
 
-**Fix** — provision an API key for compat (already implemented by the `DARIO_TEST_API_KEY` env support in `test/compat.mjs`):
+**Fix** — route the suite **through** dario, but point dario's *upstream* at the **per-token API pool** (which has no such classifier) via `ANTHROPIC_UPSTREAM_API_KEY`. The suite still exercises dario's wire — the passthrough-verification + OpenAI-compat sections **run** (unlike the older direct-Anthropic bypass, which skipped them). Implemented by the `ANTHROPIC_UPSTREAM_API_KEY` path (`upstreamAuthHeaders` in `src/proxy.ts`) + `compat-test-self-hosted.yml`:
 
-1. console.anthropic.com → Settings → API Keys → **Create Key** named e.g. `dario-compat-ci`
-2. `gh secret set ANTHROPIC_COMPAT_API_KEY -R askalf/dario --body 'sk-ant-api03-...'`
-3. Verify by dispatching a compat run: `gh workflow run compat-test-self-hosted.yml -R askalf/dario`
-4. With the secret set, compat bypasses dario and hits Anthropic directly with the API key (separate rate-limit pool from the Max subscription). Dario-specific tests (no-injection, betas-preserved, OpenAI compat) are skipped in this mode — the remaining wire-shape / SSE / tool-use tests are what's covered. Acceptable trade-off for maintenance mode
+1. console.anthropic.com → Settings → API Keys → **Create Key** e.g. `dario-compat-ci`
+2. `gh secret set ANTHROPIC_COMPAT_API_KEY -R askalf/dario --body 'sk-ant-api03-...'` — the workflow passes this to the dario-start step as `ANTHROPIC_UPSTREAM_API_KEY`, so dario forwards upstream on the per-token pool.
+3. Verify: `gh workflow run compat-test-self-hosted.yml -R askalf/dario` (expect 10/10).
 
-Cost: ~$0.05–0.20 per compat run at current cadence, hits the standard API tier.
+Do **not** switch dario's upstream back to the Max OAuth to "save the key" — passthrough on the Max pool cannot work (see **Cause**).
 
-**If the API key is unavailable** (don't want to pay, key revoked, etc.) fall back to the legacy path:
-1. `gh secret delete ANTHROPIC_COMPAT_API_KEY -R askalf/dario` (or set to empty)
-2. Compat will route through a local dario proxy again, expect compat-red, admin-merge through it. Recovery doc's `Release shipped to GitHub but not npm` then becomes the failure mode to watch for instead
+Cost: ~$0.05–0.20 per compat run, on the standard per-token API tier (a separate pool from the Max subscription).
+
+**If the API key is unavailable** (revoked, don't want to pay): there is no working path through dario→Max (every `--passthrough` request is classifier-rejected), so compat goes red. Either restore the per-token key, or temporarily set `DARIO_TEST_API_KEY` (legacy direct-Anthropic mode — hits Anthropic directly and **skips** the dario-routing sections) and admin-merge, watching for the `Release shipped to GitHub but not npm` failure mode instead.
 
 ---
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -542,9 +542,11 @@ interface ProxyOptions {
    * <this>` (the per-token API pool) instead of the Pro/Max OAuth bearer.
    * When set, OAuth/getAccessToken and the account pool are bypassed entirely
    * — dario becomes a thin per-token Anthropic proxy. Default (unset) keeps
-   * the subscription-OAuth behavior. Used by the self-hosted compat workflow
-   * so it can route the suite THROUGH dario without tripping the subscription
-   * pool's ~3/min cap. Sourced from ANTHROPIC_UPSTREAM_API_KEY (env-only — never
+   * the subscription-OAuth behavior. Used by the self-hosted compat workflow so
+   * it can route the suite THROUGH dario on the per-token pool — required
+   * because compat runs dario in --passthrough (non-CC-shaped) and the Max OAuth
+   * pool rejects non-CC traffic outright ("429 Rate limited (rejected)"), not a
+   * rate cap. Sourced from ANTHROPIC_UPSTREAM_API_KEY (env-only — never
    * a CLI flag, so the key never lands in `ps`/argv).
    */
   upstreamApiKey?: string;

--- a/test/compat.mjs
+++ b/test/compat.mjs
@@ -10,13 +10,16 @@
  * Reports PASS/FAIL for each protocol requirement.
  */
 
-// Routing: when DARIO_TEST_API_KEY is set, compat bypasses dario and hits
-// Anthropic directly with the API key on its own rate-limit pool. This is
-// the CI default: subscription-OAuth + passthrough trips Anthropic's
-// per-minute cap at ~3/min, making the suite permanently red regardless
-// of pacing. An API key sidesteps that pool entirely. The dario-specific
-// tests (no-injection, betas-preserved, OpenAI compat) skip in this mode.
-// When unset, compat runs through a local dario proxy at DARIO_TEST_URL.
+// Routing: by default (DARIO_TEST_API_KEY unset) compat runs THROUGH a local
+// dario proxy at DARIO_TEST_URL — and the workflow configures that dario to
+// forward upstream via a per-token API key (ANTHROPIC_UPSTREAM_API_KEY). That
+// is required, not a rate workaround: compat runs dario in --passthrough
+// (non-CC-shaped), and the Max OAuth pool REJECTS non-CC-shaped traffic with
+// "429 Rate limited (rejected)" (the billing classifier, not a ~3/min cap); the
+// per-token pool has no such classifier. Legacy fallback: setting
+// DARIO_TEST_API_KEY makes compat bypass dario and hit Anthropic directly with
+// the key, which SKIPS the dario-specific tests (no-injection, betas-preserved,
+// OpenAI compat).
 const API_KEY = process.env.DARIO_TEST_API_KEY ?? '';
 const VIA_API_KEY = API_KEY.length > 0;
 const BASE = VIA_API_KEY
@@ -35,19 +38,14 @@ function log(label, status, details) {
 
 async function wait(ms) { return new Promise(r => setTimeout(r, ms)); }
 
-// Per-test pacing. In passthrough mode (what compat tests), dario strips
-// the CC fingerprint from outbound requests and Anthropic's billing
-// classifier routes the calls to the Agent SDK / standard API pool —
-// which has a much stricter per-minute cap (~3–5/min on a subscription
-// OAuth credential) than the Max interactive pool. The CC-fingerprinted
-// platform dario handles tens of req/sec fine; compat under passthrough
-// trips the lower pool's cap at any pace under ~15s/req.
-//
-// 20s default stretches the 10-test suite to ~3.5min end-to-end but
-// stays under the passthrough-pool's per-minute cap. Overridable via
-// DARIO_COMPAT_PACE_MS env for the rare case a maintainer wants to run
-// faster locally (e.g., DARIO_COMPAT_PACE_MS=500 with a freshly minted
-// API key in the env).
+// Per-test pacing. compat routes through dario on the per-token API pool (see
+// Routing above), which has real per-minute / per-token rate limits; the 20s
+// default keeps the 10-test burst comfortably under them (and is gentle on a
+// freshly minted key). This is NOT about a "~3/min Max cap" — that framing was
+// a misdiagnosis. The Max pool doesn't *rate-limit* passthrough, it *rejects*
+// it outright (429 "Rate limited (rejected)"), which is the whole reason compat
+// uses the per-token pool. 20s stretches the suite to ~3.5min end-to-end.
+// Overridable via DARIO_COMPAT_PACE_MS (e.g. =500 against a higher-tier key).
 //
 // Longer-term fix is to point compat at a real sk-ant-... API key on
 // its own rate-limit pool (see docs/recovery.md "Compat suite 429s").

--- a/test/upstream-api-key.mjs
+++ b/test/upstream-api-key.mjs
@@ -2,8 +2,9 @@
 // Unit test for the ANTHROPIC_UPSTREAM_API_KEY upstream-auth override.
 // When a per-token API key is configured, dario forwards to api.anthropic.com
 // with `x-api-key` (standard API pool) instead of the Pro/Max OAuth bearer —
-// and never with both. Used by the self-hosted compat workflow so it can route
-// the suite THROUGH dario without tripping the subscription pool's ~3/min cap.
+// and never with both. Used by the self-hosted compat workflow to route the
+// suite THROUGH dario on the per-token pool — required because compat runs dario
+// in --passthrough (non-CC), which the Max OAuth pool rejects outright.
 
 import { upstreamAuthHeaders } from '../dist/proxy.js';
 


### PR DESCRIPTION
Follow-up to #462. Corrects the '~3/min cap' misdiagnosis everywhere it remained — `docs/recovery.md` (Compat suite 429s: wrong cause AND outdated fix), `test/compat.mjs` (routing + pacing comments, incl. the stale 'CI default'), `src/proxy.ts` (upstreamApiKey JSDoc), and `test/upstream-api-key.mjs`. Real cause: compat runs dario in `--passthrough` (non-CC-shaped), and the Max OAuth pool **rejects** non-CC traffic outright (`429 Rate limited (rejected)`, the billing classifier) — not a volume cap. The per-token upstream is therefore required. Comments-only, no behavior change. CHANGELOG left as the historical record.