### PR TITLE
fix: proxy /v1/messages/count_tokens (v4.8.51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.51] - 2026-06-09
+
+- **`POST /v1/messages/count_tokens` is proxied now (was 403).** The SSRF path allowlist only knew `/v1/messages`, `/v1/chat/completions`, and `/v1/complete`, so any client counting tokens through dario (Anthropic SDKs call this routinely) got dario's own `Forbidden` — surfaced by the fable test battery. The route forwards **thin**: OAuth swap + model-id normalization (`[1m]` label strip — the literal id 404s here exactly as on /v1/messages) but **no template injection**, because the endpoint counts the *client's own* prompt — bolting on CC's system/tools/effort would distort the count, and `output_config` isn't a count_tokens request field. Beta header is passthrough-style (`oauth-2025-04-20` + client betas); `?beta=true` stays a /v1/messages-only affordance. Allowlist refactored into pure `resolveProxyTarget()` with unit coverage (`test/count-tokens-route.mjs`).
+
 ## [4.8.50] - 2026-06-09
 
 - **Fable multi-turn chat works for tool-less clients (OpenAI-compat, plain Messages chat).** Replay bisect on the deployed proxy: fable soft-refuses CC-shaped requests that combine **zero tools + an assistant turn in history** (200 + `stop_reason: "refusal"`, empty content — deterministic), while the byte-identical body WITH CC's tool array answers; single-turn and tool-carrying requests were never affected. Real CC always sends its tool array, so zero-tools was already a fingerprint divergence (the `--merge-tools` docs note as much) — fable is just the first model to punish it. Fix: tool-less requests on the fable family now emit the CC base tool array pinned with `tool_choice: {type: "none"}` so the model cannot call tools the client never declared (verified necessary: without the pin it emits a spurious WebFetch `tool_use` on a weather question). Other families keep the legacy tool-less shape. Client-supplied tools behave exactly as before.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.50",
+  "version": "4.8.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "4.8.50",
+      "version": "4.8.51",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.50",
+  "version": "4.8.51",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -228,6 +228,29 @@ export function stripContext1mTag(model: string): string {
   return model.replace(/\[1m\]$/i, '');
 }
 
+/**
+ * Resolve an inbound API path to its upstream target + forwarding mode.
+ * Allowlist semantics — anything unlisted is 403'd (prevents SSRF through
+ * the OAuth-bearing proxy).
+ *
+ * `thin: true` marks endpoints forwarded WITHOUT template injection —
+ * OAuth swap + model-id normalization only. `/v1/messages/count_tokens`
+ * is thin because the endpoint counts the CLIENT's own prompt: bolting on
+ * CC's system/tools/effort would distort the count (and `output_config`
+ * is not a count_tokens request field). `?beta=true` stays a /v1/messages
+ * affordance (billing classification) — not appended for count_tokens.
+ * Exported for tests.
+ */
+export function resolveProxyTarget(urlPath: string, isOpenAI: boolean): { target: string; thin: boolean } | null {
+  if (isOpenAI) return { target: `${ANTHROPIC_API}/v1/messages?beta=true`, thin: false };
+  const allowed: Record<string, { target: string; thin: boolean }> = {
+    '/v1/messages': { target: `${ANTHROPIC_API}/v1/messages?beta=true`, thin: false },
+    '/v1/messages/count_tokens': { target: `${ANTHROPIC_API}/v1/messages/count_tokens`, thin: true },
+    '/v1/complete': { target: `${ANTHROPIC_API}/v1/complete`, thin: false },
+  };
+  return allowed[urlPath] ?? null;
+}
+
 // Orchestration tags injected by agents (Aider, Cursor, OpenCode, etc.)
 // that confuse Claude when passed through. Strip before forwarding.
 export const ORCHESTRATION_TAG_NAMES = [
@@ -1188,7 +1211,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
   const JSON_HEADERS = { 'Content-Type': 'application/json', ...SECURITY_HEADERS };
   const MODELS_JSON = JSON.stringify(OPENAI_MODELS_LIST);
   const ERR_UNAUTH = JSON.stringify({ error: 'Unauthorized', message: 'Invalid or missing API key' });
-  const ERR_FORBIDDEN = JSON.stringify({ error: 'Forbidden', message: 'Path not allowed. Supported paths: POST /v1/messages, POST /v1/chat/completions, GET /v1/models' });
+  const ERR_FORBIDDEN = JSON.stringify({ error: 'Forbidden', message: 'Path not allowed. Supported paths: POST /v1/messages, POST /v1/messages/count_tokens, POST /v1/chat/completions, GET /v1/models' });
   const ERR_METHOD = JSON.stringify({ error: 'Method not allowed' });
 
   function checkAuth(req: IncomingMessage): boolean {
@@ -1407,14 +1430,12 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
     // Detect OpenAI-format requests
     const isOpenAI = urlPath === '/v1/chat/completions';
 
-    // Allowlisted API paths — only these are proxied (prevents SSRF)
-    // ?beta=true matches native Claude Code behavior for billing classification
-    const allowedPaths: Record<string, string> = {
-      '/v1/messages': `${ANTHROPIC_API}/v1/messages?beta=true`,
-      '/v1/complete': `${ANTHROPIC_API}/v1/complete`,
-    };
-    const targetBase = isOpenAI ? `${ANTHROPIC_API}/v1/messages?beta=true` : allowedPaths[urlPath];
-    if (!targetBase) { res.writeHead(403, JSON_HEADERS); res.end(ERR_FORBIDDEN); return; }
+    // Allowlisted API paths — only these are proxied (prevents SSRF).
+    // count_tokens forwards thin (no template injection) — see resolveProxyTarget.
+    const route = resolveProxyTarget(urlPath, isOpenAI);
+    if (!route) { res.writeHead(403, JSON_HEADERS); res.end(ERR_FORBIDDEN); return; }
+    const targetBase = route.target;
+    const isCountTokens = route.thin;
     if (req.method !== 'POST') { res.writeHead(405, JSON_HEADERS); res.end(ERR_METHOD); return; }
 
     // Overage-guard halt check (v4.1, dario#288). Subscribers should never
@@ -1663,8 +1684,10 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           const result = isOpenAI ? openaiToAnthropic(parsed, modelOverride) : (modelOverride ? { ...parsed, model: modelOverride } : parsed);
           const r = result as Record<string, unknown>;
           requestModel = (r.model as string || '').toLowerCase();
-          // In passthrough mode, skip all Claude-specific injection — OAuth swap only
-          if (!passthrough) {
+          // In passthrough mode, skip all Claude-specific injection — OAuth swap only.
+          // count_tokens also forwards thin (see resolveProxyTarget) — the endpoint
+          // counts the CLIENT's own prompt, so template injection would distort it.
+          if (!passthrough && !isCountTokens) {
             // ── Template replay: replace the entire request with a CC template ──
             // Instead of transforming signals one by one, we build a new request
             // from CC's exact template and inject only the conversation content.
@@ -1803,6 +1826,11 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
             // can't use it). requestModel keeps the [1m] form so model-aware
             // logic (family buckets, fable beta/effort) sees the user intent.
             r.model = stripContext1mTag(r.model as string);
+          } else if (isCountTokens && typeof r.model === 'string') {
+            // Thin count_tokens forward still normalizes the model id —
+            // the literal `[1m]` label 404s upstream here exactly as it
+            // does on /v1/messages.
+            r.model = stripContext1mTag(r.model);
           }
           finalBody = Buffer.from(JSON.stringify(r));
         } catch { /* not JSON, send as-is */ }
@@ -1831,8 +1859,9 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
       // Beta headers
       const clientBeta = req.headers['anthropic-beta'] as string | undefined;
       let beta: string;
-      if (passthrough) {
-        // Passthrough: only add oauth beta, forward client betas as-is
+      if (passthrough || isCountTokens) {
+        // Passthrough (and thin count_tokens): only add oauth beta,
+        // forward client betas as-is — no template beta set.
         beta = 'oauth-2025-04-20';
         if (clientBeta) beta += ',' + clientBeta;
       } else {

--- a/test/count-tokens-route.mjs
+++ b/test/count-tokens-route.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// resolveProxyTarget — the proxy path allowlist (SSRF guard) + per-route
+// forwarding mode. Added when /v1/messages/count_tokens joined the
+// allowlist (it 403'd before — surfaced by the 2026-06-09 fable battery):
+// count_tokens forwards THIN (no template injection — the endpoint counts
+// the CLIENT's own prompt; CC system/tools/effort would distort it, and
+// `output_config` is not a count_tokens request field).
+
+import { resolveProxyTarget } from '../dist/proxy.js';
+
+let pass = 0;
+let fail = 0;
+function check(name, cond, detail = '') {
+  if (cond) { pass++; console.log(`  ✓ ${name}`); }
+  else { fail++; console.log(`  ✗ ${name}${detail ? ' — ' + detail : ''}`); }
+}
+
+console.log('\n=== resolveProxyTarget — allowlisted routes ===');
+{
+  const messages = resolveProxyTarget('/v1/messages', false);
+  check('/v1/messages → messages?beta=true', messages?.target === 'https://api.anthropic.com/v1/messages?beta=true');
+  check('/v1/messages → full pipeline (not thin)', messages?.thin === false);
+
+  const count = resolveProxyTarget('/v1/messages/count_tokens', false);
+  check('count_tokens → allowlisted', count !== null);
+  check('count_tokens → upstream count_tokens path', count?.target === 'https://api.anthropic.com/v1/messages/count_tokens');
+  check('count_tokens → NO ?beta=true (messages-only affordance)', !count?.target.includes('beta=true'));
+  check('count_tokens → thin forward', count?.thin === true);
+
+  const complete = resolveProxyTarget('/v1/complete', false);
+  check('/v1/complete → allowlisted, not thin', complete?.target === 'https://api.anthropic.com/v1/complete' && complete?.thin === false);
+
+  const openai = resolveProxyTarget('/v1/chat/completions', true);
+  check('openai route → messages?beta=true, not thin', openai?.target === 'https://api.anthropic.com/v1/messages?beta=true' && openai?.thin === false);
+}
+
+console.log('\n=== resolveProxyTarget — everything else stays 403 (SSRF guard) ===');
+{
+  check('unknown path → null', resolveProxyTarget('/v1/embeddings', false) === null);
+  check('traversal-ish path → null', resolveProxyTarget('/v1/messages/../admin', false) === null);
+  check('count_tokens subpath → null', resolveProxyTarget('/v1/messages/count_tokens/x', false) === null);
+  check('empty path → null', resolveProxyTarget('', false) === null);
+  check('root → null', resolveProxyTarget('/', false) === null);
+}
+
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
**`POST /v1/messages/count_tokens` returned dario's own 403** — the SSRF path allowlist only knew `/v1/messages`, `/v1/chat/completions`, `/v1/complete`. Anthropic SDKs call count_tokens routinely; surfaced by the fable test battery (it failed on every model, not just fable).

**Forwarding mode: thin.** OAuth swap + model-id normalization (`[1m]` label strip — the literal id 404s here exactly as on /v1/messages) but **no template injection**: the endpoint counts the *client's own* prompt, so CC system/tools/effort would distort the count, and `output_config` is not a count_tokens request field. Beta header is passthrough-style (`oauth-2025-04-20` + client betas). `?beta=true` stays a /v1/messages-only affordance (billing classification).

The inline allowlist is refactored into a pure exported `resolveProxyTarget(urlPath, isOpenAI)` — same matching semantics (exact paths, no prefix-greediness; traversal/subpaths still 403), now unit-covered.

**Tests**: new `test/count-tokens-route.mjs` (12 cases: routes, thin flags, SSRF-guard negatives). Full suite **83/83 green**. Will live-verify count_tokens on fable + opus + a `[1m]` id post-deploy.