### PR TITLE
fix(tui): correct Subscription % and 5h/7d NaN in Analytics tab (#600)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.104] - 2026-06-30
+
+- **Analytics tab fixes (#600)** — the TUI rate-limit gauge rendered `NaN%` for 5h/7d and `Subscription %` showed `10000%`. `Analytics.summary().utilization` now returns the current `{ lastUtil5h, lastUtil7d }` snapshot from the latest request — it was emitting a per-5-min-bucket trend array the gauge never read, so `.lastUtil5h`/`.lastUtil7d` came back `undefined` → `NaN`. The subscription-% gauge no longer multiplies an already-`0–100` value by 100. Regression tests added (`analytics-recording`, `tui-tabs`).
+
 ## [4.8.103] - 2026-06-30
 
 - **Template rebake** — re-captured `src/cc-template-data.json` after cc-drift-template-watch detected wire-fingerprint drift against a live CC capture. Bundled fallback template now matches the current CC wire shape.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.103",
+  "version": "4.8.104",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -237,7 +237,7 @@ export class Analytics extends EventEmitter {
       },
       perAccount: this.perAccountStats(recent),
       perModel: this.perModelStats(recent),
-      utilization: this.utilizationTrend(recent),
+      utilization: this.currentUtilization(recent),
       predictions: this.predict(recent),
     };
   }
@@ -339,34 +339,21 @@ export class Analytics extends EventEmitter {
     return result;
   }
 
-  private utilizationTrend(records: RequestRecord[]): Array<{
-    timestamp: number;
-    avgUtil5h: number;
-    avgUtil7d: number;
-    requests: number;
-  }> {
-    if (records.length === 0) return [];
-    const bucketMs = 5 * 60_000;
-    const buckets: Map<number, RequestRecord[]> = new Map();
-
-    for (const r of records) {
-      const key = Math.floor(r.timestamp / bucketMs) * bucketMs;
-      const existing = buckets.get(key);
-      if (existing) {
-        existing.push(r);
-      } else {
-        buckets.set(key, [r]);
-      }
-    }
-
-    return [...buckets.entries()]
-      .sort(([a], [b]) => a - b)
-      .map(([ts, recs]) => ({
-        timestamp: ts,
-        avgUtil5h: Math.round(recs.reduce((s, r) => s + r.util5h, 0) / recs.length * 100) / 100,
-        avgUtil7d: Math.round(recs.reduce((s, r) => s + r.util7d, 0) / recs.length * 100) / 100,
-        requests: recs.length,
-      }));
+  /**
+   * The most recent rate-limit snapshot in the window — current 5h / 7d
+   * utilization (0–1) as of the last request. The Analytics tab's rate-limit
+   * gauge reads this; an empty window reads 0/0. Mirrors `perAccountStats`'
+   * `last.util*` "current" semantics.
+   *
+   * Replaces the old per-5-min-bucket `utilizationTrend` array: the TUI gauge
+   * (the only consumer of `summary.utilization`) reads `.lastUtil5h` /
+   * `.lastUtil7d`, which on the array shape were `undefined` → rendered NaN%.
+   * See #600.
+   */
+  private currentUtilization(records: RequestRecord[]): { lastUtil5h: number; lastUtil7d: number } {
+    if (records.length === 0) return { lastUtil5h: 0, lastUtil7d: 0 };
+    const last = records[records.length - 1]!;
+    return { lastUtil5h: last.util5h, lastUtil7d: last.util7d };
   }
 
   private predict(records: RequestRecord[]): {
@@ -466,12 +453,8 @@ export interface AnalyticsSummary {
   };
   perAccount: Record<string, PerAccountStat>;
   perModel: Record<string, PerModelStat>;
-  utilization: Array<{
-    timestamp: number;
-    avgUtil5h: number;
-    avgUtil7d: number;
-    requests: number;
-  }>;
+  /** Current 5h / 7d rate-limit utilization (0–1) as of the last request. */
+  utilization: { lastUtil5h: number; lastUtil7d: number };
   predictions: {
     estimatedExhaustionMinutes: number | null;
     tokenBurnRate: number;

--- a/src/tui/tabs/analytics.ts
+++ b/src/tui/tabs/analytics.ts
@@ -127,7 +127,7 @@ export const AnalyticsTab: Tab<AnalyticsState> = {
     lines.push('  ' + renderKvRow('Avg latency',
       `${Math.round(s.window.avgLatencyMs)}ms`, w - 4));
     lines.push('  ' + renderKvRow('Subscription %',
-      `${(s.window.subscriptionPercent * 100).toFixed(0)}%`, w - 4));
+      `${s.window.subscriptionPercent.toFixed(0)}%`, w - 4));
 
     // ── Per-model bars ─────────────────────────────────────────
     const models = Object.entries(s.perModel).sort((a, b) => b[1].requests - a[1].requests);

--- a/test/analytics-recording.mjs
+++ b/test/analytics-recording.mjs
@@ -167,6 +167,14 @@ console.log('===================================================================
   assert('estimatedCost > 0', summary.allTime.estimatedCost > 0);
   assertEq('avgLatencyMs', summary.window.avgLatencyMs, 342);
   assertEq('errorRate === 0', summary.window.errorRate, 0);
+
+  // #600 regression — summary.utilization is the current-util object
+  // {lastUtil5h,lastUtil7d}, not the old per-5min-bucket trend array (which
+  // made the TUI rate-limit gauge read undefined → NaN%).
+  assert('utilization is an object, not an array',
+    !Array.isArray(summary.utilization) && typeof summary.utilization === 'object');
+  assertEq('utilization.lastUtil5h = last record util5h', summary.utilization.lastUtil5h, 0.12);
+  assertEq('utilization.lastUtil7d = last record util7d', summary.utilization.lastUtil7d, 0.08);
 }
 
 // ─── Test 5: Multiple records + error rate ───────────────────────────────────

--- a/test/tui-tabs.mjs
+++ b/test/tui-tabs.mjs
@@ -160,7 +160,7 @@ header('Analytics tab — loading + populated states');
         minutes: 60, requests: 247,
         totalInputTokens: 142830, totalOutputTokens: 38200, totalThinkingTokens: 9000,
         estimatedCost: 1.23, avgLatencyMs: 1234,
-        subscriptionPercent: 0.95,
+        subscriptionPercent: 95,
         billingBucketBreakdown: { subscription: 240, extra_usage: 7, api: 0, unknown: 0, subscription_fallback: 0 },
       },
       allTime: { requests: 1000 },
@@ -179,6 +179,9 @@ header('Analytics tab — loading + populated states');
   check('populated: shows 5h % label',     r2.includes('18%'));
   check('populated: shows 7d % label',     r2.includes('8%'));
   check('populated: shows Per-model',      r2.includes('Per-model'));
+  // #600 regression — subscriptionPercent is already 0–100; the gauge must not
+  // multiply by 100 again (the bug rendered "9500%" / "10000%").
+  check('populated: subscription % not double-scaled', r2.includes('95%') && !r2.includes('9500%'));
 
   // Error state
   const errored = {


### PR DESCRIPTION
## Problem

The Analytics tab (#600) renders two broken values for a 2-account user:

- **`Subscription %: 10000%`** — should be ~100%.
- **`5h  NaN%` / `7d  NaN%`** rate-limit gauges.

## Root cause

**Subscription %** — `summary.window.subscriptionPercent` is already a 0–100 percentage (`analytics.ts` computes `subscriptionHits / billedRequests * 100`; every other consumer — `cli.ts`, `mcp/tools.ts` — prints it directly). The Analytics tab multiplied it by 100 *again* → `100 * 100 = 10000%`.

**5h / 7d NaN** — `Analytics.summary()` set `utilization` to `utilizationTrend(recent)`, an **array** of `{timestamp, avgUtil5h, avgUtil7d, requests}` buckets. But the only consumer — the TUI rate-limit gauge — reads `utilization.lastUtil5h` / `.lastUtil7d` (an object). Reading those keys off the array gave `undefined`, and `undefined * 100` → `NaN`. The backend type (`AnalyticsSummary.utilization: Array<…>`) and the TUI's local type (`{ lastUtil5h, lastUtil7d }`) literally disagreed across the untyped HTTP boundary.

## Fix

- `Analytics.summary().utilization` now returns `{ lastUtil5h, lastUtil7d }` — the current 5h/7d utilization from the **last** record in the window (mirrors `perAccountStats`' `last.util*` "current" semantics; `0/0` on an empty window). The unused per-bucket `utilizationTrend` helper is removed (nothing read its array shape).
- `AnalyticsSummary.utilization` interface updated to the object shape.
- The Analytics tab drops the erroneous `* 100` on `subscriptionPercent`.

No proxy/runtime behaviour change — display + summary-shape only.

## Tests

- `test/analytics-recording.mjs` — asserts `summary.utilization` is the `{lastUtil5h,lastUtil7d}` object reflecting the last record, not an array. **41/0.**
- `test/tui-tabs.mjs` — asserts the subscription gauge renders `95%`, not `9500%`/`10000%`; fixed a mock that encoded the bug (`subscriptionPercent: 0.95` → `95`). **87/0.**
- `tsc` clean.

## Contract note

`GET /analytics` `utilization` changes from a trend array to `{ lastUtil5h, lastUtil7d }`. No in-repo consumer read the array (only the TUI, which always wanted the object); external `dario usage --json` scrapers reading `utilization` should expect the new shape.

## Not included (third point of #600)

The reporter also asked whether rate-limit should display **per-account** (they run 2 accounts). That data already exists (`summary.perAccount[alias].currentUtil5h/7d`) — it's a UX/layout decision left as a follow-up. This PR fixes the crashing values first; #600 stays open for that decision.
