### PR TITLE
fix(tools): detectNonCCByTools counts CC-native tools as CC, not foreign

### DIFF
--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -451,8 +451,9 @@ export function detectTextToolClient(systemText: string): string | null {
 /**
  * Structural fallback for non-CC clients that the identity-string
  * detector doesn't recognize. When the operator hands us 3+ tools and
- * ≥80% of them don't appear in TOOL_MAP, we're looking at a custom
- * client whose tool surface has effectively no overlap with CC's.
+ * ≥80% of them appear in neither TOOL_MAP nor CC_NATIVE_NAMES, we're
+ * looking at a custom client whose tool surface has effectively no
+ * overlap with CC's.
  * Default-mode round-robin onto CC fallback slots silently corrupts
  * those calls (the client gets back a Glob/Read/Bash response shape
  * its own tool can't parse).
@@ -465,10 +466,11 @@ export function detectTextToolClient(systemText: string): string | null {
  * per-client maintenance.
  *
  * Threshold reasoning:
- * - 100% unmapped (ANY size, including 1-2 tools): unambiguously non-CC. A real
- *   CC client always carries Bash + Read — both TOOL_MAP keys once lowercased —
- *   so it can never present a fully-unmapped surface; only a foreign tool set
- *   can. This is what catches the small in-house clients the 3-tool rule below
+ * - 100% foreign (ANY size, including 1-2 tools): unambiguously non-CC. A real
+ *   CC client always carries Bash + Read (TOOL_MAP keys once lowercased) or its
+ *   own native tools (CC_NATIVE_NAMES), so it can never present a fully-foreign
+ *   surface; only a genuinely non-CC tool set can. This catches the small
+ *   in-house clients the 3-tool rule below
  *   misses, e.g. forge inspection agents dispatched with just their capability
  *   floor ([memory_store, db_query]). Before this, those 2-tool surfaces fell
  *   under a len<3 guard and got round-robined onto CC fallback slots, which
@@ -484,12 +486,22 @@ export function detectNonCCByTools(
   if (!clientTools || clientTools.length === 0) return null;
   let unmapped = 0;
   for (const tool of clientTools) {
-    const name = (tool.name as string || '').toLowerCase();
-    if (!TOOL_MAP[name]) unmapped++;
+    const rawName = (tool.name as string) || '';
+    // A tool is "foreign" only if dario can neither map it (TOOL_MAP, by
+    // lowercased cross-client alias) nor recognize it as CC's own (CC_NATIVE_NAMES,
+    // by exact PascalCase). CC-native tools identity-map to themselves in the remap
+    // path (see buildCCRequest), so counting them here inflates the ratio and
+    // mis-flags a modern, agentic-heavy CC client (Agent, Skill, Workflow, Task*,
+    // … — in the live bundle but absent from TOOL_MAP's alias table) as
+    // 'unknown-non-cc', flipping it to preserve and discarding the CC tool
+    // fingerprint dario exists to present. Mirror the routing's membership test so
+    // detection and routing agree.
+    if (!TOOL_MAP[rawName.toLowerCase()] && !CC_NATIVE_NAMES.has(rawName)) unmapped++;
   }
   const ratio = unmapped / clientTools.length;
-  // Fully-unmapped surface → non-CC at any size. Real CC always has Bash+Read
-  // mapped, so ratio === 1 is unreachable for it; only a foreign client hits it.
+  // Fully-foreign surface → non-CC at any size. Real CC always has Bash+Read
+  // mapped or its own native tools, so ratio === 1 is unreachable for it; only a
+  // genuinely foreign client hits it.
   if (ratio === 1) return 'unknown-non-cc';
   // Mixed surface: only flag once there are enough tools to be confident.
   if (clientTools.length >= 3 && ratio >= 0.8) return 'unknown-non-cc';

--- a/test/client-detection.mjs
+++ b/test/client-detection.mjs
@@ -294,6 +294,51 @@ check('two tools, one mapped (bash) → null (mixed, below 3)', detectNonCCByToo
 ]) === null);
 
 // ────────────────────────────────────────────────────────────────────
+header('10b. detectNonCCByTools — CC-native tools are NOT foreign');
+
+// A tool counts as "foreign" only if it's absent from BOTH TOOL_MAP and
+// CC_NATIVE_NAMES (CC's live bundle). CC's newer agentic tools (Agent, Skill,
+// Workflow, Task*, Cron*, NotebookEdit, Enter/ExitPlanMode, …) aren't in
+// TOOL_MAP's cross-client alias table, but they ARE CC's own and identity-map
+// to themselves in the remap path. Counting them as foreign (TOOL_MAP-only)
+// mis-flagged an agentic-heavy CC client as 'unknown-non-cc' → preserve →
+// CC tool fingerprint lost. The names below are proven CC-native cross-platform
+// by the issue-29 "CC-native newer tools map to themselves" suite.
+
+// All-CC-native surface: TOOL_MAP-only counting saw ratio === 1 (every name
+// absent from TOOL_MAP) → unknown-non-cc; CC_NATIVE-aware → null (it's CC).
+check('all-CC-native agentic surface → null (recognized as CC, was ratio===1)',
+  detectNonCCByTools([
+    { name: 'Agent' }, { name: 'AskUserQuestion' }, { name: 'Workflow' },
+    { name: 'TaskCreate' }, { name: 'CronCreate' },
+  ]) === null);
+
+// Realistic modern CC: file tools (TOOL_MAP) + agentic (CC_NATIVE) → null.
+check('modern CC (file + agentic tools) → null (no foreign tools)',
+  detectNonCCByTools([
+    { name: 'Bash' }, { name: 'Read' }, { name: 'Edit' },
+    { name: 'Agent' }, { name: 'Workflow' }, { name: 'NotebookEdit' },
+    { name: 'EnterPlanMode' }, { name: 'TaskCreate' },
+  ]) === null);
+
+// Mostly CC-native with a couple genuinely-foreign tools (40% foreign, < 0.8)
+// → null. TOOL_MAP-only counting would have seen 5/5 = ratio 1 → unknown-non-cc.
+check('CC-native + 2 foreign (40% foreign) → null (mostly CC, remap)',
+  detectNonCCByTools([
+    { name: 'Agent' }, { name: 'Workflow' }, { name: 'TaskCreate' },
+    { name: 'custom_x' }, { name: 'custom_y' },
+  ]) === null);
+
+// Regression: a genuinely foreign-dominated surface still flags, even with one
+// CC tool present. 1 mapped + 5 foreign (none CC-native) = 83% foreign ≥ 0.8.
+check('foreign-dominated surface (1 CC + 5 foreign) → unknown-non-cc',
+  detectNonCCByTools([
+    { name: 'Bash' },
+    { name: 'memory_store' }, { name: 'db_query' }, { name: 'vector_search' },
+    { name: 'graph_walk' }, { name: 'ledger_post' },
+  ]) === 'unknown-non-cc');
+
+// ────────────────────────────────────────────────────────────────────
 header('11. buildCCRequest — structural fallback drives auto-preserve');
 
 // Client with no recognizable identity string but a custom tool surface


### PR DESCRIPTION
## What

`detectNonCCByTools` (the structural fallback that auto-enables preserve-tools for non-CC clients) counted a tool as "foreign" whenever its name was absent from `TOOL_MAP`. But the remap path in `buildCCRequest` **identity-maps CC's own tools** via `CC_NATIVE_NAMES` (built from the live CC bundle), overriding `TOOL_MAP`. So CC's newer agentic tools — `Agent`, `Skill`, `Workflow`, `Task*`, `Cron*`, `NotebookEdit`, `Enter/ExitPlanMode`, … — which are in the bundle but **not** in `TOOL_MAP`'s cross-client alias table, were miscounted as foreign by detection.

Consequence: a modern, agentic-heavy **pure-CC** client could clear the `0.8` ratio (or hit `ratio === 1`) and get mis-flagged `unknown-non-cc` → auto-preserve-tools — which discards the canonical CC tool array, the exact fingerprint dario exists to present.

## Fix

A one-line membership change so detection mirrors routing — a tool is foreign only when it's in **neither** `TOOL_MAP` **nor** `CC_NATIVE_NAMES`:

```ts
if (!TOOL_MAP[rawName.toLowerCase()] && !CC_NATIVE_NAMES.has(rawName)) unmapped++;
```

The remap path already skips `CC_NATIVE_NAMES ∪ TOOL_MAP` (identity-map at the `CC_NATIVE_NAMES.has(...)` branch in `buildCCRequest`); this aligns the detector with it.

## Not affected

- **Genuinely foreign clients still flag identically** — e.g. forge inspection agents dispatched with `[memory_store, db_query]` (neither mapped nor CC-native) → `unknown-non-cc`, unchanged.
- **Existing translation suites unchanged** — `issue-29-tool-translation` and `tool-schema-contract` route their fixtures null→remap and stay that way (verified green).
- Identity-string detection (`detectTextToolClient`), `--hybrid-tools`, `--merge-tools`, `--no-auto-detect`, and explicit `--preserve-tools` are untouched.

## Tests

`test/client-detection.mjs` §10b:

- all-CC-native agentic surface → `null` (was `ratio === 1` → `unknown-non-cc` under the old TOOL_MAP-only count)
- modern CC (file + agentic tools) → `null`
- mostly-CC + 2 foreign (40%) → `null`
- foreign-dominated (1 CC + 5 foreign, 83%) → still `unknown-non-cc`

Full unit suite green: **91/91**.

## Note

No `package.json` version bump or `CHANGELOG` entry — left to the release/auto-rebake flow.
