### PR TITLE
docs: lead with the 2026-06-15 billing split

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 
 ---
 
+> 🗓️ **2026-06-15 — Anthropic splits Claude billing.** Agent-SDK and `claude -p` (headless) traffic stops counting against your subscription pool and moves to a small separate monthly credit ($20 / $100 / $200 by plan), then metered per-token API rates. Most proxies forward your requests in exactly the shape that gets reclassified into that bucket. dario rewrites every request into interactive Claude Code wire-shape before it leaves your machine, so your traffic stays in the subscription pool you already pay for — same install, no config change for the cliff. **[What changes, and how to verify it on your own machine →](#the-deadline-2026-06-15)**
+
 > ⛔ **Claude Fable 5 / Mythos 5 — temporarily suspended for all Anthropic customers.** On 2026-06-12 a US-government legal directive disabled Fable 5 and Mythos 5 for **every** Anthropic plan and tier — `api.anthropic.com` now returns `not_found` for them, and no account or proxy can route around it ([details](https://www.anthropic.com/news/fable-mythos-access)). As of **v4.8.71**, dario filters both families out of `/v1/models` and rejects any spelling (`fable`, `fable1m`, `claude-fable-5`, `claude-fable-5[1m]`, `claude:fable`) up front with a clean `404` pointing at `claude-opus-4-8` / `claude-sonnet-4-6` — instead of forwarding into a confusing upstream error. Reversible without a code change once access is restored: set `DARIO_SUSPENDED_MODELS=` (empty) on the instance. `npm install -g @askalf/dario@latest`
 >
 > ⚠️ Still on a version **before 4.8.39**? Upgrade now — those could silently corrupt code/structured content routed through the proxy (the identifier scrub stripped tokens like the JS `continue` keyword). **[Details →](https://github.com/askalf/dario/issues/457)**
@@ -85,18 +87,6 @@ Type `dario` with no args (in another terminal) to open a full-screen control pa
 
 ---
 
-## The money
-
-| Setup | Monthly cost — heavy user |
-|---|---|
-| Cursor + Anthropic API direct | **$80–$300** |
-| Multi-tool heavy use (Cursor + Aider + Cline + Continue), per-token | **$200–$600+** |
-| **Any of the above + dario** | **$20–$200 flat** — your existing Pro/Max plan, nothing extra |
-
-Switching providers is a model-name change, not a reconfigure. Add a backend once and the same `localhost:3456` speaks OpenAI, Groq, OpenRouter, or a local Ollama too.
-
----
-
 ## The deadline: 2026-06-15
 
 On **2026-06-15**, Anthropic splits Claude billing in two. Agentic traffic — Agent SDK, `claude -p` headless — stops counting against your subscription pool and gets a separate small monthly credit. [Announced 2026-05-13](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan) via Claude's Help Center and a [@ClaudeDevs X post](https://x.com/ClaudeDevs/status/2054610152817619388) — no anthropic.com blog post, no email to most subscribers, no mention in CC release notes.
@@ -119,6 +109,18 @@ dario doesn't. Every outbound request is rebuilt into **interactive Claude Code 
 | Claude Code, interactive | subscription pool — unchanged |
 
 Same install, same `localhost:3456`, no config change for the cliff. Verify on your own machine: `dario doctor --usage` fires one request and surfaces the rate-limit headers — `representative-claim` should read `five_hour` or `seven_day` (subscription buckets). Full breakdown: [`docs/why-now-2026-06.md`](./docs/why-now-2026-06.md).
+
+---
+
+## The money
+
+| Setup | Monthly cost — heavy user |
+|---|---|
+| Cursor + Anthropic API direct | **$80–$300** |
+| Multi-tool heavy use (Cursor + Aider + Cline + Continue), per-token | **$200–$600+** |
+| **Any of the above + dario** | **$20–$200 flat** — your existing Pro/Max plan, nothing extra |
+
+Switching providers is a model-name change, not a reconfigure. Add a backend once and the same `localhost:3456` speaks OpenAI, Groq, OpenRouter, or a local Ollama too.
 
 ---
 

--- a/docs/why-now-2026-06.md
+++ b/docs/why-now-2026-06.md
@@ -1,6 +1,6 @@
 # What changes 2026-06-15
 
-Anthropic [announced](https://www.anthropic.com/) that starting **2026-06-15**, Claude Agent SDK and `claude -p` (Claude Code headless mode) usage will no longer count toward Claude plan usage limits. Instead, eligible plans receive a fixed monthly Agent-SDK credit:
+Anthropic [announced on 2026-05-13](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan) — via the Claude Help Center and a [@ClaudeDevs post](https://x.com/ClaudeDevs/status/2054610152817619388), with no anthropic.com blog post and no email to most subscribers — that starting **2026-06-15**, Claude Agent SDK and `claude -p` (Claude Code headless mode) usage will no longer count toward Claude plan usage limits. Instead, eligible plans receive a fixed monthly Agent-SDK credit:
 
 | Plan | Subscription pool (interactive Claude Code, Claude Cowork, Claude.ai) | Separate Agent-SDK / `claude -p` credit (new) |
 |---|---|---|
@@ -75,7 +75,7 @@ A clean `dario doctor` report is the per-machine equivalent of running the rate-
 
 A few things worth being precise about:
 
-1. **No verified post-2026-06-15 behavior yet.** As of this writing (2026-05-14), the cliff is four weeks out. The wire-rewrite has been classified as interactive subscription billing every day for months — but Anthropic could add a new signal on 2026-06-15 that none of the six current axes covers. If that happens, the live template extractor and drift detector will surface it on your first call, and the fix follows the same pattern as every other CC drift event the project has shipped.
+1. **No verified post-2026-06-15 behavior yet.** The split lands 2026-06-15; until it does, there's no post-cliff data to point to. The wire-rewrite has been classified as interactive subscription billing every day for months — but Anthropic could add a new signal on 2026-06-15 that none of the six current axes covers. If that happens, the live template extractor and drift detector will surface it on your first call, and the fix follows the same pattern as every other CC drift event the project has shipped.
 2. **No claim about competitor products specifically.** The table above refers to architectural patterns (`proxy that forwards request shape unchanged`), not named tools. If a particular tool also implements wire-fidelity replay, it gets the same outcome dario does. The reason this doc exists is that most subscription-billing proxies don't — they extract OAuth tokens and forward the raw client request, which is exactly the request shape that's about to be reclassified.
 3. **Beyond the subscription cap, Anthropic still rate-limits.** Dario doesn't multiply your subscription — it routes through the plan you have. Multi-account pool mode ([`multi-account-pool.md`](./multi-account-pool.md)) is the answer for hitting the cap on a single account; the 2026-06-15 work is orthogonal to it.
 4. **Anthropic terms of service still apply.** This project is independent, unofficial, third-party — see [DISCLAIMER.md](../DISCLAIMER.md). Whether any particular use complies with Anthropic's current terms is between you and Anthropic.


### PR DESCRIPTION
With the Agent-SDK / `claude -p` billing split landing **2026-06-15**, the README's highest-intent section for an arriving visitor — `## The deadline: 2026-06-15` — sat about six sections down, below the two transient service banners (Fable suspension, pre-4.8.39 upgrade). This raises it.

### Changes
- **README:** new one-paragraph 2026-06-15 lead banner above the existing notices, with a jump link to `#the-deadline-2026-06-15`. The Fable / pre-4.8.39 banners are unchanged, just one slot lower.
- **README:** reordered `## The deadline` above `## The money` (why-now before how-much). Anchors are heading-derived, so no internal links break; the FAQ's `#the-deadline-2026-06-15` link is verified intact.
- **docs/why-now-2026-06.md:** the lead citation was a bare `https://www.anthropic.com/` homepage link, which is misleading since there was no anthropic.com post. Swapped to the real source (Help Center article + @ClaudeDevs), matching the README. Dropped the stale "as of this writing (2026-05-14), four weeks out" line.

### Trade-offs
- The lead banner stacks a third blockquote at the top. If that reads too heavy, the alternative is collapsing the Fable notice into a `<details>` — I left it visible to avoid hiding an active service notice.
- Docs-only: no version bump, no code, doesn't touch `maxTested`, won't trip the auto-release gate.
