### PR TITLE
feat(admin): alias-keyed login + admin-only bootstrap (#599)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.109] - 2026-06-30
+
+- **Admin API refinements (#599)** — per reviewer feedback, the headless login flow is now keyed by the account **`alias`** instead of a separate `login_id`: `POST /admin/login/start { alias }` → `{ authorize_url, expires_at }` and `POST /admin/login/complete { alias, code }` → `{ alias, status }` (one pending login per alias; a repeat `/start` replaces it). Also: when `DARIO_ADMIN=1` and there are **no credentials yet**, the proxy now starts in **admin-only mode** instead of exiting — so the first account can be provisioned over HTTP with no console access (LLM routes return 503 until an account exists). Default (non-admin) startup is unchanged.
+
 ## [4.8.108] - 2026-06-30
 
 - **Claude Sonnet 5 support** — added `claude-sonnet-5` to dario's model knowledge: the `sonnet` family alias now resolves to Sonnet 5 (with `sonnet46` pinning the previous 4.6), and the baked `/v1/models` catalog, the analytics pricing table (standard $3/$15; intro $2/$10 through 2026-08-31, not date-modeled), `dario doctor`'s family probe, and the no-model fallback default all include it. Sonnet 5 already proxied transparently and `supportsAdaptiveThinking` already allow-listed `sonnet-5+`; this keeps the metadata current.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.108",
+  "version": "4.8.109",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/admin-api.ts
+++ b/src/admin-api.ts
@@ -7,23 +7,24 @@
  * `DARIO_API_KEY` as a fallback — even on loopback, since they add/remove
  * OAuth credentials):
  *
- *   POST   /admin/login/start     { alias }            -> { login_id, authorize_url, expires_at }
- *   POST   /admin/login/complete  { login_id, code }   -> { alias, status, expires_at }
- *   GET    /admin/accounts                              -> { accounts: [...], count }
- *   DELETE /admin/accounts/<alias>                      -> { alias, removed }
+ *   POST   /admin/login/start     { alias }        -> { authorize_url, expires_at }
+ *   POST   /admin/login/complete  { alias, code }  -> { alias, status, expires_at }
+ *   GET    /admin/accounts                          -> { accounts: [...], count }
+ *   DELETE /admin/accounts/<alias>                  -> { alias, removed }
  *
  * The login flow mirrors `dario accounts add --manual` (PKCE + manual paste):
  * `/start` returns the authorize URL the operator opens in a browser; they POST
  * the code Anthropic displays back to `/complete`. The PKCE verifier + state
- * live in an in-memory map keyed by `login_id` with a short TTL — never on
- * disk, never returned to the client, single-use.
+ * live in an in-memory map keyed by the account `alias` with a short TTL — never
+ * on disk, never returned to the client, single-use. One pending login per
+ * alias; a second `/start` for the same alias just replaces it (#599).
  *
  * Account changes take effect on the next proxy restart (the pool is built at
  * startup, src/proxy.ts). Hot-reload of a running pool is a deliberate
  * follow-up — keeping this surface small while it manipulates credentials.
  */
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import { randomUUID, timingSafeEqual } from 'node:crypto';
+import { timingSafeEqual } from 'node:crypto';
 import {
   startAddAccount,
   completeAddAccount,
@@ -41,15 +42,15 @@ export interface AdminDeps {
 }
 
 interface PendingLogin {
-  alias: string;
   codeVerifier: string;
   state: string;
   expiresAt: number;
 }
 
 const PENDING_TTL_MS = 10 * 60_000;
-const MAX_PENDING = 64; // backstop against unbounded growth from repeated /start
+const MAX_PENDING = 64; // backstop against unbounded growth (distinct aliases)
 const ACCOUNTS_PREFIX = '/admin/accounts/';
+// Keyed by account alias — one pending login per alias (#599).
 const pendingLogins = new Map<string, PendingLogin>();
 
 function prunePending(now: number): void {
@@ -141,31 +142,33 @@ export async function handleAdminRequest(
       const body = await readJsonBody(req);
       const alias = typeof body.alias === 'string' ? body.alias.trim() : '';
       if (!alias) { send(res, 400, { error: 'missing "alias"' }); return true; }
-      if (pendingLogins.size >= MAX_PENDING) { send(res, 429, { error: 'too many pending logins; complete or wait for one to expire' }); return true; }
+      // Only a brand-new alias grows the map; a repeat /start replaces in place.
+      if (!pendingLogins.has(alias) && pendingLogins.size >= MAX_PENDING) {
+        send(res, 429, { error: 'too many pending logins; complete or wait for one to expire' });
+        return true;
+      }
       const { authorizeUrl, codeVerifier, state } = await startAddAccount(alias); // throws on invalid alias
-      const loginId = randomUUID();
       const expiresAt = now + PENDING_TTL_MS;
-      pendingLogins.set(loginId, { alias, codeVerifier, state, expiresAt });
+      pendingLogins.set(alias, { codeVerifier, state, expiresAt });
       send(res, 200, {
-        login_id: loginId,
         authorize_url: authorizeUrl,
         expires_at: new Date(expiresAt).toISOString(),
-        instructions: 'Open authorize_url, approve, then POST the displayed code to /admin/login/complete with this login_id.',
+        instructions: `Open authorize_url, approve, then POST { "alias": "${alias}", "code": "<displayed code>" } to /admin/login/complete.`,
       });
       return true;
     }
 
-    // POST /admin/login/complete  { login_id, code }
+    // POST /admin/login/complete  { alias, code }
     if (urlPath === '/admin/login/complete') {
       if (method !== 'POST') { send(res, 405, { error: 'Method not allowed (use POST)' }); return true; }
       const body = await readJsonBody(req);
-      const loginId = typeof body.login_id === 'string' ? body.login_id : '';
+      const alias = typeof body.alias === 'string' ? body.alias.trim() : '';
       const rawCode = typeof body.code === 'string' ? body.code : '';
-      if (!loginId || !rawCode) { send(res, 400, { error: 'missing "login_id" or "code"' }); return true; }
-      const p = pendingLogins.get(loginId);
+      if (!alias || !rawCode) { send(res, 400, { error: 'missing "alias" or "code"' }); return true; }
+      const p = pendingLogins.get(alias);
       if (!p || p.expiresAt <= now) {
-        pendingLogins.delete(loginId);
-        send(res, 410, { error: 'login_id unknown or expired — start a new login' });
+        pendingLogins.delete(alias);
+        send(res, 410, { error: 'no pending login for that alias (unknown or expired) — start a new login' });
         return true;
       }
       // Accept "code#state" or a bare code; verify the embedded state if present.
@@ -175,8 +178,8 @@ export async function handleAdminRequest(
         send(res, 400, { error: 'state mismatch — code is from a different login attempt' });
         return true;
       }
-      pendingLogins.delete(loginId); // single-use, regardless of exchange outcome
-      const creds = await completeAddAccount(p.alias, code, p.codeVerifier, p.state);
+      pendingLogins.delete(alias); // single-use, regardless of exchange outcome
+      const creds = await completeAddAccount(alias, code, p.codeVerifier, p.state);
       deps.onAccountsChanged?.();
       send(res, 200, { alias: creds.alias, status: 'added', expires_at: new Date(creds.expiresAt).toISOString() });
       return true;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1182,8 +1182,16 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
     // Single-account mode — existing auth check
     status = await getStatus();
     if (!status.authenticated) {
-      console.error('[dario] Not authenticated. Run `dario login` first.');
-      process.exit(1);
+      if (process.env.DARIO_ADMIN === '1') {
+        // Admin API on (#599): start anyway so POST /admin/login/start can
+        // bootstrap the first account headlessly — the whole point of the API
+        // is "no console access". LLM routes return 503 until an account
+        // exists. Scoped to DARIO_ADMIN=1; default dario still exits here.
+        console.warn('[dario] No credentials yet — starting in admin-only mode (DARIO_ADMIN=1). Add an account via POST /admin/login/start (or run `dario login`); LLM requests return 503 until then.');
+      } else {
+        console.error('[dario] Not authenticated. Run `dario login` first.');
+        process.exit(1);
+      }
     }
   }
 

--- a/test/admin-api.mjs
+++ b/test/admin-api.mjs
@@ -105,7 +105,7 @@ header('POST /admin/login/start — PKCE authorize URL');
   _resetAdminStateForTest();
   const r = await call('POST', '/admin/login/start', { token: TOKEN, body: { alias: 'test-alias' } });
   check('200', r.status === 200);
-  check('returns a login_id', typeof r.json?.login_id === 'string' && r.json.login_id.length > 0);
+  check('no login_id (keyed by alias)', r.json?.login_id === undefined);
   check('returns an authorize_url', typeof r.json?.authorize_url === 'string');
   check('authorize_url is the oauth authorize endpoint', (r.json?.authorize_url || '').includes('oauth/authorize'));
   check('authorize_url carries a PKCE challenge', (r.json?.authorize_url || '').includes('code_challenge'));
@@ -127,11 +127,14 @@ header('POST /admin/login/start — PKCE authorize URL');
 // ─────────────────────────────────────────────────────────────
 header('POST /admin/login/complete — pending-login guards');
 {
-  const unknown = await call('POST', '/admin/login/complete', { token: TOKEN, body: { login_id: 'nope', code: 'abc' } });
-  check('unknown login_id → 410', unknown.status === 410);
+  const unknown = await call('POST', '/admin/login/complete', { token: TOKEN, body: { alias: 'no-pending-alias-zzz', code: 'abc' } });
+  check('unknown alias → 410', unknown.status === 410);
 
-  const missing = await call('POST', '/admin/login/complete', { token: TOKEN, body: { login_id: 'x' } });
-  check('missing code → 400', missing.status === 400);
+  const missingCode = await call('POST', '/admin/login/complete', { token: TOKEN, body: { alias: 'x' } });
+  check('missing code → 400', missingCode.status === 400);
+
+  const missingAlias = await call('POST', '/admin/login/complete', { token: TOKEN, body: { code: 'abc' } });
+  check('missing alias → 400', missingAlias.status === 400);
 }
 
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Two admin-API (#599) refinements:

**1. `alias`-keyed login (per @ramarro123's review on #599).** Dropped `login_id` — the pending PKCE login is now keyed by the account **`alias`**:

- `POST /admin/login/start` `{ alias }` → `{ authorize_url, expires_at }`
- `POST /admin/login/complete` `{ alias, code }` → `{ alias, status }`

One pending login per alias; a second `/start` for the same alias just replaces it. Simpler and more consistent — the alias is the natural key, and you'd never run two concurrent logins for the same alias.

**2. Admin-only bootstrap.** When `DARIO_ADMIN=1` and there are **no credentials yet**, the proxy now starts in **admin-only mode** instead of exiting with "Not authenticated". This is what makes *true* headless provisioning work — you can `POST /admin/login/start` to add the **first** account with no console access. LLM routes return `503` until an account exists. **Scoped to `DARIO_ADMIN=1`; default dario startup is unchanged** (still exits when unauthenticated). Surfaced by a live smoke: a credential-less instance previously never reached `server.listen`, so `/admin/*` was unreachable exactly when you'd want to bootstrap.

## Tests

- `test/admin-api.mjs` updated for alias-keying (no `login_id`; `complete` takes `{ alias, code }`; unknown-alias → `410`; missing alias/code → `400`). **25/0.**
- `tsc` clean; full suite **94/0**.

Follows #605 (admin API) and the discussion on #599. Bumps to 4.8.109.
