### PR TITLE
feat(models): add Claude Sonnet 5 (claude-sonnet-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.108] - 2026-06-30
+
+- **Claude Sonnet 5 support** — added `claude-sonnet-5` to dario's model knowledge: the `sonnet` family alias now resolves to Sonnet 5 (with `sonnet46` pinning the previous 4.6), and the baked `/v1/models` catalog, the analytics pricing table (standard $3/$15; intro $2/$10 through 2026-08-31, not date-modeled), `dario doctor`'s family probe, and the no-model fallback default all include it. Sonnet 5 already proxied transparently and `supportsAdaptiveThinking` already allow-listed `sonnet-5+`; this keeps the metadata current.
+
 ## [4.8.107] - 2026-06-30
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.196` → `2.1.197` for CC v2.1.197. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.107",
+  "version": "4.8.108",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -128,6 +128,8 @@ const PRICING: Record<string, { input: number; output: number; cacheRead: number
   'claude-opus-4-8': { input: 5, output: 25, cacheRead: 0.5, cacheCreate: 6.25 },
   'claude-opus-4-7': { input: 5, output: 25, cacheRead: 0.5, cacheCreate: 6.25 },
   'claude-opus-4-6': { input: 15, output: 75, cacheRead: 1.5, cacheCreate: 18.75 },
+  // Sonnet 5 standard $3/$15; intro $2/$10 through 2026-08-31 (display estimate, not date-modeled).
+  'claude-sonnet-5': { input: 3, output: 15, cacheRead: 0.3, cacheCreate: 3.75 },
   'claude-sonnet-4-6': { input: 3, output: 15, cacheRead: 0.3, cacheCreate: 3.75 },
   'claude-haiku-4-5': { input: 0.8, output: 4, cacheRead: 0.08, cacheCreate: 1 },
 };

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -1292,7 +1292,7 @@ export function buildCCRequest(
   opts: { preserveTools?: boolean; hybridTools?: boolean; mergeTools?: boolean; noAutoDetect?: boolean; effort?: EffortValue; maxTokens?: number | 'client'; systemPrompt?: string; skipFields?: ReadonlySet<string>; honorClientThinking?: boolean; preserveOutputFormat?: boolean } = {},
 ): { body: Record<string, unknown>; toolMap: Map<string, ToolMapping>; unmappedTools: string[]; detectedClient?: string } {
 
-  const model = clientBody.model as string || 'claude-sonnet-4-6';
+  const model = clientBody.model as string || 'claude-sonnet-5';
   const isHaiku = model.toLowerCase().includes('haiku');
   const messages = clientBody.messages as Array<Record<string, unknown>> || [];
   const clientTools = clientBody.tools as Array<Record<string, unknown>> | undefined;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1217,7 +1217,7 @@ async function help() {
     --model=MODEL            Force a model for all requests
                              Shortcuts: fable, fable1m, opus, sonnet, haiku
                              Full IDs: claude-fable-5, claude-opus-4-8,
-                             claude-sonnet-4-6 (append [1m] for 1M context)
+                             claude-sonnet-5 (append [1m] for 1M context)
                              Provider prefix: openai:gpt-4o, groq:llama-3.3-70b,
                              claude:opus, local:qwen-coder (forces backend)
                              Default: passthrough (client decides)

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -247,7 +247,7 @@ export function probeNpmLatestCC(): string | null {
  */
 const PROBE_FAMILIES: Array<{ family: string; model: string }> = [
   { family: 'haiku',  model: 'claude-haiku-4-5' },
-  { family: 'sonnet', model: 'claude-sonnet-4-6' },
+  { family: 'sonnet', model: 'claude-sonnet-5' },
   { family: 'opus',   model: 'claude-opus-4-8' },
   { family: 'fable',  model: 'claude-fable-5' },
 ];

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -43,6 +43,7 @@ export const BAKED_BASE_MODELS: readonly string[] = [
   'claude-opus-4-8',
   'claude-opus-4-7',
   'claude-opus-4-6',
+  'claude-sonnet-5',
   'claude-sonnet-4-6',
   'claude-haiku-4-5',
 ];

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -161,8 +161,9 @@ const MODEL_ALIASES: Record<string, string> = {
   'opus47': 'claude-opus-4-7',
   'opus46': 'claude-opus-4-6',
   'opus1m': 'claude-opus-4-8[1m]',
-  'sonnet': 'claude-sonnet-4-6',
-  'sonnet1m': 'claude-sonnet-4-6[1m]',
+  'sonnet': 'claude-sonnet-5',
+  'sonnet46': 'claude-sonnet-4-6',
+  'sonnet1m': 'claude-sonnet-5[1m]',
   'haiku': 'claude-haiku-4-5',
 };
 

--- a/test/model-catalog.mjs
+++ b/test/model-catalog.mjs
@@ -109,7 +109,7 @@ check("'opus1m' DERIVES from 'opus' — same base + [1m]",
 check("'fable1m' derives the same way",
   resolveAliasAgainst('fable1m', BAKED_BASE_MODELS) === 'claude-fable-5[1m]');
 check("'sonnet1m' derives the same way",
-  resolveAliasAgainst('sonnet1m', BAKED_BASE_MODELS) === 'claude-sonnet-4-6[1m]');
+  resolveAliasAgainst('sonnet1m', BAKED_BASE_MODELS) === 'claude-sonnet-5[1m]');
 check("'haiku1m' is refused by the rule", resolveAliasAgainst('haiku1m', BAKED_BASE_MODELS) === null);
 check('full ids are not alias-resolved', resolveAliasAgainst('claude-opus-4-8', BAKED_BASE_MODELS) === null);
 check('unknown shorthand is not alias-resolved', resolveAliasAgainst('zenith', BAKED_BASE_MODELS) === null);

--- a/test/provider-prefix.mjs
+++ b/test/provider-prefix.mjs
@@ -69,12 +69,13 @@ assert(resolveClaudeAlias('fable1m') === 'claude-fable-5[1m]', 'fable1m → clau
 assert(resolveClaudeAlias('opus') === 'claude-opus-4-8', 'opus → claude-opus-4-8 (latest)');
 assert(resolveClaudeAlias('opus47') === 'claude-opus-4-7', 'opus47 → claude-opus-4-7 (legacy-pin alias)');
 assert(resolveClaudeAlias('opus46') === 'claude-opus-4-6', 'opus46 → claude-opus-4-6 (legacy-pin alias)');
-assert(resolveClaudeAlias('sonnet') === 'claude-sonnet-4-6', 'sonnet → claude-sonnet-4-6');
+assert(resolveClaudeAlias('sonnet') === 'claude-sonnet-5', 'sonnet → claude-sonnet-5');
+assert(resolveClaudeAlias('sonnet46') === 'claude-sonnet-4-6', 'sonnet46 → claude-sonnet-4-6 (legacy-pin alias)');
 assert(resolveClaudeAlias('haiku') === 'claude-haiku-4-5', 'haiku → claude-haiku-4-5');
 // <family>1m derives from <family> — same base + [1m] (model-catalog rule).
 // Was pinned to 4-7[1m]: stale drift from before #389 bumped opus to 4-8.
 assert(resolveClaudeAlias('opus1m') === 'claude-opus-4-8[1m]', 'opus1m → claude-opus-4-8[1m] (derived from opus)');
-assert(resolveClaudeAlias('sonnet1m') === 'claude-sonnet-4-6[1m]', 'sonnet1m → claude-sonnet-4-6[1m]');
+assert(resolveClaudeAlias('sonnet1m') === 'claude-sonnet-5[1m]', 'sonnet1m → claude-sonnet-5[1m]');
 
 // Already-canonical names pass through unchanged
 assert(resolveClaudeAlias('claude-opus-4-7') === 'claude-opus-4-7', 'canonical claude-opus-4-7 → unchanged');


### PR DESCRIPTION
## What

Adds `claude-sonnet-5` to dario's model knowledge. Sonnet 5 is now the current Sonnet (4.6 → legacy). It already proxied transparently and `supportsAdaptiveThinking` already allow-listed `sonnet-5+` (there's an existing `claude-sonnet-5 → true` test), so this is metadata — not a fix for breakage.

## Changes

- **`sonnet` family alias → `claude-sonnet-5`** (`proxy.ts`), with **`sonnet46`** added to pin the previous 4.6 (mirrors `opus46`/`opus47`); `sonnet1m` now derives `claude-sonnet-5[1m]`.
- **Baked `/v1/models` catalog** (`model-catalog.ts`) — `claude-sonnet-5` added ahead of 4.6 (version-desc order); family resolution follows.
- **Pricing table** (`analytics.ts`) — `claude-sonnet-5` at standard **$3 / $15** (the intro $2/$10 through 2026-08-31 isn't date-modeled — this table is a rough display estimate).
- **`dario doctor`** family probe now checks `claude-sonnet-5`.
- **No-model fallback default** + `--model` help text updated to Sonnet 5.

## Tests

- Updated the two assertions that pinned the sonnet alias/derivation to 4.6 (`provider-prefix.mjs`, `model-catalog.mjs`) → Sonnet 5; added a `sonnet46` legacy-pin assertion.
- `tsc` clean; full suite green.

Pricing per Anthropic's live model docs ($3/$15 standard; intro $2/$10 to Aug 31, 2026). Bumps to 4.8.108.
