### PR TITLE
harden: /health disclosure gate + admin-token warning (v4.8.120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.120] - 2026-07-02
+
+- **`/health` no longer leaks OAuth internals to untrusted callers (#642-audit)** — the public-vs-internal decision keyed on the presence of the client-suppliable `cf-ray` header and failed **open**: a direct non-tunnel caller (LAN, another container) simply omits `cf-ray` and received the full internal view (`oauth` status, token `expiresIn`, `refreshFailures`, and a raw upstream `lastRefreshError`). Now a new `shouldDiscloseHealthInternals` gate discloses internals only to trusted callers — authenticated (valid `DARIO_API_KEY`), or bare loopback that did not arrive via the Cloudflare tunnel — so the `cf-ray` signal can only ever *deny*, never grant. `lastRefreshError` is dropped from `/health` entirely (it can carry a raw upstream error string); it remains on the key-gated `/status`. Verified live: on a keyed proxy, an unauthenticated tunnel-shaped request to `/health` now returns `{"status":"ok"}` only.
+
+- **Warn when the admin API shares the inference key (#642-audit)** — with `DARIO_ADMIN=1` and no distinct `DARIO_ADMIN_TOKEN`, the admin token falls back to `DARIO_API_KEY`, so every client holding the (widely-embedded) proxy key can add/remove OAuth accounts. dario now logs a loud startup warning recommending a distinct `DARIO_ADMIN_TOKEN`. Non-breaking (the fallback still works).
+
 ## [4.8.119] - 2026-07-02
 
 - **Fix pool-mode dual token-refresh (availability, #641-audit)** — in pool mode two background loops still refreshed the single-account `credentials.json` — the presence heartbeat (every 5s via `getAccessToken`) and the 15-min refresh loop — in parallel with the pool refreshing `accounts/login.json`. After a `login`->pool migration those two stores share one Anthropic refresh-token lineage (`ensureLoginCredentialsInPool` copies the same tokens), so a refresh in the same window rotated the family out from under the other refresher and tripped Anthropic’s refresh-token **reuse-detection** — the shape of the 2026-06-23 fleet outage. The pool refresh loop is now the sole refresher when pool mode is active: the 15-min loop no-ops under a pool, and the presence heartbeat pulses with a token the pool already keeps fresh instead of refreshing `credentials.json`. Single-account mode is unchanged.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.119",
+  "version": "4.8.120",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/health-response.ts
+++ b/src/health-response.ts
@@ -111,7 +111,7 @@ export function derivePoolStatus(
 export function buildHealthResponse(
   s: HealthStatusLike,
   requestCount: number,
-  viaPublicTunnel: boolean,
+  includeInternal: boolean,
 ): HealthResponse {
   const dead =
     s.status === 'broken' ||
@@ -119,18 +119,47 @@ export function buildHealthResponse(
     (s.status === 'expired' && s.canRefresh === false);
   const httpStatus = dead ? 503 : 200;
   const liveness = { status: dead ? 'degraded' : 'ok' };
-  const body: Record<string, unknown> = viaPublicTunnel
-    ? liveness
-    : {
+  // Only trusted callers (authenticated, or bare loopback not via the CF
+  // tunnel — see shouldDiscloseHealthInternals) get the OAuth internals.
+  // Everyone else (LAN, public tunnel) gets the liveness verdict only; the
+  // HTTP status is identical either way so uptime checks still work. #642:
+  // this used to key on the presence of the client-suppliable `cf-ray`
+  // header, which failed OPEN — a direct non-tunnel caller omits it and got
+  // the full internal view. `lastRefreshError` is no longer exposed here at
+  // all (it can carry a raw upstream error string); it remains on the
+  // key-gated /status.
+  const body: Record<string, unknown> = includeInternal
+    ? {
         ...liveness,
-        // Version for internal callers only — an update-check signal (#640),
-        // withheld from the public-tunnel view alongside the OAuth internals.
         ...(s.version ? { version: s.version } : {}),
         oauth: s.status,
         expiresIn: s.expiresIn,
         requests: requestCount,
         ...(s.refreshFailures ? { refreshFailures: s.refreshFailures } : {}),
-        ...(s.lastRefreshError ? { lastRefreshError: s.lastRefreshError } : {}),
-      };
+      }
+    : liveness;
   return { httpStatus, body };
+}
+
+/**
+ * Decide whether a /health caller may see the OAuth internals (#642).
+ *
+ * /health is intentionally auth-free (docker healthchecks need it before a
+ * key is configured), so we cannot simply gate on the API key. Trust model:
+ *   - authenticated (valid DARIO_API_KEY)      -> internal (an internal caller)
+ *   - came via the Cloudflare tunnel (cf-ray)  -> public   (world-reachable)
+ *   - otherwise bare loopback                  -> internal (docker HC / doctor)
+ *   - otherwise (LAN, other container, WAN)    -> public
+ * The cf-ray check is now only ever used to DENY (force public), never to
+ * grant, so spoofing it cannot widen disclosure — the previous fail-open
+ * direction is closed.
+ */
+export function shouldDiscloseHealthInternals(opts: {
+  authenticated: boolean;
+  loopback: boolean;
+  viaCfRay: boolean;
+}): boolean {
+  if (opts.authenticated) return true;
+  if (opts.viaCfRay) return false;
+  return opts.loopback;
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -7,7 +7,7 @@ import { homedir } from 'node:os';
 import { setDefaultResultOrder } from 'node:dns';
 import { arch, platform } from 'node:process';
 import { getAccessToken, getStatus } from './oauth.js';
-import { buildHealthResponse, derivePoolStatus } from './health-response.js';
+import { buildHealthResponse, derivePoolStatus, shouldDiscloseHealthInternals } from './health-response.js';
 import { darioVersion } from './version.js';
 import { buildCCRequest, applyCcPromptCaching, parseEffortSuffix, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, CC_TEMPLATE, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
 import { stampCch } from './cch.js';
@@ -38,6 +38,17 @@ const DEFAULT_HOST = '127.0.0.1';
 function isLoopbackHost(host: string): boolean {
   if (host === '127.0.0.1' || host === '::1' || host === 'localhost') return true;
   return host.startsWith('127.');
+}
+
+// A socket peer address is loopback if it is 127.0.0.0/8 or ::1, including the
+// IPv4-mapped-IPv6 form Node reports on dual-stack sockets (`::ffff:127.0.0.1`).
+// Distinct from isLoopbackHost (which classifies a bind-address string): this
+// classifies an inbound connection's peer for the /health disclosure gate (#642).
+function isLoopbackAddr(addr: string | undefined): boolean {
+  if (!addr) return false;
+  if (addr === '::1') return true;
+  const v4 = addr.startsWith('::ffff:') ? addr.slice(7) : addr;
+  return v4 === '127.0.0.1' || v4.startsWith('127.');
 }
 
 // Concurrency control: see src/request-queue.ts for the bounded queue
@@ -1434,6 +1445,14 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
   const adminTokenBuf = adminToken ? Buffer.from(adminToken) : null;
   if (adminEnabled) {
     console.log(`[dario] admin API enabled at /admin/* (token ${adminTokenBuf ? 'configured' : 'MISSING — endpoints return 403 until DARIO_ADMIN_TOKEN is set'})`);
+    // Hardening (#642): the admin API adds/removes OAuth accounts. When it
+    // shares DARIO_API_KEY (which is embedded in every client config) instead
+    // of a distinct DARIO_ADMIN_TOKEN, every client that can proxy can also
+    // control the account pool. Non-fatal for back-compat, but warn loudly.
+    if (adminTokenBuf && !process.env.DARIO_ADMIN_TOKEN) {
+      console.warn('[dario] WARNING: admin API is using DARIO_API_KEY as its token (no DARIO_ADMIN_TOKEN set).');
+      console.warn('[dario] every client holding the proxy key can add/remove accounts. Set a distinct DARIO_ADMIN_TOKEN.');
+    }
   }
   // Admin rate limiting (#620). Two token buckets, created once per proxy:
   // failed auth (brute-force / broken-client throttle) and mutations. Global,
@@ -1541,13 +1560,19 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
     // react instead of cheerfully passing while every /v1/messages 401s.
     if (urlPath === '/health' || urlPath === '/') {
       const s = await currentStatus();
-      // Public requests arrive through the Cloudflare tunnel (the edge stamps
-      // `cf-ray`); they get only the liveness verdict, never the OAuth internals.
-      // See buildHealthResponse for the full rationale.
+      // Disclose OAuth internals only to trusted callers (#642). This used to
+      // key on the presence of the client-suppliable `cf-ray` header and failed
+      // OPEN — a direct non-tunnel caller omits it and got the full internal
+      // view. Now: authenticated, OR bare loopback that did not arrive via CF.
+      const includeInternal = shouldDiscloseHealthInternals({
+        authenticated: authenticateRequest(req.headers, apiKeyBuf),
+        loopback: isLoopbackAddr(req.socket?.remoteAddress),
+        viaCfRay: req.headers['cf-ray'] !== undefined,
+      });
       const { httpStatus, body } = buildHealthResponse(
         { ...s, version: darioVersion() },
         requestCount,
-        req.headers['cf-ray'] !== undefined,
+        includeInternal,
       );
       res.writeHead(httpStatus, JSON_HEADERS);
       res.end(JSON.stringify(body));

--- a/test/health-response.mjs
+++ b/test/health-response.mjs
@@ -4,7 +4,7 @@
 // ONLY the liveness verdict; internal loopback callers get full OAuth detail.
 // The HTTP status code is identical for both so external uptime checks still work.
 
-import { buildHealthResponse, derivePoolStatus } from '../dist/health-response.js';
+import { buildHealthResponse, derivePoolStatus, shouldDiscloseHealthInternals } from '../dist/health-response.js';
 
 let pass = 0, fail = 0;
 function check(name, cond) {
@@ -16,9 +16,12 @@ function header(n) { console.log(`\n=== ${n} ===`); }
 const healthy = { status: 'valid', expiresIn: '4h 57m', canRefresh: true };
 const dead = { status: 'broken', expiresIn: '0s', canRefresh: false };
 
-header('public (via tunnel) — minimal, no OAuth leak');
+// NOTE: buildHealthResponse's 3rd arg is now `includeInternal` (#642):
+//   true  -> full detail (trusted caller)   false -> minimal liveness (public).
+// The trust DECISION lives in shouldDiscloseHealthInternals, tested below.
+header('minimal (untrusted) — liveness only, no OAuth leak');
 {
-  const { httpStatus, body } = buildHealthResponse(healthy, 167, true);
+  const { httpStatus, body } = buildHealthResponse(healthy, 167, false);
   check('http 200 when healthy', httpStatus === 200);
   check('status ok', body.status === 'ok');
   check('NO oauth field', !('oauth' in body));
@@ -27,9 +30,9 @@ header('public (via tunnel) — minimal, no OAuth leak');
   check('exactly one key (status only)', Object.keys(body).length === 1);
 }
 
-header('internal (no cf-ray) — full detail');
+header('internal (trusted) — full detail');
 {
-  const { httpStatus, body } = buildHealthResponse(healthy, 167, false);
+  const { httpStatus, body } = buildHealthResponse(healthy, 167, true);
   check('http 200', httpStatus === 200);
   check('oauth present', body.oauth === 'valid');
   check('expiresIn present', body.expiresIn === '4h 57m');
@@ -38,8 +41,8 @@ header('internal (no cf-ray) — full detail');
 
 header('dead OAuth — 503 + degraded, both surfaces');
 {
-  const pub = buildHealthResponse(dead, 5, true);
-  const int = buildHealthResponse(dead, 5, false);
+  const pub = buildHealthResponse(dead, 5, false);
+  const int = buildHealthResponse(dead, 5, true);
   check('public 503', pub.httpStatus === 503);
   check('public degraded', pub.body.status === 'degraded');
   check('public still leaks nothing', !('oauth' in pub.body));
@@ -47,15 +50,14 @@ header('dead OAuth — 503 + degraded, both surfaces');
   check('internal degraded + oauth=broken', int.body.status === 'degraded' && int.body.oauth === 'broken');
 }
 
-header('refresh error fields — internal only, never public');
+header('refresh error fields — lastRefreshError never on /health (#642), refreshFailures internal-only');
 {
   const s = { status: 'expired', canRefresh: true, expiresIn: '0s', refreshFailures: 3, lastRefreshError: 'token endpoint 401' };
-  const pub = buildHealthResponse(s, 1, true);
-  const int = buildHealthResponse(s, 1, false);
+  const pub = buildHealthResponse(s, 1, false);
+  const int = buildHealthResponse(s, 1, true);
   check('public hides refreshFailures', !('refreshFailures' in pub.body));
-  check('public hides lastRefreshError', !('lastRefreshError' in pub.body));
+  check('lastRefreshError never on /health, even internal (#642)', !('lastRefreshError' in int.body) && !('lastRefreshError' in pub.body));
   check('internal shows refreshFailures', int.body.refreshFailures === 3);
-  check('internal shows lastRefreshError', int.body.lastRefreshError === 'token endpoint 401');
 }
 
 // ── version field — internal only (#640) ─────────────────────────────────
@@ -63,12 +65,25 @@ header('refresh error fields — internal only, never public');
 header('buildHealthResponse — version on internal, hidden from public');
 {
   const withVer = { status: 'valid', expiresIn: '4h', canRefresh: true, version: '4.8.118' };
-  const int = buildHealthResponse(withVer, 1, false);
+  const int = buildHealthResponse(withVer, 1, true);
   check('internal /health includes version', int.body.version === '4.8.118');
-  const pub = buildHealthResponse(withVer, 1, true);
+  const pub = buildHealthResponse(withVer, 1, false);
   check('public /health hides version (like OAuth internals)', !('version' in pub.body));
-  const noVer = buildHealthResponse({ status: 'valid', canRefresh: true }, 0, false);
+  const noVer = buildHealthResponse({ status: 'valid', canRefresh: true }, 0, true);
   check('version omitted when not supplied', !('version' in noVer.body));
+}
+
+// ── shouldDiscloseHealthInternals — the /health trust gate (#642) ─────────
+
+header('shouldDiscloseHealthInternals — closed to the cf-ray fail-open');
+{
+  const D = shouldDiscloseHealthInternals;
+  check('authenticated caller -> internal', D({ authenticated: true, loopback: false, viaCfRay: false }) === true);
+  check('authenticated wins even via CF', D({ authenticated: true, loopback: false, viaCfRay: true }) === true);
+  check('bare loopback (docker HC / doctor) -> internal', D({ authenticated: false, loopback: true, viaCfRay: false }) === true);
+  check('loopback but via CF tunnel -> public (sidecar case)', D({ authenticated: false, loopback: true, viaCfRay: true }) === false);
+  check('THE #642 BUG: non-loopback, no cf-ray, unauthed -> public (was fail-open)', D({ authenticated: false, loopback: false, viaCfRay: false }) === false);
+  check('public tunnel, unauthed -> public', D({ authenticated: false, loopback: false, viaCfRay: true }) === false);
 }
 
 // ── derivePoolStatus — pool-aware /status + /health (#636) ────────────────


### PR DESCRIPTION
The exposure-model hardening from tonight's audit. Ships as v4.8.120. **Scope changed after verification: #2 was dropped as a false positive** (details below), so this is #3 + #4.

## #4 — `/health` no longer fails open (the real fix here)

The public-vs-internal disclosure decision keyed on the presence of the client-suppliable `cf-ray` header and failed **open**: a direct non-tunnel caller (LAN host, another container) omits `cf-ray` and got the full internal view — `oauth` status, token `expiresIn`, `refreshFailures`, and a raw upstream `lastRefreshError`. `/health` is intentionally auth-free (docker healthchecks need it), so it can't just be key-gated.

New pure `shouldDiscloseHealthInternals({authenticated, loopback, viaCfRay})` discloses internals only to trusted callers — authenticated (valid key), or bare loopback that did *not* arrive via the CF tunnel. `cf-ray` can now only ever **deny** (force public), never grant, so spoofing it can't widen disclosure. `lastRefreshError` is dropped from `/health` entirely (it stays on the key-gated `/status`).

**Verified live** on a keyed proxy:
- loopback, no cf-ray → full detail (docker HC / `dario doctor`)
- loopback + `cf-ray` (tunnel-shaped), no key → `{"status":"ok"}` — leak closed
- correct key + `cf-ray` → full (authenticated wins)

## #3 — warn when the admin API shares the inference key

With `DARIO_ADMIN=1` and no distinct `DARIO_ADMIN_TOKEN`, the admin token falls back to `DARIO_API_KEY`, so every client holding the (widely-embedded) proxy key can add/remove OAuth accounts. Now a loud startup warning recommends a distinct token. Non-breaking — the fallback still works.

## #2 — dropped: already mitigated (audit false positive)

The audit (two agents) reported that a non-loopback bind with no key fails open with only a warning. **This is wrong** — I smoke-tested it and dario already **refuses to start** in that case via a complete guard in `cli.ts` (`dario#74`), with a `--unsafe-no-auth` override:

```
[dario] Refusing to start proxy: --host=0.0.0.0 is non-loopback but DARIO_API_KEY is not set.
...
[dario] Override (not recommended): pass --unsafe-no-auth ...
```

Both agents focused on `startProxy`/`authenticateRequest` and missed the guard in the `proxy` CLI handler (which is what the Docker image runs). I added, then removed, a duplicate guard once the smoke test surfaced the existing one. Net: no code change for #2.

## Tests

- `test/health-response.mjs`: rewrote the disclosure suite for the flipped `includeInternal` semantics, asserted `lastRefreshError` is never on `/health`, and added 6 `shouldDiscloseHealthInternals` cases — including the explicit "non-loopback + no cf-ray + unauthed → public" (the closed #642 fail-open). 49 checks, all green.
- Full suite 101/101.
- Live smoke as above.

No doc changes needed — the `/health` status *values* (`ok`/`degraded`) documented in `docs/docker.md` / `docs/admin-api.md` are unchanged; only the disclosure gate and the `lastRefreshError` field moved.
