### PR TITLE
perf(hotpath): single body parse + memoized recomputes (v4.8.122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.122] - 2026-07-02
+
+- **Parse the request body once per request (#642-audit)** — the inbound JSON body was `JSON.parse`d twice on identical bytes: once for provider-prefix/effort detection and again for the template-build transform. The template build now reuses the object from the first parse (mutations keep it in sync with `body`; it falls back to a fresh parse when the earlier block did not run), removing a full parse + `Buffer.toString()` per request on the hot path. Behavior is unchanged — verified live with plain and `claude:`-prefix requests.
+
+- **Memoize two per-request recomputations** — `suspendedFamilies()` (called per request by the suspended-model guard) rebuilt a Set from `process.env` every call; it is now memoized by the raw env value, so the common empty case allocates once and a runtime env change still re-parses. The orchestration-tag pattern set under `--preserve-orchestration-tags` was recompiled (~28 regexes) per request; it is now memoized by the (stable) preserve-tag Set reference. Both are no-ops on the default paths.
+
 ## [4.8.121] - 2026-07-02
 
 - **Fix cross-contamination between concurrent OpenAI streaming responses (#642-audit)** — the Anthropic->OpenAI SSE translator kept tool-call index/id in module-global state, so two concurrent `/v1/chat/completions` streams that both contained `tool_use` blocks interleaved through one shared counter and emitted malformed OpenAI `tool_calls` deltas to each client. The translator is now a per-request factory (`createOpenAIStreamTranslator`) with isolated state, mirroring the streaming reverse-mapper. Unit-tested by interleaving two translators.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.121",
+  "version": "4.8.122",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -72,16 +72,25 @@ export const BAKED_BASE_MODELS: readonly string[] = [
  */
 const DEFAULT_SUSPENDED_MODELS = '';
 
-/** The set of suspended families, resolved from env at call time. */
+// Memoized by the raw env value (#642-audit): isSuspendedModel runs per request,
+// and this rebuilt a Set from process.env every call. Keyed on the raw string so
+// a runtime change to DARIO_SUSPENDED_MODELS still re-parses; the common (empty)
+// value allocates the Set once.
+let _suspendedCache: { raw: string; set: Set<string> } | null = null;
+
+/** The set of suspended families, resolved from env (memoized by raw value). */
 export function suspendedFamilies(): Set<string> {
   const raw = process.env.DARIO_SUSPENDED_MODELS ?? DEFAULT_SUSPENDED_MODELS;
-  return new Set(
+  if (_suspendedCache && _suspendedCache.raw === raw) return _suspendedCache.set;
+  const set = new Set(
     raw
       .split(',')
       .map((s) => s.trim())
       .filter((s) => s.length > 0)
       .map((s) => modelFamily(s) ?? s.toLowerCase()),
   );
+  _suspendedCache = { raw, set };
+  return set;
 }
 
 /** True when `model` (any spelling) belongs to a suspended family. */

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -465,6 +465,21 @@ function sanitizeContent(text: string, patterns: RegExp[]): string {
   return result.replace(/\n{3,}/g, '\n\n').trim();
 }
 
+// Memoize the compiled preserve-tag pattern set by Set reference (#642-audit):
+// opts.preserveOrchestrationTags is a single Set instance passed on every
+// request, so recompile the ~28 patterns once instead of per request. The
+// default (no-preserve) path already uses the precompiled constant.
+let _orchPreserveKey: Set<string> | undefined;
+let _orchPatterns: RegExp[] | undefined;
+function orchestrationPatternsFor(preserveTags?: Set<string>): RegExp[] {
+  if (preserveTags === undefined) return ORCHESTRATION_PATTERNS_DEFAULT;
+  if (preserveTags !== _orchPreserveKey) {
+    _orchPreserveKey = preserveTags;
+    _orchPatterns = buildOrchestrationPatterns(preserveTags);
+  }
+  return _orchPatterns!;
+}
+
 /**
  * Strip orchestration tags from all messages in a request body.
  *
@@ -474,7 +489,7 @@ function sanitizeContent(text: string, patterns: RegExp[]): string {
 export function sanitizeMessages(body: Record<string, unknown>, preserveTags?: Set<string>): void {
   const messages = body.messages as Array<{ role: string; content: unknown }> | undefined;
   if (!messages) return;
-  const patterns = preserveTags === undefined ? ORCHESTRATION_PATTERNS_DEFAULT : buildOrchestrationPatterns(preserveTags);
+  const patterns = orchestrationPatternsFor(preserveTags);
   for (const msg of messages) {
     if (typeof msg.content === 'string') {
       msg.content = sanitizeContent(msg.content, patterns);
@@ -2012,9 +2027,15 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
       // recognizes through its own Anthropic gateway, bypassing localhost).
       let forcedProvider: 'openai' | 'claude' | null = cliProviderOverride;
       let requestEffort: EffortValue | undefined; // dario#419 — per-request effort parsed from a model-name suffix (model:high / model-high)
+      // Parsed body, shared between the provider-prefix detection below and the
+      // template-build block further down so the same bytes are not JSON.parsed
+      // twice per request (#642-audit). Mutations in the prefix block re-serialize
+      // `body` FROM this object, so it always represents the current body.
+      let parsedBody: Record<string, unknown> | null = null;
       if (body.length > 0) {
         try {
           const parsed = JSON.parse(body.toString()) as Record<string, unknown>;
+          parsedBody = parsed;
           const rawModel = (parsed.model as string | undefined) ?? '';
           const prefix = parseProviderPrefix(rawModel);
           if (prefix) {
@@ -2117,7 +2138,11 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
       } : undefined;
       if (body.length > 0) {
         try {
-          const parsed = JSON.parse(body.toString()) as Record<string, unknown>;
+          // Reuse the object parsed for provider-prefix detection above — the same
+          // bytes, so re-parsing is wasted work on large bodies (#642-audit). Falls
+          // back to a fresh parse when the earlier block didn't run (e.g. the body
+          // was not JSON, or an OpenAI-backend reroute skipped it).
+          const parsed = parsedBody ?? (JSON.parse(body.toString()) as Record<string, unknown>);
           // Strip orchestration tags from messages (Aider, Cursor, etc.)
           sanitizeMessages(parsed, opts.preserveOrchestrationTags);
           const result = isOpenAI ? openaiToAnthropic(parsed, modelOverride) : (modelOverride ? { ...parsed, model: modelOverride } : parsed);

--- a/test/model-catalog.mjs
+++ b/test/model-catalog.mjs
@@ -322,5 +322,22 @@ console.log('  suspended models — none by default (Fable 5 returned globally 2
   else process.env.DARIO_SUSPENDED_MODELS = ORIG;
 }
 
+// suspendedFamilies memoization (#642-audit): same env value returns the cached
+// Set (no per-call rebuild); a changed env value re-parses.
+{
+  const ORIG = process.env.DARIO_SUSPENDED_MODELS;
+  process.env.DARIO_SUSPENDED_MODELS = 'fable';
+  const a = suspendedFamilies();
+  const b = suspendedFamilies();
+  check('same env value → same Set reference (memoized)', a === b);
+  process.env.DARIO_SUSPENDED_MODELS = 'opus';
+  const cSet = suspendedFamilies();
+  check('changed env value → re-parsed (new Set)', cSet !== a && cSet.has('opus'));
+  process.env.DARIO_SUSPENDED_MODELS = '';
+  check('cleared env → empty set', suspendedFamilies().size === 0);
+  if (ORIG === undefined) delete process.env.DARIO_SUSPENDED_MODELS;
+  else process.env.DARIO_SUSPENDED_MODELS = ORIG;
+}
+
 _resetModelCatalogForTest();
 console.log(`✅ model-catalog: ${passed} assertions passed`);


### PR DESCRIPTION
PR B of the audit follow-through: request hot-path perf. Ships as v4.8.122.

## #6 — body parsed once instead of twice

The inbound JSON body was `JSON.parse`d twice on the same bytes every request: once for provider-prefix/effort detection, then again for the template-build transform (plus a `Buffer.toString()` each). On large conversation bodies that's the dominant pre-forward CPU cost. The template build now reuses the object from the first parse via a shared `parsedBody` — the prefix block's mutations already re-serialize `body` *from* that object, so it always represents the current body — with a `?? JSON.parse(...)` fallback so a body that wasn't JSON at the first block (or an OpenAI-backend reroute that skipped it) still parses. Worst case equals the old behavior.

**Deliberately excluded:** the cch-stamper's extra parse/serialize (the other half of audit #6). The cch is the billing-classification hash; reworking that path to shave a parse isn't worth risking subscription mis-classification.

## Two cheap per-request recomputes memoized

- `suspendedFamilies()` — called per request by the suspended-model guard — rebuilt a Set from `process.env` every call. Now memoized by the raw env value (common empty case allocates once; a runtime env change re-parses).
- The orchestration-tag pattern set under `--preserve-orchestration-tags` recompiled ~28 regexes per request; now memoized by the stable preserve-tag Set reference. Default path already used the precompiled constant.

## Verification

- **Live**: booted a proxy and drove a plain `/v1/messages` (parsedBody reused, no mutation) and a `claude:sonnet` prefixed request (mutation branch → body re-serialized from parsedBody) — both `end_turn`.
- `test/model-catalog.mjs` +3: `suspendedFamilies` returns the cached Set on repeat, re-parses on env change, empties on clear.
- `test/provider-prefix.mjs` (31) and `test/effort-flag.mjs` (67) — the mutation branches — green; full suite 102/102.
