### PR TITLE
fix: [1m] model ids — strip the client-side tag (v4.8.49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.49] - 2026-06-09
+
+- **`[1m]` model ids work now — they 404'd upstream on every family.** Live capture (CC v2.1.170, `--model 'claude-fable-5[1m]'`): the `[1m]` form is a client-side LABEL — real CC puts the **base** model id on the wire and adds the `context-1m-2025-08-07` beta; the literal `X[1m]` id is not a valid wire model (`not_found_error: model: claude-sonnet-4-6[1m]`). dario forwarded it verbatim, so `opus1m`/`sonnet1m`/`fable1m` aliases (and any client passing an `[1m]` id) always 404'd. New `stripContext1mTag()` strips the tag at the template seam; the context-1m beta is already in the template beta set, and the existing long-context billing auto-retry (dario#36) still governs accounts without Extra Usage — on those, requests gracefully run at the standard window. Family-aware logic (per-model buckets, fable beta/effort) keeps seeing the user's `[1m]` intent.
+
 ## [4.8.48] - 2026-06-09
 
 - **Fable effort clamp — `max`/`xhigh` → `high` on the fable family (the actual fix for the fable refusal; 4.8.47 was necessary but not sufficient).** Live replay bisect on the deployed proxy (real-CC-captured fable request body replayed through passthrough, one field mutated at a time): fable-5 **soft-refuses `effort: max` and `effort: xhigh`** — 200 with `stop_reason: "refusal"` and empty content, not a 400 — while `high` answers normally; the stale billing-tag version and stripped tools were ruled out as causes. 4.8.47's per-family *default* never engaged on deployments that pin `--effort`/`DARIO_EFFORT` (the documented `max` recommendation, which most fleets use), so every pinned deployment still refused. `resolveEffort` now clamps any resolved `max`/`xhigh` to `high` on fable only — pins, `ultracode`, and `client`-mode passthrough included; every other family keeps the pinned value untouched.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.48",
+  "version": "4.8.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "4.8.48",
+      "version": "4.8.49",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.48",
+  "version": "4.8.49",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -216,6 +216,18 @@ export function betaForModel(base: string, model: string | null | undefined): st
   return base ? `${base},${FABLE_FALLBACK_CREDIT_BETA}` : FABLE_FALLBACK_CREDIT_BETA;
 }
 
+/**
+ * Strip a trailing `[1m]` long-context tag from a model id. The tag is a
+ * client-side label: real CC sends the BASE id + `context-1m-2025-08-07`
+ * beta on the wire (live capture 2026-06-09, CC v2.1.170) — the literal
+ * `X[1m]` id 404s upstream on every family. Case-insensitive, only at the
+ * very end of the id. Exported for tests.
+ */
+export function stripContext1mTag(model: string): string {
+  if (typeof model !== 'string') return model;
+  return model.replace(/\[1m\]$/i, '');
+}
+
 // Orchestration tags injected by agents (Aider, Cursor, OpenCode, etc.)
 // that confuse Claude when passed through. Strip before forwarding.
 export const ORCHESTRATION_TAG_NAMES = [
@@ -1779,6 +1791,18 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
             // Replace request body entirely with CC template
             for (const key of Object.keys(r)) delete r[key];
             Object.assign(r, ccBody);
+
+            // `X[1m]` is a client-side LABEL, never a valid wire id — real CC
+            // sends the BASE model id plus the `context-1m-2025-08-07` beta
+            // (live capture 2026-06-09, CC v2.1.170 with --model
+            // 'claude-fable-5[1m]': wire model was 'claude-fable-5').
+            // Forwarding the literal `[1m]` id upstream 404s ("model: …[1m]"
+            // not_found) on every family. Strip it here; the context-1m beta
+            // is already in the template beta set (and the existing
+            // long-context billing auto-retry still governs accounts that
+            // can't use it). requestModel keeps the [1m] form so model-aware
+            // logic (family buckets, fable beta/effort) sees the user intent.
+            r.model = stripContext1mTag(r.model as string);
           }
           finalBody = Buffer.from(JSON.stringify(r));
         } catch { /* not JSON, send as-is */ }

--- a/test/fable-beta.mjs
+++ b/test/fable-beta.mjs
@@ -9,7 +9,7 @@
 // while opus/sonnet answer normally (isolated on the live proxy 2026-06-09).
 // dario therefore mirrors CC: append for the fable family, never for others.
 
-import { betaForModel, FABLE_FALLBACK_CREDIT_BETA } from '../dist/proxy.js';
+import { betaForModel, FABLE_FALLBACK_CREDIT_BETA, stripContext1mTag } from '../dist/proxy.js';
 
 let pass = 0;
 let fail = 0;
@@ -39,6 +39,16 @@ check('haiku → unchanged',  betaForModel(BASE, 'claude-haiku-4-5') === BASE);
 check('empty model → unchanged', betaForModel(BASE, '') === BASE);
 check('null model → unchanged',  betaForModel(BASE, null) === BASE);
 check('undefined model → unchanged', betaForModel(BASE, undefined) === BASE);
+
+console.log('\n=== stripContext1mTag — [1m] is a label, never a wire id ===');
+// Real CC sends base id + context-1m beta for `X[1m]` (capture 2026-06-09);
+// the literal [1m] id 404s upstream on every family.
+check('fable[1m] → base id',  stripContext1mTag('claude-fable-5[1m]') === 'claude-fable-5');
+check('sonnet[1m] → base id', stripContext1mTag('claude-sonnet-4-6[1m]') === 'claude-sonnet-4-6');
+check('opus[1m] → base id',   stripContext1mTag('claude-opus-4-7[1m]') === 'claude-opus-4-7');
+check('uppercase tag → stripped', stripContext1mTag('claude-fable-5[1M]') === 'claude-fable-5');
+check('no tag → unchanged',   stripContext1mTag('claude-fable-5') === 'claude-fable-5');
+check('tag mid-string → unchanged (end-anchored)', stripContext1mTag('claude-[1m]-x') === 'claude-[1m]-x');
 
 console.log(`\n${pass} pass, ${fail} fail`);
 process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
**`[1m]` ids never worked through dario — on any family.** `claude-fable-5[1m]`, `claude-sonnet-4-6[1m]`, the `opus1m`/`sonnet1m`/`fable1m` aliases — all 404'd upstream (`not_found_error: model: …[1m]`).

Live capture (CC v2.1.170, `--model 'claude-fable-5[1m]'`) shows why: **the `[1m]` form is a client-side label.** Real CC puts the **base** model id on the wire (`claude-fable-5`) and adds the `context-1m-2025-08-07` beta. The literal `X[1m]` string is not a valid wire model. dario forwarded it verbatim.

Fix: `stripContext1mTag()` strips the trailing tag at the template seam (end-anchored, case-insensitive). The context-1m beta is already in the template beta set, and the existing long-context billing auto-retry (dario#36) still governs subscription accounts without Extra Usage — those gracefully run at the standard window instead of erroring. `requestModel` keeps the `[1m]` form so family-aware logic (per-model buckets, fable beta + effort clamp) sees user intent. Passthrough mode stays untouched by contract.

**Tests**: 6 strip cases added (`fable-beta.mjs`). Full suite **82/82 green**. Will live-verify `fable1m`/`sonnet1m`/`opus1m` through the deployed proxy post-deploy.