### PR TITLE
feat: per-model anthropic-beta omissions — match real CC's model-tailored set (v4.8.53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ checklist.
 
 ## [Unreleased]
 
-## [4.8.52] - 2026-06-09
+## [4.8.53] - 2026-06-09
+
+- **Per-model `anthropic-beta` omissions — match real CC's model-tailored beta set.** The baked template is opus-4-8's full 9-beta list, which dario was sending for every model; real CC v2.1.170 sends fewer betas for lesser models (live capture, same binary/account, identical `--print -p hi` request shape, deterministic across trials): `claude-sonnet-4-6` → 8 betas (omits `mid-conversation-system-2026-04-07`), `claude-haiku-4-5` → 6 betas (also omits `effort-2025-11-24`). `betaForModel` now subtracts those per family. **Safe by construction:** all three models send the same 3 system blocks, so `mid-conversation-system` is a capability advertisement, not load-bearing; haiku already gets no `output_config.effort` body field, so dropping its effort beta restores consistency; and removing a beta can never provoke an upstream 400 (the runtime rejection cache only ever adds strips). Only the two families measured to omit them are touched — opus / fable / unknown models keep the full baked set. Closes the largest remaining wire-fidelity gap after the v4.8.52 v2.1.170 rebake. New exports `MID_CONVERSATION_SYSTEM_BETA`, `EFFORT_BETA`; `test/fable-beta.mjs` extended (37 assertions; full suite 83/83).
 
 - **Wire-fidelity tuning to live CC v2.1.170** — closes the remaining outbound divergences surfaced by the 2026-06-09 fable replay-bisects:
   - **Template re-bake from live CC v2.1.170** (capture-first inspected, then baked): refreshed system prompt, `_version`/UA labels, and the beta set — which now includes `afk-mode-2026-01-31` (live CC sends it on every request; the v2.1.169 bundle predated it).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.52",
+  "version": "4.8.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "4.8.52",
+      "version": "4.8.53",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.52",
+  "version": "4.8.53",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -218,18 +218,39 @@ function filterBillableBetas(betas: string): string {
  */
 export const FABLE_FALLBACK_CREDIT_BETA = 'fallback-credit-2026-06-01';
 export const CONTEXT_1M_BETA = 'context-1m-2025-08-07';
+export const MID_CONVERSATION_SYSTEM_BETA = 'mid-conversation-system-2026-04-07';
+export const EFFORT_BETA = 'effort-2025-11-24';
 
 /**
  * Model-conditional beta flags, mirroring real CC (live captures
- * 2026-06-09, CC v2.1.170 — fable vs opus vs `--model 'claude-fable-5[1m]'`
- * from the same binary/account):
- *  - `fallback-credit-2026-06-01` rides on FABLE requests only.
- *  - `context-1m-2025-08-07` rides on `[1m]`-labelled requests only (CC
- *    does NOT send it for plain models — the base template set carries
- *    neither flag as of the v2.1.170 bake; both are appended here).
- * `skipContext1m` is the per-account long-context billing rejection cache
- * (dario#36) — when set, the [1m] append is suppressed and the request
- * gracefully runs at the standard window.
+ * 2026-06-09, CC v2.1.170 — same binary/account, `--print -p hi`, identical
+ * request shape, deterministic across repeat trials):
+ *
+ *   model            betas  effort-body  notable beta set
+ *   ---------------  -----  -----------  ------------------------------------
+ *   claude-opus-4-8     9   xhigh        baked base (all flags)
+ *   claude-sonnet-4-6   8   high         base − mid-conversation-system
+ *   claude-haiku-4-5    6   (none)       base − mid-conversation-system − effort
+ *
+ * APPENDS (CC adds for these families):
+ *  - `fallback-credit-2026-06-01` rides on FABLE requests only (without it,
+ *    subscription fable traffic is soft-refused upstream).
+ *  - `context-1m-2025-08-07` rides on `[1m]`-labelled requests only (CC does
+ *    NOT send it for plain models). `skipContext1m` (dario#36) suppresses the
+ *    [1m] append when the account's long-context billing was rejected.
+ *
+ * OMISSIONS (CC drops for these families; the baked base is opus's full set):
+ *  - `mid-conversation-system-2026-04-07` — sonnet + haiku omit it. All three
+ *    models still send the SAME 3 system blocks, so this is a capability
+ *    advertisement, not load-bearing for the system shape — safe to drop.
+ *  - `effort-2025-11-24` — haiku omits it (and sends no `output_config.effort`
+ *    body field either; dario already strips that field for haiku, so dropping
+ *    the beta just restores consistency).
+ *
+ * Removing a beta can never provoke an upstream 400 (the runtime rejection
+ * cache only ever needs to ADD strips), so the omissions are strictly safe.
+ * Only the two families measured to omit them are touched; opus / fable /
+ * unknown models keep the full baked set unchanged.
  */
 export function betaForModel(base: string, model: string | null | undefined, skipContext1m = false): string {
   let beta = base;
@@ -240,6 +261,17 @@ export function betaForModel(base: string, model: string | null | undefined, ski
   };
   if (m.includes('fable')) append(FABLE_FALLBACK_CREDIT_BETA);
   if (/\[1m\]$/.test(m) && !skipContext1m) append(CONTEXT_1M_BETA);
+
+  const drop = new Set<string>();
+  if (m.includes('haiku')) {
+    drop.add(MID_CONVERSATION_SYSTEM_BETA);
+    drop.add(EFFORT_BETA);
+  } else if (m.includes('sonnet')) {
+    drop.add(MID_CONVERSATION_SYSTEM_BETA);
+  }
+  if (drop.size > 0) {
+    beta = beta.split(',').filter((b) => !drop.has(b.trim())).join(',');
+  }
   return beta;
 }
 

--- a/test/fable-beta.mjs
+++ b/test/fable-beta.mjs
@@ -9,7 +9,7 @@
 // while opus/sonnet answer normally (isolated on the live proxy 2026-06-09).
 // dario therefore mirrors CC: append for the fable family, never for others.
 
-import { betaForModel, FABLE_FALLBACK_CREDIT_BETA, CONTEXT_1M_BETA, stripContext1mTag } from '../dist/proxy.js';
+import { betaForModel, FABLE_FALLBACK_CREDIT_BETA, CONTEXT_1M_BETA, MID_CONVERSATION_SYSTEM_BETA, EFFORT_BETA, stripContext1mTag } from '../dist/proxy.js';
 import { buildCCRequest } from '../dist/cc-template.js';
 
 let pass = 0;
@@ -33,13 +33,37 @@ check('already present → unchanged (no dup)',
 check('empty base + fable → just the flag',
   betaForModel('', 'claude-fable-5') === FABLE_FALLBACK_CREDIT_BETA);
 
-console.log('\n=== betaForModel — every other family untouched ===');
-check('opus → unchanged',   betaForModel(BASE, 'claude-opus-4-8') === BASE);
-check('sonnet → unchanged', betaForModel(BASE, 'claude-sonnet-4-6') === BASE);
-check('haiku → unchanged',  betaForModel(BASE, 'claude-haiku-4-5') === BASE);
+console.log('\n=== betaForModel — fallback-credit: every other family untouched ===');
+// BASE carries no mid-conversation-system, so the per-model omissions below
+// are no-ops here EXCEPT effort-2025-11-24 for haiku (which BASE does carry).
+check('opus → no fallback-credit',   !betaForModel(BASE, 'claude-opus-4-8').includes(FABLE_FALLBACK_CREDIT_BETA));
+check('sonnet → no fallback-credit', !betaForModel(BASE, 'claude-sonnet-4-6').includes(FABLE_FALLBACK_CREDIT_BETA));
+check('haiku → no fallback-credit',  !betaForModel(BASE, 'claude-haiku-4-5').includes(FABLE_FALLBACK_CREDIT_BETA));
 check('empty model → unchanged', betaForModel(BASE, '') === BASE);
 check('null model → unchanged',  betaForModel(BASE, null) === BASE);
 check('undefined model → unchanged', betaForModel(BASE, undefined) === BASE);
+
+console.log('\n=== betaForModel — per-model beta OMISSIONS (CC v2.1.170 wire) ===');
+// Real CC drops betas for lesser models: sonnet omits mid-conversation-system;
+// haiku omits mid-conversation-system AND effort-2025-11-24. The baked base is
+// opus's full set, so dario must subtract per model.
+{
+  const FULL = 'claude-code-20250219,interleaved-thinking-2025-05-14,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24';
+  const sonnetOut = betaForModel(FULL, 'claude-sonnet-4-6');
+  check('sonnet → drops mid-conversation-system', !sonnetOut.includes(MID_CONVERSATION_SYSTEM_BETA));
+  check('sonnet → keeps effort', sonnetOut.includes(EFFORT_BETA));
+  const haikuOut = betaForModel(FULL, 'claude-haiku-4-5');
+  check('haiku → drops mid-conversation-system', !haikuOut.includes(MID_CONVERSATION_SYSTEM_BETA));
+  check('haiku → drops effort', !haikuOut.includes(EFFORT_BETA));
+  check('opus → keeps both', betaForModel(FULL, 'claude-opus-4-8') === FULL);
+  check('fable → keeps both (unmeasured, left as opus-class)',
+    betaForModel(FULL, 'claude-fable-5').includes(MID_CONVERSATION_SYSTEM_BETA) &&
+    betaForModel(FULL, 'claude-fable-5').includes(EFFORT_BETA));
+  check('sonnet[1m] → drops mid-conv, keeps effort, appends context-1m',
+    (() => { const o = betaForModel(FULL, 'claude-sonnet-4-6[1m]'); return !o.includes(MID_CONVERSATION_SYSTEM_BETA) && o.includes(EFFORT_BETA) && o.includes(CONTEXT_1M_BETA); })());
+  check('haiku omission does not corrupt unrelated flags',
+    haikuOut === 'claude-code-20250219,interleaved-thinking-2025-05-14,advisor-tool-2026-03-01');
+}
 
 console.log('\n=== betaForModel — context-1m rides on [1m] requests only (CC v2.1.170 wire) ===');
 // Real CC sends context-1m ONLY for [1m]-labelled models; the v2.1.170 baked


### PR DESCRIPTION
## Summary

Continuation of the v4.8.52 wire-fidelity work, using fable's live-capture methodology. The baked template is **opus-4-8's full 9-beta list**, which dario sends for *every* model. Real CC v2.1.170 **tailors the beta set per model** — captured from the same binary/account, identical `--print -p hi` request shape, deterministic across repeat trials:

| model | betas | `output_config.effort` | system blocks |
|---|---|---|---|
| `claude-opus-4-8` | 9 (baked base) | xhigh | 3 |
| `claude-sonnet-4-6` | 8 — omits `mid-conversation-system-2026-04-07` | high | 3 |
| `claude-haiku-4-5` | 6 — also omits `effort-2025-11-24` | none | 3 |

`betaForModel` now subtracts those per family.

## Why it's safe (not just minimal)
- **`system_blocks = 3` for all three models** → `mid-conversation-system` is a capability *advertisement*, not load-bearing for the system shape. Sonnet proves CC sends 3 system blocks without the beta.
- Haiku already receives **no `output_config.effort` body field** (dario's existing `isHaiku` gating), yet was still sending the `effort` beta — internally inconsistent. Dropping it restores consistency *and* matches CC.
- **Removing a beta can never provoke an upstream 400** — the runtime rejection-retry cache (`proxy.ts`) only ever needs to *add* strips. This is strictly subtractive.
- **Evidence-bounded:** only the two families empirically measured to omit these betas are touched. `opus` / `fable` / unknown models keep the full baked set unchanged (no risk of introducing a divergence for an unmeasured model).

## What this is NOT
While capturing, I also re-verified the v4.8.52 `context-1m`-on-`[1m]`-only behavior — it's **correct** (a plain `--model claude-sonnet-4-6` carries no `context-1m`; the suffix drives it). An earlier-looking "always sends context-1m" was an artifact of *my* settings default being `claude-fable-5[1m]`. No change there.

## Tests
`test/fable-beta.mjs` extended with the per-model omission matrix (sonnet drops mid-conv/keeps effort; haiku drops both; opus/fable keep both; sonnet`[1m]` drops mid-conv + appends context-1m; no corruption of unrelated flags). **37 assertions in that file, full suite 83/83**, `tsc` clean.

On merge → auto-release v4.8.53 → the box autodeploy adopts it health-gated (real sonnet completion through dario, auto-rollback on failure).