### PR TITLE
fix(cch): anchor cch to the billing tag, not first-match (#528)

### DIFF
--- a/src/cch.ts
+++ b/src/cch.ts
@@ -109,15 +109,16 @@ export function xxh64(data: Uint8Array, seed: bigint): bigint {
   return h;
 }
 
-// Match the cch token INSIDE the billing-tag system block specifically — never
-// a stray `cch=#####` that happens to appear in conversation content (which
-// sorts before `system` in the body, so a naive first-match would grab it,
-// mis-hash, AND silently rewrite the user's text at stamp time — dario#528).
-// The billing tag is a single JSON string, so [^"] keeps the lazy span inside
-// it and the `;` lookahead pins the token end. Anchoring is also what real CC
-// must do — otherwise it would corrupt its own bodies that quote a cch — so
-// this matches upstream behavior, it isn't just defensive.
-const CCH_RE = /(x-anthropic-billing-header:[^"]*?cch=)[0-9a-fA-F]{5}(?=;)/;
+// Match the cch token INSIDE the billing tag specifically — never a stray
+// `cch=#####` quoted in conversation content (which sorts before `system` in
+// the body, so a naive first-match would grab it, mis-hash, AND silently
+// rewrite the user's text at stamp time — dario#528). Anchor on the
+// `cc_entrypoint=<value>; cch=` that immediately precedes it in the billing
+// header. The entrypoint value is BOUNDED ({1,32}) so the match stays linear
+// on a 10 MB body — an unbounded `[^"]*?` span here is O(n^2) when the anchor
+// repeats (CodeQL js/polynomial-redos). Anchoring is also what real CC must
+// do, so this matches upstream behavior, not just our own correctness.
+const CCH_RE = /(cc_entrypoint=[a-z0-9-]{1,32}; cch=)[0-9a-fA-F]{5}(?=;)/;
 
 /** Build the canonical cch pre-image bytes from a serialized request body. */
 function cchMaterial(bodyText: string): Uint8Array {

--- a/src/cch.ts
+++ b/src/cch.ts
@@ -109,11 +109,19 @@ export function xxh64(data: Uint8Array, seed: bigint): bigint {
   return h;
 }
 
-const CCH_RE = /cch=[0-9a-fA-F]{5}/;
+// Match the cch token INSIDE the billing-tag system block specifically — never
+// a stray `cch=#####` that happens to appear in conversation content (which
+// sorts before `system` in the body, so a naive first-match would grab it,
+// mis-hash, AND silently rewrite the user's text at stamp time — dario#528).
+// The billing tag is a single JSON string, so [^"] keeps the lazy span inside
+// it and the `;` lookahead pins the token end. Anchoring is also what real CC
+// must do — otherwise it would corrupt its own bodies that quote a cch — so
+// this matches upstream behavior, it isn't just defensive.
+const CCH_RE = /(x-anthropic-billing-header:[^"]*?cch=)[0-9a-fA-F]{5}(?=;)/;
 
 /** Build the canonical cch pre-image bytes from a serialized request body. */
 function cchMaterial(bodyText: string): Uint8Array {
-  const zeroed = bodyText.replace(CCH_RE, 'cch=00000'); // first occurrence only
+  const zeroed = bodyText.replace(CCH_RE, (_m, prefix: string) => `${prefix}00000`);
   const body = JSON.parse(zeroed) as Record<string, unknown>;
   body.model = '';
   delete body.fallbacks;
@@ -144,4 +152,17 @@ export function cchForBody(bodyText: string, version: string): string | null {
   const seed = CCH_SEEDS[version];
   if (seed === undefined) return null;
   return cchWithSeed(bodyText, seed);
+}
+
+/**
+ * Return `bodyText` with the billing-tag cch replaced in place by the
+ * deterministic value for `version`, or unchanged when the version has no
+ * known seed or the body has no billing token. The replacement is anchored to
+ * the billing tag (CCH_RE), so conversation content that quotes a cch is never
+ * touched. Used by the proxy at outbound-serialize time.
+ */
+export function stampCch(bodyText: string, version: string): string {
+  const cch = cchForBody(bodyText, version);
+  if (cch === null) return bodyText;
+  return bodyText.replace(CCH_RE, (_m, prefix: string) => `${prefix}${cch}`);
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -9,7 +9,7 @@ import { arch, platform } from 'node:process';
 import { getAccessToken, getStatus } from './oauth.js';
 import { buildHealthResponse } from './health-response.js';
 import { buildCCRequest, applyCcPromptCaching, parseEffortSuffix, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, CC_TEMPLATE, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
-import { cchForBody } from './cch.js';
+import { stampCch } from './cch.js';
 import { describeTemplate, detectDrift, checkCCCompat } from './live-fingerprint.js';
 import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCooldown, authCooldownMs, type PoolAccount } from './pool.js';
 import { Analytics, billingBucketFromClaim, type RequestRecord } from './analytics.js';
@@ -2013,16 +2013,16 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           }
           // dario#528: overwrite the random cch placeholder with the real
           // deterministic value for Claude Code versions whose seed we've
-          // reverse-engineered. cchForBody hashes a projection of THIS final
-          // body, so it must run after every mutation above. It returns null
-          // for unknown versions (keep the random placeholder) or bodies with
-          // no billing token. Only the template-replay path is stamped —
-          // passthrough / count_tokens forward the client's body (and its own
-          // cch) verbatim. Reversible kill-switch: DARIO_CCH=random.
+          // reverse-engineered. stampCch hashes a projection of THIS final body
+          // (so it must run after every mutation above) and replaces the cch
+          // anchored to the billing tag — never a cch quoted in conversation
+          // content. No-op for unknown versions (keep the random placeholder).
+          // Only the template-replay path is stamped — passthrough /
+          // count_tokens forward the client's body (and its own cch) verbatim.
+          // Reversible kill-switch: DARIO_CCH=random.
           let outboundText = JSON.stringify(r);
           if (!passthrough && !isCountTokens && process.env.DARIO_CCH !== 'random') {
-            const realCch = cchForBody(outboundText, cliVersion);
-            if (realCch) outboundText = outboundText.replace(/cch=[0-9a-fA-F]{5}/, `cch=${realCch}`);
+            outboundText = stampCch(outboundText, cliVersion);
           }
           finalBody = Buffer.from(outboundText);
         } catch { /* not JSON, send as-is */ }

--- a/test/cch.mjs
+++ b/test/cch.mjs
@@ -12,7 +12,7 @@
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { xxh64, cchForBody, cchWithSeed, CCH_SEEDS } from '../dist/cch.js';
+import { xxh64, cchForBody, cchWithSeed, stampCch, CCH_SEEDS } from '../dist/cch.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const enc = (s) => new TextEncoder().encode(s);
@@ -79,6 +79,24 @@ check('the stale 2.1.37 seed (0x6E52…) does NOT', cchWithSeed(body, 0x6e52736a
 check('matches cchForBody for the registered version',
   cchWithSeed(body, CCH_SEEDS['2.1.177']) === cchForBody(body, '2.1.177'));
 check('no cch token -> null', cchWithSeed(JSON.stringify({ model: 'x', messages: [] }), 0x4d659218e32a3268n) === null);
+
+// ── anchoring: a cch quoted in conversation content must NOT be touched ──
+// messages serialize before `system`, so a naive first-match regex would grab
+// the decoy, mis-hash, AND silently rewrite the user's prompt (dario#528).
+header('cchForBody / stampCch — anchored to the billing tag, not content');
+{
+  const p = JSON.parse(body);
+  p.messages[0].content[0].text = 'earlier the hash was cch=dead1 in the log';
+  const withDecoy = JSON.stringify(p);
+  const expected = cchForBody(withDecoy, '2.1.177'); // hashed over the billing cch, not the decoy
+  const stamped = stampCch(withDecoy, '2.1.177');
+  check('decoy cch=dead1 in user content is left UNCHANGED',
+    stamped.includes('the hash was cch=dead1 in the log'));
+  check('billing-tag cch IS stamped to the computed value',
+    new RegExp(`cc_entrypoint=sdk-cli; cch=${expected};`).test(stamped));
+  check('a content-only cch with no billing tag -> null',
+    cchForBody(JSON.stringify({ messages: [{ role: 'user', content: 'cch=dead1' }] }), '2.1.177') === null);
+}
 
 console.log(`\n${fail === 0 ? '✅ PASS' : '❌ FAIL'} — ${pass} passed, ${fail} failed`);
 process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## The bug

`#532`/`#533` matched the cch with `/cch=[0-9a-fA-F]{5}/` — **first match anywhere** in the serialized body, for both the hash pre-image (zeroing) and the outbound stamp. But `messages` serialize **before** `system`, so a `cch=#####` that appears in **conversation content** is matched first.

Confirmed repro (real 2.1.177 fixture, decoy in a user message):

```
first /cch=#####/ match : cch=dead1 @ 109      <- user content
billing-tag cch         : cch=a82da @ 318      <- the one we meant
=> stamp/hash target the DECOY, NOT the billing tag

after stamp:
  user content now : cch=99999   <- user prompt SILENTLY REWRITTEN
  billing tag still: cch=a82da   <- real cch never stamped (placeholder shipped)
```

So a request that merely *quotes* a cch (a pasted body, or a thread like dario#528 itself) gets its prompt mutated and ships a wrong cch. Low frequency in coding traffic, but silent prompt mutation in a proxy is a real correctness bug.

## The fix

Anchor the token to the billing tag and centralize the logic:

```js
const CCH_RE = /(x-anthropic-billing-header:[^"]*?cch=)[0-9a-fA-F]{5}(?=;)/;
```

- `[^"]` keeps the lazy span inside the single billing-tag JSON string; the `;` lookahead pins the token end.
- `proxy.ts` now calls `cch.ts:stampCch(text, version)` instead of duplicating the regex — one anchored implementation for both hashing and stamping.

This is also what **real Claude Code must do** — first-match would corrupt its own bodies that quote a cch — so anchoring matches upstream behavior, it isn't just defensive.

## Safety

- **Identical** output on single-cch bodies: golden vectors `a82da` / `b6ada` unchanged.
- Correct on multi-cch bodies: conversation content is never touched.
- New tests assert the decoy is left intact, the billing cch is stamped, and a content-only cch (no billing tag) returns null.

Full suite **91/91**.
