### PR TITLE
fix(oauth): pin runner credential to platform-dario canonical (prevent split-token-family death)

### DIFF
--- a/.github/workflows/cc-billing-classifier-canary.yml
+++ b/.github/workflows/cc-billing-classifier-canary.yml
@@ -78,6 +78,26 @@ jobs:
           npm ci --no-audit --no-fund
           npm run build
 
+      - name: Pin OAuth credential to platform-dario canonical (sole-refresher)
+        # The platform dario container is the SOLE refresher of the shared Max
+        # OAuth. CC / a runner-side dario proxy refreshes via atomic tmp+rename,
+        # which REPLACES the /root/.claude symlink with a regular file — splitting
+        # the shared refresh-token family across two files that then rotate each
+        # other to death via Anthropic refresh-token reuse-detection (the
+        # 2026-06-23 fleet outage). Re-link to the container's canonical before
+        # starting the runner-side proxy so it reads the always-fresh token and
+        # never refreshes here. See docs/recovery.md "OAuth credential dead".
+        run: |
+          CANON=/var/lib/askalf-dario/credentials.json
+          if [ -e "$CANON" ]; then
+            mkdir -p /root/.claude /root/.dario
+            ln -sfn "$CANON" /root/.claude/.credentials.json
+            ln -sfn "$CANON" /root/.dario/credentials.json
+            echo "pinned runner OAuth credential -> $CANON (inode $(stat -L -c %i "$CANON"))"
+          else
+            echo "::warning::canonical $CANON missing — platform dario down? proceeding as-is"
+          fi
+
       - name: Start dario proxy (canonical-rebuild — NOT passthrough)
         # OAuth credential: shares /root/.claude/.credentials.json with the
         # platform dario, same rationale as compat-test-self-hosted.yml —

--- a/.github/workflows/cc-drift-template-watch.yml
+++ b/.github/workflows/cc-drift-template-watch.yml
@@ -67,6 +67,28 @@ jobs:
           npm ci --no-audit --no-fund
           npm run build
 
+      - name: Pin OAuth credential to platform-dario canonical (sole-refresher)
+        # The platform dario container is the SOLE refresher of the shared Max
+        # OAuth (see the "no refresh from this side" note on the next step). But CC
+        # refreshes via atomic tmp+rename, which REPLACES the /root/.claude symlink
+        # with a regular file — splitting the shared refresh-token family across two
+        # files that then rotate each other to death via Anthropic refresh-token
+        # reuse-detection (the 2026-06-23 fleet outage: runner refreshed at 05:37 on
+        # a split file, container presented the rotated-away token at 06:00 → whole
+        # family invalidated). Re-link to the container's canonical before the
+        # Max-OAuth step so the runner reads its always-fresh token and never
+        # refreshes here. See docs/recovery.md "OAuth credential dead".
+        run: |
+          CANON=/var/lib/askalf-dario/credentials.json
+          if [ -e "$CANON" ]; then
+            mkdir -p /root/.claude /root/.dario
+            ln -sfn "$CANON" /root/.claude/.credentials.json
+            ln -sfn "$CANON" /root/.dario/credentials.json
+            echo "pinned runner OAuth credential -> $CANON (inode $(stat -L -c %i "$CANON"))"
+          else
+            echo "::warning::canonical $CANON missing — platform dario down? proceeding as-is"
+          fi
+
       - name: Run drift check
         id: check
         # Exit codes from capture-and-bake.mjs --check:


### PR DESCRIPTION
## What broke (2026-06-23 fleet outage)

The shared-credential design (dario#342) unifies the self-hosted runner's CC OAuth with the platform dario container by symlinking `/root/.claude/.credentials.json` + `/root/.dario/credentials.json` → the canonical `/var/lib/askalf-dario/credentials.json`. The documented intent (these workflows' own comments): *platform dario is the sole refresher; the runner just reads whatever's current — "no refresh from this side."*

That invariant is **silently broken by CC's own refresh**. CC writes credentials via atomic `tmp + rename`, which **replaces the symlink with a regular file**. Once `/root/.claude/.credentials.json` is standalone, the runner's CC and the container hold **separate copies of the same refresh-token family** and refresh independently. Anthropic rotates refresh tokens (new issued, old invalidated — dario#235); when the lagging side presents the already-rotated token, **reuse-detection invalidates the whole family** → permanent `invalid_grant` → every fleet call 401s until a manual re-login.

### Evidence
- `/root/.claude/.credentials.json` had become a **regular file, inode 262880**, mtime **05:37:41** — a runner CC job (the 05:38 CI/compat/capture batch) refreshed it there.
- `/var/lib/askalf-dario/credentials.json` (container canonical): **inode 256101** — diverged.
- ~06:00 the container refreshed its now-rotated token → `Refresh token rejected (401)` (`oauth.ts:826`) → `oauth: broken`, 181 restarts, fleet-wide 401 storm.
- v4.8.90 (deployed 22:06 the prior night) is a CC-template bump — no OAuth changes; not a version regression. The token was rotated by *our own runner*, not externally.

The in-process refresh mutex (`oauth.ts:54`) can't help — runner and container are separate processes.

## The fix

Re-establish the canonical symlinks at the start of every runner Max-OAuth job (`cc-drift-template-watch`, `cc-billing-classifier-canary`) so the runner reads the container's always-fresh token and has no reason to refresh — restoring the "no refresh from this side" invariant robustly against CC's atomic-write clobber. `cc-drift-watcher-liveness` is GitHub-hosted (no Max OAuth), untouched.

## Follow-up (not in this PR)

File-symlink sharing is inherently fragile against CC's atomic write. The fully-robust design is a **dedicated Max account for the runner** (separate token family → divergence harmless). This pin is the no-extra-seat mitigation that holds in practice.
