### PR TITLE
harden(stream): concurrent-stream isolation + backpressure (v4.8.121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.121] - 2026-07-02
+
+- **Fix cross-contamination between concurrent OpenAI streaming responses (#642-audit)** — the Anthropic->OpenAI SSE translator kept tool-call index/id in module-global state, so two concurrent `/v1/chat/completions` streams that both contained `tool_use` blocks interleaved through one shared counter and emitted malformed OpenAI `tool_calls` deltas to each client. The translator is now a per-request factory (`createOpenAIStreamTranslator`) with isolated state, mirroring the streaming reverse-mapper. Unit-tested by interleaving two translators.
+
+- **Honor downstream backpressure on the SSE relay (#642-audit)** — the relay called `res.write()` and ignored its return value, so a slow client reading a fast upstream let chunks accumulate unbounded in the Node write buffer (a memory-growth vector). The read loop now pauses on a full client buffer until it drains (resolving on `close` too, so a vanished client cannot wedge the loop).
+
+- **Release the upstream body reader on an abnormal mid-stream error** — a bare upstream socket reset mid-SSE previously left the undici response reader un-cancelled until GC; the stream error path now aborts the upstream controller so the socket is reclaimed promptly.
+
 ## [4.8.120] - 2026-07-02
 
 - **`/health` no longer leaks OAuth internals to untrusted callers (#642-audit)** — the public-vs-internal decision keyed on the presence of the client-suppliable `cf-ray` header and failed **open**: a direct non-tunnel caller (LAN, another container) simply omits `cf-ray` and received the full internal view (`oauth` status, token `expiresIn`, `refreshFailures`, and a raw upstream `lastRefreshError`). Now a new `shouldDiscloseHealthInternals` gate discloses internals only to trusted callers — authenticated (valid `DARIO_API_KEY`), or bare loopback that did not arrive via the Cloudflare tunnel — so the `cf-ray` signal can only ever *deny*, never grant. `lastRefreshError` is dropped from `/health` entirely (it can carry a raw upstream error string); it remains on the key-gated `/status`. Verified live: on a keyed proxy, an unauthenticated tunnel-shaped request to `/health` now returns `{"status":"ok"}` only.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.120",
+  "version": "4.8.121",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -549,50 +549,56 @@ function anthropicToOpenai(body: Record<string, unknown>): Record<string, unknow
   };
 }
 
-/** Translate Anthropic SSE → OpenAI SSE. */
-// Track tool call state across stream chunks
-let _streamToolIndex = 0;
-let _streamToolId = '';
+/**
+ * Translate Anthropic SSE → OpenAI SSE. Returns a stateful per-CALL closure so
+ * concurrent /v1/chat/completions streams don't share tool-call index/id state
+ * (#642-audit: the previous module-global counters cross-contaminated
+ * interleaved streams and emitted malformed tool_calls deltas). One translator
+ * per request, mirroring createStreamingReverseMapper.
+ */
+export function createOpenAIStreamTranslator(): (line: string) => string | null {
+  let toolIndex = 0;
+  let toolId = '';
+  return function translateStreamChunk(line: string): string | null {
+    if (!line.startsWith('data: ')) return null;
+    const json = line.slice(6).trim();
+    if (json === '[DONE]') return 'data: [DONE]\n\n';
+    try {
+      const e = JSON.parse(json) as Record<string, unknown>;
+      const ts = Math.floor(Date.now() / 1000);
 
-function translateStreamChunk(line: string): string | null {
-  if (!line.startsWith('data: ')) return null;
-  const json = line.slice(6).trim();
-  if (json === '[DONE]') return 'data: [DONE]\n\n';
-  try {
-    const e = JSON.parse(json) as Record<string, unknown>;
-    const ts = Math.floor(Date.now() / 1000);
-
-    if (e.type === 'content_block_start') {
-      const block = e.content_block as { type: string; id?: string; name?: string } | undefined;
-      if (block?.type === 'tool_use' && block.name) {
-        _streamToolId = block.id ?? `call_${_streamToolIndex}`;
-        return `data: ${JSON.stringify({ id: 'chatcmpl-dario', object: 'chat.completion.chunk', created: ts, model: 'claude', choices: [{ index: 0, delta: { tool_calls: [{ index: _streamToolIndex, id: _streamToolId, type: 'function', function: { name: block.name, arguments: '' } }] }, finish_reason: null }] })}\n\n`;
+      if (e.type === 'content_block_start') {
+        const block = e.content_block as { type: string; id?: string; name?: string } | undefined;
+        if (block?.type === 'tool_use' && block.name) {
+          toolId = block.id ?? `call_${toolIndex}`;
+          return `data: ${JSON.stringify({ id: 'chatcmpl-dario', object: 'chat.completion.chunk', created: ts, model: 'claude', choices: [{ index: 0, delta: { tool_calls: [{ index: toolIndex, id: toolId, type: 'function', function: { name: block.name, arguments: '' } }] }, finish_reason: null }] })}\n\n`;
+        }
       }
-    }
 
-    if (e.type === 'content_block_delta') {
-      const d = e.delta as { type: string; text?: string; partial_json?: string } | undefined;
-      if (d?.type === 'text_delta' && d.text)
-        return `data: ${JSON.stringify({ id: 'chatcmpl-dario', object: 'chat.completion.chunk', created: ts, model: 'claude', choices: [{ index: 0, delta: { content: d.text }, finish_reason: null }] })}\n\n`;
-      if (d?.type === 'input_json_delta' && d.partial_json)
-        return `data: ${JSON.stringify({ id: 'chatcmpl-dario', object: 'chat.completion.chunk', created: ts, model: 'claude', choices: [{ index: 0, delta: { tool_calls: [{ index: _streamToolIndex, function: { arguments: d.partial_json } }] }, finish_reason: null }] })}\n\n`;
-    }
-
-    if (e.type === 'content_block_stop') {
-      if (_streamToolId) {
-        _streamToolIndex++;
-        _streamToolId = '';
+      if (e.type === 'content_block_delta') {
+        const d = e.delta as { type: string; text?: string; partial_json?: string } | undefined;
+        if (d?.type === 'text_delta' && d.text)
+          return `data: ${JSON.stringify({ id: 'chatcmpl-dario', object: 'chat.completion.chunk', created: ts, model: 'claude', choices: [{ index: 0, delta: { content: d.text }, finish_reason: null }] })}\n\n`;
+        if (d?.type === 'input_json_delta' && d.partial_json)
+          return `data: ${JSON.stringify({ id: 'chatcmpl-dario', object: 'chat.completion.chunk', created: ts, model: 'claude', choices: [{ index: 0, delta: { tool_calls: [{ index: toolIndex, function: { arguments: d.partial_json } }] }, finish_reason: null }] })}\n\n`;
       }
-      return null;
-    }
 
-    if (e.type === 'message_stop') {
-      _streamToolIndex = 0;
-      _streamToolId = '';
-      return `data: ${JSON.stringify({ id: 'chatcmpl-dario', object: 'chat.completion.chunk', created: ts, model: 'claude', choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] })}\n\ndata: [DONE]\n\n`;
-    }
-  } catch {}
-  return null;
+      if (e.type === 'content_block_stop') {
+        if (toolId) {
+          toolIndex++;
+          toolId = '';
+        }
+        return null;
+      }
+
+      if (e.type === 'message_stop') {
+        toolIndex = 0;
+        toolId = '';
+        return `data: ${JSON.stringify({ id: 'chatcmpl-dario', object: 'chat.completion.chunk', created: ts, model: 'claude', choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] })}\n\ndata: [DONE]\n\n`;
+      }
+    } catch {}
+    return null;
+  };
 }
 
 // Baked /v1/models payload — what the proxy advertises before (or without)
@@ -3023,13 +3029,27 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
         const streamMapper = ccToolMap && !isOpenAI
           ? createStreamingReverseMapper(ccToolMap, reqCtx)
           : null;
+        // Per-request OpenAI SSE translator — isolated tool-call state so
+        // concurrent /v1/chat/completions streams don't cross-contaminate (#642-audit).
+        const openaiTranslate = isOpenAI ? createOpenAIStreamTranslator() : null;
         // Gated writer — a no-op once the downstream client has gone away
         // in drain-on-close mode. The read loop keeps consuming so the
         // upstream sees a full-length read; writes to a closed socket are
         // suppressed to avoid EPIPE/warnings and pointless work.
+        // Honor downstream backpressure (#642-audit): when res.write() returns
+        // false the client's socket buffer is full, so pause the read loop until
+        // it drains instead of buffering the whole (fast) upstream in memory.
+        let needsDrain = false;
         const writeToClient = (chunk: Uint8Array | string) => {
-          if (!clientDisconnected) res.write(chunk);
+          if (clientDisconnected) return;
+          if (res.write(chunk) === false) needsDrain = true;
         };
+        // Resolves on 'close' too, so a vanished client can't wedge the loop.
+        const waitForDrain = () => new Promise<void>((resolve) => {
+          const done = () => { res.off('drain', done); res.off('close', done); resolve(); };
+          res.once('drain', done);
+          res.once('close', done);
+        });
         try {
           let buffer = '';
           const MAX_LINE_LENGTH = 1_000_000; // 1MB max per SSE line
@@ -3098,7 +3118,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
               const lines = buffer.split('\n');
               buffer = lines.pop() ?? '';
               for (const line of lines) {
-                const translated = translateStreamChunk(line);
+                const translated = openaiTranslate!(line);
                 if (translated) writeToClient(translated);
               }
             } else if (streamMapper) {
@@ -3107,10 +3127,16 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
             } else {
               writeToClient(value);
             }
+            // Backpressure (#642-audit): if the last writes filled the client
+            // buffer, pause reading upstream until it drains.
+            if (needsDrain && !clientDisconnected) {
+              needsDrain = false;
+              await waitForDrain();
+            }
           }
           // Flush remaining buffer
           if (isOpenAI && buffer.trim()) {
-            const translated = translateStreamChunk(buffer);
+            const translated = openaiTranslate!(buffer);
             if (translated) writeToClient(translated);
           }
           if (streamMapper) {
@@ -3119,6 +3145,10 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           }
         } catch (err) {
           if (verbose) console.error('[dario] Stream error:', sanitizeError(err));
+          // Tear down the upstream body reader deterministically on an abnormal
+          // mid-stream error (e.g. a bare upstream socket reset) so the undici
+          // socket is released now, not at GC (#642-audit). No-op if aborted.
+          if (!upstreamAbort.signal.aborted) upstreamAbort.abort();
         }
         res.end();
         // Stamp the response-completion timestamp + token count so the

--- a/test/openai-stream-translator.mjs
+++ b/test/openai-stream-translator.mjs
@@ -1,0 +1,64 @@
+// createOpenAIStreamTranslator — per-request tool-call state isolation (#642-audit).
+//
+// The translator used to keep tool-call index/id in module globals, so two
+// concurrent /v1/chat/completions streams with tool_use blocks cross-
+// contaminated each other's counters and emitted malformed OpenAI tool_calls
+// deltas. These tests interleave two independent translators and assert their
+// state never bleeds.
+
+import { createOpenAIStreamTranslator } from '../dist/proxy.js';
+
+let pass = 0, fail = 0;
+function check(name, cond) {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else      { console.log(`  FAIL ${name}`); fail++; }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+const D = (obj) => `data: ${JSON.stringify(obj)}`;
+const start = (id, name) => D({ type: 'content_block_start', content_block: { type: 'tool_use', id, name } });
+const stop = () => D({ type: 'content_block_stop' });
+// pull the emitted tool_calls[0].index out of a translated OpenAI SSE frame
+function toolIndex(frame) {
+  const m = frame && frame.match(/"index":(\d+),"id"/);
+  return m ? Number(m[1]) : (frame && frame.match(/"tool_calls":\[\{"index":(\d+)/) ? Number(RegExp.$1) : null);
+}
+
+header('single translator advances tool index across blocks');
+{
+  const t = createOpenAIStreamTranslator();
+  const f0 = t(start('call_a', 'foo'));
+  check('first tool_use -> index 0', toolIndex(f0) === 0);
+  t(stop());
+  const f1 = t(start('call_b', 'bar'));
+  check('second tool_use -> index 1', toolIndex(f1) === 1);
+}
+
+header('two concurrent translators keep independent state (the #642 fix)');
+{
+  const a = createOpenAIStreamTranslator();
+  const b = createOpenAIStreamTranslator();
+  // Interleave: A starts a tool, B starts a tool, A closes + starts a 2nd,
+  // B closes + starts a 2nd. If state were shared, indices would collide.
+  const a0 = a(start('a0', 'toolA'));
+  const b0 = b(start('b0', 'toolB'));
+  check('A first tool -> index 0', toolIndex(a0) === 0);
+  check('B first tool -> index 0 (NOT bumped by A)', toolIndex(b0) === 0);
+  a(stop());
+  const a1 = a(start('a1', 'toolA2'));
+  check('A second tool -> index 1', toolIndex(a1) === 1);
+  b(stop());
+  const b1 = b(start('b1', 'toolB2'));
+  check('B second tool -> index 1 (independent of A)', toolIndex(b1) === 1);
+}
+
+header('non-data lines and [DONE] handled');
+{
+  const t = createOpenAIStreamTranslator();
+  check('non-data line -> null', t('event: ping') === null);
+  check('[DONE] passthrough', t('data: [DONE]') === 'data: [DONE]\n\n');
+  check('text_delta -> content frame', (t(D({ type: 'content_block_delta', delta: { type: 'text_delta', text: 'hi' } })) || '').includes('"content":"hi"'));
+}
+
+console.log(`\nopenai-stream-translator: ${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
PR A of the audit follow-through: streaming robustness. Ships as v4.8.121. Three findings, all in the SSE relay path.

## #5 — concurrent OpenAI streams cross-contaminate (correctness)

`translateStreamChunk` kept tool-call `index`/`id` in **module-global** state (`_streamToolIndex`/`_streamToolId`). Two concurrent `/v1/chat/completions` responses that both contain `tool_use` blocks interleave through that one shared counter, so each client gets malformed OpenAI `tool_calls` deltas (wrong indices, leaked ids). Fixed by making it a per-request factory `createOpenAIStreamTranslator()` with closure-local state — the same pattern `createStreamingReverseMapper` already uses. One translator per request; module globals removed.

## #7 — SSE relay ignored backpressure (memory)

The relay called `res.write(chunk)` and discarded the return value; the read loop pulled from upstream as fast as it arrived and never awaited `'drain'`. A slow client on a fast/long stream let chunks pile up unbounded in the Node write buffer. Now `writeToClient` records when `res.write()` returns false and the read loop pauses (`await waitForDrain()`) before pulling more — propagating backpressure to upstream. The drain waiter resolves on `'close'` too, so a vanished client can't wedge the loop.

## reader teardown (resource nit)

On an abnormal mid-stream error (bare upstream socket reset), the stream `catch` now aborts the upstream controller if not already aborted, so the undici body reader/socket is released promptly instead of at GC.

## Tests

- `test/openai-stream-translator.mjs` (new, 9 checks): single-translator index advance, **two interleaved translators keep independent state** (the #5 repro), and non-data/`[DONE]`/text-delta handling.
- Full suite 102/102.

The backpressure + reader-teardown changes are in the live streaming loop (not unit-isolable without a slow-socket harness); they're verified by build + inspection and covered end-to-end by the existing `npm run e2e`. The #5 correctness fix — the one with a real client-visible failure — has direct unit coverage.
