### PR TITLE
docs(readme): feature fable-5 in the TUI analytics example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ Type `dario` with no args (in another terminal) to open a full-screen control pa
 │  Tokens out:      38,200               Subscription %:  98%         │
 │                                                                     │
 │  Per-model:                                                         │
-│   opus-4-8      ████████████████████░  72%  (178 req)               │
-│   sonnet-4-6    █████░░░░░░░░░░░░░░░░  22%  ( 54 req)               │
+│   fable-5       ██████████░░░░░░░░░░░  50%  (124 req)               │
+│   opus-4-8      ██████░░░░░░░░░░░░░░░  30%  ( 74 req)               │
+│   sonnet-4-6    ███░░░░░░░░░░░░░░░░░░  14%  ( 34 req)               │
 │   haiku-4-5     █░░░░░░░░░░░░░░░░░░░░   6%  ( 15 req)               │
 │                                                                     │
 │  Rate-limit:                                                        │


### PR DESCRIPTION
The README's interactive-TUI screenshot showed a per-model burn-rate breakdown led by `opus-4-8` with **no fable row** — out of step with fable-5 being the current flagship and, in practice, the most-used model.

Added a `fable-5` row at the top of the Per-model bars and rebalanced the request shares so they still sum to the 247 requests / 100% shown in the same panel:

```
fable-5    50%  (124 req)
opus-4-8   30%  ( 74 req)
sonnet-4-6 14%  ( 34 req)
haiku-4-5   6%  ( 15 req)
```

Box-drawing alignment preserved — every row is 72 code-points like the rest of the panel (verified programmatically). The overage-guard TUI example below still shows `claude-opus-4-8`, left as-is since that's a current model and a model-agnostic incident illustration. Docs-only; no version bump (won't trigger auto-release).