### PR TITLE
fix(cc-template): explicit precedence framing for client system prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ checklist.
 
 ## [Unreleased]
 
+- **Client system prompts get explicit precedence framing in the merged block-3 system prompt.** A bare `\n\n` append after CC's persona silently stopped steering `claude-sonnet-4-6` (observed 2026-06-12 via a deepdive planner regression: the model answered the user's question instead of following the client's "return JSON" system instruction — 0/6 on a trivial obedience probe, deterministic, while haiku obeyed 6/6 on the identical merged body; the same shape had obeyed on sonnet the previous evening, pointing at an upstream serving-side shift, not a dario change). The merge now inserts `CLIENT_SYSTEM_PREFACE` — "the operator supplied the following task-specific instructions; they OVERRIDE conflicting general behavior above" — between the persona and the client text, which restored sonnet obedience 6/6 in live probes. System-prompt content/length are not billing-classifier inputs (docs/research/system-prompt-classifier-study.md), so pool routing is unaffected. New test: `test/client-system-precedence.mjs`.
+
 ## [4.8.65] - 2026-06-12
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.174` → `2.1.175` for CC v2.1.175. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -90,6 +90,28 @@ export const CC_AGENT_IDENTITY = TEMPLATE.agent_identity;
  *     CLI resolves file paths to file contents up-front so this layer
  *     stays filesystem-pure.
  */
+/**
+ * Precedence framing inserted between CC's persona prompt and the client's
+ * own system text in the merged block-3 system prompt.
+ *
+ * Why this exists (observed 2026-06-12, deepdive planner regression): a bare
+ * `\n\n` append silently stopped working on claude-sonnet-4-6 — the model
+ * followed the CC persona and treated the appended client instructions as
+ * ignorable boilerplate, deterministically (0/6 on a trivial "reply with
+ * only PONG" system instruction; haiku obeyed 6/6 on the identical merged
+ * body, and the same shape had obeyed on sonnet the previous evening — an
+ * upstream serving-side behavior shift, not a dario regression). With this
+ * explicit override framing, sonnet obedience returned to 6/6.
+ *
+ * Billing-safety: system prompt CONTENT/length are not classifier inputs —
+ * docs/research/system-prompt-classifier-study.md — so this framing cannot
+ * affect Max-pool routing.
+ */
+export const CLIENT_SYSTEM_PREFACE =
+  '\n\n---\n\nIMPORTANT: The operator of this session has supplied the following ' +
+  'task-specific instructions. For this conversation they OVERRIDE any ' +
+  'conflicting general behavior described above. Follow them exactly:\n\n';
+
 export function resolveSystemPrompt(arg: string | undefined): string {
   if (!arg || arg === 'verbatim') return CC_SYSTEM_PROMPT;
   if (arg === 'partial') return stripBehavioralConstraints(CC_SYSTEM_PROMPT, 'partial');
@@ -1480,7 +1502,7 @@ export function buildCCRequest(
   // validation that this slot is unfingerprinted by the billing classifier.
   const baseSystemPrompt = resolveSystemPrompt(opts.systemPrompt);
   const fullSystemPrompt = systemText
-    ? `${baseSystemPrompt}\n\n${systemText}`
+    ? `${baseSystemPrompt}${CLIENT_SYSTEM_PREFACE}${systemText}`
     : baseSystemPrompt;
 
   const ccRequest: Record<string, unknown> = {

--- a/test/client-system-precedence.mjs
+++ b/test/client-system-precedence.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// Client system-prompt precedence framing — regression test for the
+// 2026-06-12 deepdive planner outage.
+//
+// dario merges the API client's `system` text into block 3 of the outbound
+// CC-shaped system array, after CC's persona prompt. A bare `\n\n` append
+// silently stopped steering claude-sonnet-4-6 (the model followed the CC
+// persona and ignored the appended client instructions — deterministically,
+// while haiku obeyed the identical merged body). The fix frames the client
+// text with an explicit override preamble (CLIENT_SYSTEM_PREFACE), which
+// restored sonnet obedience 0/6 → 6/6 in live probes.
+//
+// These tests pin the merge structure: preface present exactly when client
+// system text exists, client text intact and AFTER the preface, base prompt
+// untouched when no client system is supplied.
+
+import { buildCCRequest, CLIENT_SYSTEM_PREFACE, CC_SYSTEM_PROMPT } from '../dist/cc-template.js';
+
+let pass = 0, fail = 0;
+function check(name, cond, detail) {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else      { console.log(`  FAIL ${name}${detail ? ': ' + detail : ''}`); fail++; }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+const IDENTITY = { deviceId: 'dev-test', accountUuid: 'acct-test', sessionId: 'sess-test' };
+const CACHE = { type: 'ephemeral' };
+const BILLING = 'x-anthropic-billing-header: test';
+
+function build(clientBody) {
+  return buildCCRequest(clientBody, BILLING, CACHE, IDENTITY, {}).body;
+}
+
+function block3(body) {
+  return body.system?.[2]?.text ?? '';
+}
+
+const CLIENT_SYSTEM = 'You are a research planner. Output FORMAT (strict): one JSON object, no prose.';
+
+header('1. string-form client system gets the precedence preface');
+{
+  const body = build({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 100,
+    system: CLIENT_SYSTEM,
+    messages: [{ role: 'user', content: 'q' }],
+  });
+  const text = block3(body);
+  check('preface present', text.includes(CLIENT_SYSTEM_PREFACE));
+  check('client text present and intact', text.includes(CLIENT_SYSTEM));
+  check('client text comes AFTER the preface',
+    text.indexOf(CLIENT_SYSTEM) > text.indexOf(CLIENT_SYSTEM_PREFACE));
+  check('preface comes AFTER the base persona prompt',
+    text.indexOf(CLIENT_SYSTEM_PREFACE) > 0);
+  check('exactly one preface occurrence',
+    text.split(CLIENT_SYSTEM_PREFACE).length === 2);
+}
+
+header('2. array-form client system merges the same way');
+{
+  const body = build({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 100,
+    system: [
+      { type: 'text', text: 'First client block.' },
+      { type: 'text', text: 'Second client block.' },
+    ],
+    messages: [{ role: 'user', content: 'q' }],
+  });
+  const text = block3(body);
+  check('preface present for array form', text.includes(CLIENT_SYSTEM_PREFACE));
+  check('both client blocks present',
+    text.includes('First client block.') && text.includes('Second client block.'));
+}
+
+header('3. no client system → no preface, base prompt byte-identical');
+{
+  const body = build({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 100,
+    messages: [{ role: 'user', content: 'q' }],
+  });
+  const text = block3(body);
+  check('no preface injected', !text.includes(CLIENT_SYSTEM_PREFACE));
+  check('block 3 ends with the unmodified base prompt', text === CC_SYSTEM_PROMPT);
+}
+
+header('4. haiku path gets the same merge');
+{
+  const body = build({
+    model: 'claude-haiku-4-5',
+    max_tokens: 100,
+    system: CLIENT_SYSTEM,
+    messages: [{ role: 'user', content: 'q' }],
+  });
+  const text = block3(body);
+  check('haiku: preface present', text.includes(CLIENT_SYSTEM_PREFACE));
+  check('haiku: client text present', text.includes(CLIENT_SYSTEM));
+}
+
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## Symptom

deepdive's planner broke on every default-model run this morning: `planner did not return JSON` — the model answered the research question directly instead of following the client's "return one JSON object" system instruction. Bench went from working (previous evening) to 3/6 planner deaths.

## Diagnosis trail

- Trivial probe (`system: "Reply with ONLY the word PONG"`): **sonnet-4-6 0/6 obeyed, haiku-4-5 6/6** — deterministic, model-split.
- Reproduces on dario **4.8.57 and 4.8.65**, and on the **bundled v2.1.170** and **live v2.1.173/175** templates — rules out the version and the overnight template re-capture.
- Wire-level dump of the outbound body: the client text **was present** in system block 3 (length delta matches the probe instruction). Delivery was fine; the model privileged the persona over the bare-appended text.
- Skipping `thinking`/`context_management`/`output_config` injection: still 0/6 — not the per-model field injection.
- Same shape obeyed on sonnet the previous evening → upstream serving-side behavior shift for CC-presented traffic, not a dario regression. Unknown remains *why* upstream changed; the fix below is robust either way.

## Fix

Insert `CLIENT_SYSTEM_PREFACE` between CC's persona and the client's system text in the merged block-3 prompt: the client text is framed as operator-supplied, task-specific instructions that override conflicting general behavior above.

Live result: sonnet **0/6 → 6/6**, haiku stays 6/6, deepdive planner returns clean JSON again.

## Trade-offs / unknowns surfaced

- Adds ~240 bytes to block 3 on requests that carry client system text; absent otherwise (block 3 stays byte-identical to the persona — pinned by test).
- System-prompt content/length are not billing-classifier inputs per `docs/research/system-prompt-classifier-study.md`, so pool routing should be unaffected — worth one eye on the drift watcher after deploy regardless.
- CC-as-client traffic (people proxying real CC through dario) also gets the preface ahead of CC's own extracted system text; that path already received an appended copy before this change, so the delta is framing only.
- Left under `[Unreleased]` per the release convention — no version bump, so this doesn't collide with the cc-drift bot's auto-bumps.

If the Hetzner box's auto-deploy tracks master, the platform's forge agents (which all send system prompts through dario) pick this up on the next roll — they're plausibly degraded by the same upstream shift today.

## Tests

`test/client-system-precedence.mjs` (auto-discovered): preface present iff client system text exists (string and array form), client text intact and after the preface, base prompt byte-identical when no client system, haiku path identical. Full suite 87/87 + new file green.
