### PR TITLE
feat(doctor): display duration until 5h limit resets

### DIFF
--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -655,10 +655,25 @@ export async function runChecks(opts: RunChecksOptions = {}): Promise<Check[]> {
       const bucket = billingBucketFromClaim(firstOk.claim);
       const pct = (n: number) => `${(n * 100).toFixed(1)}%`;
 
+      let resetStr = '';
+      if (firstOk.reset > 0) {
+        const diffMs = (firstOk.reset * 1000) - Date.now();
+        if (diffMs > 0) {
+          const diffMins = Math.ceil(diffMs / 60000);
+          if (diffMins >= 60) {
+            const hrs = Math.floor(diffMins / 60);
+            const mins = diffMins % 60;
+            resetStr = `  •  resets in ${hrs}h ${mins}m`;
+          } else {
+            resetStr = `  •  resets in ${diffMins}m`;
+          }
+        }
+      }
+
       checks.push({
         status: firstOk.util5h >= 0.90 ? 'warn' : 'ok',
         label: 'Usage 5h (all)',
-        detail: `${pct(firstOk.util5h)} used  •  status=${firstOk.status}  •  claim=${firstOk.claim} (${bucket})`,
+        detail: `${pct(firstOk.util5h)} used  •  status=${firstOk.status}${resetStr}  •  claim=${firstOk.claim} (${bucket})`,
       });
       checks.push({
         status: firstOk.util7d >= 0.90 ? 'warn' : 'ok',

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -48,6 +48,29 @@ export interface Check {
 }
 
 /**
+ * Format a epoch timestamp reset time relative to the current time.
+ * Returns a human-friendly string like "1h 9m", "45m", "2d 3h".
+ */
+export function formatReset(resetEpochSecs: number, nowMs: number): string {
+  const ms = (resetEpochSecs * 1000) - nowMs;
+  if (ms <= 0) return '0m';
+  const totalMins = Math.round(ms / 60000);
+  if (totalMins <= 0) return '0m';
+
+  const days = Math.floor(totalMins / 1440);
+  const hours = Math.floor((totalMins % 1440) / 60);
+  const mins = totalMins % 60;
+
+  if (days > 0) {
+    return `${days}d ${hours}h`;
+  }
+  if (hours > 0) {
+    return `${hours}h ${mins}m`;
+  }
+  return `${mins}m`;
+}
+
+/**
  * Pretty-print a list of Check results as aligned ASCII. No color codes —
  * Windows cmd / CI logs render plain text reliably; colors are a downside
  * not an upside for a report that's often piped or pasted.
@@ -655,26 +678,26 @@ export async function runChecks(opts: RunChecksOptions = {}): Promise<Check[]> {
       const bucket = billingBucketFromClaim(firstOk.claim);
       const pct = (n: number) => `${(n * 100).toFixed(1)}%`;
 
-      let resetStr = '';
+      let reset5hStr = '';
+      let reset7dStr = '';
       if (firstOk.reset > 0) {
-        const date = new Date(firstOk.reset * 1000);
-        const options: Intl.DateTimeFormatOptions = { hour: '2-digit', minute: '2-digit' };
-        if (date.getDate() !== new Date().getDate()) {
-          options.weekday = 'short';
+        const relativeReset = formatReset(firstOk.reset, Date.now());
+        if (firstOk.claim.startsWith('five_hour')) {
+          reset5hStr = `  •  resets in ${relativeReset}`;
+        } else if (firstOk.claim.startsWith('seven_day')) {
+          reset7dStr = `  •  resets in ${relativeReset}`;
         }
-        const timeStr = date.toLocaleTimeString([], options);
-        resetStr = `  •  resets at ${timeStr}`;
       }
 
       checks.push({
         status: firstOk.util5h >= 0.90 ? 'warn' : 'ok',
         label: 'Usage 5h (all)',
-        detail: `${pct(firstOk.util5h)} used  •  status=${firstOk.status}${resetStr}  •  claim=${firstOk.claim} (${bucket})`,
+        detail: `${pct(firstOk.util5h)} used  •  status=${firstOk.status}${reset5hStr}  •  claim=${firstOk.claim} (${bucket})`,
       });
       checks.push({
         status: firstOk.util7d >= 0.90 ? 'warn' : 'ok',
         label: 'Usage 7d (all)',
-        detail: `${pct(firstOk.util7d)} used`,
+        detail: `${pct(firstOk.util7d)} used${reset7dStr}`,
       });
 
       // Merge per-model buckets across all probes — each probe's response

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -657,17 +657,13 @@ export async function runChecks(opts: RunChecksOptions = {}): Promise<Check[]> {
 
       let resetStr = '';
       if (firstOk.reset > 0) {
-        const diffMs = (firstOk.reset * 1000) - Date.now();
-        if (diffMs > 0) {
-          const diffMins = Math.ceil(diffMs / 60000);
-          if (diffMins >= 60) {
-            const hrs = Math.floor(diffMins / 60);
-            const mins = diffMins % 60;
-            resetStr = `  •  resets in ${hrs}h ${mins}m`;
-          } else {
-            resetStr = `  •  resets in ${diffMins}m`;
-          }
+        const date = new Date(firstOk.reset * 1000);
+        const options: Intl.DateTimeFormatOptions = { hour: '2-digit', minute: '2-digit' };
+        if (date.getDate() !== new Date().getDate()) {
+          options.weekday = 'short';
         }
+        const timeStr = date.toLocaleTimeString([], options);
+        resetStr = `  •  resets at ${timeStr}`;
       }
 
       checks.push({

--- a/test/doctor-formatter.mjs
+++ b/test/doctor-formatter.mjs
@@ -8,7 +8,7 @@
 // unit-testing execFileSync probes against fixtures when the whole
 // point is to reflect the current host.
 
-import { formatChecks, formatChecksJson, exitCodeFor } from '../dist/doctor.js';
+import { formatChecks, formatChecksJson, exitCodeFor, formatReset } from '../dist/doctor.js';
 
 let pass = 0, fail = 0;
 function check(label, cond) {
@@ -127,6 +127,20 @@ header('formatChecksJson — empty checks');
   check('empty list → exitCode 0',    parsed.exitCode === 0);
   check('empty list → all summary 0', Object.values(parsed.summary).every((n) => n === 0));
   check('empty list → checks: []',    Array.isArray(parsed.checks) && parsed.checks.length === 0);
+}
+
+// ======================================================================
+//  formatReset — relative rate-limit reset times
+// ======================================================================
+header('formatReset — relative reset times');
+{
+  const now = 1000000000000; // 1,000,000,000 seconds
+
+  check('resets in past/now returns 0m', formatReset(1000000000 - 10, now) === '0m');
+  check('resets in 45s rounds to 1m', formatReset(1000000000 + 45, now) === '1m');
+  check('resets in 45m returns 45m', formatReset(1000000000 + 45 * 60, now) === '45m');
+  check('resets in 69m returns 1h 9m', formatReset(1000000000 + 69 * 60, now) === '1h 9m');
+  check('resets in 2d 3h returns 2d 3h', formatReset(1000000000 + (2 * 1440 + 3 * 60) * 60, now) === '2d 3h');
 }
 
 // ======================================================================


### PR DESCRIPTION
This PR extracts the rate limit reset timestamp from the 'anthropic-ratelimit-unified-reset' header and calculates/displays a human-readable duration countdown (e.g. 'resets in 1h 9m') inside the 'Usage 5h (all)' doctor check. This allows developers to see exactly when their rate limits will expire.