### PR TITLE
feat(tui): per-account rate-limit rows in Analytics tab (#600)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.105] - 2026-06-30
+
+- **Per-account rate-limit rows in Analytics (#600)** — when more than one account is configured, the Analytics tab's Rate-limit section shows one row per account (each account hits its own 5h/7d windows, so a single aggregate gauge was misleading). The bar tracks the binding constraint (max of 5h/7d); single-account setups keep the existing 5h/7d gauge.
+
 ## [4.8.104] - 2026-06-30
 
 - **Analytics tab fixes (#600)** — the TUI rate-limit gauge rendered `NaN%` for 5h/7d and `Subscription %` showed `10000%`. `Analytics.summary().utilization` now returns the current `{ lastUtil5h, lastUtil7d }` snapshot from the latest request — it was emitting a per-5-min-bucket trend array the gauge never read, so `.lastUtil5h`/`.lastUtil7d` came back `undefined` → `NaN`. The subscription-% gauge no longer multiplies an already-`0–100` value by 100. Regression tests added (`analytics-recording`, `tui-tabs`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.104",
+  "version": "4.8.105",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/tui/tabs/analytics.ts
+++ b/src/tui/tabs/analytics.ts
@@ -32,6 +32,7 @@ interface SummaryShape {
   allTime: { requests: number };
   perModel: Record<string, { requests: number; totalInputTokens: number; totalOutputTokens: number }>;
   utilization: { lastUtil5h: number; lastUtil7d: number };
+  perAccount: Record<string, { requests: number; currentUtil5h: number; currentUtil7d: number; lastClaim: string }>;
 }
 
 export interface AnalyticsState {
@@ -145,14 +146,32 @@ export const AnalyticsTab: Tab<AnalyticsState> = {
     }
 
     // ── Rate-limit ────────────────────────────────────────────
+    // Each account hits its OWN 5h/7d windows, so with >1 account an
+    // aggregate gauge is misleading (#600) — show one row per account, the
+    // bar tracking the binding constraint (max of 5h/7d = closest to a limit).
     lines.push('');
-    lines.push(' ' + brand('Rate-limit'));
-    lines.push('  ' + pad('5h', 6) +
-      fg('cyan', progressBar(s.utilization.lastUtil5h, barWidth)) +
-      '  ' + dim(`${(s.utilization.lastUtil5h * 100).toFixed(0)}%`));
-    lines.push('  ' + pad('7d', 6) +
-      fg('cyan', progressBar(s.utilization.lastUtil7d, barWidth)) +
-      '  ' + dim(`${(s.utilization.lastUtil7d * 100).toFixed(0)}%`));
+    const accts = s.perAccount ? Object.entries(s.perAccount) : [];
+    if (accts.length > 1) {
+      lines.push(' ' + brand('Rate-limit') + dim('  (per account)'));
+      const acctBarWidth = Math.max(8, Math.min(20, w - 48));
+      for (const [alias, a] of accts.sort((x, y) => y[1].requests - x[1].requests)) {
+        const u5 = a.currentUtil5h ?? 0;
+        const u7 = a.currentUtil7d ?? 0;
+        const peak = Math.max(u5, u7);
+        lines.push('  ' + pad(alias, 14) +
+          fg(peak >= 0.9 ? 'red' : 'cyan', progressBar(peak, acctBarWidth)) +
+          '  ' + dim(`5h ${(u5 * 100).toFixed(0)}%`.padEnd(8)) +
+          dim(`7d ${(u7 * 100).toFixed(0)}%`));
+      }
+    } else {
+      lines.push(' ' + brand('Rate-limit'));
+      lines.push('  ' + pad('5h', 6) +
+        fg('cyan', progressBar(s.utilization.lastUtil5h, barWidth)) +
+        '  ' + dim(`${(s.utilization.lastUtil5h * 100).toFixed(0)}%`));
+      lines.push('  ' + pad('7d', 6) +
+        fg('cyan', progressBar(s.utilization.lastUtil7d, barWidth)) +
+        '  ' + dim(`${(s.utilization.lastUtil7d * 100).toFixed(0)}%`));
+    }
     // Overage bucket (v4.1, dario#288). Count of requests that landed in
     // the overage bucket within the rolling window. Empty bar in normal
     // operation; non-zero count renders in red. Hard zero IS the success

--- a/test/tui-tabs.mjs
+++ b/test/tui-tabs.mjs
@@ -193,6 +193,35 @@ header('Analytics tab — loading + populated states');
   const r3 = AnalyticsTab.render(errored, DIM);
   check('error: surfaces error message',   r3.includes('ECONNREFUSED'));
   check('error: hints at proxy start',     r3.includes('dario proxy'));
+
+  // #600 — with >1 account, rate-limit renders per-account rows (each account
+  // has its own 5h/7d windows; an aggregate gauge would be misleading).
+  const multiAcct = {
+    ...initial,
+    loading: false,
+    summary: {
+      window: {
+        minutes: 60, requests: 30,
+        totalInputTokens: 1000, totalOutputTokens: 200, totalThinkingTokens: 0,
+        estimatedCost: 0.1, avgLatencyMs: 500, subscriptionPercent: 100,
+        billingBucketBreakdown: { subscription: 30 },
+      },
+      allTime: { requests: 30 },
+      perModel: { 'claude-opus-4-8': { requests: 30, totalInputTokens: 1000, totalOutputTokens: 200 } },
+      utilization: { lastUtil5h: 0.42, lastUtil7d: 0.12 },
+      perAccount: {
+        primary: { requests: 20, currentUtil5h: 0.42, currentUtil7d: 0.12, lastClaim: 'five_hour' },
+        backup:  { requests: 10, currentUtil5h: 0.18, currentUtil7d: 0.08, lastClaim: 'five_hour' },
+      },
+    },
+    lastFetchAt: Date.now(),
+  };
+  const r4 = AnalyticsTab.render(multiAcct, DIM);
+  check('per-account: section labelled',    r4.includes('per account'));
+  check('per-account: shows primary alias', r4.includes('primary'));
+  check('per-account: shows backup alias',  r4.includes('backup'));
+  check('per-account: primary peak 42%',    r4.includes('42%'));
+  check('per-account: backup 5h 18%',       r4.includes('18%'));
 }
 
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Implements the third point of #600: with **more than one account**, the Analytics tab's **Rate-limit** section now renders **one row per account** instead of a single aggregate gauge. Each account hits its *own* 5h/7d subscription windows, so the old single bar (driven by whichever account served the last request) hid per-account saturation.

- Bar tracks the **binding constraint** — `max(5h, 7d)`, i.e. closest to a limit — and turns **red at ≥90%**.
- Detail shows both `5h X%  7d Y%`.
- Rows sorted by request volume (busiest first).
- **Single-account setups are unchanged** — they keep the existing 5h/7d gauge.

`perAccount` is now threaded through the TUI's `SummaryShape` (the `/analytics` response already carries it; only the type + render needed it — `fetchSummary` already casts the whole payload).

## Preview

Two accounts (backup near its 5h limit — its bar renders red in a real terminal):

```
 Rate-limit  (per account)
  primary       ████████░░░░░░░░░░░░  5h 42%  7d 12%
  backup        ███████████████████░  5h 93%  7d 85%
```

Single account (unchanged):

```
 Rate-limit
  5h    ██████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  18%
  7d    ███░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  8%
```

## Tests

`test/tui-tabs.mjs` — new multi-account case asserts the per-account rows + percentages render; the single-account/aggregate path is unchanged. **92/0.** `analytics-recording` **41/0**, `tsc` clean.

Follow-up to #601 (the `NaN%` / `10000%` fixes). Builds on `summary.perAccount`, which is already populated (`currentUtil5h` / `currentUtil7d`).
