### PR TITLE
release: v4.8.112 — Fable 5 wire lock-step with CC 2.1.198

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.112] - 2026-07-01
+
 - **Fable 5 wire lock-step with CC 2.1.198** — after Fable 5's 2026-07-01 redeploy, a fresh live replay (CC 2.1.198's verbatim fable body through the proxy, only `output_config.effort` mutated) shows two divergences from CC, now fixed. (1) **Effort clamp removed** — the pre-suspension fable soft-refused `max`/`xhigh` (200 + `stop_reason:"refusal"`), so dario clamped them to `high` and defaulted fable to `high`; the redeployed model now answers `high`/`xhigh`/`max` (all `end_turn`, zero refusals) and CC 2.1.198 sends `effort:"xhigh"` on fable, so fable now takes the general path (default `max`, no clamp) exactly like opus. A box pinning `DARIO_EFFORT=max` now sends fable full effort instead of a silently-downgraded `high`. (2) **`thinking.display:"omitted"`** — CC 2.1.198 emits `{ type:"adaptive", display:"omitted" }` on every adaptive-thinking model; dario emitted only `{ type:"adaptive" }`. Added `display:"omitted"` to match the wire byte-for-byte. The `fallback-credit-2026-06-01` beta on fable is unchanged and still valid (verified end_turn through prod).
 
 ## [4.8.111] - 2026-07-01

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.111",
+  "version": "4.8.112",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "4.8.111",
+      "version": "4.8.112",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.111",
+  "version": "4.8.112",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Ships the fable lock-step fix (#624) to prod: effort-clamp removal (redeployed fable answers high/xhigh/max; CC 2.1.198 sends xhigh on fable) + `thinking.display:"omitted"`.

Version bump only (`package.json` + `package-lock.json` → 4.8.112, CHANGELOG `[Unreleased]` → `[4.8.112]`). No code change — #624 already passed CI. The auto-release is tag-gated (`v4.8.111` exists), so the bump is what triggers the build + GHCR push that the box auto-deploy then pulls. `check-package-json` green.