### PR TITLE
docs(proxy): correct misleading cch random comment (refs #528)

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -49,7 +49,19 @@ function computeBuildTag(userMessage: string, version: string): string {
   return createHash('sha256').update(`${BILLING_SEED}${chars}${version}`).digest('hex').slice(0, 3);
 }
 
-// Per-request cch: random 5-char hex value each request (Claude Code does the same).
+// Per-request cch. NOTE: real Claude Code does NOT randomise this — it's a
+// deterministic xxHash64 integrity hash over the serialized request body,
+// written in place over a `cch=00000` placeholder inside the billing-tag
+// system block (reverse-engineered on cc_version=2.1.37; see dario#528).
+//
+// We emit a random 5-hex value on purpose. The published seed
+// (0x6E52736AC806831E) + scope do NOT reproduce the cch on current CC
+// (falsified against a live 2.1.177 capture), and the seed/scope appear to
+// rotate between releases. A deterministic-but-wrong value is no better than
+// random against a server that recomputes — and a cleaner tell — whereas a
+// random value keeps the right shape (5 lowercase hex) and varies per request
+// like the real one. Revisit only if Anthropic starts rejecting on cch, which
+// would require re-RE'ing the current binary for the live seed + pre-image.
 function computeCch(): string {
   return randomBytes(3).toString('hex').slice(0, 5);
 }


### PR DESCRIPTION
Corrects the `computeCch` comment, which claimed the value is random "(Claude Code does the same)". It isn't — real Claude Code computes `cch` as a **deterministic xxHash64 integrity hash over the request body**, not an RNG.

Context: #528. I verified against a live capture of the genuine `claude` binary (v2.1.177): the published algorithm (seed `0x6E52736AC806831E`, reverse-engineered on `cc_version=2.1.37`) does **not** reproduce the current `cch` — cross-checked against known XXH64 vectors and two independent hash libs, sweeping seed endianness, pre-image scope, XXH64/XXH3, and bit-extraction. The seed/scope appear to rotate between releases.

So we keep emitting a random per-request value as a deliberate stand-in (right shape, varies per request like the real one; a deterministic-but-wrong value would be no better against server-side recomputation, and a cleaner tell). The comment now says exactly that and points to #528.

Comment-only change — no behavior change.
