### PR TITLE
chore(template): label refresh _version -> v2.1.181 (clears sdk-drift)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.84] - 2026-06-18
+
+- **Template label refresh** — `_version`, `_supportedMaxTested`, and the `user-agent` header bumped to `2.1.181` to track `@anthropic-ai/claude-code@latest`. The live wire shape is unchanged — cc-drift-template-watch ran `capture-and-bake --check` against live CC v2.1.181 and found zero shape drift vs the bundle — so this is a label refresh, not a re-capture (`_captured` stays at the last real capture). Auto-merged; clears the `sdk-drift` early-warning signal.
 ## [4.8.83] - 2026-06-17
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.179` → `2.1.181` for CC v2.1.181. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.83",
+  "version": "4.8.84",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template-data.json
+++ b/src/cc-template-data.json
@@ -1,5 +1,5 @@
 {
-  "_version": "2.1.179",
+  "_version": "2.1.181",
   "_captured": "2026-06-11T20:43:54.573Z",
   "_source": "bundled",
   "_schemaVersion": 3,
@@ -1294,7 +1294,7 @@
   "anthropic_beta": "claude-code-20250219,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24",
   "header_values": {
     "accept": "application/json",
-    "user-agent": "claude-cli/2.1.179 (external, sdk-cli)",
+    "user-agent": "claude-cli/2.1.181 (external, sdk-cli)",
     "x-stainless-arch": "x64",
     "x-stainless-lang": "js",
     "x-stainless-os": "Linux",
@@ -1319,5 +1319,5 @@
     "output_config",
     "stream"
   ],
-  "_supportedMaxTested": "2.1.179"
+  "_supportedMaxTested": "2.1.181"
 }


### PR DESCRIPTION
## Auto label-sync — wire shape unchanged

Generated by [`cc-drift-template-watch.yml`](.github/workflows/cc-drift-template-watch.yml) on 2026-06-18T07:25:35+00:00.

`capture-and-bake.mjs --check` captured **live CC v2.1.181** and `computeDrift` returned **zero shape drift** vs the bundled template — but the bundle's `_version` label still read the previous version, which `check-sdk-drift.mjs` flags against npm (the `sdk-drift` signal). There is no wire-shape change to re-bake, so this PR bumps only the version-label fields:

- `_version` and `_supportedMaxTested` -> `2.1.181`
- the `claude-cli/<version>` token in the `user-agent` header -> `2.1.181`

`_captured` (last real capture) and `x-stainless-package-version` are intentionally left untouched. Patch-bumped to `v4.8.84` so merging ships via `cc-drift-auto-release.yml`, and the next `sdk-drift-watch` run auto-closes the signal.

### Why auto-merge is safe here

Unlike a shape rebake (which a human reviews because the wire contract changed), this PR's **empty `computeDrift`** is a proof that the tools / system_prompt / beta headers / field orders are byte-identical at v2.1.181. Only the label moves — the same deterministic-bump risk class `cc-drift-watch.yml` already auto-merges for `maxTested`. Auto-merge still gates on required checks (build x3, compat, test, docker-cap-drop-smoke); a red check leaves this PR open with the bot branch preserved.
