### PR TITLE
chore(cc-drift): v4.8.68 — maxTested → v2.1.176

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.68] - 2026-06-12
+
+- **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.175` → `2.1.176` for CC v2.1.176. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.
 ## [4.8.67] - 2026-06-12
 
 - **`dario doctor --obedience` — per-family client-system obedience probe (dario#509).** The 2026-06-12 sonnet regression (client system prompts silently ignored; fixed by the precedence framing in 4.8.66) was invisible to every existing check: 200s, subscription billing, label-clean templates, and the model smoke all stayed green, and detection came from a downstream consumer failing to parse JSON. The new opt-in probe sends each model family — through the running proxy, so it exercises the cc-template merge seam — a trivial client system prompt ("reply with ONLY the word PONG") and asserts the reply obeys, up to 3 attempts per family to tolerate sampling (families probe in parallel). Verdicts are deliberately two-tier: `[FAIL]` = the model *answered but ignored the instruction* (behavioral drift — and per the runbook, that means "investigate presentation/merge", since this property is upstream-influenced and not necessarily a dario bug); `[WARN]` = the probe couldn't complete (infra flake, not drift). `scripts/check-doctor-drift.mjs` now runs `doctor --obedience` and treats obedience `[FAIL]` rows as drift, so the 6-hourly `dario-doctor-watch` files the dedup'd issue the morning behavior shifts — before any consumer notices. A deployed dario predating the flag ignores it and emits no rows, so the watch upgrade is safe to ship ahead of the container image. New e2e section in `test/e2e.mjs` covers the same probe per family; pure verdict helpers (`isObedientReply`, `extractMessageText`) are unit-tested in `test/doctor-obedience.mjs`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.67",
+  "version": "4.8.68",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/live-fingerprint.ts
+++ b/src/live-fingerprint.ts
@@ -885,7 +885,7 @@ export function _resetInstalledVersionProbeForTest(): void {
  */
 export const SUPPORTED_CC_RANGE = {
   min: '1.0.0',
-  maxTested: '2.1.175',
+  maxTested: '2.1.176',
 } as const;
 
 /**


### PR DESCRIPTION
## Auto-drafted by cc-drift-watch.yml

The drift watcher flagged CC v2.1.176 as outside the current supported range. This PR:

1. Bumps `SUPPORTED_CC_RANGE.maxTested` from `2.1.175` → `2.1.176` in `src/live-fingerprint.ts`
2. Bumps `package.json` version → `4.8.68`
3. Promotes `## [Unreleased]` in `CHANGELOG.md` to `## [4.8.68] - 2026-06-12` and appends the drift-fix bullet

### Items in the drift report

- **compat.range** (medium) — CC v2.1.176 is beyond SUPPORTED_CC_RANGE.maxTested (v2.1.175). Run the e2e suite against the new CC and bump maxTested in src/live-fingerprint.ts — users on the new CC currently get a soft "untested-above" warning from dario doctor.
- **template.version** (low) — baked cc-template-data.json is v2.1.175; npm latest is v2.1.176. Re-capture the template (MITM a real CC v2.1.176 request) if any fingerprint-sensitive field (system prompt, header order, metadata shape, beta flags) changed.

### What happens when you merge this

A separate workflow (`cc-drift-auto-release.yml`) fires on merge of any version-bumping PR to `master`. It reads `package.json` from master, tags `v4.8.68`, creates the GitHub release, and runs `npm publish --provenance` + the GHCR docker push inline — all in one run (the old separate `publish.yml` was removed in #369). Net: merging this PR ships `@askalf/dario@4.8.68` to npm within ~3 minutes, no further maintainer action.

### Maintainer checklist before merging

- [ ] Install the new CC locally: `npm install -g @anthropic-ai/claude-code@2.1.176`
- [ ] Run `dario doctor` and confirm it comes back clean against v2.1.176
- [x] Template fingerprint is auto-verified every 30 min by `cc-drift-template-watch.yml` (live capture on the self-hosted runner); if the wire format actually drifts it opens its own `bot/template-rebake-*` PR. No manual capture needed here unless that watcher is failing.
- [ ] Confirm the CHANGELOG entry under `## [4.8.68]` reads cleanly. The bot wrote a short factual line; feel free to rewrite with more context.
- [ ] Mark as ready for review + merge. Auto-merge will ship it through CI, and the auto-release workflow handles the tag + release + npm publish.

### About this auto-draft

Only `compat.range` items are auto-patched by this script. Template re-capture is auto-handled separately by `cc-drift-template-watch.yml`. The remaining categories (scope rotations, URL / clientId / tokenUrl changes) require judgment and stay manual — the bot opens the plain drift-issue for those as before.

---

_Generated by `scripts/auto-draft-drift-fix.mjs`. Closes the detection-latency arc: [#112](https://github.com/askalf/dario/pull/112) (CF bypass), [#113](https://github.com/askalf/dario/pull/113) (hourly cadence), [#114](https://github.com/askalf/dario/pull/114) (auto-draft PR)._
