### PR TITLE
fix(fable): drop obsolete effort clamp + add thinking.display, lock-step to CC 2.1.198

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ checklist.
 
 ## [Unreleased]
 
+- **Fable 5 wire lock-step with CC 2.1.198** — after Fable 5's 2026-07-01 redeploy, a fresh live replay (CC 2.1.198's verbatim fable body through the proxy, only `output_config.effort` mutated) shows two divergences from CC, now fixed. (1) **Effort clamp removed** — the pre-suspension fable soft-refused `max`/`xhigh` (200 + `stop_reason:"refusal"`), so dario clamped them to `high` and defaulted fable to `high`; the redeployed model now answers `high`/`xhigh`/`max` (all `end_turn`, zero refusals) and CC 2.1.198 sends `effort:"xhigh"` on fable, so fable now takes the general path (default `max`, no clamp) exactly like opus. A box pinning `DARIO_EFFORT=max` now sends fable full effort instead of a silently-downgraded `high`. (2) **`thinking.display:"omitted"`** — CC 2.1.198 emits `{ type:"adaptive", display:"omitted" }` on every adaptive-thinking model; dario emitted only `{ type:"adaptive" }`. Added `display:"omitted"` to match the wire byte-for-byte. The `fallback-credit-2026-06-01` beta on fable is unchanged and still valid (verified end_turn through prod).
+
 ## [4.8.111] - 2026-07-01
 
 - **Fable 5 pricing corrected** — the analytics cost estimate now uses Fable 5's official published rate (`$10 / $50` per 1M in/out, 5m cache-write `$12.50`, cache-read `$1`) instead of the placeholder opus-4-8 rate (`$5 / $25`) assumed when fable shipped before pricing was public. Display-only; real billing is the flat Max subscription.

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -1139,48 +1139,41 @@ function normalizeEffortForWire(effort: string): string {
  *   - May 17 2026, CC 2.1.143: effort = 'xhigh'   (verified by capture-full-body.mjs)
  *
  *   undefined → 'max' (highest *universally*-supported level. CC's own wire
- *               default is 'xhigh', but that's Opus-only — Sonnet/Haiku-class
+ *               default is 'xhigh', but that's Opus/Fable-only — Sonnet/Haiku-class
  *               400 on 'xhigh' ("supported: high|low|max|medium"). 'max' is
  *               accepted by all and still routes to the subscription pool
  *               (verified: representative-claim=five_hour on Opus + Sonnet).
- *               Set --effort=xhigh / DARIO_EFFORT=xhigh for Opus's extra tier.)
- *               EXCEPT fable: real CC's print-mode default for fable is
- *               'high' (live capture 2026-06-09, CC v2.1.170 — the same
- *               capture got 'xhigh' on opus and 'high' on fable), so the
- *               unset-flag default mirrors that per-family. An explicit
- *               flag still pins (subject to the fable clamp below).
+ *               Set --effort=xhigh / DARIO_EFFORT=xhigh for the Opus/Fable tier.)
  *   'low' / 'medium' / 'high' / 'xhigh' / 'max' → pin to that value
  *   'ultracode' → 'xhigh' (CC's ultracode mode; xhigh on the wire)
  *   'client' → extract from `clientBody.output_config.effort` (normalized
- *              for the wire); fall back to the per-family default if
- *              absent/non-string
+ *              for the wire); fall back to the default if absent/non-string
  *
- * FABLE CLAMP (2026-06-09, live replay bisect on the deployed proxy):
- * fable-5 SOFT-REFUSES `max` and `xhigh` — 200 with stop_reason "refusal"
- * and empty content on every prompt, not a 400 — while `high` answers
- * normally (byte-identical request bodies, only output_config.effort
- * mutated). Empirical matrix on claude-fable-5:
- *   high  → answers      xhigh → refusal      max → refusal
- * So on the fable family any resolved 'max'/'xhigh' (from --effort /
- * DARIO_EFFORT pins, ultracode, or client passthrough) is clamped to
- * 'high', the strongest level fable accepts. Operators who pin
- * --effort=max for Opus's sake keep that on every other family.
+ * FABLE CLAMP — REMOVED 2026-07-01. Fable 5 was SUSPENDED 2026-06-12 (US-gov
+ * directive) and REDEPLOYED 2026-07-01. The pre-suspension model (2026-06-09
+ * replay bisect) soft-refused `max`/`xhigh` (200 + stop_reason "refusal") and
+ * defaulted to `high`; dario special-cased it. A fresh live replay on 2026-07-01
+ * through the deployed proxy (CC 2.1.198's verbatim fable body, only
+ * output_config.effort mutated) shows the redeployed fable now ANSWERS all three
+ * — high/xhigh/max → end_turn, zero refusals — and CC 2.1.198 itself sends
+ * `effort: xhigh` on fable (same as opus). So the clamp + the fable-only default
+ * are gone: fable now takes the general path (default 'max', no clamp), matching
+ * how dario treats opus. `model` is retained in the signature for callers and in
+ * case a future model needs per-family effort handling again.
  *
  * Exported for tests.
  */
 export function resolveEffort(flag: EffortValue | undefined, clientBody: Record<string, unknown>, model?: string): string {
-  const isFable = (model ?? '').toLowerCase().includes('fable');
-  const familyDefault = isFable ? 'high' : 'max';
-  const clamp = (effort: string): string =>
-    isFable && (effort === 'max' || effort === 'xhigh') ? 'high' : effort;
+  void model; // no per-family effort handling at present (see FABLE CLAMP note above)
+  const familyDefault = 'max';
   if (flag === undefined) return familyDefault;
   if (flag === 'client') {
     const clientOC = clientBody.output_config as { effort?: unknown } | undefined;
     const clientEffort = clientOC?.effort;
-    if (typeof clientEffort === 'string' && clientEffort.length > 0) return clamp(normalizeEffortForWire(clientEffort));
+    if (typeof clientEffort === 'string' && clientEffort.length > 0) return normalizeEffortForWire(clientEffort);
     return familyDefault;
   }
-  return clamp(normalizeEffortForWire(flag));
+  return normalizeEffortForWire(flag);
 }
 
 /**
@@ -1715,7 +1708,11 @@ export function buildCCRequest(
       // when honoring client thinking — the pairing is shape-specific.
     } else if (supportsAdaptiveThinking(model)) {
       if (!skip || !skip.has('thinking')) {
-        ccRequest.thinking = { type: 'adaptive' };
+        // CC 2.1.198 sends `display: "omitted"` alongside the adaptive type on
+        // every adaptive-thinking model (verified via capture-full-body.mjs on
+        // fable-5 + opus-4-8, 2026-07-01). Match it so the wire shape stays
+        // byte-aligned with CC.
+        ccRequest.thinking = { type: 'adaptive', display: 'omitted' };
       }
       if (!skip || !skip.has('context_management')) {
         ccRequest.context_management = { edits: [{ type: 'clear_thinking_20251015', keep: 'all' }] };

--- a/test/adaptive-thinking-gate.mjs
+++ b/test/adaptive-thinking-gate.mjs
@@ -110,6 +110,7 @@ const billingTag = 'x-anthropic-billing-header: cc_version=test;';
     billingTag, cacheControl, identity,
   ).body;
   check('sonnet-4-6: thinking emitted',           body.thinking?.type === 'adaptive');
+  check('sonnet-4-6: thinking display=omitted (CC 2.1.198 wire shape)', body.thinking?.display === 'omitted');
   check('sonnet-4-6: context_management emitted', body.context_management?.edits?.[0]?.type === 'clear_thinking_20251015');
   check('sonnet-4-6: output_config emitted',      typeof body.output_config?.effort === 'string');
 }

--- a/test/effort-flag.mjs
+++ b/test/effort-flag.mjs
@@ -40,35 +40,31 @@ header('resolveEffort — explicit values pin');
   check('max → max', resolveEffort('max', {}) === 'max');
 }
 
-header('resolveEffort — fable per-family default (live capture 2026-06-09)');
+header('resolveEffort — fable takes the general path (clamp removed 2026-07-01 redeploy)');
 {
-  // Real CC's print-mode default for fable is 'high' (opus got 'xhigh' in the
-  // same capture); the unset-flag default mirrors that per-family.
-  check('undefined + fable → high', resolveEffort(undefined, {}, 'claude-fable-5') === 'high');
-  check('undefined + fable[1m] → high', resolveEffort(undefined, {}, 'claude-fable-5[1m]') === 'high');
+  // Fable 5 was suspended 2026-06-12 and redeployed 2026-07-01. A fresh live
+  // replay (CC 2.1.198 verbatim body, only effort mutated) shows the redeployed
+  // fable ANSWERS high/xhigh/max (end_turn, no refusal), and CC 2.1.198 sends
+  // effort=xhigh on fable. So the fable-only default ('high') and the max/xhigh
+  // clamp are gone — fable behaves like opus: default 'max', nothing clamped.
+  check('undefined + fable → max (general default)', resolveEffort(undefined, {}, 'claude-fable-5') === 'max');
+  check('undefined + fable[1m] → max', resolveEffort(undefined, {}, 'claude-fable-5[1m]') === 'max');
   check('undefined + opus → max (unchanged)', resolveEffort(undefined, {}, 'claude-opus-4-8') === 'max');
-  check('client + fable, no client effort → high fallback',
-    resolveEffort('client', {}, 'claude-fable-5') === 'high');
-  check('client + fable, client effort wins',
-    resolveEffort('client', { output_config: { effort: 'low' } }, 'claude-fable-5') === 'low');
-}
-
-header('resolveEffort — fable clamp (max/xhigh soft-refused; replay bisect 2026-06-09)');
-{
-  // fable-5 soft-refuses max + xhigh (200 + stop_reason "refusal", empty
-  // content) but answers on high — byte-identical bodies, only effort mutated.
-  check('max flag + fable → clamped to high', resolveEffort('max', {}, 'claude-fable-5') === 'high');
-  check('xhigh flag + fable → clamped to high', resolveEffort('xhigh', {}, 'claude-fable-5') === 'high');
-  check('ultracode + fable → clamped to high', resolveEffort('ultracode', {}, 'claude-fable-5') === 'high');
-  check('high flag + fable → high (untouched)', resolveEffort('high', {}, 'claude-fable-5') === 'high');
-  check('low flag + fable → low (untouched)', resolveEffort('low', {}, 'claude-fable-5') === 'low');
-  check('client max + fable → clamped to high',
-    resolveEffort('client', { output_config: { effort: 'max' } }, 'claude-fable-5') === 'high');
-  check('client xhigh + fable → clamped to high',
-    resolveEffort('client', { output_config: { effort: 'xhigh' } }, 'claude-fable-5') === 'high');
-  check('max flag + opus → max (clamp is fable-only)', resolveEffort('max', {}, 'claude-opus-4-8') === 'max');
-  check('xhigh flag + opus → xhigh (clamp is fable-only)', resolveEffort('xhigh', {}, 'claude-opus-4-8') === 'xhigh');
-  check('max flag + no model → max (clamp needs fable)', resolveEffort('max', {}) === 'max');
+  check('max flag + fable → max (no clamp)', resolveEffort('max', {}, 'claude-fable-5') === 'max');
+  check('xhigh flag + fable → xhigh (no clamp)', resolveEffort('xhigh', {}, 'claude-fable-5') === 'xhigh');
+  check('ultracode + fable → xhigh (no clamp)', resolveEffort('ultracode', {}, 'claude-fable-5') === 'xhigh');
+  check('high flag + fable → high', resolveEffort('high', {}, 'claude-fable-5') === 'high');
+  check('low flag + fable → low', resolveEffort('low', {}, 'claude-fable-5') === 'low');
+  check('client max + fable → max (no clamp)',
+    resolveEffort('client', { output_config: { effort: 'max' } }, 'claude-fable-5') === 'max');
+  check('client xhigh + fable → xhigh (no clamp)',
+    resolveEffort('client', { output_config: { effort: 'xhigh' } }, 'claude-fable-5') === 'xhigh');
+  check('client + fable, no client effort → max fallback',
+    resolveEffort('client', {}, 'claude-fable-5') === 'max');
+  check('client + fable, client effort wins', resolveEffort('client', { output_config: { effort: 'low' } }, 'claude-fable-5') === 'low');
+  check('max flag + opus → max', resolveEffort('max', {}, 'claude-opus-4-8') === 'max');
+  check('xhigh flag + opus → xhigh', resolveEffort('xhigh', {}, 'claude-opus-4-8') === 'xhigh');
+  check('max flag + no model → max', resolveEffort('max', {}) === 'max');
 }
 
 header('resolveEffort — client passthrough');


### PR DESCRIPTION
Now that Fable 5 is back (redeployed 2026-07-01), a fresh live wire re-measure surfaced two ways dario had drifted from CC on fable. Both fixed.

## Method
Captured CC **2.1.198**'s outbound fable body (`capture-full-body.mjs`), then replayed it through a **passthrough** dario (OAuth-swap only, no injection) against the live account, mutating **only** `output_config.effort`:

```
== fable-5 effort re-measure (CC 2.1.198 verbatim body) ==
  effort=high   -> ✅ ANSWERED  stop_reason=end_turn
  effort=xhigh  -> ✅ ANSWERED  stop_reason=end_turn
  effort=max    -> ✅ ANSWERED  stop_reason=end_turn
```

## Fixes
1. **Effort clamp removed.** The pre-suspension fable soft-refused `max`/`xhigh` (200 + `stop_reason:"refusal"`), so `resolveEffort` clamped fable `max`/`xhigh` → `high` and defaulted fable to `high`. The redeployed model **answers all three**, and CC 2.1.198 now sends `effort:"xhigh"` on fable (same as opus). So fable takes the general path — default `max`, no clamp — matching how dario treats opus. A box pinning `DARIO_EFFORT=max` now sends fable full effort instead of a silently-downgraded `high`.
2. **`thinking.display:"omitted"`.** CC 2.1.198 emits `{ type:"adaptive", display:"omitted" }` on every adaptive-thinking model (verified on fable-5 + opus-4-8); dario emitted only `{ type:"adaptive" }`. Added `display:"omitted"` so the wire stays byte-aligned. This one is built in code, so the drift bot's template rebake wouldn't catch it.

`fallback-credit-2026-06-01` beta on fable is unchanged and still valid (real fable round-trip through prod returns `end_turn`, not a soft-refusal).

## Not touched
Template `_version` / `SUPPORTED_CC_RANGE.maxTested` (2.1.197) — left to the cc-drift bot per repo convention; this PR is behavioral only.

## Tests
`resolveEffort` fable assertions rewritten to the new reality (no clamp, default `max`); added a `thinking.display==="omitted"` assertion. **effort-flag 67/67, adaptive-thinking-gate 42/42, full suite 97/97**, tsc clean.