### PR TITLE
chore: release 4.8.80 - effort + max_tokens clamp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.75",
+  "version": "4.8.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "4.8.75",
+      "version": "4.8.80",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.79",
+  "version": "4.8.80",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release bump for the effort-param strip + max_tokens clamp (#539, already on master).

On merge, `cc-drift-auto-release` (pull_request:closed with version 4.8.79 -> 4.8.80) builds, creates the `v4.8.80` release, and publishes to npm + `ghcr.io/askalf/dario:latest`. The box's health-gated autodeploy then swaps the live hot-patch for the official image — both fixes already verified live (15/15 catalog models green).