### PR TITLE
chore(release): v4.8.89 — ship #554 (tool-detection fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.89] - 2026-06-21
+
+- **Tool detection** — `detectNonCCByTools` now auto-preserves a *fully*-unmapped tool surface (`ratio === 1`) at any size, not just 3+ tools. A non-CC client carrying only 1–2 custom tools (none in `TOOL_MAP`) previously slipped under the `len < 3` guard and had its tools round-robined onto CC fallback slots, which silently corrupts every call (the model upstream never sees the real tool). Safe for real CC — it always carries `Bash`+`Read` (both `TOOL_MAP` keys once lowercased), so it can never present a 100%-unmapped surface; its detection result and wire shape are unchanged. The mixed-surface rule (3+ tools, ≥80% unmapped) is retained. (#554)
+
 ## [4.8.88] - 2026-06-21
 
 - **Template label refresh** — `_version`, `_supportedMaxTested`, and the `user-agent` header bumped to `2.1.185` to track `@anthropic-ai/claude-code@latest`. The live wire shape is unchanged — cc-drift-template-watch ran `capture-and-bake --check` against live CC v2.1.185 and found zero shape drift vs the bundle — so this is a label refresh, not a re-capture (`_captured` stays at the last real capture). Auto-merged; clears the `sdk-drift` early-warning signal.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.88",
+  "version": "4.8.89",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What

Patch release **v4.8.89** to ship #554.

## Why a separate PR

#554 ("auto-preserve fully-unmapped tool surfaces") merged under the existing
`4.8.88`. The `Auto release on version bump` gate checks for an existing
`v<version>` tag, found `v4.8.88`, and short-circuited — so no release was cut
and **no new GHCR image was built**. The box runs `ghcr.io/askalf/dario:latest`
via `dario-autodeploy.timer`, which only recreates on a version bump, so #554 is
merged to `master` but not deployed.

This bump (`4.8.88` → `4.8.89`) + CHANGELOG entry triggers the release pipeline
(build → smoke → tag → `gh release` → npm publish → `ghcr:latest`), after which
the box's autodeploy picks it up automatically (within-minor bump, health-gated).

## Changes

- `package.json`: `4.8.88` → `4.8.89`
- `CHANGELOG.md`: `4.8.89` section describing the #554 detection fix

No code changes.
