### PR TITLE
fix(tools): auto-preserve fully-unmapped tool surfaces of any size

### DIFF
--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -465,24 +465,34 @@ export function detectTextToolClient(systemText: string): string | null {
  * per-client maintenance.
  *
  * Threshold reasoning:
- * - len < 3: too few tools to be confident; let the existing detector
- *   decide. Single-purpose bridges and partial loads land here.
- * - 80% unmapped: leaves room for a non-CC client that legitimately
- *   reuses 1-2 of TOOL_MAP's bash/grep/read aliases. 100% would miss
- *   those; 50% would catch Cline forks that use 4 mapped + 4 custom.
+ * - 100% unmapped (ANY size, including 1-2 tools): unambiguously non-CC. A real
+ *   CC client always carries Bash + Read — both TOOL_MAP keys once lowercased —
+ *   so it can never present a fully-unmapped surface; only a foreign tool set
+ *   can. This is what catches the small in-house clients the 3-tool rule below
+ *   misses, e.g. forge inspection agents dispatched with just their capability
+ *   floor ([memory_store, db_query]). Before this, those 2-tool surfaces fell
+ *   under a len<3 guard and got round-robined onto CC fallback slots, which
+ *   silently corrupts every call (the model upstream never sees the real tool).
+ * - Mixed surface (some tools map): require 3+ tools AND ≥80% unmapped. The 80%
+ *   leaves room for a non-CC client that legitimately reuses 1-2 of TOOL_MAP's
+ *   bash/grep/read aliases; the 3-tool floor avoids mis-flagging a partial CC
+ *   load (1-2 tools, some mapped) mid-handshake — those stay null and remap.
  */
 export function detectNonCCByTools(
   clientTools: Array<Record<string, unknown>> | undefined,
 ): string | null {
-  if (!clientTools || clientTools.length < 3) return null;
+  if (!clientTools || clientTools.length === 0) return null;
   let unmapped = 0;
   for (const tool of clientTools) {
     const name = (tool.name as string || '').toLowerCase();
     if (!TOOL_MAP[name]) unmapped++;
   }
-  if (unmapped / clientTools.length >= 0.8) {
-    return 'unknown-non-cc';
-  }
+  const ratio = unmapped / clientTools.length;
+  // Fully-unmapped surface → non-CC at any size. Real CC always has Bash+Read
+  // mapped, so ratio === 1 is unreachable for it; only a foreign client hits it.
+  if (ratio === 1) return 'unknown-non-cc';
+  // Mixed surface: only flag once there are enough tools to be confident.
+  if (clientTools.length >= 3 && ratio >= 0.8) return 'unknown-non-cc';
   return null;
 }
 

--- a/test/client-detection.mjs
+++ b/test/client-detection.mjs
@@ -270,11 +270,27 @@ check(
 // Edge cases
 check('undefined tools → null', detectNonCCByTools(undefined) === null);
 check('empty array → null', detectNonCCByTools([]) === null);
-check('len < 3 (single custom tool) → null', detectNonCCByTools([
+
+// Small FULLY-unmapped surfaces are flagged regardless of count.
+// A 1-2 tool surface where every name is foreign can only be a non-CC client:
+// real CC always carries Bash+Read, so it can't produce a 100%-unmapped set.
+// These used to fall under a len<3 guard and get round-robined onto CC fallback
+// slots, which corrupts the calls.
+check('single fully-unmapped tool → unknown-non-cc', detectNonCCByTools([
   { name: 'something_custom' },
-]) === null);
-check('len < 3 (two custom tools) → null', detectNonCCByTools([
+]) === 'unknown-non-cc');
+check('two fully-unmapped tools → unknown-non-cc', detectNonCCByTools([
   { name: 'foo' }, { name: 'bar' },
+]) === 'unknown-non-cc');
+// forge inspection-agent capability floor — the exact surface behind the prod
+// "tool substitution: 2/2 ... (db_query, memory_store)" log.
+check('forge floor [memory_store, db_query] → unknown-non-cc', detectNonCCByTools([
+  { name: 'memory_store' }, { name: 'db_query' },
+]) === 'unknown-non-cc');
+// A small MIXED surface (some mapped) stays null: a 1-2 tool partial CC load
+// that reuses a TOOL_MAP alias must not be mis-flagged as foreign.
+check('two tools, one mapped (bash) → null (mixed, below 3)', detectNonCCByTools([
+  { name: 'bash' }, { name: 'custom_x' },
 ]) === null);
 
 // ────────────────────────────────────────────────────────────────────
@@ -293,6 +309,26 @@ const customBuilt = buildCCRequest(customClientBody, billingTag, cache1h, identi
 check('structural fallback: detectedClient === "unknown-non-cc"', customBuilt.detectedClient === 'unknown-non-cc');
 check('structural fallback: tools preserved', customBuilt.body.tools === customNonCCTools);
 check('structural fallback: tools[0].name still "network_check"', customBuilt.body.tools?.[0]?.name === 'network_check');
+
+// A realistic forge inspection agent — custom system prompt with NO
+// identity match, and only its 2-tool capability floor. Both tools are foreign
+// (ratio === 1), so the structural fallback must auto-preserve end-to-end.
+// Before the fix this 2-tool body fell under the len<3 guard and got the CC
+// canonical remap (memory_store→Bash, db_query→Read), corrupting every call.
+const forgeAgentBody = {
+  model: 'claude-sonnet-4-6',
+  system: '[PERSONALITY: Vigilant and protective.]\n\nYou are the Watchdog. Monitor system health every cycle and create tickets for anything that needs attention.',
+  messages: [{ role: 'user', content: 'check system health' }],
+  tools: [
+    { name: 'memory_store', input_schema: { type: 'object', properties: { content: { type: 'string' } } } },
+    { name: 'db_query', input_schema: { type: 'object', properties: { sql: { type: 'string' } } } },
+  ],
+};
+const forgeBuilt = buildCCRequest(forgeAgentBody, billingTag, cache1h, identity);
+check('forge 2-tool surface → detectedClient === "unknown-non-cc"', forgeBuilt.detectedClient === 'unknown-non-cc');
+check('forge 2-tool surface → tools preserved (not remapped)', forgeBuilt.body.tools === forgeAgentBody.tools);
+check('forge 2-tool surface → tools[0].name still "memory_store"', forgeBuilt.body.tools?.[0]?.name === 'memory_store');
+check('forge 2-tool surface → tools[1].name still "db_query"', forgeBuilt.body.tools?.[1]?.name === 'db_query');
 
 // Identity match takes precedence over structural fallback. arnie's real
 // surface reuses TOOL_MAP names (shell, read_file, ...) — structural


### PR DESCRIPTION
## Problem

`detectNonCCByTools` is the structural fallback that flips a request into
preserve-tools mode when the client's tool surface is clearly non-CC. It bailed
out below 3 tools:

```ts
if (!clientTools || clientTools.length < 3) return null;
```

So a client whose **entire** tool surface is foreign to `TOOL_MAP` but only
carries 1–2 tools slipped past detection, fell through to default mode, and had
its tools round-robined onto CC fallback slots (Bash/Read/…). The model upstream
then never sees the real tools, and the best-effort reverse-map corrupts every
call — the exact failure preserve-tools exists to avoid, just below the size
threshold.

## Fix

Flag a **fully-unmapped surface (`ratio === 1`) as non-CC at any size**, while
keeping the mixed-surface rule (3+ tools AND ≥80% unmapped) unchanged.

This is safe for real CC: a real CC client always carries `Bash` + `Read` (both
`TOOL_MAP` keys once lowercased), so it can never present a 100%-unmapped surface
— its detection result and wire shape are unchanged. The 3-tool floor is retained
only for the **mixed** case, so a partial CC load that legitimately reuses one or
two `TOOL_MAP` aliases mid-handshake still isn't mis-flagged.

## Tests

`test/client-detection.mjs`:
- the two former `len < 3 → null` cases now assert `unknown-non-cc` (a 1-tool and
  a 2-tool fully-unmapped surface)
- new: a small in-house surface `[memory_store, db_query]` → `unknown-non-cc`
- new guard: a 2-tool **mixed** surface (`[bash, custom]`) stays `null`
- new end-to-end `buildCCRequest` case: a 2-tool custom client with no identity
  match auto-preserves (tools forwarded verbatim, not remapped)

Full suite green (91/91).
