### PR TITLE
fix(cc-template): CC-native identity-map overrides TOOL_MAP (4.8.73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.73] - 2026-06-13
+
+- **CC-native identity-map must OVERRIDE TOOL_MAP (completes 4.8.72)** — 4.8.72 stopped CC's *missing* tools from being round-robined, but `Read` (and other core tools) were still corrupted: they ARE in TOOL_MAP, as the lowercase cross-client alias `read` whose `translateBack` emits `{path, filePath}` and drops `file_path`. A CC client's `Read` lowercased to `read` and hit that alias, so every Read still failed validation client-side (`file_path` missing). Fix: match CC's own tools by **exact** name (`CC_NATIVE_NAMES`, PascalCase) and identity-map them *ahead of* TOOL_MAP — exact case is the discriminator, so a genuine non-CC `read` (lowercase/snake) still routes through TOOL_MAP unchanged. Verified end-to-end: a dock session now uses `Read` with `file_path` preserved instead of falling back to `Bash`.
+
 ## [4.8.72] - 2026-06-13
 
 - **CC-native tools identity-map (fixes Read/tool corruption for current CC)** — `TOOL_MAP` carries the legacy core surface + cross-client aliases, but it lagged CC's newer built-ins (`Agent`, `AskUserQuestion`, `Cron*`, `Task*`, `NotebookEdit`, `Enter/ExitPlanMode`, `Workflow`, …). The bundled *template* (`cc-template-data.json`) was current at 31 tools, but the runtime *matcher* wasn't — so ~22 of a current CC client's own tools were treated as **foreign**, round-robined onto the 6 CC fallback slots (`Bash`, `Read`, `Grep`, …), and collided. That corrupted the calls of the tools that *did* map — most visibly `Read`'s `file_path` arriving as `path`/`filePath`, so every Read failed and clients fell back to `Bash`. This hit **any** client on current CC (surfaced via the headless session dock). Fix: a CC client's tool now identity-maps to itself when its name matches the live CC tool set (`CC_NATIVE_LOWER`, refreshed by every `capture-and-bake`) — so newer built-ins map 1:1 instead of being round-robined, and the canonical CC fingerprint is preserved. No per-client patterns; tracks the bundle automatically.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.72",
+  "version": "4.8.73",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -54,11 +54,14 @@ export function filterToolsForPlatform<T extends { name: string }>(
 /** CC's exact tool definitions for the current platform — filtered from the bundled union. */
 export const CC_TOOL_DEFINITIONS = filterToolsForPlatform(TEMPLATE.tools, process.platform);
 
-/** Lowercased CC tool name → canonical name, for identity-matching a CC client's
- *  own tools (so newer built-ins not yet in TOOL_MAP map to themselves rather
- *  than being treated as foreign and round-robined). Tracks the live bundle. */
-export const CC_NATIVE_LOWER: Map<string, string> = new Map(
-  CC_TOOL_DEFINITIONS.map((t) => [String((t as { name: string }).name).toLowerCase(), String((t as { name: string }).name)]),
+/** CC's own tool names, EXACT case ("Read", "Bash", "Agent", …). A CC client's
+ *  tools identity-map to themselves and OVERRIDE TOOL_MAP — whose lowercase
+ *  cross-client aliases ('read' → {path}/{filePath}) would otherwise mistranslate
+ *  a CC tool (Read's file_path → path). Exact case is the discriminator: CC sends
+ *  PascalCase, the {path}-style clients send lowercase/snake, so a non-CC `read`
+ *  still routes through TOOL_MAP. Tracks the live bundle (refreshed each bake). */
+export const CC_NATIVE_NAMES: Set<string> = new Set(
+  CC_TOOL_DEFINITIONS.map((t) => String((t as { name: string }).name)),
 );
 
 /** CC's static system prompt (~25KB). */
@@ -1336,19 +1339,20 @@ export function buildCCRequest(
     const claimedCC = new Set<string>();
     for (const tool of clientTools) {
       const name = (tool.name as string || '').toLowerCase();
-      // A CC client's OWN tools map to THEMSELVES (identity). TOOL_MAP only
-      // carries the legacy core surface + cross-client aliases, so it lags CC's
-      // newer built-ins (Agent, AskUserQuestion, Cron*, Task*, NotebookEdit,
-      // Enter/ExitPlanMode, Workflow, …). Without this, those land "unmapped",
-      // get round-robined onto Read/Bash/etc., and the collision corrupts the
-      // calls of the tools that DID map (the dock saw Read's `file_path` arrive
-      // as `path`/`filePath`). Identity-matching against the live CC tool set
-      // (CC_NATIVE_LOWER, refreshed by every capture-and-bake) fixes it for
-      // every current-and-future CC client and keeps the canonical CC fingerprint.
-      const mapping = TOOL_MAP[name]
-        ?? (CC_NATIVE_LOWER.get(name)
-            ? { ccTool: CC_NATIVE_LOWER.get(name)!, translateArgs: (a: Record<string, unknown>) => a, translateBack: (a: Record<string, unknown>) => a }
-            : undefined);
+      // A CC client's OWN tools map to THEMSELVES (identity), and this OVERRIDES
+      // TOOL_MAP. Two failure modes it fixes, both seen via the dock:
+      //  1. TOOL_MAP's lowercase cross-client aliases mistranslate a CC tool —
+      //     `Read` → TOOL_MAP['read'] whose translateBack emits {path, filePath}
+      //     instead of {file_path}, so every Read failed validation client-side.
+      //  2. CC's newer built-ins (Agent, AskUserQuestion, Cron*, Task*, Workflow,
+      //     NotebookEdit, Enter/ExitPlanMode, …) aren't in TOOL_MAP at all, so
+      //     they were round-robined onto Read/Bash/etc. and collided.
+      // Exact case is the discriminator (CC sends PascalCase; {path}-style clients
+      // send lowercase/snake) so a genuine non-CC `read` still routes via TOOL_MAP.
+      // Tracks the live bundle, so future CC tools are covered after the next bake.
+      const mapping = CC_NATIVE_NAMES.has(tool.name as string)
+        ? { ccTool: tool.name as string, translateArgs: (a: Record<string, unknown>) => a, translateBack: (a: Record<string, unknown>) => a }
+        : TOOL_MAP[name];
       if (mapping) {
         // In hybrid mode, clone the shared mapping and attach the
         // client-declared top-level field names from input_schema.
@@ -1384,7 +1388,7 @@ export function buildCCRequest(
     const CC_FALLBACK_TOOLS = ['Bash', 'Read', 'Grep', 'Glob', 'WebSearch', 'WebFetch'];
     for (const tool of clientTools) {
       const name = (tool.name as string || '').toLowerCase();
-      if (TOOL_MAP[name] || CC_NATIVE_LOWER.has(name)) continue; // mapped, or a CC-native tool (identity in pass 1)
+      if (CC_NATIVE_NAMES.has(tool.name as string) || TOOL_MAP[name]) continue; // CC-native (identity in pass 1) or mapped
       unmappedTools.push(tool.name as string);
       if (opts.hybridTools) continue; // dropped — see comment above
       // Default mode: round-robin distribution. Exclude CC tools the client

--- a/test/issue-29-tool-translation.mjs
+++ b/test/issue-29-tool-translation.mjs
@@ -372,11 +372,23 @@ const ccNativeBody = {
 };
 const { toolMap: ccNativeMap, unmappedTools: ccNativeUnmapped } = buildCCRequest(ccNativeBody, billingTag, cache1h, identity);
 check('no CC-native tool is left unmapped', ccNativeUnmapped.length === 0);
-check('Read maps to Read (identity, file_path preserved)', ccNativeMap.get('Read')?.ccTool === 'Read');
-check('Agent maps to Agent (identity, not a fallback slot)', ccNativeMap.get('Agent')?.ccTool === 'Agent');
-check('CronCreate maps to CronCreate (identity)', ccNativeMap.get('CronCreate')?.ccTool === 'CronCreate');
-check('NotebookEdit maps to NotebookEdit (identity, underscore-key miss fixed)', ccNativeMap.get('NotebookEdit')?.ccTool === 'NotebookEdit');
-check('identity translateArgs is passthrough', JSON.stringify(ccNativeMap.get('Agent')?.translateArgs({ a: 1 })) === '{"a":1}');
+check('Read maps to Read', ccNativeMap.get('Read')?.ccTool === 'Read');
+check('Agent maps to Agent (not a fallback slot)', ccNativeMap.get('Agent')?.ccTool === 'Agent');
+check('CronCreate maps to CronCreate', ccNativeMap.get('CronCreate')?.ccTool === 'CronCreate');
+check('NotebookEdit maps to NotebookEdit', ccNativeMap.get('NotebookEdit')?.ccTool === 'NotebookEdit');
+// THE bug: TOOL_MAP['read'].translateBack emits {path, filePath} and drops file_path.
+// CC's exact-name Read must OVERRIDE that alias with an identity passthrough.
+const readBack = ccNativeMap.get('Read')?.translateBack({ file_path: '/etc/hostname' });
+check('Read.translateBack PRESERVES file_path (identity, not the {path} alias)', readBack?.file_path === '/etc/hostname');
+check('Read.translateBack does NOT emit corrupt path/filePath', readBack?.path === undefined && readBack?.filePath === undefined);
+check('Read.translateArgs is passthrough', JSON.stringify(ccNativeMap.get('Read')?.translateArgs({ file_path: '/x' })) === '{"file_path":"/x"}');
+
+// Regression guard: a genuine non-CC lowercase `read` (path-style) STILL routes
+// through TOOL_MAP (exact-case discriminator), so cross-client clients are intact.
+const nonCcBody = { model: 'claude-sonnet-4-6', messages: [{ role: 'user', content: 'hi' }],
+  tools: [{ name: 'read', description: 'read', input_schema: { type: 'object', properties: { path: { type: 'string' } } } }] };
+const { toolMap: nonCcMap } = buildCCRequest(nonCcBody, billingTag, cache1h, identity);
+check('lowercase `read` still uses TOOL_MAP alias (translateBack emits path)', nonCcMap.get('read')?.translateBack({ file_path: '/x' })?.path === '/x');
 
 // ── Summary ──
 


### PR DESCRIPTION
**Completes #522 / 4.8.72.** That release stopped CC's *missing* tools from being round-robined — but core tools like `Read` were **still corrupted**, and the dock still fell back to `Bash`.

## Why 4.8.72 wasn't enough
`Read` *is* in TOOL_MAP — as the lowercase cross-client alias `read`, whose `translateBack` is `(a) => ({ path: a.file_path, filePath: a.file_path })`: it **drops `file_path` and emits `path`/`filePath`**. A CC client's `Read` lowercases to `read`, hits that Cline-oriented alias, and every Read fails validation client-side. 4.8.72 only added identity for tools *absent* from TOOL_MAP, so `Read` kept using the bad alias.

## Fix
Match CC's own tools by **exact name** (`CC_NATIVE_NAMES`, PascalCase) and identity-map them **ahead of** TOOL_MAP. Exact case is the discriminator — CC sends `Read`, the `{path}`-style clients send `read`/`read_file` — so a genuine non-CC `read` still routes through TOOL_MAP unchanged.

## Tests
issue-29 now asserts `Read.translateBack` **preserves `file_path`** (the actual bug) + a regression guard that lowercase `read` still translates to `path`. Suites green: issue-29 **54**, schema-contract **127**, template-invariants **228**, strict **16**, detection **63**, hybrid **60**, platform **41** — **0 fail**. Will verify end-to-end on the box after deploy.