### PR TITLE
fix(drift-watch): treat CC-older-than-bundle as infra failure, not drift

### DIFF
--- a/.github/workflows/cc-drift-template-watch.yml
+++ b/.github/workflows/cc-drift-template-watch.yml
@@ -93,7 +93,11 @@ jobs:
         id: check
         # Exit codes from capture-and-bake.mjs --check:
         #   0 — no drift, template matches live capture
-        #   1 — infrastructure failure (CC not on PATH, capture timeout)
+        #   1 — infrastructure failure (CC not on PATH, capture timeout, or
+        #       the runner's installed CC is OLDER than the bundle's capture —
+        #       an older binary re-captures the previous wire shape, so its
+        #       "drift" would auto-rebake a template DOWNGRADE (PR #632); fix
+        #       is `npm i -g @anthropic-ai/claude-code@latest` on the runner)
         #   2 — drift detected vs current bundled template
         # We want the workflow to keep running through exit 2 so the
         # auto-rebake + issue steps can run; the final `Set job status`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ checklist.
 
 ## [Unreleased]
 
+- **Stale-binary guard for `capture-and-bake.mjs`** — a drift-watch runner whose installed CC is *older* than the CC that baked the current bundle re-captures the previous wire shape and reports it as drift, and the watcher's auto-rebake then ships a template **downgrade** (PR #632: runner at CC 2.1.197 against the 2.1.198-baked bundle reported the `afk-mode-2026-01-31` beta "removed"). The bake script now compares the captured CC version against the bundle's `_version` and treats an older binary as an infrastructure failure (exit 1, same class as CC-not-on-PATH) with an update-the-runner message — in both `--check` and real-bake modes — so a stale runner can never reach the ship gate as exit-2 drift. Deliberate downgrade bakes (an upstream CC release gets pulled) bypass with `--allow-older-cc`. Fail-open on missing/unparseable versions (`isOlderCCVersion`, unit-tested in `test/bake-drift-report.mjs`).
+
 ## [4.8.116] - 2026-07-02
 
 - **Template rebake** — re-captured `src/cc-template-data.json` after cc-drift-template-watch detected wire-fingerprint drift against a live CC capture. Bundled fallback template now matches the current CC wire shape.

--- a/docs/drift-monitor.md
+++ b/docs/drift-monitor.md
@@ -72,12 +72,22 @@ Exit codes:
 | Code | Meaning |
 |---|---|
 | 0   | Full match — wire shape AND `_version` label both current |
-| 1   | Infrastructure failure (CC not on PATH, capture timeout, scrub leak) |
+| 1   | Infrastructure failure (CC not on PATH, capture timeout, scrub leak, or installed CC **older** than the bundle's capture — stale runner) |
 | 2   | **Shape** drift vs current bundled template (needs a real re-bake) |
 | 3   | **Label-only** drift — wire shape matches but `_version` lags the live CC version |
 
 The workflow swallows exit 2 and 3 (continues to the next step) so the
 remediation steps can run; exit 1 fails the job.
+
+The stale-runner case matters because an older binary cannot observe forward
+drift — it re-captures the *previous* wire shape, which `--check` would report
+as exit-2 drift and the watcher would auto-rebake as a template **downgrade**.
+That exact sequence reached the ship gate on 2026-07-02 (PR #632: runner CC at
+2.1.197 against the 2.1.198-baked bundle reported the afk-mode beta
+"removed"). The guard compares the captured CC version against the bundle's
+`_version` and exits 1 with an update-the-runner message when the binary is
+older. A *deliberate* downgrade bake (an upstream CC release gets pulled and
+the bundle must go backward) bypasses it with `--allow-older-cc`.
 
 ### Exit 2 vs exit 3 — why the split, and why only one auto-merges
 

--- a/scripts/capture-and-bake.mjs
+++ b/scripts/capture-and-bake.mjs
@@ -11,6 +11,7 @@
  *   npm run build          # the script imports from dist/
  *   node scripts/capture-and-bake.mjs              # capture + scrub + write
  *   node scripts/capture-and-bake.mjs --check      # capture + diff; exit 2 on shape drift, 3 on label-only drift, 0 on full match
+ *   node scripts/capture-and-bake.mjs --allow-older-cc  # bypass the stale-binary guard (deliberate downgrade bake)
  *
  * The --check mode is non-destructive: it captures + scrubs but does not
  * write to disk. Useful from a scheduled cron (see docs/drift-monitor.md)
@@ -22,7 +23,11 @@
  * Exits:
  *   0 — capture succeeded; in default mode wrote OUT; in --check mode, full match
  *       (wire shape AND _version label both current)
- *   1 — infrastructure failure (CC not on PATH, capture timeout, scrub failure)
+ *   1 — infrastructure failure (CC not on PATH, capture timeout, scrub failure,
+ *       or installed CC OLDER than the bundle's capture — stale runner; an older
+ *       binary re-captures yesterday's wire shape and would report it as drift,
+ *       which reached the ship gate as a template downgrade in PR #632. Bypass
+ *       for a deliberate downgrade bake with --allow-older-cc)
  *   2 — --check mode only: wire-SHAPE drift vs current OUT (tools / system_prompt /
  *       beta / field order changed — needs a real re-bake; human-reviewed)
  *   3 — --check mode only: LABEL-only drift — wire shape matches but the bundled
@@ -41,13 +46,14 @@ import { fileURLToPath } from 'node:url';
 import { captureLiveTemplateAsync, findInstalledCC } from '../dist/live-fingerprint.js';
 import { scrubTemplate, findUserPathHits } from '../dist/scrub-template.js';
 import { PLATFORM_ONLY_TOOLS, INTERACTIVE_ONLY_TOOLS } from '../dist/cc-template.js';
-import { computeDrift, formatDriftReport, interpretDrift, formatDriftSummary, stripModelConditionalBetas } from './drift-report.mjs';
+import { computeDrift, formatDriftReport, interpretDrift, formatDriftSummary, stripModelConditionalBetas, isOlderCCVersion } from './drift-report.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, '..');
 const OUT = join(repoRoot, 'src/cc-template-data.json');
 
 const CHECK_MODE = process.argv.includes('--check');
+const ALLOW_OLDER_CC = process.argv.includes('--allow-older-cc');
 
 function log(msg) {
   console.error(`[bake] ${msg}`);
@@ -116,6 +122,27 @@ log(`  tools: ${captured.tools.length} → ${scrubbed.tools.length} (dropped ${d
 log(`  system_prompt: ${captured.system_prompt.length} → ${scrubbed.system_prompt.length} chars${strippedAutoMemory ? ' (# auto memory section removed)' : ''}`);
 
 const prev = JSON.parse(readFileSync(OUT, 'utf-8'));
+
+// ── Stale-binary guard ────────────────────────────────────────────────
+// An installed CC OLDER than the one that baked the current bundle cannot
+// observe forward drift — it re-captures the previous wire shape, and in
+// --check mode that reads as exit-2 "drift" whose auto-rebake is a template
+// DOWNGRADE (PR #632: runner at 2.1.197 against the 2.1.198 bundle reported
+// the afk-mode beta "removed"). Treat it as an infrastructure failure (exit 1,
+// same class as CC-not-on-PATH) so the watcher run fails red with a fix-the-
+// runner message instead of reaching the ship gate. A deliberate downgrade
+// bake (e.g. an upstream CC release gets pulled and the bundle must go
+// backward) bypasses with --allow-older-cc.
+if (isOlderCCVersion(captured._version, prev._version)) {
+  if (ALLOW_OLDER_CC) {
+    log(`warning: installed CC v${captured._version} is older than the bundle's capture (v${prev._version}) — proceeding because --allow-older-cc was passed.`);
+  } else {
+    log(`error: installed CC v${captured._version} is OLDER than the CC that baked the current bundle (v${prev._version}).`);
+    log('error: an older binary cannot observe forward drift; any "drift" it reports would re-bake the previous wire shape (a downgrade).');
+    log('error: update CC on this machine (npm i -g @anthropic-ai/claude-code@latest) and re-run, or pass --allow-older-cc for a deliberate downgrade bake.');
+    process.exit(1);
+  }
+}
 
 // Preserve other-platform tools from the previous bundle so the baked file
 // remains a union across maintainers' platforms. A bake on Linux must not

--- a/scripts/drift-report.mjs
+++ b/scripts/drift-report.mjs
@@ -37,6 +37,37 @@ export function stripModelConditionalBetas(beta) {
 }
 
 /**
+ * True when `live` is a strictly OLDER CC version than `bundled`. Used by the
+ * stale-binary guard in capture-and-bake.mjs: a runner whose installed CC is
+ * older than the CC that produced the current bundle re-captures yesterday's
+ * wire shape and reports it as "drift" — which reached the ship gate as a
+ * template DOWNGRADE on 2026-07-02 (PR #632: runner at 2.1.197 against a
+ * 2.1.198-baked bundle). An older binary cannot observe forward drift.
+ *
+ * Fails OPEN: if either version is missing or doesn't parse as dotted
+ * numerics (optional leading `v`), returns false — the guard must never
+ * block a legitimate bake over a weird version string; shape detection
+ * still applies downstream.
+ */
+export function isOlderCCVersion(live, bundled) {
+  const parse = (v) => {
+    if (typeof v !== 'string') return null;
+    const m = v.trim().replace(/^v/, '');
+    if (!/^\d+(\.\d+)*$/.test(m)) return null;
+    return m.split('.').map(Number);
+  };
+  const a = parse(live);
+  const b = parse(bundled);
+  if (!a || !b) return false;
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const x = a[i] ?? 0;
+    const y = b[i] ?? 0;
+    if (x !== y) return x < y;
+  }
+  return false;
+}
+
+/**
  * Collapse the environment-specific CC memory directory path to a placeholder so
  * a cross-OS bake doesn't read as system_prompt drift: the bundle may be baked on
  * one platform (e.g. Windows `C:\Users\user\.claude\projects\…\memory\`) while the

--- a/test/bake-drift-report.mjs
+++ b/test/bake-drift-report.mjs
@@ -3,7 +3,7 @@
 // test runner spawns each file via node:test which is fine for imports
 // too, but the existing pattern groups script-imports in serial).
 
-import { unifiedDiff, computeDrift, describeTool, formatDriftReport, interpretDrift, formatDriftSummary, MODEL_CONDITIONAL_BETAS, normalizeMemoryPath, stripModelConditionalBetas } from '../scripts/drift-report.mjs';
+import { unifiedDiff, computeDrift, describeTool, formatDriftReport, interpretDrift, formatDriftSummary, MODEL_CONDITIONAL_BETAS, normalizeMemoryPath, stripModelConditionalBetas, isOlderCCVersion } from '../scripts/drift-report.mjs';
 
 let pass = 0;
 let fail = 0;
@@ -411,6 +411,27 @@ header('39. bake-vs-check consistency — a re-baked base no longer drifts from 
   const baked = makeTemplate({ anthropic_beta: stripModelConditionalBetas(capture.anthropic_beta) });
   check('baked base omits context-1m', !baked.anthropic_beta.includes('context-1m'));
   check('no beta drift between baked base and the capture it came from', computeDrift(baked, capture).length === 0);
+}
+
+// ──────────────────────────────────────────────────────────────────────
+header('isOlderCCVersion — stale-binary guard (PR #632 regression)');
+{
+  // The PR #632 shape: runner binary one patch behind the bundle's capture.
+  check('2.1.197 is older than 2.1.198', isOlderCCVersion('2.1.197', '2.1.198') === true);
+  check('equal versions are not older', isOlderCCVersion('2.1.198', '2.1.198') === false);
+  check('newer patch is not older (legit forward rebake)', isOlderCCVersion('2.1.199', '2.1.198') === false);
+  check('newer minor is not older', isOlderCCVersion('2.2.0', '2.1.198') === false);
+  check('older minor is older despite bigger patch', isOlderCCVersion('2.1.198', '2.2.0') === true);
+  check('major beats all segments', isOlderCCVersion('3.0.0', '2.9.9') === false);
+  check('leading v tolerated', isOlderCCVersion('v2.1.197', '2.1.198') === true);
+  check('shorter live version pads with zeros (2.1 < 2.1.1)', isOlderCCVersion('2.1', '2.1.1') === true);
+  check('shorter bundled version pads with zeros (2.1.0 == 2.1)', isOlderCCVersion('2.1.0', '2.1') === false);
+  // Fail-open cases: the guard must never block on unparseable versions.
+  check('missing live version fails open', isOlderCCVersion(undefined, '2.1.198') === false);
+  check('missing bundled version fails open', isOlderCCVersion('2.1.198', undefined) === false);
+  check('non-numeric live version fails open', isOlderCCVersion('unknown', '2.1.198') === false);
+  check('prerelease-style suffix fails open', isOlderCCVersion('2.1.197-beta.1', '2.1.198') === false);
+  check('non-string fails open', isOlderCCVersion(2, '2.1.198') === false);
 }
 
 // ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes the false-drift hole PR #632 fell through.

## What happened

The `dario-drift` runner's `/usr/bin/claude` was at 2.1.197 while the bundle had been baked from 2.1.198 (#629). The watcher's capture on the older binary reproduced the *previous* wire shape, `--check` reported it as exit-2 drift, and the auto-rebake opened #632 — a template **downgrade** (`_version` 2.1.198 → 2.1.197, afk-mode beta "removed") that reached the human ship gate looking like legitimate remote-config drift. An older binary cannot observe forward drift; everything it reports is yesterday's shape.

(In that specific incident the drift turned out to be real *after* the runner was updated — but the 2.1.197-labeled bake was still wrong and had to be closed in favor of #634. With this guard, the stale run fails red instead, and the first rebake PR is the correct one.)

## What this does

- `scripts/capture-and-bake.mjs`: after reading the previous bundle, compares the captured CC version against the bundle's `_version`. Older binary → log a clear update-the-runner message and **exit 1** (infrastructure, same class as CC-not-on-PATH) in both `--check` and real-bake modes. The watcher workflow already fails the job on exit 1, so a stale runner now produces a red run instead of a rebake PR.
- `--allow-older-cc` flag: escape hatch for a *deliberate* downgrade bake (e.g. an upstream CC release gets pulled and the bundle must go backward). Logs a warning and proceeds.
- `isOlderCCVersion(live, bundled)` in `scripts/drift-report.mjs` (pure, exported): dotted-numeric compare, tolerates a leading `v`, **fails open** on missing/unparseable versions so the guard can never block a legitimate bake over a weird version string.
- Guard sits before the fable-variant capture, so a stale runner exits without the second CC spawn.
- Docs: exit-code table + a stale-runner section in `docs/drift-monitor.md`; exit-code comment in `cc-drift-template-watch.yml` (comment-only).
- CHANGELOG under `[Unreleased]` — no version bump; `scripts/` isn't in the npm `files` set, so this rides the next release.

## Tests

`test/bake-drift-report.mjs` + 14 cases (the #632 shape, equal/newer versions, segment-length padding, leading-`v`, and all fail-open paths): 102 pass, 0 fail locally. Both scripts pass `node --check`.
