### PR TITLE
feat: Claude Fable 5 integration (v4.8.46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.46] - 2026-06-09
+
+- **Claude Fable 5 support** — full integration of Anthropic's new flagship family across every model-aware seam:
+  - **Adaptive-thinking gate** (`supportsAdaptiveThinking`): `fable` added to both family regexes, so `claude-fable-5` / `claude-fable-5[1m]` get `thinking:{type:"adaptive"}` like real CC sends (the default-deny gate was silently omitting thinking blocks for the whole family).
+  - **Pool routing** (`modelFamily`): `fable` family token recognized, so per-model 7d buckets (`7d_fable`, captured automatically by the generic header parser) actually inform account routing, and `doctor --usage` probes the family (`claude-fable-5` added to the probe matrix).
+  - **Aliases**: `fable` → `claude-fable-5`, `fable1m` → `claude-fable-5[1m]` (Cursor BYOK `claude:fable` shorthand works).
+  - **OpenAI-compat**: `claude-fable-5` + `claude-fable-5[1m]` listed in `/v1/models`.
+  - **Analytics**: pricing entry (assumed at flagship/opus-4-8 rate until official per-token pricing is published — display-only burn-rate). Also fixes a latent bug where `[1m]` model ids (`claude-opus-4-7[1m]`, …) fell through to the sonnet fallback rate — the trailing context tag is now stripped before the pricing lookup.
+  - Effort suffixes (`fable:xhigh`, `claude-fable-5-high`) and the `[1m]` long-context tag already worked family-agnostically; locked in by tests (`adaptive-thinking-gate`, `provider-prefix`, `per-model-buckets`).
+
 ## [4.8.45] - 2026-06-09
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.169` → `2.1.170` for CC v2.1.170. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.
@@ -20,6 +30,7 @@ checklist.
 ## [4.8.43] - 2026-06-08
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.168` → `2.1.169` for CC v2.1.169. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.
+
 ## [4.8.42] - 2026-06-07
 
 - **docs:** adds the README critical-update banner (see #457) — pointing to the pre-4.8.39 silent content-corruption fix and the 4.8.41 prompt-caching win. **No code change from 4.8.41**; this release exists only to surface the banner on the npm package page (npm caches the README from the last publish). Functionally identical to 4.8.41.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.42",
+  "version": "4.8.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "4.8.42",
+      "version": "4.8.46",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.45",
+  "version": "4.8.46",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -83,6 +83,9 @@ export function billingBucketFromClaim(claim: string | null | undefined): Billin
 // Anthropic pricing (per 1M tokens, USD). Not authoritative — used for
 // rough burn-rate display in the /analytics summary.
 const PRICING: Record<string, { input: number; output: number; cacheRead: number; cacheCreate: number }> = {
+  // Fable 5 official per-token pricing wasn't published at integration time
+  // (2026-06-09) — assumed at the current flagship (opus-4-8) rate. Display-only.
+  'claude-fable-5': { input: 5, output: 25, cacheRead: 0.5, cacheCreate: 6.25 },
   'claude-opus-4-8': { input: 5, output: 25, cacheRead: 0.5, cacheCreate: 6.25 },
   'claude-opus-4-7': { input: 5, output: 25, cacheRead: 0.5, cacheCreate: 6.25 },
   'claude-opus-4-6': { input: 15, output: 75, cacheRead: 1.5, cacheCreate: 18.75 },
@@ -91,7 +94,11 @@ const PRICING: Record<string, { input: number; output: number; cacheRead: number
 };
 
 function estimateCost(record: RequestRecord): number {
-  const p = PRICING[record.model] ?? PRICING['claude-sonnet-4-6']!;
+  // Strip a trailing context tag (`claude-fable-5[1m]`, `claude-opus-4-7[1m]`)
+  // before the lookup — the [1m] ids billed at the wrong family's rate before
+  // (fell through to the sonnet fallback).
+  const baseModel = record.model.replace(/\[[^\]]*\]$/, '');
+  const p = PRICING[baseModel] ?? PRICING['claude-sonnet-4-6']!;
   return (
     (record.inputTokens * p.input) +
     (record.outputTokens * p.output) +

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -1095,6 +1095,9 @@ export function resolveEffort(flag: EffortValue | undefined, clientBody: Record<
  *   claude-opus-4-7    ✓ accepts adaptive
  *   claude-opus-4-6    ✓ accepts adaptive
  *   claude-sonnet-4-6  ✓ accepts adaptive
+ *   claude-fable-5     ✓ accepts adaptive (2026-06-09 — Fable 5 is CC's new
+ *                        flagship and real CC sends `thinking:{type:"adaptive"}`
+ *                        on it, incl. the `claude-fable-5[1m]` long-context id)
  *   claude-opus-4-5    ✗ "adaptive thinking is not supported on this model"
  *   claude-sonnet-4-5  ✗ same
  *   claude-haiku-4-5   ✗ same (already gated separately by isHaiku)
@@ -1111,24 +1114,28 @@ export function resolveEffort(flag: EffortValue | undefined, clientBody: Record<
  */
 export function supportsAdaptiveThinking(modelId: string): boolean {
   const m = modelId.toLowerCase();
-  // Opus/Sonnet, major-minor form: opus-4-6+, sonnet-4-6+, opus-5-X, etc.
+  // Opus/Sonnet/Fable, major-minor form: opus-4-6+, sonnet-4-6+, opus-5-X,
+  // fable-5-X, etc. (Fable launched at 5 — there is no fable-4 line — so the
+  // shared "4-6+" threshold is correct for it by construction.)
   //
   // Digit groups are bounded to {1,2} so the dated-suffix pre-4.x line
   // (`claude-3-5-sonnet-20241022`, `claude-3-7-sonnet-20250219`) doesn't
   // accidentally match the date as `sonnet-2024-1022` and parse year as
   // major. Realistic Anthropic version numbers are 1-2 digits.
-  const mm = m.match(/(?:opus|sonnet)-(\d{1,2})-(\d{1,2})\b/);
+  const mm = m.match(/(?:opus|sonnet|fable)-(\d{1,2})-(\d{1,2})\b/);
   if (mm) {
     const major = Number(mm[1]);
     const minor = Number(mm[2]);
-    if (major > 4) return true;                       // any opus-5+ / sonnet-5+
+    if (major > 4) return true;                       // any opus-5+ / sonnet-5+ / fable-5+
     if (major === 4 && minor >= 6) return true;       // 4-6, 4-7, …
     return false;                                     // 4-5 and older
   }
-  // Major-only form (e.g. `opus-5`, `opus-10`). The negative lookahead
-  // prevents matching the `5` in `opus-5-X` (handled above), and the
-  // {1,2} bound prevents matching long dated suffixes.
-  const majorOnly = m.match(/(?:opus|sonnet)-(\d{1,2})(?!\d|-)/);
+  // Major-only form (e.g. `opus-5`, `fable-5`, `opus-10`). The negative
+  // lookahead prevents matching the `5` in `opus-5-X` (handled above), and
+  // the {1,2} bound prevents matching long dated suffixes. A trailing
+  // context tag (`claude-fable-5[1m]`) is fine: `[` is neither digit nor
+  // hyphen, so the lookahead passes.
+  const majorOnly = m.match(/(?:opus|sonnet|fable)-(\d{1,2})(?!\d|-)/);
   if (majorOnly && Number(majorOnly[1]) >= 5) return true;
   return false;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1199,8 +1199,9 @@ async function help() {
 
   Proxy options:
     --model=MODEL            Force a model for all requests
-                             Shortcuts: opus, sonnet, haiku
-                             Full IDs: claude-opus-4-6, claude-sonnet-4-6
+                             Shortcuts: fable, fable1m, opus, sonnet, haiku
+                             Full IDs: claude-fable-5, claude-opus-4-8,
+                             claude-sonnet-4-6 (append [1m] for 1M context)
                              Provider prefix: openai:gpt-4o, groq:llama-3.3-70b,
                              claude:opus, local:qwen-coder (forces backend)
                              Default: passthrough (client decides)
@@ -1490,7 +1491,7 @@ async function help() {
     curl http://localhost:3456/v1/messages \\
       -H "Content-Type: application/json" \\
       -H "anthropic-version: 2023-06-01" \\
-      -d '{"model":"claude-opus-4-6","max_tokens":1024,"messages":[{"role":"user","content":"Hello"}]}'
+      -d '{"model":"claude-fable-5","max_tokens":1024,"messages":[{"role":"user","content":"Hello"}]}'
 
   Your subscription handles the billing. No API key needed.
   Tokens auto-refresh in the background — set it and forget it.

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -572,6 +572,7 @@ export async function runChecks(opts: RunChecksOptions = {}): Promise<Check[]> {
         { family: 'haiku',  model: 'claude-haiku-4-5' },
         { family: 'sonnet', model: 'claude-sonnet-4-6' },
         { family: 'opus',   model: 'claude-opus-4-8' },
+        { family: 'fable',  model: 'claude-fable-5' },
       ];
       const probe = async (model: string) => {
         const res = await fetch(probeEndpoint, {

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -171,15 +171,18 @@ export function parseRateLimits(headers: Headers): RateLimitSnapshot {
 }
 
 /**
- * Extract the model family (`opus` / `sonnet` / `haiku`) from a request's
- * model id. Used to look up the per-model 7d bucket in
+ * Extract the model family (`opus` / `sonnet` / `haiku` / `fable`) from a
+ * request's model id. Used to look up the per-model 7d bucket in
  * `RateLimitSnapshot.perModel7d` during routing decisions. Returns null
  * for non-Claude models or model ids that don't carry a recognizable
  * family token (those requests just use the unified buckets).
  *
  * Generous on input shape: matches `claude-opus-4-7`, `opus`, `claude-3-7-sonnet-…`,
- * `claude-haiku-4-5`, anything containing the family token. Lowercase-normalized
- * so it pairs cleanly with `parseRateLimits`'s lowercase family keys.
+ * `claude-haiku-4-5`, `claude-fable-5[1m]`, anything containing the family token.
+ * Lowercase-normalized so it pairs cleanly with `parseRateLimits`'s lowercase
+ * family keys (the header parser is generic on `7d_<family>`, so a `7d_fable`
+ * bucket is captured automatically the moment Anthropic starts emitting it —
+ * this function is what lets routing USE it).
  */
 export function modelFamily(modelId: string | null | undefined): string | null {
   if (!modelId) return null;
@@ -187,6 +190,7 @@ export function modelFamily(modelId: string | null | undefined): string | null {
   if (m.includes('opus')) return 'opus';
   if (m.includes('sonnet')) return 'sonnet';
   if (m.includes('haiku')) return 'haiku';
+  if (m.includes('fable')) return 'fable';
   return null;
 }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -132,6 +132,8 @@ function loadClaudeIdentity(): { deviceId: string; accountUuid: string } {
 
 // Model shortcuts — users can pass short names
 const MODEL_ALIASES: Record<string, string> = {
+  'fable': 'claude-fable-5',
+  'fable1m': 'claude-fable-5[1m]',
   'opus': 'claude-opus-4-8',
   'opus47': 'claude-opus-4-7',
   'opus46': 'claude-opus-4-6',
@@ -373,7 +375,7 @@ function translateStreamChunk(line: string): string | null {
   return null;
 }
 
-const OPENAI_MODELS_LIST = { object: 'list', data: ['claude-opus-4-8', 'claude-opus-4-7', 'claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5'].map(id => ({ id, object: 'model', created: 1700000000, owned_by: 'anthropic' })) };
+const OPENAI_MODELS_LIST = { object: 'list', data: ['claude-fable-5', 'claude-fable-5[1m]', 'claude-opus-4-8', 'claude-opus-4-7', 'claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5'].map(id => ({ id, object: 'model', created: 1700000000, owned_by: 'anthropic' })) };
 
 interface ProxyOptions {
   port?: number;

--- a/test/adaptive-thinking-gate.mjs
+++ b/test/adaptive-thinking-gate.mjs
@@ -37,6 +37,8 @@ const adaptiveYes = [
   'claude-opus-4-7',
   'claude-opus-4-6',
   'claude-sonnet-4-6',
+  'claude-fable-5',            // Fable 5 flagship (2026-06) — CC sends adaptive on it
+  'claude-fable-5[1m]',        // long-context id; `[` must not break the major-only match
 ];
 // Models that empirically 400 on adaptive thinking
 const adaptiveNo = [
@@ -72,6 +74,10 @@ check('claude-opus-10 → true',   supportsAdaptiveThinking('claude-opus-10') ==
 // Future Sonnet 5+
 check('claude-sonnet-5 → true',   supportsAdaptiveThinking('claude-sonnet-5') === true);
 check('claude-sonnet-5-0 → true', supportsAdaptiveThinking('claude-sonnet-5-0') === true);
+
+// Fable family (launched at 5 — no fable-4 line exists)
+check('claude-fable-5-1 → true',  supportsAdaptiveThinking('claude-fable-5-1') === true);
+check('claude-fable-6 → true',    supportsAdaptiveThinking('claude-fable-6') === true);
 
 // Default-deny on unrecognized shapes — never returns true for nonsense
 check('empty string → false',    supportsAdaptiveThinking('') === false);

--- a/test/per-model-buckets.mjs
+++ b/test/per-model-buckets.mjs
@@ -187,6 +187,8 @@ header('modelFamily — extracts family token from common model ids');
   check('opus 4.7 → opus',         modelFamily('claude-opus-4-7') === 'opus');
   check('sonnet 4.6 → sonnet',     modelFamily('claude-sonnet-4-6') === 'sonnet');
   check('haiku 4.5 → haiku',       modelFamily('claude-haiku-4-5') === 'haiku');
+  check('fable 5 → fable',         modelFamily('claude-fable-5') === 'fable');
+  check('fable 5 [1m] → fable',    modelFamily('claude-fable-5[1m]') === 'fable');
   check('alias "opus" → opus',     modelFamily('opus') === 'opus');
   check('uppercase OK',            modelFamily('CLAUDE-SONNET-4-6') === 'sonnet');
   check('legacy 3-7-sonnet → sonnet', modelFamily('claude-3-7-sonnet-20250219') === 'sonnet');

--- a/test/provider-prefix.mjs
+++ b/test/provider-prefix.mjs
@@ -64,6 +64,8 @@ console.log('\n=================================================================
 console.log('  resolveClaudeAlias — request-time alias resolution (dario#190)');
 console.log('======================================================================');
 
+assert(resolveClaudeAlias('fable') === 'claude-fable-5', 'fable → claude-fable-5 (flagship)');
+assert(resolveClaudeAlias('fable1m') === 'claude-fable-5[1m]', 'fable1m → claude-fable-5[1m]');
 assert(resolveClaudeAlias('opus') === 'claude-opus-4-8', 'opus → claude-opus-4-8 (latest)');
 assert(resolveClaudeAlias('opus47') === 'claude-opus-4-7', 'opus47 → claude-opus-4-7 (legacy-pin alias)');
 assert(resolveClaudeAlias('opus46') === 'claude-opus-4-6', 'opus46 → claude-opus-4-6 (legacy-pin alias)');


### PR DESCRIPTION
Full integration of Anthropic's new flagship family across every model-aware seam in dario.

- **Adaptive-thinking gate** (`supportsAdaptiveThinking`): `fable` added to both family regexes — `claude-fable-5` / `claude-fable-5[1m]` now get `thinking:{type:"adaptive"}` like real CC sends. Without this the default-deny gate silently omitted thinking blocks for the whole family (by design — that's the gate's safe failure mode, and this is the allow-list update it anticipated).
- **Pool routing** (`modelFamily`): `fable` family token recognized — per-model 7d buckets (`7d_fable`, already captured by the generic header parser) now actually inform account routing.
- **Doctor**: `claude-fable-5` added to the `--usage` per-family probe matrix.
- **Aliases**: `fable` → `claude-fable-5`, `fable1m` → `claude-fable-5[1m]` (Cursor BYOK `claude:fable` shorthand works).
- **OpenAI-compat**: both fable ids listed in `/v1/models`.
- **Analytics**: pricing entry (assumed at flagship/opus-4-8 rate until official pricing is published — display-only). Also fixes a latent bug: `[1m]` ids (`claude-opus-4-7[1m]`, …) fell through to the **sonnet** fallback rate; the trailing context tag is now stripped before the lookup.
- **Docs**: `--model` help + curl example updated.

Effort suffixes (`fable:xhigh`, `claude-fable-5-high`) and the `[1m]` tag + context-1m auto-retry already worked family-agnostically — locked in by tests.

**Tests**: `adaptive-thinking-gate`, `provider-prefix`, `per-model-buckets` extended with fable cases. Full suite: **81/81 files green** on the rebased tree. Build clean; package-lock resynced.

**Release**: v4.8.46 (rebased over the bot releases 4.8.43–4.8.45 that landed mid-flight) — merging fires auto-release (npm + GHCR), and the box's autodeploy timer rolls it to the fleet within ~15m.