### PR TITLE
chore(cc-drift): v4.8.95 — maxTested → v2.1.191

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.95] - 2026-06-24
+
+- **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.190` → `2.1.191` for CC v2.1.191. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.
 ## [4.8.94] - 2026-06-24
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.187` → `2.1.190` for CC v2.1.190. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.94",
+  "version": "4.8.95",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/live-fingerprint.ts
+++ b/src/live-fingerprint.ts
@@ -885,7 +885,7 @@ export function _resetInstalledVersionProbeForTest(): void {
  */
 export const SUPPORTED_CC_RANGE = {
   min: '1.0.0',
-  maxTested: '2.1.190',
+  maxTested: '2.1.191',
 } as const;
 
 /**


### PR DESCRIPTION
## Auto-drafted by cc-drift-watch.yml

The drift watcher flagged CC v2.1.191 as outside the current supported range. This PR:

1. Bumps `SUPPORTED_CC_RANGE.maxTested` from `2.1.190` → `2.1.191` in `src/live-fingerprint.ts`
2. Bumps `package.json` version → `4.8.95`
3. Promotes `## [Unreleased]` in `CHANGELOG.md` to `## [4.8.95] - 2026-06-24` and appends the drift-fix bullet

### Items in the drift report

- **compat.range** (medium) — CC v2.1.191 is beyond SUPPORTED_CC_RANGE.maxTested (v2.1.190). Run the e2e suite against the new CC and bump maxTested in src/live-fingerprint.ts — users on the new CC currently get a soft "untested-above" warning from dario doctor.
- **template.version** (low) — baked cc-template-data.json is v2.1.187; npm latest is v2.1.191. Re-capture the template (MITM a real CC v2.1.191 request) if any fingerprint-sensitive field (system prompt, header order, metadata shape, beta flags) changed.
- **cch.seed** (low) — No cch seed for CC v2.1.191 in src/cch.ts (CCH_SEEDS) — dario sends a random cch for it (safe fallback). Run `node scripts/cch-calibrate.mjs` on a host with claude v2.1.191: it confirms whether an existing seed still applies (just add the version → seed line) or whether the seed rotated (saves the live capture so we extract the new seed ourselves). dario#528.

### What happens when you merge this

A separate workflow (`cc-drift-auto-release.yml`) fires on merge of any version-bumping PR to `master`. It reads `package.json` from master, tags `v4.8.95`, creates the GitHub release, and runs `npm publish --provenance` + the GHCR docker push inline — all in one run (the old separate `publish.yml` was removed in #369). Net: merging this PR ships `@askalf/dario@4.8.95` to npm within ~3 minutes, no further maintainer action.

### Maintainer checklist before merging

- [ ] Install the new CC locally: `npm install -g @anthropic-ai/claude-code@2.1.191`
- [ ] Run `dario doctor` and confirm it comes back clean against v2.1.191
- [x] Template fingerprint is auto-verified every 30 min by `cc-drift-template-watch.yml` (live capture on the self-hosted runner); if the wire format actually drifts it opens its own `bot/template-rebake-*` PR. No manual capture needed here unless that watcher is failing.
- [ ] Confirm the CHANGELOG entry under `## [4.8.95]` reads cleanly. The bot wrote a short factual line; feel free to rewrite with more context.
- [ ] Mark as ready for review + merge. Auto-merge will ship it through CI, and the auto-release workflow handles the tag + release + npm publish.

### About this auto-draft

Only `compat.range` items are auto-patched by this script. Template re-capture is auto-handled separately by `cc-drift-template-watch.yml`. The remaining categories (scope rotations, URL / clientId / tokenUrl changes) require judgment and stay manual — the bot opens the plain drift-issue for those as before.

---

_Generated by `scripts/auto-draft-drift-fix.mjs`. Closes the detection-latency arc: [#112](https://github.com/askalf/dario/pull/112) (CF bypass), [#113](https://github.com/askalf/dario/pull/113) (hourly cadence), [#114](https://github.com/askalf/dario/pull/114) (auto-draft PR)._
