### PR TITLE
feat(admin): headless empty-start + hot-reload for the account pool (#599)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ checklist.
 
 ## [Unreleased]
 
+- **Headless admin bootstrap — empty start + hot-reload (#599)** — an operator running dario headless (Docker / Raspberry Pi) can now bring it up with `DARIO_ADMIN=1` and **zero accounts**, provision the first account over HTTP, and have it serve **without a restart**. Concretely: when admin mode is on, requests route through the account pool even at 0–1 accounts, so an LLM call against an empty pool returns a truthful `503 { error: "No account configured" }` (with a "add one via `POST /admin/login/start`" hint) instead of the single-account path's generic `502 Failed to reach upstream API`. Adding or removing an account via `/admin/*` now **hot-reloads the live pool** (`onAccountsChanged`, awaited before the response) — the account is routable the moment the client sees its `200`, superseding the earlier "takes effect on next proxy restart" limitation. An existing single-account `dario login` setup is preserved when admin mode is enabled (its credentials are back-filled into the pool). Default (non-admin) startup and routing are byte-for-byte unchanged.
+
 ## [4.8.110] - 2026-07-01
 
 - **Template label refresh** — `_version`, `_supportedMaxTested`, and the `user-agent` header bumped to `2.1.197` to track `@anthropic-ai/claude-code@latest`. The live wire shape is unchanged — cc-drift-template-watch ran `capture-and-bake --check` against live CC v2.1.197 and found zero shape drift vs the bundle — so this is a label refresh, not a re-capture (`_captured` stays at the last real capture). Auto-merged; clears the `sdk-drift` early-warning signal.

--- a/src/admin-api.ts
+++ b/src/admin-api.ts
@@ -19,9 +19,10 @@
  * on disk, never returned to the client, single-use. One pending login per
  * alias; a second `/start` for the same alias just replaces it (#599).
  *
- * Account changes take effect on the next proxy restart (the pool is built at
- * startup, src/proxy.ts). Hot-reload of a running pool is a deliberate
- * follow-up — keeping this surface small while it manipulates credentials.
+ * Account changes take effect immediately: the proxy passes an
+ * `onAccountsChanged` hook (src/proxy.ts) that hot-reloads the live pool from
+ * disk, awaited before this handler responds, so an added account is routable
+ * by the time the client sees its 200 — no proxy restart (#599).
  */
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { timingSafeEqual } from 'node:crypto';
@@ -37,8 +38,12 @@ import { parseManualPaste } from './oauth.js';
 export interface AdminDeps {
   /** Admin bearer token buffer; `null` = enabled but no token configured (fail closed). */
   adminTokenBuf: Buffer | null;
-  /** Invoked after an account is added or removed (e.g. to log / signal a reload). */
-  onAccountsChanged?: () => void;
+  /**
+   * Invoked after an account is added or removed. Awaited before the response
+   * is sent, so a handler that hot-reloads the live pool (src/proxy.ts) makes
+   * the change routable by the time the client sees its 200.
+   */
+  onAccountsChanged?: () => void | Promise<void>;
 }
 
 interface PendingLogin {
@@ -180,7 +185,7 @@ export async function handleAdminRequest(
       }
       pendingLogins.delete(alias); // single-use, regardless of exchange outcome
       const creds = await completeAddAccount(alias, code, p.codeVerifier, p.state);
-      deps.onAccountsChanged?.();
+      await deps.onAccountsChanged?.();
       send(res, 200, { alias: creds.alias, status: 'added', expires_at: new Date(creds.expiresAt).toISOString() });
       return true;
     }
@@ -206,7 +211,7 @@ export async function handleAdminRequest(
     if (isAccountDelete) {
       const alias = decodeURIComponent(urlPath.slice(ACCOUNTS_PREFIX.length));
       const removed = await removeAccount(alias); // validates alias internally
-      if (removed) deps.onAccountsChanged?.();
+      if (removed) await deps.onAccountsChanged?.();
       send(res, removed ? 200 : 404, { alias, removed });
       return true;
     }

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -594,3 +594,43 @@ export class AccountPool {
     }
   }
 }
+
+/** Minimal account shape the pool needs to route — a structural subset of
+ *  accounts.ts' AccountCredentials, declared here to keep pool.ts dependency-free. */
+export interface ReconcilableAccount {
+  alias: string;
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  deviceId: string;
+  accountUuid: string;
+}
+
+/**
+ * Reconcile a live pool against the current on-disk account set: add or refresh
+ * the tokens of every account that exists on disk, and drop any the pool still
+ * holds that no longer does. `add` preserves a known alias's rate-limit and
+ * identity state, so re-adding an unchanged account is a cheap token refresh
+ * rather than a reset.
+ *
+ * This is the hot-reload primitive behind the headless admin API (#599): the
+ * proxy calls it from `onAccountsChanged` so accounts provisioned or removed
+ * over HTTP take effect immediately, with no proxy restart. Returns the pool
+ * size after reconciliation.
+ */
+export function reconcilePoolAccounts(pool: AccountPool, accounts: ReconcilableAccount[]): number {
+  const wanted = new Set(accounts.map(a => a.alias));
+  for (const a of accounts) {
+    pool.add(a.alias, {
+      accessToken: a.accessToken,
+      refreshToken: a.refreshToken,
+      expiresAt: a.expiresAt,
+      deviceId: a.deviceId,
+      accountUuid: a.accountUuid,
+    });
+  }
+  for (const existing of pool.all()) {
+    if (!wanted.has(existing.alias)) pool.remove(existing.alias);
+  }
+  return pool.size;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -11,11 +11,11 @@ import { buildHealthResponse } from './health-response.js';
 import { buildCCRequest, applyCcPromptCaching, parseEffortSuffix, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, CC_TEMPLATE, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
 import { stampCch } from './cch.js';
 import { describeTemplate, detectDrift, checkCCCompat } from './live-fingerprint.js';
-import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCooldown, authCooldownMs, type PoolAccount } from './pool.js';
+import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCooldown, authCooldownMs, reconcilePoolAccounts, type PoolAccount } from './pool.js';
 import { Analytics, billingBucketFromClaim, type RequestRecord } from './analytics.js';
 import { OverageGuard, buildHaltErrorBody, type HaltState } from './overage-guard.js';
 import { notify as osNotify } from './notify.js';
-import { loadAllAccounts, loadAccount, refreshAccountToken, resyncLoginFromCredentialsIfStale } from './accounts.js';
+import { loadAllAccounts, loadAccount, refreshAccountToken, resyncLoginFromCredentialsIfStale, ensureLoginCredentialsInPool } from './accounts.js';
 import { handleAdminRequest } from './admin-api.js';
 import { getOpenAIBackend, isOpenAIModel, forwardToOpenAI, type BackendCredentials } from './openai-backend.js';
 import { RequestQueue, QueueFullError, QueueTimeoutError, DEFAULT_MAX_CONCURRENT, DEFAULT_MAX_QUEUED, DEFAULT_QUEUE_TIMEOUT_MS } from './request-queue.js';
@@ -1081,8 +1081,9 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
     console.log(`  OpenAI-compat backend: ${openaiBackend.name} → ${openaiBackend.baseUrl}`);
   }
 
-  // Multi-account pool — activated when ~/.dario/accounts/ has 2+ entries.
-  // Single-account dario keeps its existing code path unchanged.
+  // Multi-account pool — activated when ~/.dario/accounts/ has 2+ entries (or
+  // whenever admin mode is on; see the #599 block below). Single-account dario
+  // keeps its existing code path unchanged.
   //
   // Before loading the pool, check whether the back-filled `login` snapshot
   // has gone stale relative to credentials.json (dario#235). The single-
@@ -1094,8 +1095,21 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
     console.log('[dario] re-synced pool `login` account from current credentials.json (was stale; dario#235)');
   }
 
+  // Admin mode (#599) manages the account pool over HTTP, so route through the
+  // pool engine even for 0–1 accounts. This is what makes a headless deploy
+  // work: an empty pool returns a clean 503 (not the single-account path's
+  // generic upstream error), and accounts added via POST /admin/login/* take
+  // effect immediately — no proxy restart (see onAccountsChanged below).
+  //
+  // Back-fill first: an operator who enables admin mode on top of an existing
+  // single-account `dario login` setup keeps that account (ensureLogin… is a
+  // no-op when accounts/ is already populated or no credentials are reachable).
+  const adminEnabled = process.env.DARIO_ADMIN === '1';
+  if (adminEnabled) {
+    try { await ensureLoginCredentialsInPool(); } catch { /* non-fatal — pool just starts empty */ }
+  }
   const accountsList = await loadAllAccounts();
-  const pool = accountsList.length >= 2 ? new AccountPool() : null;
+  const pool = (accountsList.length >= 2 || adminEnabled) ? new AccountPool() : null;
   // Per-model rate-limit bucket families seen during this proxy run. First-
   // sight is logged once when verbose so a new Anthropic bucket (e.g. an
   // eventual `7d_opus`) doesn't slip past unnoticed. Pure observability —
@@ -1169,29 +1183,30 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
     }, 15 * 60 * 1000);
     refreshInterval.unref();
     // Pool mode doesn't check single-account status — compute a placeholder
-    // for the startup banner using the pool's earliest expiry.
-    const earliest = Math.min(...pool.all().map(a => a.expiresAt));
-    const msLeft = Math.max(0, earliest - Date.now());
-    status = {
-      authenticated: true,
-      status: 'healthy',
-      expiresAt: earliest,
-      expiresIn: `${Math.floor(msLeft / 3600000)}h ${Math.floor((msLeft % 3600000) / 60000)}m`,
-    };
+    // for the startup banner using the pool's earliest expiry. An admin-mode
+    // pool can legitimately start empty (#599): report that plainly instead of
+    // Math.min([]) === Infinity, and tell the operator how to bootstrap.
+    if (pool.size === 0) {
+      console.warn('[dario] Starting with no accounts (admin mode). Add one via POST /admin/login/start; LLM requests return 503 until then.');
+      status = { authenticated: false, status: 'none', expiresAt: 0, expiresIn: 'no accounts yet' };
+    } else {
+      const earliest = Math.min(...pool.all().map(a => a.expiresAt));
+      const msLeft = Math.max(0, earliest - Date.now());
+      status = {
+        authenticated: true,
+        status: 'healthy',
+        expiresAt: earliest,
+        expiresIn: `${Math.floor(msLeft / 3600000)}h ${Math.floor((msLeft % 3600000) / 60000)}m`,
+      };
+    }
   } else {
-    // Single-account mode — existing auth check
+    // Single-account mode — the classic `dario login` path. Admin mode never
+    // lands here: it always routes through the pool above (#599), which starts
+    // even with zero accounts and returns a clean 503 until one is added.
     status = await getStatus();
     if (!status.authenticated) {
-      if (process.env.DARIO_ADMIN === '1') {
-        // Admin API on (#599): start anyway so POST /admin/login/start can
-        // bootstrap the first account headlessly — the whole point of the API
-        // is "no console access". LLM routes return 503 until an account
-        // exists. Scoped to DARIO_ADMIN=1; default dario still exits here.
-        console.warn('[dario] No credentials yet — starting in admin-only mode (DARIO_ADMIN=1). Add an account via POST /admin/login/start (or run `dario login`); LLM requests return 503 until then.');
-      } else {
-        console.error('[dario] Not authenticated. Run `dario login` first.');
-        process.exit(1);
-      }
+      console.error('[dario] Not authenticated. Run `dario login` first.');
+      process.exit(1);
     }
   }
 
@@ -1397,7 +1412,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
   // these endpoints add/remove OAuth accounts: the admin token is
   // DARIO_ADMIN_TOKEN, falling back to DARIO_API_KEY. Enabled-but-tokenless
   // fails closed (403) so account control is never left open on loopback.
-  const adminEnabled = process.env.DARIO_ADMIN === '1';
+  // adminEnabled is resolved once up top (it gates pool activation). Reuse it.
   const adminToken = process.env.DARIO_ADMIN_TOKEN || process.env.DARIO_API_KEY || '';
   const adminTokenBuf = adminToken ? Buffer.from(adminToken) : null;
   if (adminEnabled) {
@@ -1479,8 +1494,18 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
     if (adminEnabled && urlPath.startsWith('/admin/')) {
       const handled = await handleAdminRequest(req, res, urlPath, {
         adminTokenBuf,
-        onAccountsChanged: () => {
-          if (verbose) console.log('[dario] admin: account pool changed on disk (effective on next proxy restart)');
+        onAccountsChanged: async () => {
+          // Hot-reload the live pool from disk so accounts added / removed via
+          // the admin API take effect immediately — no proxy restart (#599).
+          // Awaited by handleAdminRequest before it responds, so the account is
+          // already routable by the time the client sees the 200.
+          if (!pool) return;
+          try {
+            const size = reconcilePoolAccounts(pool, await loadAllAccounts());
+            if (verbose) console.log(`[dario] admin: pool hot-reloaded — ${size} account${size === 1 ? '' : 's'}`);
+          } catch (err) {
+            console.error(`[dario] admin: pool hot-reload failed: ${err instanceof Error ? err.message : err}`);
+          }
         },
       });
       if (handled) return;
@@ -1774,8 +1799,25 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
       } else if (pool) {
         poolAccount = pool.select();
         if (!poolAccount) {
+          // Two distinct empty-selection cases (#599): the pool has no accounts
+          // at all (headless admin bootstrap — nothing added yet), vs. it has
+          // accounts but all are rate-limited / in auth cool-down. Give each a
+          // truthful, actionable message so a headless operator isn't told
+          // "rate-limited" when they simply haven't added an account.
           res.writeHead(503, JSON_HEADERS);
-          res.end(JSON.stringify({ error: 'No accounts available in pool' }));
+          res.end(JSON.stringify(
+            pool.size === 0
+              ? {
+                  error: 'No account configured',
+                  message: adminEnabled
+                    ? 'dario is running in admin mode with no account yet. Add one via POST /admin/login/start, then retry.'
+                    : 'No accounts available. Run `dario login`, or add accounts with `dario accounts add`.',
+                }
+              : {
+                  error: 'No accounts available in pool',
+                  message: 'all accounts are rate-limited or in auth cool-down; retry shortly',
+                },
+          ));
           return;
         }
         accessToken = poolAccount.accessToken;

--- a/test/pool-reconcile.mjs
+++ b/test/pool-reconcile.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// Tests for reconcilePoolAccounts (#599) — the hot-reload primitive behind the
+// headless admin API. Exercises the live AccountPool directly with synthetic
+// accounts: no disk, no network, no proxy, so it never touches a real ~/.dario.
+//
+// Covers the two behaviours the admin/headless flow depends on:
+//   1. An empty pool selects nothing -> the request path returns a clean 503
+//      ("No account configured") instead of the single-account upstream error.
+//   2. Reconciling the pool against the on-disk set adds new accounts, drops
+//      removed ones, refreshes an existing account's tokens, and preserves its
+//      rate-limit / auth-cooldown state — so an account added over HTTP becomes
+//      routable immediately, with no proxy restart.
+
+import { AccountPool, reconcilePoolAccounts, isInAuthCooldown } from '../dist/pool.js';
+
+let pass = 0, fail = 0;
+function check(name, cond, detail) {
+  if (cond) { pass++; console.log(`  OK ${name}`); }
+  else { fail++; console.log(`  FAIL ${name}${detail ? ' :: ' + detail : ''}`); }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+const HOUR = 3600_000;
+function mkAcc(alias, accessToken = `tok-${alias}`) {
+  return {
+    alias,
+    accessToken,
+    refreshToken: `refresh-${alias}`,
+    expiresAt: Date.now() + 2 * HOUR,
+    deviceId: `dev-${alias}`,
+    accountUuid: `uuid-${alias}`,
+  };
+}
+const aliasesOf = (pool) => pool.all().map(a => a.alias).sort();
+const tokenOf = (pool, alias) => pool.all().find(a => a.alias === alias)?.accessToken;
+
+// ─────────────────────────────────────────────────────────────
+header('Empty pool -> select() is null (the clean-503 trigger, #599)');
+{
+  const pool = new AccountPool();
+  check('fresh pool size is 0', pool.size === 0);
+  check('select() on empty pool returns null', pool.select() === null);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Reconcile: bootstrap from empty, then add');
+{
+  const pool = new AccountPool();
+
+  const n0 = reconcilePoolAccounts(pool, []);
+  check('reconcile([]) keeps size 0', n0 === 0 && pool.size === 0);
+  check('still selects nothing while empty', pool.select() === null);
+
+  const n1 = reconcilePoolAccounts(pool, [mkAcc('acct1')]);
+  check('first account added -> size 1', n1 === 1 && pool.size === 1);
+  check('the lone account is now selectable', pool.select()?.alias === 'acct1');
+
+  const n2 = reconcilePoolAccounts(pool, [mkAcc('acct1'), mkAcc('acct2')]);
+  check('second account added -> size 2', n2 === 2);
+  check('both aliases present', JSON.stringify(aliasesOf(pool)) === JSON.stringify(['acct1', 'acct2']));
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Reconcile: removals drop accounts no longer on disk');
+{
+  const pool = new AccountPool();
+  reconcilePoolAccounts(pool, [mkAcc('a'), mkAcc('b'), mkAcc('c')]);
+  check('seeded 3', pool.size === 3);
+
+  const n = reconcilePoolAccounts(pool, [mkAcc('b')]);
+  check('reconcile to just [b] -> size 1', n === 1);
+  check('only b remains', JSON.stringify(aliasesOf(pool)) === JSON.stringify(['b']));
+
+  const nEmpty = reconcilePoolAccounts(pool, []);
+  check('reconcile to [] -> size 0 (all removed)', nEmpty === 0 && pool.size === 0);
+  check('empty again selects nothing', pool.select() === null);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Reconcile: existing account gets fresh tokens, keeps its state');
+{
+  const pool = new AccountPool();
+  reconcilePoolAccounts(pool, [mkAcc('keep', 'old-token')]);
+  check('seeded token is old-token', tokenOf(pool, 'keep') === 'old-token');
+
+  // Put the account into auth cool-down (mirrors a 401 during use).
+  pool.markAuthFailure('keep');
+  const before = pool.all().find(a => a.alias === 'keep');
+  check('account is in auth cool-down after a failure', isInAuthCooldown(before));
+  check('cool-down makes it unselectable', pool.select() === null);
+
+  // A reconcile (e.g. background refresh wrote a new token to disk) must update
+  // the token WITHOUT clearing the cool-down / resetting failure state.
+  reconcilePoolAccounts(pool, [mkAcc('keep', 'new-token')]);
+  check('token refreshed to new-token', tokenOf(pool, 'keep') === 'new-token');
+  const after = pool.all().find(a => a.alias === 'keep');
+  check('auth cool-down preserved across reconcile', isInAuthCooldown(after));
+  check('failure counter preserved (not reset by re-add)', after.consecutiveAuthFailures >= 1);
+}
+
+console.log(`\n${pass} pass, ${fail} fail`);
+if (fail > 0) process.exit(1);


### PR DESCRIPTION
Closes the remaining ask on #599: run dario **fully headless** — start with `DARIO_ADMIN=1` and **no accounts**, provision the first one over HTTP, and have it serve **without a restart**.

## Why
The empty-start banner shipped in v4.8.109 promises *"LLM requests return 503 until then,"* but two things didn't actually hold:

1. **Wrong error while empty.** With zero accounts the pool is `null`, so a request falls through to the single-account `getAccessToken()`, which throws `Not authenticated` → the handler returns a misleading **`502 Failed to reach upstream API`**, not a 503.
2. **First account never served.** The admin API writes accounts to `~/.dario/accounts/` (`saveAccount`), but the pool only activates at **2+** accounts and the single-account path reads a *different* store (`credentials.json`). A lone admin-added account was therefore never routable — not at runtime (`onAccountsChanged` only logged *"effective on next restart"*), and not even after a restart. So *"when I add the first user it starts working"* failed.

## What changed
- **Admin mode routes through the pool at 0–1 accounts too.** An empty pool now returns a truthful `503 { error: "No account configured" }` with an *"add one via `POST /admin/login/start`"* hint (and a distinct message for the all-rate-limited case, so a headless operator isn't told "rate-limited" when they just haven't added an account).
- **Hot-reload on account change.** `onAccountsChanged` now reconciles the live pool from disk and is **awaited before the response** — the account is routable the instant the client sees its `200`. No proxy restart. Supersedes the old restart-required limitation (admin-api docstring updated).
- **Existing `dario login` preserved.** When admin mode is enabled on top of a single-account setup, the login credentials are back-filled into the pool (via the existing `ensureLoginCredentialsInPool`), so nothing is stranded.
- **Extracted `reconcilePoolAccounts()`** into `pool.ts` (leaner handler, testable seam).

**Default (non-admin) startup and routing are byte-for-byte unchanged** — every new behavior is gated on `DARIO_ADMIN=1`.

## Tests
New `test/pool-reconcile.mjs` (19 assertions, all in-memory — no disk/network): empty-pool `select() === null` (the 503 trigger), bootstrap-from-empty → add → remove, and token-refresh-with-state-preservation across a reconcile (auth cool-down + failure counter survive a re-add). Full suite green: **95/95**, `tsc --noEmit` clean.

## Reviewer notes
- The `onAccountsChanged` callback type widened to `() => void | Promise<void>`; both call sites now `await` it.
- Edge case (pre-existing, unchanged by this PR): admin mode + a `credentials.json` account + exactly one *different* account already in `~/.dario/accounts/` routes via the pool's lone entry and won't merge the `credentials.json` account until a second `accounts/` entry trips the resync — an established quirk of the 2+ threshold, not introduced here.
