### PR TITLE
fix(health): don't leak OAuth internals on the public /health (4.8.74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.74] - 2026-06-14
+
+- **`/health` no longer leaks OAuth internals to the public internet** — when dario sits behind a Cloudflare tunnel with a public `/health` bypass (uptime monitoring), the endpoint was world-readable and returned `oauth` status, the access-token `expiresIn` countdown, request volume, and refresh-error detail. Public requests (identified by the CF-edge-stamped `cf-ray` header) now receive only the liveness verdict (`{status: ok|degraded}`); internal loopback callers — the docker healthcheck, `dario doctor`, the self-probe — still get full detail. The HTTP 200/503 is unchanged, so external uptime checks keying on the status code are unaffected. Logic extracted to `buildHealthResponse` with unit coverage.
+
 ## [4.8.73] - 2026-06-13
 
 - **CC-native identity-map must OVERRIDE TOOL_MAP (completes 4.8.72)** — 4.8.72 stopped CC's *missing* tools from being round-robined, but `Read` (and other core tools) were still corrupted: they ARE in TOOL_MAP, as the lowercase cross-client alias `read` whose `translateBack` emits `{path, filePath}` and drops `file_path`. A CC client's `Read` lowercased to `read` and hit that alias, so every Read still failed validation client-side (`file_path` missing). Fix: match CC's own tools by **exact** name (`CC_NATIVE_NAMES`, PascalCase) and identity-map them *ahead of* TOOL_MAP — exact case is the discriminator, so a genuine non-CC `read` (lowercase/snake) still routes through TOOL_MAP unchanged. Verified end-to-end: a dock session now uses `Read` with `file_path` preserved instead of falling back to `Bash`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.73",
+  "version": "4.8.74",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/health-response.ts
+++ b/src/health-response.ts
@@ -1,0 +1,53 @@
+/**
+ * /health response builder — extracted so the public-vs-internal disclosure rule
+ * is unit-testable without spinning a proxy.
+ *
+ * dario's /health is auth-free (docker healthchecks + `depends_on: service_healthy`
+ * need it before any secret is configured). When dario sits behind a Cloudflare
+ * tunnel with a public /health bypass (uptime monitoring), that endpoint is
+ * world-readable — so it must not leak OAuth internals (token countdown, request
+ * volume, refresh errors). The Cloudflare edge stamps `cf-ray` on every request it
+ * proxies, so its presence marks a request as having come from the public internet.
+ * Internal callers (the docker healthcheck, `dario doctor`, the self-probe) hit
+ * dario directly on loopback with no CF headers and still get the full detail.
+ *
+ * The HTTP status (200 healthy / 503 degraded) is identical either way, so external
+ * uptime monitoring that keys on the status code is unaffected.
+ */
+
+export interface HealthStatusLike {
+  status: string;
+  canRefresh?: boolean;
+  expiresIn?: string;
+  refreshFailures?: number;
+  lastRefreshError?: string;
+}
+
+export interface HealthResponse {
+  httpStatus: number;
+  body: Record<string, unknown>;
+}
+
+export function buildHealthResponse(
+  s: HealthStatusLike,
+  requestCount: number,
+  viaPublicTunnel: boolean,
+): HealthResponse {
+  const dead =
+    s.status === 'broken' ||
+    s.status === 'none' ||
+    (s.status === 'expired' && s.canRefresh === false);
+  const httpStatus = dead ? 503 : 200;
+  const liveness = { status: dead ? 'degraded' : 'ok' };
+  const body: Record<string, unknown> = viaPublicTunnel
+    ? liveness
+    : {
+        ...liveness,
+        oauth: s.status,
+        expiresIn: s.expiresIn,
+        requests: requestCount,
+        ...(s.refreshFailures ? { refreshFailures: s.refreshFailures } : {}),
+        ...(s.lastRefreshError ? { lastRefreshError: s.lastRefreshError } : {}),
+      };
+  return { httpStatus, body };
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -7,6 +7,7 @@ import { homedir } from 'node:os';
 import { setDefaultResultOrder } from 'node:dns';
 import { arch, platform } from 'node:process';
 import { getAccessToken, getStatus } from './oauth.js';
+import { buildHealthResponse } from './health-response.js';
 import { buildCCRequest, applyCcPromptCaching, parseEffortSuffix, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, CC_TEMPLATE, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
 import { describeTemplate, detectDrift, checkCCCompat } from './live-fingerprint.js';
 import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCooldown, authCooldownMs, type PoolAccount } from './pool.js';
@@ -1357,18 +1358,12 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
     // react instead of cheerfully passing while every /v1/messages 401s.
     if (urlPath === '/health' || urlPath === '/') {
       const s = await getStatus();
-      const dead = s.status === 'broken' || s.status === 'none' ||
-                   (s.status === 'expired' && s.canRefresh === false);
-      const httpStatus = dead ? 503 : 200;
+      // Public requests arrive through the Cloudflare tunnel (the edge stamps
+      // `cf-ray`); they get only the liveness verdict, never the OAuth internals.
+      // See buildHealthResponse for the full rationale.
+      const { httpStatus, body } = buildHealthResponse(s, requestCount, req.headers['cf-ray'] !== undefined);
       res.writeHead(httpStatus, JSON_HEADERS);
-      res.end(JSON.stringify({
-        status: dead ? 'degraded' : 'ok',
-        oauth: s.status,
-        expiresIn: s.expiresIn,
-        requests: requestCount,
-        ...(s.refreshFailures ? { refreshFailures: s.refreshFailures } : {}),
-        ...(s.lastRefreshError ? { lastRefreshError: s.lastRefreshError } : {}),
-      }));
+      res.end(JSON.stringify(body));
       return;
     }
 

--- a/test/health-response.mjs
+++ b/test/health-response.mjs
@@ -1,0 +1,62 @@
+// Tests for buildHealthResponse — the /health public-vs-internal disclosure rule.
+//
+// Public requests (through the Cloudflare tunnel, marked by `cf-ray`) must get
+// ONLY the liveness verdict; internal loopback callers get full OAuth detail.
+// The HTTP status code is identical for both so external uptime checks still work.
+
+import { buildHealthResponse } from '../dist/health-response.js';
+
+let pass = 0, fail = 0;
+function check(name, cond) {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else      { console.log(`  FAIL ${name}`); fail++; }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+const healthy = { status: 'valid', expiresIn: '4h 57m', canRefresh: true };
+const dead = { status: 'broken', expiresIn: '0s', canRefresh: false };
+
+header('public (via tunnel) — minimal, no OAuth leak');
+{
+  const { httpStatus, body } = buildHealthResponse(healthy, 167, true);
+  check('http 200 when healthy', httpStatus === 200);
+  check('status ok', body.status === 'ok');
+  check('NO oauth field', !('oauth' in body));
+  check('NO expiresIn field', !('expiresIn' in body));
+  check('NO requests field', !('requests' in body));
+  check('exactly one key (status only)', Object.keys(body).length === 1);
+}
+
+header('internal (no cf-ray) — full detail');
+{
+  const { httpStatus, body } = buildHealthResponse(healthy, 167, false);
+  check('http 200', httpStatus === 200);
+  check('oauth present', body.oauth === 'valid');
+  check('expiresIn present', body.expiresIn === '4h 57m');
+  check('requests present', body.requests === 167);
+}
+
+header('dead OAuth — 503 + degraded, both surfaces');
+{
+  const pub = buildHealthResponse(dead, 5, true);
+  const int = buildHealthResponse(dead, 5, false);
+  check('public 503', pub.httpStatus === 503);
+  check('public degraded', pub.body.status === 'degraded');
+  check('public still leaks nothing', !('oauth' in pub.body));
+  check('internal 503', int.httpStatus === 503);
+  check('internal degraded + oauth=broken', int.body.status === 'degraded' && int.body.oauth === 'broken');
+}
+
+header('refresh error fields — internal only, never public');
+{
+  const s = { status: 'expired', canRefresh: true, expiresIn: '0s', refreshFailures: 3, lastRefreshError: 'token endpoint 401' };
+  const pub = buildHealthResponse(s, 1, true);
+  const int = buildHealthResponse(s, 1, false);
+  check('public hides refreshFailures', !('refreshFailures' in pub.body));
+  check('public hides lastRefreshError', !('lastRefreshError' in pub.body));
+  check('internal shows refreshFailures', int.body.refreshFailures === 3);
+  check('internal shows lastRefreshError', int.body.lastRefreshError === 'token endpoint 401');
+}
+
+console.log(`\nhealth-response: ${pass} passed, ${fail} failed`);
+if (fail > 0) process.exit(1);


### PR DESCRIPTION
## Why
Found during a Cloudflare security audit. dario's `/health` is auth-free (docker healthchecks + `depends_on: service_healthy` need it before any secret is set). But behind the CF tunnel with a **public /health bypass** (uptime monitoring), the endpoint is world-readable and returned:
```
{"status":"ok","oauth":"healthy","expiresIn":"4h 57m","requests":167}
```
— leaking OAuth status, the access-token expiry countdown, request volume, and (on failure) refresh-error detail to anyone.

## What
Public requests carry the CF-edge-stamped `cf-ray` header → they now get **only** the liveness verdict (`{status: ok|degraded}`). Internal loopback callers (the docker healthcheck `wget 127.0.0.1:3456/health`, `dario doctor` (`DARIO_TEST_URL || http://127.0.0.1:3456`), and the self-probe) have no CF headers and still receive full detail. **HTTP 200/503 is identical for both**, so external uptime monitoring keying on the status code is unaffected.

Verified no internal consumer parses the body: `doctor.ts` checks `healthRes.ok`; the docker healthcheck uses wget exit/HTTP status.

## Test
Extracted to `buildHealthResponse` (pure, unit-testable). `test/health-response.mjs` — 19 cases: public minimal, internal full, dead→503+degraded on both, refresh-error fields internal-only. Full suite 89/89.

Releases 4.8.74 → autodeploys to the box; I'll verify the public surface goes minimal post-deploy.