### PR TITLE
fix: temp-disable suspended model families (Fable 5 / Mythos 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.71] - 2026-06-13
+
+- **Temp-disable suspended model families (Fable 5 / Mythos 5)** — Fable 5 and Mythos 5 were disabled for all Anthropic customers by a US-government legal directive on 2026-06-12 (other models unaffected; https://www.anthropic.com/news/fable-mythos-access). dario was still advertising `claude-fable-5[1m]` in `/v1/models` and forwarding fable requests into Anthropic's `not_found`. Now: suspended families are filtered out of both the autodetected upstream catalog and the baked fallback (so `/v1/models` and alias resolution never offer them), and any spelling of a suspended model (`fable`/`fable1m`/`claude-fable-5`/`claude-fable-5[1m]`/`claude:fable`) is rejected up front with a `404 not_found` pointing at `claude-opus-4-8` / `claude-sonnet-4-6`. Reversible via `DARIO_SUSPENDED_MODELS` (default `fable`); set it empty to re-enable when access is restored.
+
 ## [4.8.70] - 2026-06-13
 
 - **Template label refresh** — `_version`, `_supportedMaxTested`, and the `user-agent` header bumped to `2.1.177` to track `@anthropic-ai/claude-code@latest`. The live wire shape is unchanged — cc-drift-template-watch ran `capture-and-bake --check` against live CC v2.1.177 and found zero shape drift vs the bundle — so this is a label refresh, not a re-capture (`_captured` stays at the last real capture). Auto-merged; clears the `sdk-drift` early-warning signal.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.70",
+  "version": "4.8.71",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -48,6 +48,50 @@ export const BAKED_BASE_MODELS: readonly string[] = [
 ];
 
 /**
+ * Globally-suspended model families — dario neither advertises nor proxies
+ * them, even when upstream still lists the id, because api.anthropic.com
+ * returns `not_found` for every request to them.
+ *
+ * Claude Fable 5 AND Mythos 5 were disabled for ALL Anthropic customers by a
+ * US-government legal directive on 2026-06-12 (all plans/tiers; other models
+ * unaffected) — https://www.anthropic.com/news/fable-mythos-access. dario's
+ * baked fallback still carries `claude-fable-5`, and upstream may still list
+ * it, so without this filter dario keeps advertising a model that 404s.
+ *
+ * TEMP — reversible without a code change: `DARIO_SUSPENDED_MODELS` overrides
+ * the default (comma-separated families or model ids; each is normalized to
+ * its family). Set `DARIO_SUSPENDED_MODELS=` (empty) to re-enable everything
+ * once access is restored. Matching is by FAMILY, so every spelling is caught:
+ * `fable`, `fable1m`, `claude-fable-5`, `claude-fable-5[1m]`, `claude:fable`.
+ */
+const DEFAULT_SUSPENDED_MODELS = 'fable';
+
+/** The set of suspended families, resolved from env at call time. */
+export function suspendedFamilies(): Set<string> {
+  const raw = process.env.DARIO_SUSPENDED_MODELS ?? DEFAULT_SUSPENDED_MODELS;
+  return new Set(
+    raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+      .map((s) => modelFamily(s) ?? s.toLowerCase()),
+  );
+}
+
+/** True when `model` (any spelling) belongs to a suspended family. */
+export function isSuspendedModel(model: string): boolean {
+  const fams = suspendedFamilies();
+  if (fams.size === 0) return false;
+  const fam = modelFamily(model);
+  return fam !== null && fams.has(fam);
+}
+
+/** Drop suspended families from an advertised base list. */
+export function dropSuspendedModels(bases: readonly string[]): string[] {
+  return bases.filter((b) => !isSuspendedModel(b));
+}
+
+/**
  * THE long-context rule — applied identically to every family. A base id
  * takes a `[1m]` variant unless it's the haiku family (CC's picker never
  * offers 1M haiku; it's also the family CC strips the effort and
@@ -240,7 +284,7 @@ async function fetchUpstreamBases(deps: CatalogDeps): Promise<string[]> {
 async function refresh(deps: CatalogDeps): Promise<void> {
   const now = deps.now ?? Date.now;
   lastAttempt = now();
-  const bases = await fetchUpstreamBases(deps);
+  const bases = dropSuspendedModels(await fetchUpstreamBases(deps));
   cache = { bases, source: 'upstream', fetchedAt: now() };
   deps.log?.(`[dario] model catalog: autodetected ${bases.length} base models upstream`);
 }
@@ -284,7 +328,7 @@ export async function getModelCatalog(deps: CatalogDeps = {}): Promise<ModelCata
       );
     }
   }
-  if (cache === null) cache = { bases: [...BAKED_BASE_MODELS], source: 'baked', fetchedAt: 0 };
+  if (cache === null) cache = { bases: dropSuspendedModels(BAKED_BASE_MODELS), source: 'baked', fetchedAt: 0 };
   return cache;
 }
 
@@ -294,7 +338,7 @@ export async function getModelCatalog(deps: CatalogDeps = {}): Promise<ModelCata
  * Never blocks the hot path on the network.
  */
 export function getCachedBases(): readonly string[] {
-  return cache?.bases ?? BAKED_BASE_MODELS;
+  return cache?.bases ?? dropSuspendedModels(BAKED_BASE_MODELS);
 }
 
 /** Fire-and-forget warmup so the first client /v1/models call is served warm. */

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -17,7 +17,7 @@ import { loadAllAccounts, loadAccount, refreshAccountToken, resyncLoginFromCrede
 import { getOpenAIBackend, isOpenAIModel, forwardToOpenAI, type BackendCredentials } from './openai-backend.js';
 import { RequestQueue, QueueFullError, QueueTimeoutError, DEFAULT_MAX_CONCURRENT, DEFAULT_MAX_QUEUED, DEFAULT_QUEUE_TIMEOUT_MS } from './request-queue.js';
 import { redactSecrets } from './redact.js';
-import { BAKED_BASE_MODELS, withLongContextVariants, buildOpenAIModelsList, getModelCatalog, getCachedBases, resolveAliasAgainst, prewarmModelCatalog, type CatalogDeps } from './model-catalog.js';
+import { BAKED_BASE_MODELS, withLongContextVariants, buildOpenAIModelsList, getModelCatalog, getCachedBases, resolveAliasAgainst, prewarmModelCatalog, isSuspendedModel, type CatalogDeps } from './model-catalog.js';
 
 const ANTHROPIC_API = 'https://api.anthropic.com';
 const DEFAULT_PORT = 3456;
@@ -1818,6 +1818,25 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           const result = isOpenAI ? openaiToAnthropic(parsed, modelOverride) : (modelOverride ? { ...parsed, model: modelOverride } : parsed);
           const r = result as Record<string, unknown>;
           requestModel = (r.model as string || '').toLowerCase();
+          // Suspended-model guard. Fable 5 / Mythos 5 are disabled for ALL
+          // Anthropic customers (US-gov directive 2026-06-12); forwarding any
+          // spelling of them 404s upstream with a confusing not_found. Reject
+          // up front with an actionable error instead — runs before the
+          // template build / account lease / forwarding, so nothing to unwind.
+          // TEMP + reversible: governed by DARIO_SUSPENDED_MODELS (default
+          // 'fable'); set it empty to re-enable when access is restored.
+          if (requestModel && isSuspendedModel(requestModel)) {
+            if (verbose) console.log(`[dario] suspended model rejected: ${requestModel} (${urlPath})`);
+            res.writeHead(404, JSON_HEADERS);
+            res.end(JSON.stringify({
+              type: 'error',
+              error: {
+                type: 'not_found_error',
+                message: `Model "${requestModel}" is suspended in this dario instance. Claude Fable 5 and Mythos 5 are disabled for all Anthropic customers (US government directive 2026-06-12 — https://www.anthropic.com/news/fable-mythos-access). Use claude-opus-4-8 or claude-sonnet-4-6 instead. To re-enable when access is restored, set DARIO_SUSPENDED_MODELS= (empty) on the dario instance.`,
+              },
+            }));
+            return;
+          }
           // In passthrough mode, skip all Claude-specific injection — OAuth swap only.
           // count_tokens also forwards thin (see resolveProxyTarget) — the endpoint
           // counts the CLIENT's own prompt, so template injection would distort it.

--- a/test/model-catalog.mjs
+++ b/test/model-catalog.mjs
@@ -22,6 +22,9 @@ import {
   getCachedBases,
   _resetModelCatalogForTest,
   DEFAULT_CATALOG_TTL_MS,
+  suspendedFamilies,
+  isSuspendedModel,
+  dropSuspendedModels,
 } from '../dist/model-catalog.js';
 import { OPENAI_MODELS_LIST, resolveClaudeAlias } from '../dist/proxy.js';
 
@@ -163,7 +166,7 @@ _resetModelCatalogForTest();
   };
   const cat = await getModelCatalog(failingDeps);
   check('fetch failure → baked fallback', cat.source === 'baked');
-  check('baked fallback serves the full baked set', JSON.stringify(cat.bases) === JSON.stringify(BAKED_BASE_MODELS));
+  check('baked fallback serves the baked set minus suspended families', JSON.stringify(cat.bases) === JSON.stringify(dropSuspendedModels(BAKED_BASE_MODELS)));
   await getModelCatalog(failingDeps);
   await new Promise((r) => setImmediate(r));
   check('failures back off (no hammering within retry window)', attempts === 1);
@@ -205,6 +208,82 @@ _resetModelCatalogForTest();
 const shape = buildOpenAIModelsList(['claude-fable-5']);
 check('OpenAI list shape', shape.object === 'list' && shape.data[0].id === 'claude-fable-5'
   && shape.data[0].object === 'model' && shape.data[0].owned_by === 'anthropic');
+
+// ---------------------------------------------------------------------------
+console.log('  suspended models — Fable 5 / Mythos 5 global suspension (2026-06-12)');
+{
+  const ORIG = process.env.DARIO_SUSPENDED_MODELS;
+
+  // Default suspension (env unset): the fable family is suspended in every
+  // spelling; the other families are untouched.
+  delete process.env.DARIO_SUSPENDED_MODELS;
+  check('default: fable id suspended', isSuspendedModel('claude-fable-5'));
+  check('default: fable[1m] suspended', isSuspendedModel('claude-fable-5[1m]'));
+  check('default: bare `fable` alias suspended', isSuspendedModel('fable'));
+  check('default: `fable1m` alias suspended', isSuspendedModel('fable1m'));
+  check('default: `claude:fable` prefix suspended', isSuspendedModel('claude:fable'));
+  check('default: opus NOT suspended', !isSuspendedModel('claude-opus-4-8'));
+  check('default: sonnet NOT suspended', !isSuspendedModel('claude-sonnet-4-6'));
+  check('default: haiku NOT suspended', !isSuspendedModel('claude-haiku-4-5'));
+  check('default: suspendedFamilies = {fable}',
+    suspendedFamilies().size === 1 && suspendedFamilies().has('fable'));
+
+  // dropSuspendedModels removes the family, preserving the order of the rest.
+  const dropped = dropSuspendedModels(['claude-fable-5', 'claude-opus-4-8', 'claude-sonnet-4-6']);
+  check('dropSuspendedModels removes fable', !dropped.includes('claude-fable-5'));
+  check('dropSuspendedModels keeps the rest in order',
+    dropped.length === 2 && dropped[0] === 'claude-opus-4-8' && dropped[1] === 'claude-sonnet-4-6');
+
+  // Catalog never advertises a suspended family — even when upstream still lists it.
+  _resetModelCatalogForTest();
+  {
+    const cat = await getModelCatalog({
+      fetchImpl: async () => ({ ok: true, status: 200,
+        json: async () => ({ data: [{ id: 'claude-fable-5' }, { id: 'claude-opus-4-8' }] }) }),
+      getToken: async () => 'tok', now: () => 6_000_000,
+    });
+    check('upstream catalog drops fable despite upstream listing it',
+      cat.source === 'upstream' && !cat.bases.includes('claude-fable-5'));
+    check('upstream catalog keeps opus', cat.bases.includes('claude-opus-4-8'));
+    check('getCachedBases excludes fable', !getCachedBases().includes('claude-fable-5'));
+  }
+
+  // Baked fallback is filtered too (cold start, upstream unreachable).
+  _resetModelCatalogForTest();
+  {
+    const cat = await getModelCatalog({
+      fetchImpl: async () => { throw new Error('offline'); },
+      getToken: async () => 'tok', now: () => 7_000_000,
+    });
+    check('baked fallback drops fable', cat.source === 'baked' && !cat.bases.includes('claude-fable-5'));
+    check('baked fallback keeps opus', cat.bases.includes('claude-opus-4-8'));
+  }
+
+  // Re-enable path: clearing the env unsuspends everything (access restored).
+  process.env.DARIO_SUSPENDED_MODELS = '';
+  check('empty env: nothing suspended', !isSuspendedModel('claude-fable-5'));
+  check('empty env: suspendedFamilies empty', suspendedFamilies().size === 0);
+  _resetModelCatalogForTest();
+  {
+    const cat = await getModelCatalog({
+      fetchImpl: async () => ({ ok: true, status: 200,
+        json: async () => ({ data: [{ id: 'claude-fable-5' }, { id: 'claude-opus-4-8' }] }) }),
+      getToken: async () => 'tok', now: () => 8_000_000,
+    });
+    check('empty env: catalog re-advertises fable', cat.bases.includes('claude-fable-5'));
+  }
+
+  // Override path: suspend a different family, by id or by name (both → family).
+  process.env.DARIO_SUSPENDED_MODELS = 'claude-opus-4-8, sonnet';
+  check('override: opus suspended (id → family)', isSuspendedModel('claude-opus-4-8'));
+  check('override: sonnet suspended (name → family)', isSuspendedModel('claude-sonnet-4-6'));
+  check('override: fable NOT suspended', !isSuspendedModel('claude-fable-5'));
+  check('override: families = {opus, sonnet}',
+    suspendedFamilies().size === 2 && suspendedFamilies().has('opus') && suspendedFamilies().has('sonnet'));
+
+  if (ORIG === undefined) delete process.env.DARIO_SUSPENDED_MODELS;
+  else process.env.DARIO_SUSPENDED_MODELS = ORIG;
+}
 
 _resetModelCatalogForTest();
 console.log(`✅ model-catalog: ${passed} assertions passed`);


### PR DESCRIPTION
## Why
Fable 5 **and** Mythos 5 were disabled for **all** Anthropic customers by a US government legal directive on 2026-06-12 (all plans/tiers; other models unaffected) — https://www.anthropic.com/news/fable-mythos-access. Verified against the box's prod OAuth: `claude-fable-5` / `claude-fable-5[1m]` return a hard `not_found` from api.anthropic.com while opus/sonnet answer fine.

dario still advertised `claude-fable-5[1m]` in `/v1/models` (baked fallback + any stale upstream listing) and forwarded fable requests straight into Anthropic's `not_found`, so every consumer (forge, agents, CC-via-dario) got a confusing failure.

## What
- **model-catalog**: `suspendedFamilies()` / `isSuspendedModel()` / `dropSuspendedModels()`, filtered out of **both** the autodetected upstream catalog (`refresh`) and the baked fallback (`getModelCatalog` cold path + `getCachedBases`). `/v1/models` and catalog-driven alias resolution never offer a suspended family.
- **proxy**: reject any spelling of a suspended model up front — `404 not_found` with an actionable message pointing at `claude-opus-4-8` / `claude-sonnet-4-6` — before the template build / account lease / forwarding (nothing to unwind).
- **Reversible** via `DARIO_SUSPENDED_MODELS` (default `fable`); set it empty (`DARIO_SUSPENDED_MODELS=`) to re-enable when access is restored. Matching is by **family**, so `fable` / `fable1m` / `claude-fable-5` / `claude-fable-5[1m]` / `claude:fable` are all caught.

## Tests
`test/model-catalog.mjs` +31 assertions (default suspension across every spelling, upstream + baked filtering, re-enable path, env override by id/name). **Full suite 87/87.**

## Scope notes
- `doctor`'s manual `--usage`/`--obedience` fable probe is **left for `feat/doctor-obedience-probe`** (where the `PROBE_FAMILIES` abstraction lives) to avoid a merge conflict. `dario-doctor-watch.yml` runs plain `dario doctor` (no model probe), so the scheduled watcher stays clean regardless.
- `OPENAI_MODELS_LIST` (proxy.ts) is a legacy export **served nowhere** (the `/v1/models` route builds from the filtered catalog) — left untouched.

## ⚠️ Release sequencing (no version bump in this PR)
master is at the **released** v4.8.66 (#508); `feat/doctor-obedience-probe` claims 4.8.67. This PR deliberately does **not** bump — to deploy to the box, bump to **4.8.67** (renumber the obedience branch to 4.8.68) **or** **4.8.68** (leaving 4.8.67 for obedience). Mind npm `latest` ordering: whichever releases last wins `latest`, so release the lower number first. On a version-bumped merge, `cc-drift-auto-release.yml` ships it and the box autodeploys from GHCR.