### PR TITLE
auto-rebake: template drift detected 2026-06-24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ checklist.
 
 ## [4.8.93] - 2026-06-24
 
-- **Template rebake** — re-captured `src/cc-template-data.json` after cc-drift-template-watch detected wire-fingerprint drift against a live CC capture. Bundled fallback template now matches the current CC wire shape.
+- **Template rebake (v2.1.187)** — re-captured `src/cc-template-data.json` after cc-drift-template-watch detected drift against a live CC capture.
+- **Fix — preserve interactive-only tools across headless rebakes** — the bake captures CC headlessly (`claude --print -p hi`), and CC v2.1.187 stopped advertising `AskUserQuestion` / `EnterPlanMode` / `ExitPlanMode` in `--print` mode, so the auto-rebake dropped them from the bundled template. Because `buildCCRequest` advertises only the intersection of the client's declared tools and the template, a full CC client that declared `AskUserQuestion` no longer had it advertised (the advertise-respects-client contract). The bake now preserves `INTERACTIVE_ONLY_TOOLS` from the previous bundle — mirroring the existing win32-only `PowerShell`/`Glob`/`Grep` preservation — so the bundled template stays a superset. Added `test/template-interactive-tools.mjs` to guard the invariant.
 ## [4.8.92] - 2026-06-23
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.186` → `2.1.187` for CC v2.1.187. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.93] - 2026-06-24
+
+- **Template rebake** — re-captured `src/cc-template-data.json` after cc-drift-template-watch detected wire-fingerprint drift against a live CC capture. Bundled fallback template now matches the current CC wire shape.
 ## [4.8.92] - 2026-06-23
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.186` → `2.1.187` for CC v2.1.187. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.92",
+  "version": "4.8.93",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/scripts/capture-and-bake.mjs
+++ b/scripts/capture-and-bake.mjs
@@ -40,7 +40,7 @@ import { fileURLToPath } from 'node:url';
 
 import { captureLiveTemplateAsync, findInstalledCC } from '../dist/live-fingerprint.js';
 import { scrubTemplate, findUserPathHits } from '../dist/scrub-template.js';
-import { PLATFORM_ONLY_TOOLS } from '../dist/cc-template.js';
+import { PLATFORM_ONLY_TOOLS, INTERACTIVE_ONLY_TOOLS } from '../dist/cc-template.js';
 import { computeDrift, formatDriftReport, interpretDrift, formatDriftSummary, stripModelConditionalBetas } from './drift-report.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -119,6 +119,22 @@ if (preservedOtherPlatTools.length > 0) {
   // CC sends tools alphabetically by name — sort after merge so the preserved
   // tools insert at their natural position rather than appending at the end.
   scrubbed.tools = [...scrubbed.tools, ...preservedOtherPlatTools].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+// Preserve interactive-only tools from the previous bundle. The capture spawns
+// CC headlessly (`claude --print -p hi`), and CC v2.1.187 stopped advertising
+// AskUserQuestion / EnterPlanMode / ExitPlanMode in --print mode — so a fresh
+// headless capture drops them even though every real interactive CC client still
+// sends them. Like the platform-tool preservation above, re-add them from the
+// previous bundle so the bundled JSON stays a superset; dropping them broke
+// buildCCRequest's advertise-respects-client contract (v4.8.93). Sorted back in
+// alphabetically to match CC's wire order.
+const preservedInteractiveTools = (prev.tools || []).filter(
+  (t) => INTERACTIVE_ONLY_TOOLS.has(t.name) && !scrubbed.tools.some((s) => s.name === t.name),
+);
+if (preservedInteractiveTools.length > 0) {
+  log(`preserved ${preservedInteractiveTools.length} interactive-only tool${preservedInteractiveTools.length === 1 ? '' : 's'} from previous bundle (headless capture omits them): ${preservedInteractiveTools.map((t) => t.name).join(', ')}`);
+  scrubbed.tools = [...scrubbed.tools, ...preservedInteractiveTools].sort((a, b) => a.name.localeCompare(b.name));
 }
 log(`previous baked template: CC v${prev._version} captured ${prev._captured}, ${prev.tools.length} tools, ${prev.system_prompt.length} char system prompt`);
 

--- a/src/cc-template-data.json
+++ b/src/cc-template-data.json
@@ -56,6 +56,121 @@
       }
     },
     {
+      "name": "AskUserQuestion",
+      "description": "Use this tool only when you are blocked on a decision that is genuinely the user's to make: one you cannot resolve from the request, the code, or sensible defaults.\n\nUsage notes:\n- Users will always be able to select \"Other\" to provide custom text input\n- Use multiSelect: true to allow multiple answers to be selected for a question\n- If you recommend a specific option, make that the first option in the list and add \"(Recommended)\" at the end of the label\n\nPlan mode note: To switch into plan mode, use EnterPlanMode (not this tool). Once in plan mode, use this tool to clarify requirements or choose between approaches BEFORE finalizing your plan. Do NOT use this tool to ask \"Is my plan ready?\", \"Should I proceed?\", or otherwise reference \"the plan\" in questions — the user cannot see the plan until you call ExitPlanMode for approval.\n\nReserve this for decisions where the user's answer changes what you do next — not for choices with a conventional default or facts you can verify in the codebase yourself. In those cases pick the obvious option, mention it in your response, and proceed.\n\nPreview feature:\nUse the optional `preview` field on options when presenting concrete artifacts that users need to visually compare:\n- ASCII mockups of UI layouts or components\n- Code snippets showing different implementations\n- Diagram variations\n- Configuration examples\n\nPreview content is rendered as markdown in a monospace box. Multi-line text with newlines is supported. When any option has a preview, the UI switches to a side-by-side layout with a vertical option list on the left and preview on the right. Do not use previews for simple preference questions where labels and descriptions suffice. Note: previews are only supported for single-select questions (not multiSelect).\n",
+      "input_schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "questions": {
+            "description": "Questions to ask the user (1-4 questions)",
+            "minItems": 1,
+            "maxItems": 4,
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "question": {
+                  "description": "The complete question to ask the user. Should be clear, specific, and end with a question mark. Example: \"Which library should we use for date formatting?\" If multiSelect is true, phrase it accordingly, e.g. \"Which features do you want to enable?\"",
+                  "type": "string"
+                },
+                "header": {
+                  "description": "Very short label displayed as a chip/tag (max 12 chars). Examples: \"Auth method\", \"Library\", \"Approach\".",
+                  "type": "string"
+                },
+                "options": {
+                  "description": "The available choices for this question. Must have 2-4 options. Each option should be a distinct, mutually exclusive choice (unless multiSelect is enabled). There should be no 'Other' option, that will be provided automatically.",
+                  "minItems": 2,
+                  "maxItems": 4,
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "label": {
+                        "description": "The display text for this option that the user will see and select. Should be concise (1-5 words) and clearly describe the choice.",
+                        "type": "string"
+                      },
+                      "description": {
+                        "description": "Explanation of what this option means or what will happen if chosen. Useful for providing context about trade-offs or implications.",
+                        "type": "string"
+                      },
+                      "preview": {
+                        "description": "Optional preview content rendered when this option is focused. Use for mockups, code snippets, or visual comparisons that help users compare options. See the tool description for the expected content format.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "label",
+                      "description"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "multiSelect": {
+                  "description": "Set to true to allow the user to select multiple options instead of just one. Use when choices are not mutually exclusive.",
+                  "default": false,
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "question",
+                "header",
+                "options",
+                "multiSelect"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "answers": {
+            "description": "User answers collected by the permission component",
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "annotations": {
+            "description": "Optional per-question annotations from the user (e.g., notes on preview selections). Keyed by question text.",
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "preview": {
+                  "description": "The preview content of the selected option, if the question used previews.",
+                  "type": "string"
+                },
+                "notes": {
+                  "description": "Free-text notes the user added to their selection.",
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "metadata": {
+            "description": "Optional metadata for tracking and analytics purposes. Not displayed to user.",
+            "type": "object",
+            "properties": {
+              "source": {
+                "description": "Optional identifier for the source of this question (e.g., \"remember\" for /remember command). Used for analytics tracking.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "required": [
+          "questions"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
       "name": "Bash",
       "description": "Executes a bash command and returns its output.\n\n- Working directory persists between calls, but prefer absolute paths — `cd` in a compound command can trigger a permission prompt. Shell state (env vars, functions) does not persist; the shell is initialized from the user's profile.\n- IMPORTANT: Avoid using this tool to run `cat`, `head`, `tail`, `sed`, `awk`, or `echo` commands, unless explicitly instructed or after you have verified that a dedicated tool cannot accomplish your task. Instead, use the appropriate dedicated tool as this will provide a much better experience for the user.\n- `timeout` is in milliseconds: default 120000, max 600000.\n- `run_in_background` runs the command detached: it keeps running across turns and re-invokes you when it exits. No `&` needed. Foreground `sleep` is blocked; use Monitor with an until-loop to wait on a condition.\n\n# Git\n- Interactive flags (`-i`, e.g. `git rebase -i`, `git add -i`) are not supported in this environment.\n- Use the `gh` CLI for GitHub operations (PRs, issues, API).\n- Commit or push only when the user asks. If on the default branch, branch first.\n- End git commit messages with:\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>\n- End PR bodies with:\n🤖 Generated with [Claude Code](https://claude.com/claude-code)",
       "input_schema": {
@@ -403,6 +518,16 @@
       }
     },
     {
+      "name": "EnterPlanMode",
+      "description": "Use this tool proactively when you're about to start a non-trivial implementation task. Getting user sign-off on your approach before writing code prevents wasted effort and ensures alignment. This tool transitions you into plan mode where you can explore the codebase and design an implementation approach for user approval.\n\n## When to Use This Tool\n\n**Prefer using EnterPlanMode** for implementation tasks unless they're simple. Use it when ANY of these conditions apply:\n\n1. **New Feature Implementation**: Adding meaningful new functionality\n   - Example: \"Add a logout button\" - where should it go? What should happen on click?\n   - Example: \"Add form validation\" - what rules? What error messages?\n\n2. **Multiple Valid Approaches**: The task can be solved in several different ways\n   - Example: \"Add caching to the API\" - could use Redis, in-memory, file-based, etc.\n   - Example: \"Improve performance\" - many optimization strategies possible\n\n3. **Code Modifications**: Changes that affect existing behavior or structure\n   - Example: \"Update the login flow\" - what exactly should change?\n   - Example: \"Refactor this component\" - what's the target architecture?\n\n4. **Architectural Decisions**: The task requires choosing between patterns or technologies\n   - Example: \"Add real-time updates\" - WebSockets vs SSE vs polling\n   - Example: \"Implement state management\" - Redux vs Context vs custom solution\n\n5. **Multi-File Changes**: The task will likely touch more than 2-3 files\n   - Example: \"Refactor the authentication system\"\n   - Example: \"Add a new API endpoint with tests\"\n\n6. **Unclear Requirements**: You need to explore before understanding the full scope\n   - Example: \"Make the app faster\" - need to profile and identify bottlenecks\n   - Example: \"Fix the bug in checkout\" - need to investigate root cause\n\n7. **User Preferences Matter**: The implementation could reasonably go multiple ways\n   - If you would use AskUserQuestion to clarify the approach, use EnterPlanMode instead\n   - Plan mode lets you explore first, then present options with context\n\n## When NOT to Use This Tool\n\nOnly skip EnterPlanMode for simple tasks:\n- Single-line or few-line fixes (typos, obvious bugs, small tweaks)\n- Adding a single function with clear requirements\n- Tasks where the user has given very specific, detailed instructions\n- Pure research/exploration tasks (use the Agent tool with explore agent instead)\n\n## What Happens in Plan Mode\n\nIn plan mode, you'll:\n1. Thoroughly explore the codebase using `find`/Glob, `grep`/Grep, and Read\n2. Understand existing patterns and architecture\n3. Design an implementation approach\n4. Present your plan to the user for approval\n5. Use AskUserQuestion if you need to clarify approaches\n6. Exit plan mode with ExitPlanMode when ready to implement\n\n## Examples\n\n### GOOD - Use EnterPlanMode:\nUser: \"Add user authentication to the app\"\n- Requires architectural decisions (session vs JWT, where to store tokens, middleware structure)\n\nUser: \"Optimize the database queries\"\n- Multiple approaches possible, need to profile first, significant impact\n\nUser: \"Implement dark mode\"\n- Architectural decision on theme system, affects many components\n\nUser: \"Add a delete button to the user profile\"\n- Seems simple but involves: where to place it, confirmation dialog, API call, error handling, state updates\n\nUser: \"Update the error handling in the API\"\n- Affects multiple files, user should approve the approach\n\n### BAD - Don't use EnterPlanMode:\nUser: \"Fix the typo in the README\"\n- Straightforward, no planning needed\n\nUser: \"Add a console.log to debug this function\"\n- Simple, obvious implementation\n\nUser: \"What files handle routing?\"\n- Research task, not implementation planning\n\n## Important Notes\n\n- This tool REQUIRES user approval - they must consent to entering plan mode\n- If unsure whether to use it, err on the side of planning - it's better to get alignment upfront than to redo work\n- Users appreciate being consulted before significant changes are made to their codebase\n",
+      "input_schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+      }
+    },
+    {
       "name": "EnterWorktree",
       "description": "Use this tool ONLY when explicitly instructed to work in a worktree — either by the user directly, or by project instructions (CLAUDE.md / memory). This tool creates an isolated git worktree and switches the current session into it.\n\n## When to Use\n\n- The user explicitly says \"worktree\" (e.g., \"start a worktree\", \"work in a worktree\", \"create a worktree\", \"use a worktree\")\n- CLAUDE.md or memory instructions direct you to work in a worktree for the current task\n\n## When NOT to Use\n\n- The user asks to create a branch, switch branches, or work on a different branch — use git commands instead\n- The user asks to fix a bug or work on a feature — use normal git workflow unless worktrees are explicitly requested by the user or project instructions\n- Never use this tool unless \"worktree\" is explicitly mentioned by the user or in CLAUDE.md / memory instructions\n\n## Requirements\n\n- Must be in a git repository, OR have WorktreeCreate/WorktreeRemove hooks configured in settings.json\n- Must not already be in a worktree session when creating a new worktree (`name`); switching into another existing worktree via `path` is allowed\n\n## Behavior\n\n- In a git repository: creates a new git worktree inside `.claude/worktrees/` on a new branch. The base ref is governed by the `worktree.baseRef` setting: `fresh` (default) branches from origin/<default-branch>; `head` branches from your current local HEAD\n- Outside a git repository: delegates to WorktreeCreate/WorktreeRemove hooks for VCS-agnostic isolation\n- Switches the session's working directory to the new worktree\n- Use ExitWorktree to leave the worktree mid-session (keep or remove). On session exit, if still in the worktree, the user will be prompted to keep or remove it\n\n## Entering an existing worktree\n\nPass `path` instead of `name` to switch the session into a worktree that already exists (e.g., one you just created with `git worktree add`). The path must appear in `git worktree list` for the current repository — paths that are not registered worktrees of this repo are rejected. ExitWorktree will not remove a worktree entered this way; use `action: \"keep\"` to return to the original directory.\n\nSwitching with `path` also works when the session is already in a worktree (the previous worktree is left on disk, untouched, and only the new one is tracked for exit-time cleanup), and from agents whose working directory was pinned at launch (subagent isolation or explicit cwd). In both cases the target must be a worktree under `.claude/worktrees/` of the same repository, and from a pinned agent the switch only affects this agent, not the parent session. After a further switch, previously-visited worktrees are no longer writable — re-issue EnterWorktree with `path` to return to one.\n\n## Parameters\n\n- `name` (optional): A name for a new worktree. If neither `name` nor `path` is provided, a random name is generated.\n- `path` (optional): Path to an existing worktree of the current repository to enter instead of creating one. Mutually exclusive with `name`.\n",
       "input_schema": {
@@ -419,6 +544,42 @@
           }
         },
         "additionalProperties": false
+      }
+    },
+    {
+      "name": "ExitPlanMode",
+      "description": "Use this tool when you are in plan mode and have finished writing your plan to the plan file and are ready for user approval.\n\n## How This Tool Works\n- You should have already written your plan to the plan file specified in the plan mode system message\n- This tool does NOT take the plan content as a parameter - it will read the plan from the file you wrote\n- This tool simply signals that you're done planning and ready for the user to review and approve\n- The user will see the contents of your plan file when they review it\n\n## When to Use This Tool\nIMPORTANT: Only use this tool when the task requires planning the implementation steps of a task that requires writing code. For research tasks where you're gathering information, searching files, reading files or in general trying to understand the codebase - do NOT use this tool.\n\n## Before Using This Tool\nEnsure your plan is complete and unambiguous:\n- If you have unresolved questions about requirements or approach, use AskUserQuestion first (in earlier phases)\n- Once your plan is finalized, use THIS tool to request approval\n\n**Important:** Do NOT use AskUserQuestion to ask \"Is this plan okay?\" or \"Should I proceed?\" - that's exactly what THIS tool does. ExitPlanMode inherently requests user approval of your plan.\n\n## Examples\n\n1. Initial task: \"Search for and understand the implementation of vim mode in the codebase\" - Do not use the exit plan mode tool because you are not planning the implementation steps of a task.\n2. Initial task: \"Help me implement yank mode for vim\" - Use the exit plan mode tool after you have finished planning the implementation steps of the task.\n3. Initial task: \"Add a new feature to handle user authentication\" - If unsure about auth method (OAuth, JWT, etc.), use AskUserQuestion first, then use exit plan mode tool after clarifying the approach.\n",
+      "input_schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "allowedPrompts": {
+            "description": "Prompt-based permissions needed to implement the plan. These describe categories of actions rather than specific commands.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "tool": {
+                  "description": "The tool this prompt applies to",
+                  "type": "string",
+                  "enum": [
+                    "Bash"
+                  ]
+                },
+                "prompt": {
+                  "description": "Semantic description of the action, e.g. \"run tests\", \"install dependencies\"",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "tool",
+                "prompt"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "additionalProperties": {}
       }
     },
     {

--- a/src/cc-template-data.json
+++ b/src/cc-template-data.json
@@ -1,6 +1,6 @@
 {
-  "_version": "2.1.186",
-  "_captured": "2026-06-23T05:37:45.965Z",
+  "_version": "2.1.187",
+  "_captured": "2026-06-24T06:27:30.671Z",
   "_source": "bundled",
   "_schemaVersion": 3,
   "agent_identity": "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
@@ -51,121 +51,6 @@
         "required": [
           "description",
           "prompt"
-        ],
-        "additionalProperties": false
-      }
-    },
-    {
-      "name": "AskUserQuestion",
-      "description": "Use this tool only when you are blocked on a decision that is genuinely the user's to make: one you cannot resolve from the request, the code, or sensible defaults.\n\nUsage notes:\n- Users will always be able to select \"Other\" to provide custom text input\n- Use multiSelect: true to allow multiple answers to be selected for a question\n- If you recommend a specific option, make that the first option in the list and add \"(Recommended)\" at the end of the label\n\nPlan mode note: To switch into plan mode, use EnterPlanMode (not this tool). Once in plan mode, use this tool to clarify requirements or choose between approaches BEFORE finalizing your plan. Do NOT use this tool to ask \"Is my plan ready?\", \"Should I proceed?\", or otherwise reference \"the plan\" in questions — the user cannot see the plan until you call ExitPlanMode for approval.\n\nReserve this for decisions where the user's answer changes what you do next — not for choices with a conventional default or facts you can verify in the codebase yourself. In those cases pick the obvious option, mention it in your response, and proceed.\n\nPreview feature:\nUse the optional `preview` field on options when presenting concrete artifacts that users need to visually compare:\n- ASCII mockups of UI layouts or components\n- Code snippets showing different implementations\n- Diagram variations\n- Configuration examples\n\nPreview content is rendered as markdown in a monospace box. Multi-line text with newlines is supported. When any option has a preview, the UI switches to a side-by-side layout with a vertical option list on the left and preview on the right. Do not use previews for simple preference questions where labels and descriptions suffice. Note: previews are only supported for single-select questions (not multiSelect).\n",
-      "input_schema": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "type": "object",
-        "properties": {
-          "questions": {
-            "description": "Questions to ask the user (1-4 questions)",
-            "minItems": 1,
-            "maxItems": 4,
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "question": {
-                  "description": "The complete question to ask the user. Should be clear, specific, and end with a question mark. Example: \"Which library should we use for date formatting?\" If multiSelect is true, phrase it accordingly, e.g. \"Which features do you want to enable?\"",
-                  "type": "string"
-                },
-                "header": {
-                  "description": "Very short label displayed as a chip/tag (max 12 chars). Examples: \"Auth method\", \"Library\", \"Approach\".",
-                  "type": "string"
-                },
-                "options": {
-                  "description": "The available choices for this question. Must have 2-4 options. Each option should be a distinct, mutually exclusive choice (unless multiSelect is enabled). There should be no 'Other' option, that will be provided automatically.",
-                  "minItems": 2,
-                  "maxItems": 4,
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "label": {
-                        "description": "The display text for this option that the user will see and select. Should be concise (1-5 words) and clearly describe the choice.",
-                        "type": "string"
-                      },
-                      "description": {
-                        "description": "Explanation of what this option means or what will happen if chosen. Useful for providing context about trade-offs or implications.",
-                        "type": "string"
-                      },
-                      "preview": {
-                        "description": "Optional preview content rendered when this option is focused. Use for mockups, code snippets, or visual comparisons that help users compare options. See the tool description for the expected content format.",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "label",
-                      "description"
-                    ],
-                    "additionalProperties": false
-                  }
-                },
-                "multiSelect": {
-                  "description": "Set to true to allow the user to select multiple options instead of just one. Use when choices are not mutually exclusive.",
-                  "default": false,
-                  "type": "boolean"
-                }
-              },
-              "required": [
-                "question",
-                "header",
-                "options",
-                "multiSelect"
-              ],
-              "additionalProperties": false
-            }
-          },
-          "answers": {
-            "description": "User answers collected by the permission component",
-            "type": "object",
-            "propertyNames": {
-              "type": "string"
-            },
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "annotations": {
-            "description": "Optional per-question annotations from the user (e.g., notes on preview selections). Keyed by question text.",
-            "type": "object",
-            "propertyNames": {
-              "type": "string"
-            },
-            "additionalProperties": {
-              "type": "object",
-              "properties": {
-                "preview": {
-                  "description": "The preview content of the selected option, if the question used previews.",
-                  "type": "string"
-                },
-                "notes": {
-                  "description": "Free-text notes the user added to their selection.",
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "metadata": {
-            "description": "Optional metadata for tracking and analytics purposes. Not displayed to user.",
-            "type": "object",
-            "properties": {
-              "source": {
-                "description": "Optional identifier for the source of this question (e.g., \"remember\" for /remember command). Used for analytics tracking.",
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          }
-        },
-        "required": [
-          "questions"
         ],
         "additionalProperties": false
       }
@@ -518,16 +403,6 @@
       }
     },
     {
-      "name": "EnterPlanMode",
-      "description": "Use this tool proactively when you're about to start a non-trivial implementation task. Getting user sign-off on your approach before writing code prevents wasted effort and ensures alignment. This tool transitions you into plan mode where you can explore the codebase and design an implementation approach for user approval.\n\n## When to Use This Tool\n\n**Prefer using EnterPlanMode** for implementation tasks unless they're simple. Use it when ANY of these conditions apply:\n\n1. **New Feature Implementation**: Adding meaningful new functionality\n   - Example: \"Add a logout button\" - where should it go? What should happen on click?\n   - Example: \"Add form validation\" - what rules? What error messages?\n\n2. **Multiple Valid Approaches**: The task can be solved in several different ways\n   - Example: \"Add caching to the API\" - could use Redis, in-memory, file-based, etc.\n   - Example: \"Improve performance\" - many optimization strategies possible\n\n3. **Code Modifications**: Changes that affect existing behavior or structure\n   - Example: \"Update the login flow\" - what exactly should change?\n   - Example: \"Refactor this component\" - what's the target architecture?\n\n4. **Architectural Decisions**: The task requires choosing between patterns or technologies\n   - Example: \"Add real-time updates\" - WebSockets vs SSE vs polling\n   - Example: \"Implement state management\" - Redux vs Context vs custom solution\n\n5. **Multi-File Changes**: The task will likely touch more than 2-3 files\n   - Example: \"Refactor the authentication system\"\n   - Example: \"Add a new API endpoint with tests\"\n\n6. **Unclear Requirements**: You need to explore before understanding the full scope\n   - Example: \"Make the app faster\" - need to profile and identify bottlenecks\n   - Example: \"Fix the bug in checkout\" - need to investigate root cause\n\n7. **User Preferences Matter**: The implementation could reasonably go multiple ways\n   - If you would use AskUserQuestion to clarify the approach, use EnterPlanMode instead\n   - Plan mode lets you explore first, then present options with context\n\n## When NOT to Use This Tool\n\nOnly skip EnterPlanMode for simple tasks:\n- Single-line or few-line fixes (typos, obvious bugs, small tweaks)\n- Adding a single function with clear requirements\n- Tasks where the user has given very specific, detailed instructions\n- Pure research/exploration tasks (use the Agent tool with explore agent instead)\n\n## What Happens in Plan Mode\n\nIn plan mode, you'll:\n1. Thoroughly explore the codebase using `find`/Glob, `grep`/Grep, and Read\n2. Understand existing patterns and architecture\n3. Design an implementation approach\n4. Present your plan to the user for approval\n5. Use AskUserQuestion if you need to clarify approaches\n6. Exit plan mode with ExitPlanMode when ready to implement\n\n## Examples\n\n### GOOD - Use EnterPlanMode:\nUser: \"Add user authentication to the app\"\n- Requires architectural decisions (session vs JWT, where to store tokens, middleware structure)\n\nUser: \"Optimize the database queries\"\n- Multiple approaches possible, need to profile first, significant impact\n\nUser: \"Implement dark mode\"\n- Architectural decision on theme system, affects many components\n\nUser: \"Add a delete button to the user profile\"\n- Seems simple but involves: where to place it, confirmation dialog, API call, error handling, state updates\n\nUser: \"Update the error handling in the API\"\n- Affects multiple files, user should approve the approach\n\n### BAD - Don't use EnterPlanMode:\nUser: \"Fix the typo in the README\"\n- Straightforward, no planning needed\n\nUser: \"Add a console.log to debug this function\"\n- Simple, obvious implementation\n\nUser: \"What files handle routing?\"\n- Research task, not implementation planning\n\n## Important Notes\n\n- This tool REQUIRES user approval - they must consent to entering plan mode\n- If unsure whether to use it, err on the side of planning - it's better to get alignment upfront than to redo work\n- Users appreciate being consulted before significant changes are made to their codebase\n",
-      "input_schema": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "type": "object",
-        "properties": {},
-        "additionalProperties": false
-      }
-    },
-    {
       "name": "EnterWorktree",
       "description": "Use this tool ONLY when explicitly instructed to work in a worktree — either by the user directly, or by project instructions (CLAUDE.md / memory). This tool creates an isolated git worktree and switches the current session into it.\n\n## When to Use\n\n- The user explicitly says \"worktree\" (e.g., \"start a worktree\", \"work in a worktree\", \"create a worktree\", \"use a worktree\")\n- CLAUDE.md or memory instructions direct you to work in a worktree for the current task\n\n## When NOT to Use\n\n- The user asks to create a branch, switch branches, or work on a different branch — use git commands instead\n- The user asks to fix a bug or work on a feature — use normal git workflow unless worktrees are explicitly requested by the user or project instructions\n- Never use this tool unless \"worktree\" is explicitly mentioned by the user or in CLAUDE.md / memory instructions\n\n## Requirements\n\n- Must be in a git repository, OR have WorktreeCreate/WorktreeRemove hooks configured in settings.json\n- Must not already be in a worktree session when creating a new worktree (`name`); switching into another existing worktree via `path` is allowed\n\n## Behavior\n\n- In a git repository: creates a new git worktree inside `.claude/worktrees/` on a new branch. The base ref is governed by the `worktree.baseRef` setting: `fresh` (default) branches from origin/<default-branch>; `head` branches from your current local HEAD\n- Outside a git repository: delegates to WorktreeCreate/WorktreeRemove hooks for VCS-agnostic isolation\n- Switches the session's working directory to the new worktree\n- Use ExitWorktree to leave the worktree mid-session (keep or remove). On session exit, if still in the worktree, the user will be prompted to keep or remove it\n\n## Entering an existing worktree\n\nPass `path` instead of `name` to switch the session into a worktree that already exists (e.g., one you just created with `git worktree add`). The path must appear in `git worktree list` for the current repository — paths that are not registered worktrees of this repo are rejected. ExitWorktree will not remove a worktree entered this way; use `action: \"keep\"` to return to the original directory.\n\nSwitching with `path` also works when the session is already in a worktree (the previous worktree is left on disk, untouched, and only the new one is tracked for exit-time cleanup), and from agents whose working directory was pinned at launch (subagent isolation or explicit cwd). In both cases the target must be a worktree under `.claude/worktrees/` of the same repository, and from a pinned agent the switch only affects this agent, not the parent session. After a further switch, previously-visited worktrees are no longer writable — re-issue EnterWorktree with `path` to return to one.\n\n## Parameters\n\n- `name` (optional): A name for a new worktree. If neither `name` nor `path` is provided, a random name is generated.\n- `path` (optional): Path to an existing worktree of the current repository to enter instead of creating one. Mutually exclusive with `name`.\n",
       "input_schema": {
@@ -544,42 +419,6 @@
           }
         },
         "additionalProperties": false
-      }
-    },
-    {
-      "name": "ExitPlanMode",
-      "description": "Use this tool when you are in plan mode and have finished writing your plan to the plan file and are ready for user approval.\n\n## How This Tool Works\n- You should have already written your plan to the plan file specified in the plan mode system message\n- This tool does NOT take the plan content as a parameter - it will read the plan from the file you wrote\n- This tool simply signals that you're done planning and ready for the user to review and approve\n- The user will see the contents of your plan file when they review it\n\n## When to Use This Tool\nIMPORTANT: Only use this tool when the task requires planning the implementation steps of a task that requires writing code. For research tasks where you're gathering information, searching files, reading files or in general trying to understand the codebase - do NOT use this tool.\n\n## Before Using This Tool\nEnsure your plan is complete and unambiguous:\n- If you have unresolved questions about requirements or approach, use AskUserQuestion first (in earlier phases)\n- Once your plan is finalized, use THIS tool to request approval\n\n**Important:** Do NOT use AskUserQuestion to ask \"Is this plan okay?\" or \"Should I proceed?\" - that's exactly what THIS tool does. ExitPlanMode inherently requests user approval of your plan.\n\n## Examples\n\n1. Initial task: \"Search for and understand the implementation of vim mode in the codebase\" - Do not use the exit plan mode tool because you are not planning the implementation steps of a task.\n2. Initial task: \"Help me implement yank mode for vim\" - Use the exit plan mode tool after you have finished planning the implementation steps of the task.\n3. Initial task: \"Add a new feature to handle user authentication\" - If unsure about auth method (OAuth, JWT, etc.), use AskUserQuestion first, then use exit plan mode tool after clarifying the approach.\n",
-      "input_schema": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "type": "object",
-        "properties": {
-          "allowedPrompts": {
-            "description": "Prompt-based permissions needed to implement the plan. These describe categories of actions rather than specific commands.",
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "tool": {
-                  "description": "The tool this prompt applies to",
-                  "type": "string",
-                  "enum": [
-                    "Bash"
-                  ]
-                },
-                "prompt": {
-                  "description": "Semantic description of the action, e.g. \"run tests\", \"install dependencies\"",
-                  "type": "string"
-                }
-              },
-              "required": [
-                "tool",
-                "prompt"
-              ],
-              "additionalProperties": false
-            }
-          }
-        },
-        "additionalProperties": {}
       }
     },
     {
@@ -1269,16 +1108,13 @@
   ],
   "tool_names": [
     "Agent",
-    "AskUserQuestion",
     "Bash",
     "CronCreate",
     "CronDelete",
     "CronList",
     "DesignSync",
     "Edit",
-    "EnterPlanMode",
     "EnterWorktree",
-    "ExitPlanMode",
     "ExitWorktree",
     "Monitor",
     "NotebookEdit",
@@ -1324,7 +1160,7 @@
   "anthropic_beta": "claude-code-20250219,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24",
   "header_values": {
     "accept": "application/json",
-    "user-agent": "claude-cli/2.1.186 (external, sdk-cli)",
+    "user-agent": "claude-cli/2.1.187 (external, sdk-cli)",
     "x-stainless-arch": "x64",
     "x-stainless-lang": "js",
     "x-stainless-os": "Linux",
@@ -1349,5 +1185,5 @@
     "output_config",
     "stream"
   ],
-  "_supportedMaxTested": "2.1.186"
+  "_supportedMaxTested": "2.1.187"
 }

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -51,6 +51,28 @@ export function filterToolsForPlatform<T extends { name: string }>(
   });
 }
 
+/**
+ * Tools CC only advertises in an INTERACTIVE session. The bake captures CC
+ * headlessly (`claude --print -p hi`, see live-fingerprint.ts), and CC v2.1.187
+ * dropped these plan-mode / clarification tools in `--print` mode — so a fresh
+ * headless capture no longer carries them even though every real interactive CC
+ * client still advertises them. Like PLATFORM_ONLY_TOOLS, the bundled template
+ * must stay a SUPERSET: register them here so a headless auto-rebake preserves
+ * them from the previous bundle instead of dropping them. Dropping them broke
+ * buildCCRequest's advertise-respects-client contract (the v4.8.93 regression):
+ * dario advertises only the intersection of the client's declared tools and this
+ * template, so a missing AskUserQuestion meant dario could not advertise it even
+ * when a full CC client declared it. Unlike PLATFORM_ONLY_TOOLS these are NOT
+ * platform-filtered — they stay in CC_TOOL_DEFINITIONS on every host so a client
+ * that declares them is always honored. Add new interactive-only tools here as
+ * CC adds them.
+ */
+export const INTERACTIVE_ONLY_TOOLS: Set<string> = new Set([
+  'AskUserQuestion',
+  'EnterPlanMode',
+  'ExitPlanMode',
+]);
+
 /** CC's exact tool definitions for the current platform — filtered from the bundled union. */
 export const CC_TOOL_DEFINITIONS = filterToolsForPlatform(TEMPLATE.tools, process.platform);
 

--- a/test/template-interactive-tools.mjs
+++ b/test/template-interactive-tools.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * Regression: the bundled CC template must always carry the interactive-only
+ * tools (AskUserQuestion, EnterPlanMode, ExitPlanMode).
+ *
+ * Bug (v4.8.93): the bake captures CC headlessly (`claude --print -p hi`, see
+ * live-fingerprint.ts). CC v2.1.187 stopped advertising the plan-mode /
+ * clarification tools in `--print` mode, so an auto-rebake dropped them from
+ * src/cc-template-data.json. Because buildCCRequest advertises only the
+ * INTERSECTION of the client's declared tools and the bundled template, a full
+ * CC client that declared AskUserQuestion no longer had it advertised — the
+ * "advertise-respects-client" contract broke (tool-advertise-respects-client.mjs
+ * caught it). These tools are not platform-scoped, so they must remain in the
+ * template (and in CC_TOOL_DEFINITIONS) on EVERY host, the same way the bake
+ * preserves win32-only PowerShell/Glob/Grep from the previous bundle.
+ *
+ * Fix: scripts/capture-and-bake.mjs preserves INTERACTIVE_ONLY_TOOLS from the
+ * previous bundle on every bake; this test guards the resulting invariant so a
+ * future headless bake (or manual edit) can't silently re-drop them.
+ *
+ * In-process — no proxy / OAuth / upstream.
+ */
+
+import { CC_TEMPLATE, CC_TOOL_DEFINITIONS, INTERACTIVE_ONLY_TOOLS } from '../dist/cc-template.js';
+
+let pass = 0, fail = 0;
+function check(label, cond) {
+  if (cond) { pass++; console.log(`  ✅ ${label}`); }
+  else { fail++; console.log(`  ❌ ${label}`); }
+}
+function header(name) { console.log(`\n${'='.repeat(70)}\n  ${name}\n${'='.repeat(70)}`); }
+
+header('bundled template carries every interactive-only tool');
+{
+  check('INTERACTIVE_ONLY_TOOLS is non-empty', INTERACTIVE_ONLY_TOOLS.size > 0);
+
+  const templateNames = new Set((CC_TEMPLATE.tools || []).map((t) => t.name));
+  for (const name of INTERACTIVE_ONLY_TOOLS) {
+    check(`template tools[] contains ${name}`, templateNames.has(name));
+    const def = (CC_TEMPLATE.tools || []).find((t) => t.name === name);
+    check(`${name} has a non-empty description`,
+      !!def && typeof def.description === 'string' && def.description.length > 0);
+    check(`${name} has an input_schema`, !!def && typeof def.input_schema === 'object' && def.input_schema !== null);
+  }
+}
+
+header('interactive-only tools are NOT platform-filtered (present on every host)');
+{
+  // CC_TOOL_DEFINITIONS is the current platform's filtered view of the bundle.
+  // Interactive tools must survive that filter everywhere — unlike PowerShell/
+  // Glob/Grep, they are not registered in PLATFORM_ONLY_TOOLS.
+  const ccNames = new Set(CC_TOOL_DEFINITIONS.map((t) => t.name));
+  for (const name of INTERACTIVE_ONLY_TOOLS) {
+    check(`CC_TOOL_DEFINITIONS (platform ${process.platform}) contains ${name}`, ccNames.has(name));
+  }
+}
+
+console.log(`\ntemplate-interactive-tools: ${pass} passed, ${fail} failed`);
+if (fail > 0) process.exit(1);


### PR DESCRIPTION
## Auto-rebake from class-B drift detection

Generated by [`cc-drift-template-watch.yml`](.github/workflows/cc-drift-template-watch.yml) on 2026-06-24T06:27:50+00:00.

The watcher's `--check` exited 2 against a live capture from the self-hosted runner. This PR contains the freshly-baked `src/cc-template-data.json` from that capture (with the v4.2.2 platform-superset preservation applied), plus a patch version bump to `v4.8.93` and a CHANGELOG entry — so merging ships the rebake to npm via `cc-drift-auto-release.yml`.

### Summary

**Verdict:** 🔴 Substantive — investigate before merging

- **Tools removed:** `AskUserQuestion`, `EnterPlanMode`, `ExitPlanMode` ⚠ (can break canonical-rebuild paths)

### Drift report

```
[bake] using CC at /usr/bin/claude (version 2.1.187) [--check mode: dry-run]
[bake] spawning CC against loopback MITM to capture /v1/messages...
[bake] captured: CC v2.1.187, 26 tools, 5826 char system prompt
[bake] stripped model-conditional beta(s) from baked base: claude-code-20250219,context-1m-2025-08-07,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24 → claude-code-20250219,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24
[bake] scrubbed:
[bake]   tools: 26 → 26 (dropped 0 mcp__* tools)
[bake]   system_prompt: 5826 → 4395 chars
[bake] preserved 3 other-platform tools from previous bundle: Glob, Grep, PowerShell
[bake] previous baked template: CC v2.1.186 captured 2026-06-23T05:37:45.965Z, 32 tools, 4395 char system prompt
[bake] check: drift detected — 1 differing slot (verdict: substantive):
[bake] **Verdict:** 🔴 Substantive — investigate before merging
[bake] 
[bake] - **Tools removed:** `AskUserQuestion`, `EnterPlanMode`, `ExitPlanMode` ⚠ (can break canonical-rebuild paths)
[bake] 
[bake] check: per-slot detail:
[bake]   • tools removed: AskUserQuestion, EnterPlanMode, ExitPlanMode
[bake]       AskUserQuestion: Use this tool only when you are blocked on a decision that is genuinely the user's to make: one you …
[bake]         input keys: questions, answers, annotations, metadata
[bake]       EnterPlanMode: Use this tool proactively when you're about to start a non-trivial implementation task. Getting user…
[bake]       ExitPlanMode: Use this tool when you are in plan mode and have finished writing your plan to the plan file and are…
[bake]         input keys: allowedPrompts
[bake] check: bundled template is stale relative to live CC. Run `node scripts/capture-and-bake.mjs` to re-bake.
[bake] wrote drift-summary.md for workflow embedding
```

### Validation

Compat-test (`compat-test-self-hosted.yml`) will auto-fire on this PR because it touches `src/cc-template-data.json`. If it goes green, this is mergeable as-is. If it fails, the rebake captured something Anthropic isn't ready to ship — close the PR, investigate manually.

### Why not auto-merged

The bundled template is the wire-shape contract for non-CC clients. compat-test exercises passthrough mode; it cannot validate the rebuild-from-canonical path, so a human approves the bake. Approving + merging bumps the patch version and triggers `cc-drift-auto-release.yml` — approval is the ship gate.

Background: [v4.2.1 CHANGELOG entry](https://github.com/askalf/dario/blob/master/CHANGELOG.md#421---2026-05-17) documents this drift class — same CC binary, different runtime wire shape via remote configuration.
