### PR TITLE
feat(cch): self-owned seed calibration — pick up rotations ourselves (#528)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "compat": "node test/compat.mjs",
     "lint:pkg": "node scripts/check-package-json.mjs",
     "drift:sdk": "node scripts/check-sdk-drift.mjs",
+    "cch:calibrate": "node scripts/cch-calibrate.mjs",
     "fix:pkg": "node -e \"const fs=require('fs');fs.writeFileSync('package.json',JSON.stringify(JSON.parse(fs.readFileSync('package.json','utf-8')),null,2)+'\\n')\""
   },
   "keywords": [

--- a/scripts/cch-calibrate.mjs
+++ b/scripts/cch-calibrate.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * cch seed calibration (dario#528) — keep src/cch.ts:CCH_SEEDS current WITHOUT
+ * depending on anyone else to hand us the rotating seed.
+ *
+ * The seed Claude Code uses for the `cch` integrity hash rotates between
+ * releases and lives inside the compiled binary, so we can't algebraically
+ * derive it. But we can run the genuine binary and read the cch it stamps,
+ * then check it against what we know:
+ *
+ *   1. src/cch.ts already covers this version AND reproduces the cch  -> OK.
+ *   2. some seed we ALREADY know reproduces it (version bumped, seed
+ *      unchanged — the common case) -> print the one-line CCH_SEEDS entry to
+ *      add; nothing to reverse-engineer.
+ *   3. no known seed reproduces it -> the seed ROTATED. Save the captured
+ *      material + observed cch so WE extract the new seed (binary string-scan
+ *      or a debugger watchpoint on the cch region) on our own schedule, then
+ *      add it to CCH_SEEDS. Exit non-zero.
+ *
+ * Capture path is the safe one the drift/probe scripts use: point the real
+ * binary at a loopback collector with a STUB api key — the cch is built into
+ * the request body before it's sent, so a stub key + fake endpoint still
+ * yields a real cch, and no OAuth/credentials are touched.
+ *
+ *   node scripts/cch-calibrate.mjs
+ *   DARIO_CLAUDE_BIN=/path/to/claude node scripts/cch-calibrate.mjs
+ *
+ * Wiring: run on the dario self-hosted runner when cc-drift flags a new CC
+ * version (that host has `claude` installed; GH-hosted runners don't). Until a
+ * seed is added, dario just ships a random cch for the new version — safe, no
+ * breakage, see src/cch.ts.
+ */
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import { gunzipSync } from 'node:zlib';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { cchForBody, cchWithSeed, CCH_SEEDS } from '../dist/cch.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CC_BIN = process.env.DARIO_CLAUDE_BIN || 'claude';
+const TIMEOUT_MS = 35_000;
+const useShell = process.platform === 'win32' && !/[\\/]/.test(CC_BIN);
+
+function log(m) { console.error(`[cch-calibrate] ${m}`); }
+
+const server = http.createServer((req, res) => {
+  const chunks = [];
+  req.on('data', (c) => chunks.push(c));
+  req.on('end', () => {
+    const buf = Buffer.concat(chunks);
+    if (req.url.startsWith('/v1/messages') && req.method === 'POST' && !server._cap) {
+      server._cap = { headers: req.headers, buf };
+    }
+    res.writeHead(200, { 'content-type': 'text/event-stream' });
+    res.end('event: error\ndata: {"type":"error","error":{"type":"capture_only"}}\n\n');
+  });
+});
+
+server.listen(0, '127.0.0.1', () => {
+  const port = server.address().port;
+  const env = {
+    ...process.env,
+    ANTHROPIC_BASE_URL: `http://127.0.0.1:${port}`,
+    ANTHROPIC_API_KEY: 'sk-capture-stub',
+    CLAUDE_NONINTERACTIVE: '1',
+  };
+  log(`MITM :${port} -> spawning "${CC_BIN}" --print (stub key + loopback, no OAuth)`);
+  const cc = spawn(CC_BIN, ['--print', '-p', 'calibrate'], {
+    env, stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true, shell: useShell,
+  });
+  cc.stderr.on('data', () => {});
+  cc.stdout.on('data', () => {});
+  cc.on('exit', () => setTimeout(finish, 250));
+  cc.on('error', (e) => { log(`spawn error: ${e.message} (set DARIO_CLAUDE_BIN to the claude path)`); process.exit(3); });
+  setTimeout(() => { try { cc.kill(); } catch {} finish(); }, TIMEOUT_MS);
+});
+
+let done = false;
+function finish() {
+  if (done) return; done = true;
+  const cap = server._cap;
+  if (!cap) { log('no /v1/messages captured — is claude installed and runnable?'); process.exit(2); }
+
+  let buf = cap.buf;
+  if ((cap.headers['content-encoding'] || '').includes('gzip')) { try { buf = gunzipSync(buf); } catch {} }
+  const text = buf.toString('utf8');
+  const cchM = /cch=([0-9a-fA-F]{5})/.exec(text);
+  const verM = /cc_version=([0-9]+\.[0-9]+\.[0-9]+)/.exec(text);
+  if (!cchM || !verM) { log('captured body carries no cch / cc_version billing tag'); process.exit(2); }
+
+  const observed = cchM[1].toLowerCase();
+  const version = verM[1];
+  log(`captured cc_version=${version} cch=${observed} (body ${buf.length}B)`);
+
+  // 1) already covered and still correct?
+  const known = cchForBody(text, version);
+  if (known === observed) {
+    console.log(`OK: ${version} is in CCH_SEEDS and reproduces the live cch (${observed}). No action needed.`);
+    process.exit(0);
+  }
+  if (known !== null && known !== observed) {
+    log(`WARNING: ${version} is in CCH_SEEDS but its seed no longer reproduces the live cch (${known} != ${observed}).`);
+  }
+
+  // 2) does a seed we already know reproduce it? (version bumped, seed unchanged)
+  for (const [v, seed] of Object.entries(CCH_SEEDS)) {
+    if (cchWithSeed(text, seed) === observed) {
+      console.log(`COVERED BY EXISTING SEED — add this line to CCH_SEEDS in src/cch.ts:`);
+      console.log(`  '${version}': 0x${seed.toString(16)}n,   // same seed as ${v}, confirmed live`);
+      process.exit(0);
+    }
+  }
+
+  // 3) genuine rotation — hand ourselves the data to extract the new seed.
+  const out = join(__dirname, '..', `cch-rotated-${version}.json`);
+  writeFileSync(out, JSON.stringify({ version, observed, body: text }, null, 2));
+  console.log(`SEED ROTATED for ${version}: no known seed reproduces cch=${observed}.`);
+  console.log(`Saved capture -> ${out}`);
+  console.log(`Extract the new seed (scan the CC binary's embedded JS for the xxh64 call / debugger watchpoint on the cch region), add it to CCH_SEEDS, and re-run to confirm.`);
+  process.exit(1);
+}

--- a/scripts/check-cc-drift.mjs
+++ b/scripts/check-cc-drift.mjs
@@ -45,6 +45,7 @@ import { tmpdir } from 'node:os';
 import { scanBinaryForOAuthConfig } from '../dist/cc-oauth-detect.js';
 import { SUPPORTED_CC_RANGE, compareVersions } from '../dist/live-fingerprint.js';
 import { findUserPathHits } from '../dist/scrub-template.js';
+import { CCH_SEEDS } from '../dist/cch.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, '..');
@@ -293,6 +294,20 @@ try {
       severity: 'low',
       message:
         `baked cc-template-data.json is v${PINNED_TEMPLATE_VERSION}; npm latest is v${ccVersion}. Re-capture the template (MITM a real CC v${ccVersion} request) if any fingerprint-sensitive field (system prompt, header order, metadata shape, beta flags) changed.`,
+    });
+  }
+
+  // cch seed coverage (dario#528). The cch integrity-hash seed rotates between
+  // CC releases. If we have no seed for the latest version, dario ships a
+  // RANDOM cch for it — a safe fallback, not a failure — but we want to close
+  // that gap ourselves, not wait for someone to report it. Surface it so the
+  // maintainer runs the owned calibration step.
+  if (ccVersion && !CCH_SEEDS[ccVersion]) {
+    items.push({
+      category: 'cch.seed',
+      severity: 'low',
+      message:
+        `No cch seed for CC v${ccVersion} in src/cch.ts (CCH_SEEDS) — dario sends a random cch for it (safe fallback). Run \`node scripts/cch-calibrate.mjs\` on a host with claude v${ccVersion}: it confirms whether an existing seed still applies (just add the version → seed line) or whether the seed rotated (saves the live capture so we extract the new seed ourselves). dario#528.`,
     });
   }
 

--- a/src/cch.ts
+++ b/src/cch.ts
@@ -123,6 +123,18 @@ function cchMaterial(bodyText: string): Uint8Array {
 }
 
 /**
+ * Deterministic 5-hex cch for a serialized body under an EXPLICIT seed, or
+ * null if the body carries no `cch=XXXXX` token. Used by `scripts/cch-
+ * calibrate.mjs` to test candidate seeds against a live capture without going
+ * through the version table.
+ */
+export function cchWithSeed(bodyText: string, seed: bigint): string | null {
+  if (!CCH_RE.test(bodyText)) return null;
+  const h = xxh64(cchMaterial(bodyText), seed) & MASK;
+  return h.toString(16).padStart(5, '0');
+}
+
+/**
  * Deterministic 5-hex `cch` for a serialized request body, or null when:
  *  - `version` (major.minor.patch) has no known seed, or
  *  - the body carries no `cch=XXXXX` billing token to stamp.
@@ -131,7 +143,5 @@ function cchMaterial(bodyText: string): Uint8Array {
 export function cchForBody(bodyText: string, version: string): string | null {
   const seed = CCH_SEEDS[version];
   if (seed === undefined) return null;
-  if (!CCH_RE.test(bodyText)) return null;
-  const h = xxh64(cchMaterial(bodyText), seed) & MASK;
-  return h.toString(16).padStart(5, '0');
+  return cchWithSeed(bodyText, seed);
 }

--- a/test/cch.mjs
+++ b/test/cch.mjs
@@ -12,7 +12,7 @@
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { xxh64, cchForBody, CCH_SEEDS } from '../dist/cch.js';
+import { xxh64, cchForBody, cchWithSeed, CCH_SEEDS } from '../dist/cch.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const enc = (s) => new TextEncoder().encode(s);
@@ -71,6 +71,14 @@ header('cchForBody — pre-existing cch token value is ignored');
   check('cch=00000 in body -> a82da', cchForBody(withZeros, '2.1.177') === 'a82da');
   check('cch=fffff in body -> a82da', cchForBody(withOther, '2.1.177') === 'a82da');
 }
+
+// ── cchWithSeed: explicit-seed helper used by scripts/cch-calibrate.mjs ──
+header('cchWithSeed — explicit seed (calibration helper)');
+check("known 2.1.177 seed reproduces a82da", cchWithSeed(body, 0x4d659218e32a3268n) === 'a82da');
+check('the stale 2.1.37 seed (0x6E52…) does NOT', cchWithSeed(body, 0x6e52736ac806831en) !== 'a82da');
+check('matches cchForBody for the registered version',
+  cchWithSeed(body, CCH_SEEDS['2.1.177']) === cchForBody(body, '2.1.177'));
+check('no cch token -> null', cchWithSeed(JSON.stringify({ model: 'x', messages: [] }), 0x4d659218e32a3268n) === null);
 
 console.log(`\n${fail === 0 ? '✅ PASS' : '❌ FAIL'} — ${pass} passed, ${fail} failed`);
 process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## Why

#532 wired in the real `cch` for CC 2.1.177, but the seed **rotates per Claude Code release**. Depending on an external contributor to post the next one isn't a maintenance plan — it's a liability. This makes obtaining the seed an **owned, repeatable step** off our existing drift detection.

## What

**`scripts/cch-calibrate.mjs`** (`npm run cch:calibrate`) — spawns the genuine `claude` binary at a loopback collector with a **stub key (no OAuth, no credential touch** — the same safe capture path the drift/probe scripts use), reads the `cch` it actually stamps, and resolves to one of three outcomes:

1. **Covered & correct** — the version is in `CCH_SEEDS` and reproduces the live `cch`. Exit 0, no action.
2. **Covered by an existing seed** — a seed we already know reproduces it (version bumped, seed unchanged — the common case). Prints the one-line `CCH_SEEDS` entry to add. No RE needed.
3. **Rotated** — no known seed matches. Saves the live capture (`cch-rotated-<version>.json`) so *we* extract the new seed on our own schedule, and exits non-zero.

**`scripts/check-cc-drift.mjs`** — emits a low-severity `cch.seed` item when the latest CC on npm has no seed in `CCH_SEEDS`, pointing at the calibration step. Our drift watcher already runs the day CC ships, so the gap surfaces immediately instead of when a user notices.

**`src/cch.ts`** — exports `cchWithSeed(body, seed)` (projection + explicit seed) so calibration can test candidate seeds without going through the version table.

## Verified

```
$ DARIO_CLAUDE_BIN=…/claude.exe npm run cch:calibrate
[cch-calibrate] captured cc_version=2.1.177 cch=1b362 (body 139482B)
OK: 2.1.177 is in CCH_SEEDS and reproduces the live cch (1b362). No action needed.
```

Tests extended (`cchWithSeed` golden + negative vectors); full suite **91/91**.

## Honest limits

The seed is a constant inside a Bun-compiled binary, so a **genuine** rotation still needs a one-time extraction — but calibration hands us the exact `(material, cch)` to do it, immediately and on our own terms. The drift watcher already notes that Bun embeds the JS source verbatim (its OAuth scanner relies on that), so a follow-up `scanForCchSeed` that string-scans the fetched binary could make even rotations push-button — to be confirmed against a real binary before wiring in (avoiding a false "rotated" alarm).

## Safety

Unknown/un-calibrated versions keep shipping a **random** `cch` (the pre-#528 fallback) — there is never a hard failure while a seed is missing. `DARIO_CCH=random` remains the global kill-switch.
