### PR TITLE
docs(tui): refresh hits-tab layout example to fable-5

### DIFF
--- a/src/tui/tabs/hits.ts
+++ b/src/tui/tabs/hits.ts
@@ -10,13 +10,13 @@
  *
  *   ┌─ Hits ────────────────────────[ ↑↓ select · r refresh ]
  *   │  HH:MM:SS  METHOD  MODEL          IN     OUT   LAT    ST
- *   │  18:42:01  POST    opus-4-7       842    216   1.2s  200  ←
+ *   │  18:42:01  POST    fable-5        842    216   1.2s  200  ←
  *   │  18:42:03  POST    sonnet-4-6     1.2k   480   0.8s  200
  *   │  …
  *   ├─────────────────────────────────────────────────────────────
  *   │  selected: 18:42:01  req_011…NvMn
  *   │    account:  sprayberryit (single)
- *   │    model:    claude-opus-4-7
+ *   │    model:    claude-fable-5
  *   │    bucket:   subscription
  *   │    tokens:   in 842 / out 216 / cache-read 6.2k / thinking 84
  *   │    latency:  1.18s   stream: yes  status: 200


### PR DESCRIPTION
The `hits.ts` header comment that illustrates the Hits tab layout still showed `claude-opus-4-7` as the selected-record example. Cosmetic only — it's a doc comment, never rendered — refreshed the lead row and the detail block to `claude-fable-5` (current flagship). The second example row stays `sonnet-4-6` for realistic mixed-traffic variety.

No version bump (comment-only — must not trigger the version-bump auto-release). `tsc` clean.