### PR TITLE
fix(tools): only advertise CC tools the client declared (4.8.75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.75] - 2026-06-14
+
+- **Don't advertise CC tools the client didn't declare** — in default (template) mode `buildCCRequest` replaced the client's tool array with the FULL `CC_TOOL_DEFINITIONS` (all 31 tools, incl. `AskUserQuestion`, `Agent`, `Task*`, `Workflow`, …). A CC session with a tool *disabled* (e.g. a headless or SDK context where `AskUserQuestion` isn't enabled) sends its array without it; dario re-added it; the model then emitted a tool_use the client's harness couldn't run, surfacing as `"<Tool> exists but is not enabled in this context"`. Default mode now advertises only the CC-native tools the client actually declared (using CC's canonical definitions for them) — a real reduced-tool CC client sends exactly this array, so it tracks CC's wire shape rather than diverging. Full-tool clients are unaffected; if a client declares no CC-native tool at all the full template is kept as the fingerprint default. `--preserve-tools` / `--merge-tools` unchanged. Regression test added.
+
 ## [4.8.74] - 2026-06-14
 
 - **`/health` no longer leaks OAuth internals to the public internet** — when dario sits behind a Cloudflare tunnel with a public `/health` bypass (uptime monitoring), the endpoint was world-readable and returned `oauth` status, the access-token `expiresIn` countdown, request volume, and refresh-error detail. Public requests (identified by the CF-edge-stamped `cf-ray` header) now receive only the liveness verdict (`{status: ok|degraded}`); internal loopback callers — the docker healthcheck, `dario doctor`, the self-probe — still get full detail. The HTTP 200/503 is unchanged, so external uptime checks keying on the status code are unaffected. Logic extracted to `buildHealthResponse` with unit coverage.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.74",
+  "version": "4.8.75",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -1562,7 +1562,25 @@ export function buildCCRequest(
       });
       ccRequest.tools = [...CC_TOOL_DEFINITIONS, ...appended];
     } else {
-      ccRequest.tools = CC_TOOL_DEFINITIONS;
+      // Advertise only the CC-native tools the client actually declared.
+      // Substituting the FULL CC template here makes the model emit a tool_use
+      // for a tool the client never sent — e.g. AskUserQuestion when a headless
+      // or SDK session has it disabled — and the client harness then rejects it
+      // with "<Tool> exists but is not enabled in this context" (reported via a
+      // dario-routed CC session). A real CC client with a reduced tool set sends
+      // exactly this reduced array (every --disallowedTools / MCP delta does
+      // this), so filtering tracks CC's wire shape rather than diverging from it.
+      // If the client declared no CC-native tool at all it isn't really CC; keep
+      // the full template as the safer fingerprint default in that case.
+      const clientToolNames = new Set(
+        clientTools
+          .map((t) => (t.name as string | undefined)?.toLowerCase())
+          .filter((n): n is string => Boolean(n)),
+      );
+      const availableCC = (CC_TOOL_DEFINITIONS as Array<{ name: string }>).filter((t) =>
+        clientToolNames.has(t.name.toLowerCase()),
+      );
+      ccRequest.tools = availableCC.length > 0 ? availableCC : CC_TOOL_DEFINITIONS;
     }
   } else if (effectiveMergeTools) {
     // Operator opted into merge but the client sent no tools. Still

--- a/test/tool-advertise-respects-client.mjs
+++ b/test/tool-advertise-respects-client.mjs
@@ -3,14 +3,17 @@
  * Regression: dario must not advertise CC tools the client didn't declare.
  *
  * Bug: in default (template) mode buildCCRequest set ccRequest.tools to the FULL
- * CC_TOOL_DEFINITIONS (31 tools incl. AskUserQuestion), REPLACING the client's
- * list. A CC session with AskUserQuestion disabled (headless / SDK) sent a tool
- * array WITHOUT it; dario re-added it; the model emitted an AskUserQuestion
- * tool_use; the client harness rejected it with
+ * CC_TOOL_DEFINITIONS (all CC tools incl. AskUserQuestion), REPLACING the
+ * client's list. A CC session with AskUserQuestion disabled (headless / SDK)
+ * sent a tool array WITHOUT it; dario re-added it; the model emitted an
+ * AskUserQuestion tool_use; the client harness rejected it with
  *   "AskUserQuestion exists but is not enabled in this context".
  *
- * Fix: in default mode advertise only the CC-native tools the client actually
- * declared (a real reduced-tool CC client sends exactly that array).
+ * Fix: in default mode advertise only the CC-native tools the client declared.
+ *
+ * Tools used here are all CROSS-PLATFORM (avoid PowerShell/Glob/Grep, which are
+ * win32-only per PLATFORM_ONLY_TOOLS) so assertions hold on Linux CI and Windows
+ * alike. The primary check is the platform-agnostic SUBSET invariant.
  *
  * In-process — no proxy / OAuth / upstream.
  */
@@ -28,48 +31,45 @@ const billingTag = 'x-anthropic-billing-header: cc_version=test;';
 const cache1h = { type: 'ephemeral' };
 const identity = { deviceId: 'd', accountUuid: 'u', sessionId: 's' };
 
-// A real CC client (PascalCase native tools → detected CC → default mode) that
-// has AskUserQuestion DISABLED, so it never appears in its declared tools.
-const reducedCC = {
-  model: 'claude-sonnet-4-6',
-  messages: [{ role: 'user', content: 'list files' }],
-  tools: [
-    { name: 'Read', input_schema: { type: 'object', properties: { file_path: { type: 'string' } }, required: ['file_path'] } },
-    { name: 'Bash', input_schema: { type: 'object', properties: { command: { type: 'string' } }, required: ['command'] } },
-    { name: 'Grep', input_schema: { type: 'object', properties: { pattern: { type: 'string' } }, required: ['pattern'] } },
-    { name: 'Edit', input_schema: { type: 'object', properties: { file_path: { type: 'string' } }, required: ['file_path'] } },
-    { name: 'Write', input_schema: { type: 'object', properties: { file_path: { type: 'string' } }, required: ['file_path'] } },
-    { name: 'Glob', input_schema: { type: 'object', properties: { pattern: { type: 'string' } }, required: ['pattern'] } },
-  ],
-};
+const t = (name, props) => ({ name, input_schema: { type: 'object', properties: props, required: Object.keys(props) } });
+// Cross-platform CC-native tools only (no PowerShell/Glob/Grep).
+const DECLARED = [
+  t('Read', { file_path: { type: 'string' } }),
+  t('Bash', { command: { type: 'string' } }),
+  t('Edit', { file_path: { type: 'string' } }),
+  t('Write', { file_path: { type: 'string' } }),
+  t('WebSearch', { query: { type: 'string' } }),
+];
+const declaredNames = new Set(DECLARED.map((x) => x.name.toLowerCase()));
 
 header('reduced CC client (AskUserQuestion disabled)');
 {
-  const { body } = buildCCRequest(reducedCC, billingTag, cache1h, identity, {});
-  const names = (body.tools || []).map((t) => t.name);
-  check('AskUserQuestion is NOT advertised', !names.includes('AskUserQuestion'));
-  check('no undeclared CC tool leaks in (Agent/Workflow/Task* absent)',
-    !['Agent', 'Workflow', 'TaskCreate', 'CronCreate'].some((n) => names.includes(n)));
-  check('the 6 declared tools ARE advertised', ['Read', 'Bash', 'Grep', 'Edit', 'Write', 'Glob'].every((n) => names.includes(n)));
-  check('advertises exactly the declared set (6, not the full 31-tool template)', names.length === 6);
-  const readTool = (body.tools || []).find((t) => t.name === 'Read');
+  const clientBody = { model: 'claude-sonnet-4-6', messages: [{ role: 'user', content: 'hi' }], tools: DECLARED };
+  const { body } = buildCCRequest(clientBody, billingTag, cache1h, identity, {});
+  const names = (body.tools || []).map((x) => x.name);
+  // Core invariant (platform-agnostic): every advertised tool was declared.
+  check('SUBSET invariant: no undeclared tool is advertised',
+    names.every((n) => declaredNames.has(n.toLowerCase())));
+  check('AskUserQuestion specifically NOT advertised', !names.includes('AskUserQuestion'));
+  check('no undeclared CC tool leaks (Agent/Workflow/Task*/Cron* absent)',
+    !['Agent', 'Workflow', 'TaskCreate', 'CronCreate', 'NotebookEdit'].some((n) => names.includes(n)));
+  check('the declared cross-platform tools ARE advertised',
+    ['Read', 'Bash', 'Edit', 'Write', 'WebSearch'].every((n) => names.includes(n)));
+  check('advertises exactly the declared set (not the full template)', names.length === DECLARED.length);
+  const readTool = (body.tools || []).find((x) => x.name === 'Read');
   check('uses CANONICAL CC defs (Read carries the CC description, not the client stub)',
     !!readTool && typeof readTool.description === 'string' && readTool.description.length > 0);
 }
 
 header('full CC client (sends AskUserQuestion) — still advertised');
 {
-  const fullCC = {
-    ...reducedCC,
-    tools: [
-      ...reducedCC.tools,
-      { name: 'AskUserQuestion', input_schema: { type: 'object', properties: { questions: { type: 'array' } }, required: ['questions'] } },
-    ],
-  };
-  const { body } = buildCCRequest(fullCC, billingTag, cache1h, identity, {});
-  const names = (body.tools || []).map((t) => t.name);
+  const withAsk = [...DECLARED, t('AskUserQuestion', { questions: { type: 'array' } })];
+  const clientBody = { model: 'claude-sonnet-4-6', messages: [{ role: 'user', content: 'hi' }], tools: withAsk };
+  const { body } = buildCCRequest(clientBody, billingTag, cache1h, identity, {});
+  const names = (body.tools || []).map((x) => x.name);
   check('AskUserQuestion IS advertised when the client declares it', names.includes('AskUserQuestion'));
-  check('full-tool client unaffected (7 declared → 7 advertised)', names.length === 7);
+  check('still a strict subset of declared', names.every((n) => withAsk.some((d) => d.name.toLowerCase() === n.toLowerCase())));
+  check('exactly the declared set', names.length === withAsk.length);
 }
 
 console.log(`\ntool-advertise-respects-client: ${pass} passed, ${fail} failed`);

--- a/test/tool-advertise-respects-client.mjs
+++ b/test/tool-advertise-respects-client.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Regression: dario must not advertise CC tools the client didn't declare.
+ *
+ * Bug: in default (template) mode buildCCRequest set ccRequest.tools to the FULL
+ * CC_TOOL_DEFINITIONS (31 tools incl. AskUserQuestion), REPLACING the client's
+ * list. A CC session with AskUserQuestion disabled (headless / SDK) sent a tool
+ * array WITHOUT it; dario re-added it; the model emitted an AskUserQuestion
+ * tool_use; the client harness rejected it with
+ *   "AskUserQuestion exists but is not enabled in this context".
+ *
+ * Fix: in default mode advertise only the CC-native tools the client actually
+ * declared (a real reduced-tool CC client sends exactly that array).
+ *
+ * In-process — no proxy / OAuth / upstream.
+ */
+
+import { buildCCRequest } from '../dist/cc-template.js';
+
+let pass = 0, fail = 0;
+function check(label, cond) {
+  if (cond) { pass++; console.log(`  ✅ ${label}`); }
+  else { fail++; console.log(`  ❌ ${label}`); }
+}
+function header(name) { console.log(`\n${'='.repeat(70)}\n  ${name}\n${'='.repeat(70)}`); }
+
+const billingTag = 'x-anthropic-billing-header: cc_version=test;';
+const cache1h = { type: 'ephemeral' };
+const identity = { deviceId: 'd', accountUuid: 'u', sessionId: 's' };
+
+// A real CC client (PascalCase native tools → detected CC → default mode) that
+// has AskUserQuestion DISABLED, so it never appears in its declared tools.
+const reducedCC = {
+  model: 'claude-sonnet-4-6',
+  messages: [{ role: 'user', content: 'list files' }],
+  tools: [
+    { name: 'Read', input_schema: { type: 'object', properties: { file_path: { type: 'string' } }, required: ['file_path'] } },
+    { name: 'Bash', input_schema: { type: 'object', properties: { command: { type: 'string' } }, required: ['command'] } },
+    { name: 'Grep', input_schema: { type: 'object', properties: { pattern: { type: 'string' } }, required: ['pattern'] } },
+    { name: 'Edit', input_schema: { type: 'object', properties: { file_path: { type: 'string' } }, required: ['file_path'] } },
+    { name: 'Write', input_schema: { type: 'object', properties: { file_path: { type: 'string' } }, required: ['file_path'] } },
+    { name: 'Glob', input_schema: { type: 'object', properties: { pattern: { type: 'string' } }, required: ['pattern'] } },
+  ],
+};
+
+header('reduced CC client (AskUserQuestion disabled)');
+{
+  const { body } = buildCCRequest(reducedCC, billingTag, cache1h, identity, {});
+  const names = (body.tools || []).map((t) => t.name);
+  check('AskUserQuestion is NOT advertised', !names.includes('AskUserQuestion'));
+  check('no undeclared CC tool leaks in (Agent/Workflow/Task* absent)',
+    !['Agent', 'Workflow', 'TaskCreate', 'CronCreate'].some((n) => names.includes(n)));
+  check('the 6 declared tools ARE advertised', ['Read', 'Bash', 'Grep', 'Edit', 'Write', 'Glob'].every((n) => names.includes(n)));
+  check('advertises exactly the declared set (6, not the full 31-tool template)', names.length === 6);
+  const readTool = (body.tools || []).find((t) => t.name === 'Read');
+  check('uses CANONICAL CC defs (Read carries the CC description, not the client stub)',
+    !!readTool && typeof readTool.description === 'string' && readTool.description.length > 0);
+}
+
+header('full CC client (sends AskUserQuestion) — still advertised');
+{
+  const fullCC = {
+    ...reducedCC,
+    tools: [
+      ...reducedCC.tools,
+      { name: 'AskUserQuestion', input_schema: { type: 'object', properties: { questions: { type: 'array' } }, required: ['questions'] } },
+    ],
+  };
+  const { body } = buildCCRequest(fullCC, billingTag, cache1h, identity, {});
+  const names = (body.tools || []).map((t) => t.name);
+  check('AskUserQuestion IS advertised when the client declares it', names.includes('AskUserQuestion'));
+  check('full-tool client unaffected (7 declared → 7 advertised)', names.length === 7);
+}
+
+console.log(`\ntool-advertise-respects-client: ${pass} passed, ${fail} failed`);
+if (fail > 0) process.exit(1);


### PR DESCRIPTION
## Why
A dario-routed CC session hit:
```
Error: No such tool available: AskUserQuestion. AskUserQuestion exists but is not enabled in this context.
```
Root cause: in **default (template) mode**, `buildCCRequest` set `ccRequest.tools = CC_TOOL_DEFINITIONS` — the **full 31-tool** CC array (incl. `AskUserQuestion`, `Agent`, `Task*`, `Workflow`, …), **replacing** whatever the client sent. A CC session with `AskUserQuestion` disabled (headless / SDK) sends its tool array *without* it; dario re-added it; the model then emitted an `AskUserQuestion` tool_use that the client's harness couldn't execute → that error. (It's intermittent: it only fires when the client's enabled-tool set is a strict subset of the template.)

## Fix
Default mode now advertises **only the CC-native tools the client actually declared**, using CC's canonical definitions for them:
```ts
const clientToolNames = new Set(clientTools.map(t => t.name?.toLowerCase()).filter(Boolean));
const availableCC = CC_TOOL_DEFINITIONS.filter(t => clientToolNames.has(t.name.toLowerCase()));
ccRequest.tools = availableCC.length > 0 ? availableCC : CC_TOOL_DEFINITIONS;
```
A real CC client with a reduced tool set (every `--disallowedTools` / MCP delta) sends exactly this array, so it **tracks** CC's wire shape rather than diverging. Full-tool clients are unchanged; if the client declares no CC-native tool the full template is kept (fingerprint default). `--preserve-tools` / `--merge-tools` untouched.

Note: `--merge-tools` has the same latent over-advertisement (`[...CC_TOOL_DEFINITIONS, ...appended]`) but it's opt-in/experimental and not the reported path — left for a separate change.

## Test
`test/tool-advertise-respects-client.mjs` — 7 cases: reduced CC drops AskUserQuestion + undeclared tools, keeps declared, exactly-6-not-31, canonical defs; full CC still advertises it. Full suite **90/90**.

Releases 4.8.75 → autodeploys.