### PR TITLE
release: v4.8.111 — re-enable Fable 5 + admin API (#599/#620) + pricing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.111] - 2026-07-01
+
 - **Fable 5 pricing corrected** — the analytics cost estimate now uses Fable 5's official published rate (`$10 / $50` per 1M in/out, 5m cache-write `$12.50`, cache-read `$1`) instead of the placeholder opus-4-8 rate (`$5 / $25`) assumed when fable shipped before pricing was public. Display-only; real billing is the flat Max subscription.
 - **Fable 5 re-enabled** — the US-government export-control directive that suspended Claude Fable 5 (2026-06-12) was lifted, and Fable 5 [returned globally on 2026-07-01](https://www.anthropic.com/news/redeploying-fable-5) — Claude Platform, Claude.ai, Claude Code, and Cowork, including Pro/Max/Team (up to 50% of weekly limits through 2026-07-07, then via credits). dario's default `fable` suspension (added in v4.8.71) is removed: `claude-fable-5` / `claude-fable-5[1m]` are advertised and proxied again, and the `fable` / `fable1m` aliases resolve as before. The `DARIO_SUSPENDED_MODELS` mechanism is retained for future use — set `DARIO_SUSPENDED_MODELS=fable` to re-suspend if access is ever pulled again. (Mythos 5 remains restored only to a set of US organizations, not globally; dario never carried it.)
 - **Opus 4.6 pricing corrected** — the analytics cost estimate priced `claude-opus-4-6` at the old `$15/$75` Opus-4.1 rate; Opus 4.6 is `$5/$25` (same as Opus 4.7/4.8) per current platform pricing. Display-only.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.101",
+  "version": "4.8.111",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "4.8.101",
+      "version": "4.8.111",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.110",
+  "version": "4.8.111",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Cuts the release that ships the accumulated `[Unreleased]` work to prod now that **Fable 5 serves again on the account** (probed 200/end_turn).

## Why a release is needed
The fable re-enable code (#615) is already on `master`, but the auto-release is **tag-gated** — `v4.8.110` already exists, so no new image builds and the box keeps the fable-suspended image. Prod dario (v4.8.110) confirmed still returns its **local** suspend-404 for `claude-fable-5`. This bump builds + publishes v4.8.111 so the box auto-deploy flips prod off `DEFAULT_SUSPENDED_MODELS='fable'`.

## What ships in v4.8.111
- **Fable 5 re-enabled** (#615) — `DEFAULT_SUSPENDED_MODELS: 'fable' → ''`; `claude-fable-5`/`[1m]` advertised + proxied again.
- **Headless admin API** (#599) — live pool status, audit trail, rate limiting, optional `login/start` alias.
- **Admin rate-limit follow-up** (#620).
- **Analytics pricing** — Fable 5 $10/$50, Opus 4.6 $5/$25, date-modeled Sonnet 5 intro.

## Change
Version bump only (`package.json` + `package-lock.json` → 4.8.111) and CHANGELOG `[Unreleased]` → `[4.8.111]`. No code change — the code already passed CI on its own PRs. `check-package-json` green.