### PR TITLE
fix(pool): pool is the sole token refresher — avert reuse-detection outage (v4.8.119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.119] - 2026-07-02
+
+- **Fix pool-mode dual token-refresh (availability, #641-audit)** — in pool mode two background loops still refreshed the single-account `credentials.json` — the presence heartbeat (every 5s via `getAccessToken`) and the 15-min refresh loop — in parallel with the pool refreshing `accounts/login.json`. After a `login`->pool migration those two stores share one Anthropic refresh-token lineage (`ensureLoginCredentialsInPool` copies the same tokens), so a refresh in the same window rotated the family out from under the other refresher and tripped Anthropic’s refresh-token **reuse-detection** — the shape of the 2026-06-23 fleet outage. The pool refresh loop is now the sole refresher when pool mode is active: the 15-min loop no-ops under a pool, and the presence heartbeat pulses with a token the pool already keeps fresh instead of refreshing `credentials.json`. Single-account mode is unchanged.
+
 ## [4.8.118] - 2026-07-02
 
 - **Accounts TUI reads the live pool, not local disk (#641)** — the Accounts tab loaded accounts by reading `~/.dario/accounts/` in the TUI process, which is separate from the proxy. In a containerized / admin (#599) / login-less-pool (#630) deployment the accounts live in the proxy's volume, so the tab showed "No accounts in the pool" while `GET /admin/accounts` (and the proxy) correctly saw several. It now sources the list from the running proxy's `GET /accounts` (the actual live pool, with util5h/util7d/status columns), falling back to the on-disk read only when the proxy is unreachable — flagged as stale — and shows a distinct message for single-account mode. Manual refresh (`r`) now actually refetches (driven from `onTick`; previously it just spun on "loading").

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.118",
+  "version": "4.8.119",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3401,7 +3401,16 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
     if (now - lastPresencePulse < 5000) return;
     lastPresencePulse = now;
     try {
-      const token = await getAccessToken();
+      // In pool mode the pool refresh loop (above) is the SOLE refresher of
+      // every account's token lineage. credentials.json shares its refresh-
+      // token family with accounts/login.json after a login->pool migration
+      // (ensureLoginCredentialsInPool), so refreshing credentials.json here
+      // via getAccessToken() races the pool refreshing login.json and trips
+      // Anthropic's refresh-token reuse-detection (the 2026-06-23 fleet
+      // outage, dario#641-audit). Pulse with a token the pool already keeps
+      // fresh; never refresh from this side in pool mode.
+      const token = pool ? (pool.all()[0]?.accessToken ?? '') : await getAccessToken();
+      if (!token) return;
       const presenceUrl = `${ANTHROPIC_API}/v1/code/sessions/${SESSION_ID}/client/presence`;
       await fetch(presenceUrl, {
         method: 'POST',
@@ -3419,6 +3428,11 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
 
   // Periodic token refresh (every 15 minutes)
   const refreshInterval = setInterval(async () => {
+    // Pool mode: the pool's own 15-min refresh loop (above) owns token refresh
+    // for every account. Refreshing credentials.json here too would double-
+    // refresh a shared token lineage (see the presence-loop note) -> reuse-
+    // detection. Skip; the pool is the sole refresher.
+    if (pool) return;
     try {
       const s = await getStatus();
       if (s.status === 'expiring' || s.status === 'expired') {


### PR DESCRIPTION
The HIGH finding from tonight's full audit — a latent availability bug matching the 2026-06-23 fleet outage. Ships as v4.8.119.

## The bug

In pool mode, `credentials.json` was still being refreshed by two background loops that run at the top level of `startProxy` (not gated by `if (!pool)`):
- the **presence heartbeat** — every 5s, calls `getAccessToken()` (refreshes `credentials.json` when near expiry), and
- the **15-min refresh loop** — `getStatus()` + `getAccessToken()`.

Meanwhile the pool's own refresh loop refreshes `accounts/login.json`. After a `login`→pool migration, `ensureLoginCredentialsInPool()` copies `credentials.json`'s access+refresh tokens into `accounts/login.json` verbatim, so **both stores share one Anthropic refresh-token lineage**. When both refreshers fire in the same expiry window, one rotates R0→R1 (Anthropic consumes R0) and the other then presents the now-consumed R0 → refresh-token **reuse-detection**, which can invalidate the whole token family. That is the exact mechanism of the 6/23 outage (a split credential refreshed from two sides).

Verified premise (not assumed): request-path token use in pool mode is `poolAccount.accessToken` (proxy.ts:1941), `getStatus()` is read-only, and the catalog's `getToken` is already pool-gated — so these two intervals were the only remaining `credentials.json` refreshers under a pool.

## The fix

Make the pool refresh loop the **sole** refresher when pool mode is active:
- The 15-min single-account refresh loop `if (pool) return;` — no-op under a pool.
- The presence heartbeat pulses with a token the pool already keeps fresh (`pool.all()[0]?.accessToken`) instead of calling `getAccessToken()`; if the pool is empty (admin bootstrap, 0 accounts) it simply skips the pulse.

Single-account mode (`!pool`) is byte-for-byte unchanged — both loops behave exactly as before.

## Testing

Full suite green (101/101). This change is startup-wiring inside `startProxy` (the intervals aren't dependency-injectable), so it's verified by build + inspection rather than a new unit test: after the change, grepping every `getAccessToken`/`getStatus`/`refreshTokens` call site in proxy.ts confirms no `credentials.json` refresher remains reachable in pool mode (1943 and the 3440 refresh are both `!pool`; 3412 presence is pool-token; 1223/1510 are read-only / pool-token). If you want belt-and-suspenders, the follow-up is to refactor `startProxy` to accept injectable timers so the loops can be asserted directly — happy to do that separately.
