### PR TITLE
ci(release): make ghcr build cache non-fatal (ignore-error on cache-to)

### DIFF
--- a/.github/workflows/cc-drift-auto-release.yml
+++ b/.github/workflows/cc-drift-auto-release.yml
@@ -437,7 +437,13 @@ jobs:
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # ignore-error: a GitHub Actions cache backend failure ("failed to
+          # reserve cache" — quota/contention) must NOT fail the release. Cache
+          # export is best-effort; the multi-arch build + push still proceeds.
+          # This bit v4.8.102 and v4.8.103 deterministically (survived
+          # `gh run rerun`), leaving ghcr without the image. #594 made the gate
+          # retry the push; this stops the push itself dying on the cache.
+          cache-to: type=gha,mode=max,ignore-error=true
 
       - name: Close matching cc-drift issues
         if: |


### PR DESCRIPTION
## Problem

The release pipeline's multi-arch docker push has been failing deterministically on:

```
#53 ERROR: error writing layer blob: failed to reserve cache
ERROR: failed to build: failed to solve: error writing layer blob: failed to reserve cache
```

This is a **GitHub Actions cache backend** failure on the `cache-to: type=gha,mode=max` export — not a build, auth, or registry problem. It bit **v4.8.102** and **v4.8.103**, and it is **not transient**: `gh run rerun --failed` on the v4.8.103 release hit the exact same error on attempt 2.

The fallout: the GitHub release + npm publish succeed (they run before the push), but ghcr never gets the image → Hetzner auto-deploy can't pull the new tag and stays pinned at 4.8.101.

#594 added a ghcr axis to the idempotency gate so a rerun *retries* the push instead of skipping it — necessary, but it can't help when the push itself dies on the cache every time.

## Fix

Add `ignore-error=true` to `cache-to`:

```yaml
cache-to: type=gha,mode=max,ignore-error=true
```

Cache *export* becomes best-effort. BuildKit still populates the gha cache (so warm-cache builds stay fast when the backend is healthy), but a cache-reservation failure no longer fails the build — the multi-arch image still builds and pushes. `cache-from` is unchanged (a cold/missing cache was never fatal).

Workflow-only; no app code, no version bump.

## After merge

The next version-bumping release (the queued #600 → v4.8.104) runs the push under this hardened workflow and lands the ghcr image, which also moves Hetzner off 4.8.101. The orphaned ghcr tags for v4.8.102 / v4.8.103 are superseded by `:latest` once a newer version ships; they can be backfilled via `workflow_dispatch` if desired.
