### PR TITLE
fix: fable-5 soft-refusal — fallback-credit beta + per-family effort default (v4.8.47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.47] - 2026-06-09
+
+- **Fable 5 actually answers now (fixes the 100%-refusal gate that 4.8.46 left).** Post-4.8.46 live verification on the deployed proxy: `claude-fable-5` requests returned 200 with `stop_reason: "refusal"` and empty content on EVERY prompt (even "what is 2+2"), while opus/sonnet through the same proxy answered normally. Live captures of real CC v2.1.170 (capture-full-body, fable vs opus from the same binary/account) isolated two fable-only wire deltas, both now mirrored:
+  - **`fallback-credit-2026-06-01` beta** — real CC appends it on fable requests only; subscription traffic on fable without it is soft-refused upstream. New `betaForModel()` appends it model-conditionally at the proxy seam (other families' beta set byte-identical to before; client-supplied and operator-pinned betas unaffected). Unit-tested in `test/fable-beta.mjs`.
+  - **Effort default `high` on fable** — CC's print-mode default for fable is `high` (`xhigh` on opus in the same capture). `resolveEffort()` gains a model param: unset-flag default is now `high` for fable, still `max` for everything else; explicit `--effort` / `DARIO_EFFORT` / `client` mode pin exactly as before.
+
 ## [4.8.46] - 2026-06-09
 
 - **Claude Fable 5 support** — full integration of Anthropic's new flagship family across every model-aware seam:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.46",
+  "version": "4.8.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "4.8.46",
+      "version": "4.8.47",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.46",
+  "version": "4.8.47",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -1068,20 +1068,27 @@ function normalizeEffortForWire(effort: string): string {
  *               accepted by all and still routes to the subscription pool
  *               (verified: representative-claim=five_hour on Opus + Sonnet).
  *               Set --effort=xhigh / DARIO_EFFORT=xhigh for Opus's extra tier.)
+ *               EXCEPT fable: real CC's print-mode default for fable is
+ *               'high' (live capture 2026-06-09, CC v2.1.170 — the same
+ *               capture got 'xhigh' on opus and 'high' on fable), so the
+ *               unset-flag default mirrors that per-family. An explicit
+ *               flag still pins.
  *   'low' / 'medium' / 'high' / 'xhigh' / 'max' → pin to that value
  *   'ultracode' → 'xhigh' (CC's ultracode mode; xhigh on the wire)
  *   'client' → extract from `clientBody.output_config.effort` (normalized
- *              for the wire); fall back to 'max' if absent/non-string
+ *              for the wire); fall back to the per-family default if
+ *              absent/non-string
  *
  * Exported for tests.
  */
-export function resolveEffort(flag: EffortValue | undefined, clientBody: Record<string, unknown>): string {
-  if (flag === undefined) return 'max';
+export function resolveEffort(flag: EffortValue | undefined, clientBody: Record<string, unknown>, model?: string): string {
+  const familyDefault = (model ?? '').toLowerCase().includes('fable') ? 'high' : 'max';
+  if (flag === undefined) return familyDefault;
   if (flag === 'client') {
     const clientOC = clientBody.output_config as { effort?: unknown } | undefined;
     const clientEffort = clientOC?.effort;
     if (typeof clientEffort === 'string' && clientEffort.length > 0) return normalizeEffortForWire(clientEffort);
-    return 'max';
+    return familyDefault;
   }
   return normalizeEffortForWire(flag);
 }
@@ -1580,7 +1587,7 @@ export function buildCCRequest(
       }
     }
     if (!skip || !skip.has('output_config')) {
-      ccRequest.output_config = { effort: resolveEffort(opts.effort, clientBody) };
+      ccRequest.output_config = { effort: resolveEffort(opts.effort, clientBody, model) };
     }
   }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -199,6 +199,23 @@ function filterBillableBetas(betas: string): string {
   ).join(',');
 }
 
+/**
+ * Fable-5 (2026-06) — real CC appends `fallback-credit-2026-06-01` to the
+ * beta set on fable requests ONLY (live captures 2026-06-09, CC v2.1.170:
+ * the fable request carries it, the opus request does not). Subscription
+ * traffic on fable WITHOUT it is soft-refused upstream — every request
+ * returns 200 with `stop_reason: "refusal"` and empty content, while the
+ * same request on opus/sonnet answers normally. Mirror CC exactly: append
+ * for the fable family, leave every other family's set untouched.
+ * Exported for tests.
+ */
+export const FABLE_FALLBACK_CREDIT_BETA = 'fallback-credit-2026-06-01';
+export function betaForModel(base: string, model: string | null | undefined): string {
+  if (!model || !model.toLowerCase().includes('fable')) return base;
+  if (base.split(',').includes(FABLE_FALLBACK_CREDIT_BETA)) return base;
+  return base ? `${base},${FABLE_FALLBACK_CREDIT_BETA}` : FABLE_FALLBACK_CREDIT_BETA;
+}
+
 // Orchestration tags injected by agents (Aider, Cursor, OpenCode, etc.)
 // that confuse Claude when passed through. Strip before forwarding.
 export const ORCHESTRATION_TAG_NAMES = [
@@ -1803,7 +1820,9 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
         // skip context-1m entirely (dario#36).
         const acctKey = poolAccount?.alias ?? ACCOUNT_KEY_SINGLE;
         const skipContext1m = context1mUnavailable.has(acctKey);
-        beta = skipContext1m ? betaWithoutContext1m : betaBase;
+        // Fable requires its fallback-credit beta or upstream soft-refuses
+        // every request (see betaForModel) — model-conditional, like real CC.
+        beta = betaForModel(skipContext1m ? betaWithoutContext1m : betaBase, requestModel);
         if (clientBeta) {
           const baseSet = new Set(beta.split(','));
           const filtered = filterBillableBetas(clientBeta)

--- a/test/effort-flag.mjs
+++ b/test/effort-flag.mjs
@@ -40,6 +40,20 @@ header('resolveEffort — explicit values pin');
   check('max → max', resolveEffort('max', {}) === 'max');
 }
 
+header('resolveEffort — fable per-family default (live capture 2026-06-09)');
+{
+  // Real CC's print-mode default for fable is 'high' (opus got 'xhigh' in the
+  // same capture); the unset-flag default mirrors that per-family.
+  check('undefined + fable → high', resolveEffort(undefined, {}, 'claude-fable-5') === 'high');
+  check('undefined + fable[1m] → high', resolveEffort(undefined, {}, 'claude-fable-5[1m]') === 'high');
+  check('undefined + opus → max (unchanged)', resolveEffort(undefined, {}, 'claude-opus-4-8') === 'max');
+  check('explicit flag still pins on fable', resolveEffort('xhigh', {}, 'claude-fable-5') === 'xhigh');
+  check('client + fable, no client effort → high fallback',
+    resolveEffort('client', {}, 'claude-fable-5') === 'high');
+  check('client + fable, client effort wins',
+    resolveEffort('client', { output_config: { effort: 'low' } }, 'claude-fable-5') === 'low');
+}
+
 header('resolveEffort — client passthrough');
 {
   check('client, no output_config → max fallback',

--- a/test/fable-beta.mjs
+++ b/test/fable-beta.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// betaForModel — fable-conditional `fallback-credit-2026-06-01` beta.
+//
+// Live captures (2026-06-09, CC v2.1.170): real CC appends
+// `fallback-credit-2026-06-01` to the anthropic-beta set on FABLE requests
+// only — the opus request from the same binary/account does not carry it.
+// Subscription traffic on fable without the flag is soft-refused upstream:
+// every request returns 200 with stop_reason "refusal" and empty content,
+// while opus/sonnet answer normally (isolated on the live proxy 2026-06-09).
+// dario therefore mirrors CC: append for the fable family, never for others.
+
+import { betaForModel, FABLE_FALLBACK_CREDIT_BETA } from '../dist/proxy.js';
+
+let pass = 0;
+let fail = 0;
+function check(name, cond) {
+  if (cond) { pass++; console.log(`  ✓ ${name}`); }
+  else { fail++; console.log(`  ✗ ${name}`); }
+}
+
+const BASE = 'claude-code-20250219,context-1m-2025-08-07,effort-2025-11-24';
+
+console.log('\n=== betaForModel — fable gets the fallback-credit beta ===');
+check('fable full id → appended',
+  betaForModel(BASE, 'claude-fable-5') === `${BASE},${FABLE_FALLBACK_CREDIT_BETA}`);
+check('fable [1m] id → appended',
+  betaForModel(BASE, 'claude-fable-5[1m]') === `${BASE},${FABLE_FALLBACK_CREDIT_BETA}`);
+check('uppercase model → appended',
+  betaForModel(BASE, 'CLAUDE-FABLE-5') === `${BASE},${FABLE_FALLBACK_CREDIT_BETA}`);
+check('already present → unchanged (no dup)',
+  betaForModel(`${BASE},${FABLE_FALLBACK_CREDIT_BETA}`, 'claude-fable-5') === `${BASE},${FABLE_FALLBACK_CREDIT_BETA}`);
+check('empty base + fable → just the flag',
+  betaForModel('', 'claude-fable-5') === FABLE_FALLBACK_CREDIT_BETA);
+
+console.log('\n=== betaForModel — every other family untouched ===');
+check('opus → unchanged',   betaForModel(BASE, 'claude-opus-4-8') === BASE);
+check('sonnet → unchanged', betaForModel(BASE, 'claude-sonnet-4-6') === BASE);
+check('haiku → unchanged',  betaForModel(BASE, 'claude-haiku-4-5') === BASE);
+check('empty model → unchanged', betaForModel(BASE, '') === BASE);
+check('null model → unchanged',  betaForModel(BASE, null) === BASE);
+check('undefined model → unchanged', betaForModel(BASE, undefined) === BASE);
+
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
**Follow-up to #469 — fable-5 routed but refused everything; this makes it actually answer.**

Post-4.8.46 live verification on the deployed proxy: `claude-fable-5` returned 200 + `stop_reason: "refusal"` + empty content on EVERY prompt (even "what is 2+2"), while opus/sonnet through the same proxy answered normally — clean isolation to fable-specific wire shape.

Live captures of real CC v2.1.170 (`capture-full-body.mjs`, fable vs opus from the same binary/account) found exactly two fable-only deltas, both now mirrored:

1. **`fallback-credit-2026-06-01` beta** — real CC appends it on fable requests ONLY (opus capture lacks it). New `betaForModel()` appends it model-conditionally at the proxy beta seam. Other families' beta set stays byte-identical; client-supplied + operator-pinned betas unaffected. Unit-tested (`test/fable-beta.mjs`).
2. **Effort default `high` on fable** — CC's print-mode default for fable is `high` (`xhigh` on opus in the same capture). `resolveEffort()` gains an optional model param: unset-flag default `high` for fable, still `max` for everything else. Explicit `--effort`/`DARIO_EFFORT`/`client` pin exactly as before.

Capture-first discipline observed: inspected via capture-full-body before changing anything.

**Tests**: 82/82 files green (new `fable-beta.mjs`; `effort-flag.mjs` extended). Build clean; lock resynced.

**Release**: v4.8.47 — auto-release on merge; box autodeploy follows. Will live-verify fable answers post-deploy.