### PR TITLE
ci(self-healing): treat npm provenance tlog errors as transient

### DIFF
--- a/.github/workflows/self-healing-supervisor.yml
+++ b/.github/workflows/self-healing-supervisor.yml
@@ -85,7 +85,9 @@ jobs:
           HTTP 503
           ECONNRESET
           ETIMEDOUT
-          Unable to reserve cache with key'
+          Unable to reserve cache with key
+          TLOG_CREATE_ENTRY_ERROR
+          error creating tlog entry'
 
           # Build extended regex (newline -> pipe), keeping the literal
           # patterns. The leading sed strips the 10-space YAML indent


### PR DESCRIPTION
## What

Adds two patterns to `TRANSIENT_PATTERNS` in `.github/workflows/self-healing-supervisor.yml`:

- `TLOG_CREATE_ENTRY_ERROR` — the npm error `code` for Sigstore/Rekor transparency-log failures
- `error creating tlog entry` — the descriptive message line (left un-pinned to a status code so it also catches the 502/503 Rekor variants, not just 409)

## Why

dario v4.8.49 release (run 27235351627) failed at `npm publish --provenance` with `TLOG_CREATE_ENTRY_ERROR` — a known transient Sigstore/Rekor flake. The auto-release idempotency gate already recovered it, but this error class was **not** in the supervisor's explicit transient set, so a failed run wouldn't auto-retry without manual triage. Defense-in-depth: make the class explicit.

## Verification

- Simulated the workflow's exact `PATTERNS_RE` build (sed strip-indent → `tr` newline-to-pipe) and confirmed the new patterns match real npm log lines, including GHA-timestamp-prefixed and the 502 variant.
- Regression: existing patterns (ECONNRESET, reserve-cache, HTTP 503) still match.
- Negative controls: `E404` and a generic build TypeError stay **non-matching** — the regex is not broadened into real failures.
- `actionlint` (v1.7.1, repo config) clean.

## Risk

Low — additive only, +3/-1 lines inside the existing quoted pattern list. No structural change.

Ticket: 00MQ7EADXK55A62F9DF0FE5AD8
Parent: 00MQ751H0DB549A44DEEC914BF