### PR TITLE
fix: fable effort clamp — max/xhigh → high (v4.8.48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.48] - 2026-06-09
+
+- **Fable effort clamp — `max`/`xhigh` → `high` on the fable family (the actual fix for the fable refusal; 4.8.47 was necessary but not sufficient).** Live replay bisect on the deployed proxy (real-CC-captured fable request body replayed through passthrough, one field mutated at a time): fable-5 **soft-refuses `effort: max` and `effort: xhigh`** — 200 with `stop_reason: "refusal"` and empty content, not a 400 — while `high` answers normally; the stale billing-tag version and stripped tools were ruled out as causes. 4.8.47's per-family *default* never engaged on deployments that pin `--effort`/`DARIO_EFFORT` (the documented `max` recommendation, which most fleets use), so every pinned deployment still refused. `resolveEffort` now clamps any resolved `max`/`xhigh` to `high` on fable only — pins, `ultracode`, and `client`-mode passthrough included; every other family keeps the pinned value untouched.
+
 ## [4.8.47] - 2026-06-09
 
 - **Fable 5 actually answers now (fixes the 100%-refusal gate that 4.8.46 left).** Post-4.8.46 live verification on the deployed proxy: `claude-fable-5` requests returned 200 with `stop_reason: "refusal"` and empty content on EVERY prompt (even "what is 2+2"), while opus/sonnet through the same proxy answered normally. Live captures of real CC v2.1.170 (capture-full-body, fable vs opus from the same binary/account) isolated two fable-only wire deltas, both now mirrored:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.47",
+  "version": "4.8.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "4.8.47",
+      "version": "4.8.48",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.47",
+  "version": "4.8.48",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -1072,25 +1072,39 @@ function normalizeEffortForWire(effort: string): string {
  *               'high' (live capture 2026-06-09, CC v2.1.170 — the same
  *               capture got 'xhigh' on opus and 'high' on fable), so the
  *               unset-flag default mirrors that per-family. An explicit
- *               flag still pins.
+ *               flag still pins (subject to the fable clamp below).
  *   'low' / 'medium' / 'high' / 'xhigh' / 'max' → pin to that value
  *   'ultracode' → 'xhigh' (CC's ultracode mode; xhigh on the wire)
  *   'client' → extract from `clientBody.output_config.effort` (normalized
  *              for the wire); fall back to the per-family default if
  *              absent/non-string
  *
+ * FABLE CLAMP (2026-06-09, live replay bisect on the deployed proxy):
+ * fable-5 SOFT-REFUSES `max` and `xhigh` — 200 with stop_reason "refusal"
+ * and empty content on every prompt, not a 400 — while `high` answers
+ * normally (byte-identical request bodies, only output_config.effort
+ * mutated). Empirical matrix on claude-fable-5:
+ *   high  → answers      xhigh → refusal      max → refusal
+ * So on the fable family any resolved 'max'/'xhigh' (from --effort /
+ * DARIO_EFFORT pins, ultracode, or client passthrough) is clamped to
+ * 'high', the strongest level fable accepts. Operators who pin
+ * --effort=max for Opus's sake keep that on every other family.
+ *
  * Exported for tests.
  */
 export function resolveEffort(flag: EffortValue | undefined, clientBody: Record<string, unknown>, model?: string): string {
-  const familyDefault = (model ?? '').toLowerCase().includes('fable') ? 'high' : 'max';
+  const isFable = (model ?? '').toLowerCase().includes('fable');
+  const familyDefault = isFable ? 'high' : 'max';
+  const clamp = (effort: string): string =>
+    isFable && (effort === 'max' || effort === 'xhigh') ? 'high' : effort;
   if (flag === undefined) return familyDefault;
   if (flag === 'client') {
     const clientOC = clientBody.output_config as { effort?: unknown } | undefined;
     const clientEffort = clientOC?.effort;
-    if (typeof clientEffort === 'string' && clientEffort.length > 0) return normalizeEffortForWire(clientEffort);
+    if (typeof clientEffort === 'string' && clientEffort.length > 0) return clamp(normalizeEffortForWire(clientEffort));
     return familyDefault;
   }
-  return normalizeEffortForWire(flag);
+  return clamp(normalizeEffortForWire(flag));
 }
 
 /**

--- a/test/effort-flag.mjs
+++ b/test/effort-flag.mjs
@@ -47,11 +47,28 @@ header('resolveEffort — fable per-family default (live capture 2026-06-09)');
   check('undefined + fable → high', resolveEffort(undefined, {}, 'claude-fable-5') === 'high');
   check('undefined + fable[1m] → high', resolveEffort(undefined, {}, 'claude-fable-5[1m]') === 'high');
   check('undefined + opus → max (unchanged)', resolveEffort(undefined, {}, 'claude-opus-4-8') === 'max');
-  check('explicit flag still pins on fable', resolveEffort('xhigh', {}, 'claude-fable-5') === 'xhigh');
   check('client + fable, no client effort → high fallback',
     resolveEffort('client', {}, 'claude-fable-5') === 'high');
   check('client + fable, client effort wins',
     resolveEffort('client', { output_config: { effort: 'low' } }, 'claude-fable-5') === 'low');
+}
+
+header('resolveEffort — fable clamp (max/xhigh soft-refused; replay bisect 2026-06-09)');
+{
+  // fable-5 soft-refuses max + xhigh (200 + stop_reason "refusal", empty
+  // content) but answers on high — byte-identical bodies, only effort mutated.
+  check('max flag + fable → clamped to high', resolveEffort('max', {}, 'claude-fable-5') === 'high');
+  check('xhigh flag + fable → clamped to high', resolveEffort('xhigh', {}, 'claude-fable-5') === 'high');
+  check('ultracode + fable → clamped to high', resolveEffort('ultracode', {}, 'claude-fable-5') === 'high');
+  check('high flag + fable → high (untouched)', resolveEffort('high', {}, 'claude-fable-5') === 'high');
+  check('low flag + fable → low (untouched)', resolveEffort('low', {}, 'claude-fable-5') === 'low');
+  check('client max + fable → clamped to high',
+    resolveEffort('client', { output_config: { effort: 'max' } }, 'claude-fable-5') === 'high');
+  check('client xhigh + fable → clamped to high',
+    resolveEffort('client', { output_config: { effort: 'xhigh' } }, 'claude-fable-5') === 'high');
+  check('max flag + opus → max (clamp is fable-only)', resolveEffort('max', {}, 'claude-opus-4-8') === 'max');
+  check('xhigh flag + opus → xhigh (clamp is fable-only)', resolveEffort('xhigh', {}, 'claude-opus-4-8') === 'xhigh');
+  check('max flag + no model → max (clamp needs fable)', resolveEffort('max', {}) === 'max');
 }
 
 header('resolveEffort — client passthrough');


### PR DESCRIPTION
**The actual fix for the fable-5 refusal. #470 was necessary (fallback-credit beta) but not sufficient.**

Live replay bisect on the deployed proxy — a real-CC-captured fable request body replayed through dario passthrough (same OAuth/account), one field mutated per run:

| variant | result |
|---|---|
| control (exact CC body) | ✅ answers |
| dario's stale billing block | ✅ answers |
| tools stripped | ✅ answers |
| **effort: max** | ❌ **refusal** |
| **effort: xhigh** | ❌ **refusal** |
| effort: high | ✅ answers |

fable-5 **soft-refuses `max`/`xhigh`** — 200 + `stop_reason: "refusal"` + empty content, not a 400, so dario's existing invalid-effort handling never saw it.

#470's per-family *default* never engages on deployments that pin `--effort`/`DARIO_EFFORT` (the documented `max` recommendation — which is exactly what the fleet box pins), so pinned deployments kept refusing. `resolveEffort` now **clamps any resolved `max`/`xhigh` to `high` on the fable family only** — covers pins, `ultracode`, and `client`-mode passthrough; every other family keeps pinned values untouched.

**Tests**: clamp matrix added to `effort-flag.mjs` (10 new cases incl. fable-only scoping). Full suite green. Build clean.

**Release**: v4.8.48 — auto-release on merge; box autodeploy follows. Will live-verify fable answers through the deployed (effort-pinned) proxy post-deploy.