### PR TITLE
fix: fable tool-less multi-turn refusal — CC tools + tool_choice none (v4.8.50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.50] - 2026-06-09
+
+- **Fable multi-turn chat works for tool-less clients (OpenAI-compat, plain Messages chat).** Replay bisect on the deployed proxy: fable soft-refuses CC-shaped requests that combine **zero tools + an assistant turn in history** (200 + `stop_reason: "refusal"`, empty content — deterministic), while the byte-identical body WITH CC's tool array answers; single-turn and tool-carrying requests were never affected. Real CC always sends its tool array, so zero-tools was already a fingerprint divergence (the `--merge-tools` docs note as much) — fable is just the first model to punish it. Fix: tool-less requests on the fable family now emit the CC base tool array pinned with `tool_choice: {type: "none"}` so the model cannot call tools the client never declared (verified necessary: without the pin it emits a spurious WebFetch `tool_use` on a weather question). Other families keep the legacy tool-less shape. Client-supplied tools behave exactly as before.
+
 ## [4.8.49] - 2026-06-09
 
 - **`[1m]` model ids work now — they 404'd upstream on every family.** Live capture (CC v2.1.170, `--model 'claude-fable-5[1m]'`): the `[1m]` form is a client-side LABEL — real CC puts the **base** model id on the wire and adds the `context-1m-2025-08-07` beta; the literal `X[1m]` id is not a valid wire model (`not_found_error: model: claude-sonnet-4-6[1m]`). dario forwarded it verbatim, so `opus1m`/`sonnet1m`/`fable1m` aliases (and any client passing an `[1m]` id) always 404'd. New `stripContext1mTag()` strips the tag at the template seam; the context-1m beta is already in the template beta set, and the existing long-context billing auto-retry (dario#36) still governs accounts without Extra Usage — on those, requests gracefully run at the standard window. Family-aware logic (per-model buckets, fable beta/effort) keeps seeing the user's `[1m]` intent.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.49",
+  "version": "4.8.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "4.8.49",
+      "version": "4.8.50",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.49",
+  "version": "4.8.50",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -1525,6 +1525,20 @@ export function buildCCRequest(
     // (zero-tools requests are themselves a divergence from CC's
     // wire footprint).
     ccRequest.tools = CC_TOOL_DEFINITIONS;
+  } else if (model.toLowerCase().includes('fable')) {
+    // Fable refuses tool-less CC-shaped MULTI-TURN requests (live replay
+    // bisect 2026-06-09): scrubbed system + zero tools + an assistant turn
+    // in history → 200 + stop_reason "refusal" with empty content on every
+    // request, while the byte-identical body WITH CC's tool array answers.
+    // Real CC always sends its tool array, so zero-tools is itself a
+    // fingerprint divergence (see the merge-tools note above) — fable's
+    // refusal layer is just the first model to punish it. Emit the CC base
+    // array pinned with `tool_choice: none` so the model cannot call tools
+    // the client never declared (without the pin it DOES — verified
+    // spurious WebFetch on a weather prompt). Other families keep the
+    // legacy tool-less shape, which they demonstrably accept.
+    ccRequest.tools = CC_TOOL_DEFINITIONS;
+    ccRequest.tool_choice = { type: 'none' };
   }
 
   // Metadata

--- a/test/fable-beta.mjs
+++ b/test/fable-beta.mjs
@@ -10,6 +10,7 @@
 // dario therefore mirrors CC: append for the fable family, never for others.
 
 import { betaForModel, FABLE_FALLBACK_CREDIT_BETA, stripContext1mTag } from '../dist/proxy.js';
+import { buildCCRequest } from '../dist/cc-template.js';
 
 let pass = 0;
 let fail = 0;
@@ -49,6 +50,31 @@ check('opus[1m] → base id',   stripContext1mTag('claude-opus-4-7[1m]') === 'cl
 check('uppercase tag → stripped', stripContext1mTag('claude-fable-5[1M]') === 'claude-fable-5');
 check('no tag → unchanged',   stripContext1mTag('claude-fable-5') === 'claude-fable-5');
 check('tag mid-string → unchanged (end-anchored)', stripContext1mTag('claude-[1m]-x') === 'claude-[1m]-x');
+
+console.log('\n=== fable tool-less requests get CC tools + tool_choice none ===');
+// Fable refuses tool-less CC-shaped multi-turn requests (replay bisect
+// 2026-06-09); the same body with CC's tool array answers. tool_choice none
+// pins the model from calling tools the client never declared.
+{
+  const identity = { deviceId: 'D', accountUuid: 'A', sessionId: 'S' };
+  const cc = { type: 'ephemeral' };
+  const mk = (model, tools) => buildCCRequest(
+    { model, messages: [{ role: 'user', content: 'hi' }], ...(tools ? { tools } : {}) },
+    'billing', cc, identity,
+  ).body;
+
+  const fable = mk('claude-fable-5');
+  check('fable, no client tools → CC tools emitted', Array.isArray(fable.tools) && fable.tools.length > 0);
+  check('fable, no client tools → tool_choice none', fable.tool_choice?.type === 'none');
+
+  const opus = mk('claude-opus-4-8');
+  check('opus, no client tools → no tools (legacy shape)', opus.tools === undefined);
+  check('opus, no client tools → no tool_choice', opus.tool_choice === undefined);
+
+  const fableTools = mk('claude-fable-5', [{ name: 'my_tool', description: 'd', input_schema: { type: 'object' } }]);
+  check('fable, WITH client tools → no tool_choice pin', fableTools.tool_choice === undefined);
+  check('fable, WITH client tools → tools present', Array.isArray(fableTools.tools) && fableTools.tools.length > 0);
+}
 
 console.log(`\n${pass} pass, ${fail} fail`);
 process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
**Last fable gap from the post-4.8.49 test battery: multi-turn chat for tool-less clients.**

Replay bisect on the deployed proxy (dario's exact refused outbound body replayed through passthrough, one component swapped per run):

| variant | result |
|---|---|
| dario body as-is | ❌ refusal |
| + real-CC system blocks (all 3) | ✅ answers |
| + real-CC billing block only | ❌ refusal |
| + single system block swaps | ❌ refusal |
| **+ CC tool array** | ✅ **answers** |
| + CC tools + `tool_choice: none` | ✅ answers, **no tool_use** |
| + CC tools, tempting prompt, no pin | ⚠️ answers but **spurious WebFetch tool_use** |

fable soft-refuses CC-shaped requests combining **zero tools + an assistant turn in history** (deterministic; single-turn and tool-carrying traffic unaffected — which is why agents with tools worked all along). Real CC always sends its tool array; zero-tools was already a documented fingerprint divergence (`--merge-tools` note) — fable is the first model to punish it.

Fix: tool-less requests on the **fable family only** emit the CC base tool array pinned with `tool_choice: {type: "none"}` (the pin is verified-necessary, see matrix). Client-supplied tools behave exactly as before; other families keep the legacy shape.

**Tests**: 6 new cases in `fable-beta.mjs` (fable tool-less → tools+pin; opus tool-less → legacy; fable with tools → no pin). Full suite **82/82 green**.

**Release**: v4.8.50 — auto-release on merge; box autodeploy follows. Will live-verify multi-turn chat + OpenAI-compat multi-turn + no-spurious-tool_use post-deploy.