### PR TITLE
chore: release 4.8.76 — overage-guard halts on any non-subscription claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.76] - 2026-06-15
+
 - **Overage-guard now halts on any non-subscription billing claim, not just `overage` (dario#288).** The guard matched `representative-claim === 'overage'` exactly, so two cases slipped through: `api` billing, and — the reason for this change — a request reclassified into the new Agent-SDK / headless **credit bucket** from the 2026-06-15 split, whose claim string dario has never observed (it keeps traffic in the pool, so the credit-bucket value is unknown and can't be hardcoded). Detection is now an allow-list (`isNonSubscriptionBilling`): it halts on anything that is not a known subscription claim (`five_hour`/`seven_day` + `_fallback` variants) and not the `unknown` sentinel (no rate-limit header = a transient non-200/stream-abort, which must not halt). The guard is auto-disabled in `--upstream-api-key` passthrough mode, where `api` billing is intended rather than a failure. No TUI credit-balance tracking was added: dario's invariant is subscription-pool-or-halt, so credit usage is always zero when it's working, and the per-request rate-limit headers it reads don't carry account credit balances. New unit coverage in `test/overage-guard.mjs` (`api` + novel `sdk_credit`/`agent_credit` claims halt; subscription + `unknown` stay clear) and `test/analytics-billing-bucket.mjs` (the `isNonSubscriptionBilling` predicate).
 
 ## [4.8.75] - 2026-06-14

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.75",
+  "version": "4.8.76",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What

Cuts **v4.8.76**, promoting the overage-guard fix from #530 to a tagged release.

- `package.json`: `4.8.75` → `4.8.76`
- `CHANGELOG.md`: `## [Unreleased]` → `## [4.8.76] - 2026-06-15`, fresh `## [Unreleased]` added above

## Why

#530 (`fix(overage-guard)`) landed on master but **did not bump `package.json`**, so the *Auto release on version bump* workflow correctly fast-exited (version unchanged at 4.8.75) and no release was cut. The overage-guard change is a billing-safety fix that should ship — this bump lets the release pipeline pick it up (fast path on merge, schedule fallback within the hour).

No code changes; release-prep only.