### PR TITLE
chore: remove agent from stack listing (held back pre-launch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,6 @@ dario is the routing layer of **[Own Your Stack](https://github.com/askalf)** �
 - **[hybrid](https://github.com/askalf/hybrid)** — own your inference
 - **[deepdive](https://github.com/askalf/deepdive)** — own your research
 - **[hands](https://github.com/askalf/hands)** — own your computer-use
-- **[agent](https://github.com/askalf/agent)** — own your fleet
 - **[browser-bridge](https://github.com/askalf/browser-bridge)** — own your browser
 - **[warden](https://github.com/askalf/warden)** — own your agent security
 - **[canon](https://github.com/askalf/canon)** — own your agent skills


### PR DESCRIPTION
The agent repo (@askalf/agent) is being made private and held back until the platform goes live. Remove public references/links so nothing 404s in the meantime. To be re-added at launch.