### PR TITLE
chore: re-sync package-lock.json version (4.8.55 → 4.8.57)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.55",
+  "version": "4.8.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "4.8.55",
+      "version": "4.8.57",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"


### PR DESCRIPTION
Lockfile-only sync per the RELEASING.md pre-merge checklist — missed in #489, and the 4.8.56 bump before it had the same drift (lock said 4.8.55). No dependency changes, no `package.json` version change, so the auto-release workflow does not fire.