### PR TITLE
perf(pool): concurrent-401 debounce + sticky-cleanup amortization (v4.8.123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.123] - 2026-07-02
+
+- **Concurrent 401s no longer over-escalate an account cool-down (#642-audit)** — `markAuthFailure` incremented the consecutive-failure counter on every call, so a burst of concurrent in-flight requests that all 401 on the same account (one bad token) jumped the exponential window to e.g. `authCooldownMs(3)` = 240s instead of 60s, keeping a recoverable account out of rotation ~4x too long. It now escalates only for a genuinely fresh failure (the account is already cooling down after the first of a burst); genuine re-failures spaced past the cool-down still escalate.
+
+- **Amortize the sticky-binding cleanup (#642-audit)** — `cleanupSticky` ran a full O(n) TTL/orphan scan on every `selectSticky` call and, at the 2000-entry cap, sorted all entries to evict a single overflow on every new conversation. The TTL sweep now runs at most once per 30s (stale bindings are never wrongly used — `selectSticky` re-validates before returning), and the size cap batch-evicts down to 80% so the O(n log n) sort amortizes over many inserts. Memory bound unchanged.
+
+- **Single-pass account selection** — `select()` and `selectExcluding()` used a `.reduce()` that recomputed the incumbent's headroom every iteration (~2n `computeHeadroom` calls); a shared `pickMaxHeadroom` helper computes each once.
+
 ## [4.8.122] - 2026-07-02
 
 - **Parse the request body once per request (#642-audit)** — the inbound JSON body was `JSON.parse`d twice on identical bytes: once for provider-prefix/effort detection and again for the template-build transform. The template build now reuses the object from the first parse (mutations keep it in sync with `body`; it falls back to a fresh parse when the earlier block did not run), removing a full parse + `Buffer.toString()` per request on the hot path. Behavior is unchanged — verified live with plain and `claude:`-prefix requests.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.122",
+  "version": "4.8.123",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -236,6 +236,7 @@ interface StickyBinding {
 }
 const STICKY_TTL_MS = 6 * 60 * 60 * 1000; // 6h
 const STICKY_MAX_ENTRIES = 2_000;          // lazy cleanup cap
+const STICKY_CLEANUP_INTERVAL_MS = 30_000; // amortize the O(n) TTL/orphan sweep
 
 /**
  * Headroom floor under which an account is treated as "effectively exhausted"
@@ -246,6 +247,19 @@ const STICKY_MAX_ENTRIES = 2_000;          // lazy cleanup cap
  */
 const POOL_HEADROOM_FLOOR = 0.02;
 
+// Pick the account with the most headroom in a single pass. The prior
+// `.reduce()` form recomputed the incumbent's headroom every iteration
+// (~2n computeHeadroom calls); this computes each once (#642-audit).
+function pickMaxHeadroom(accounts: PoolAccount[], family?: string | null): PoolAccount {
+  let best = accounts[0];
+  let bestHeadroom = computeHeadroom(best.rateLimit, family);
+  for (let i = 1; i < accounts.length; i++) {
+    const h = computeHeadroom(accounts[i].rateLimit, family);
+    if (h > bestHeadroom) { best = accounts[i]; bestHeadroom = h; }
+  }
+  return best;
+}
+
 export class AccountPool {
   private accounts: Map<string, PoolAccount> = new Map();
   private queue: QueuedRequest[] = [];
@@ -253,6 +267,8 @@ export class AccountPool {
   private queueTimeoutMs = 60_000;
   private drainTimer: ReturnType<typeof setInterval> | null = null;
   private sticky: Map<string, StickyBinding> = new Map();
+  // Amortize the O(n) sticky TTL/orphan sweep — timestamp of the last run.
+  private lastStickyCleanup = 0;
 
   add(alias: string, opts: {
     accessToken: string;
@@ -299,8 +315,17 @@ export class AccountPool {
   markAuthFailure(alias: string): void {
     const account = this.accounts.get(alias);
     if (!account) return;
-    account.lastAuthFailureAt = Date.now();
-    account.consecutiveAuthFailures = (account.consecutiveAuthFailures ?? 0) + 1;
+    const now = Date.now();
+    // Escalate the exponential cool-down only for a genuinely fresh failure.
+    // A burst of concurrent in-flight requests that all 401 on the same account
+    // (before the first cool-down takes hold) would otherwise bump the counter
+    // k times and jump the window to authCooldownMs(k) instead of 60s
+    // (#642-audit). isInAuthCooldown reflects state BEFORE this failure, so the
+    // burst escalates once; always refresh the timestamp to hold the window.
+    if (!isInAuthCooldown(account, now)) {
+      account.consecutiveAuthFailures = (account.consecutiveAuthFailures ?? 0) + 1;
+    }
+    account.lastAuthFailureAt = now;
   }
 
   /**
@@ -339,11 +364,7 @@ export class AccountPool {
     );
 
     if (eligible.length > 0) {
-      return eligible.reduce((best, curr) => {
-        const bestHeadroom = computeHeadroom(best.rateLimit, family);
-        const currHeadroom = computeHeadroom(curr.rateLimit, family);
-        return currHeadroom > bestHeadroom ? curr : best;
-      });
+      return pickMaxHeadroom(eligible, family);
     }
 
     // All accounts exhausted — return the one with the earliest reset.
@@ -423,14 +444,25 @@ export class AccountPool {
    */
   private cleanupSticky(): void {
     const now = Date.now();
-    for (const [key, b] of this.sticky) {
-      if (!this.accounts.has(b.alias) || now - b.boundAt > STICKY_TTL_MS) {
-        this.sticky.delete(key);
+    // TTL/orphan sweep is O(n); amortize it — run at most once per
+    // STICKY_CLEANUP_INTERVAL_MS instead of on every selectSticky (#642-audit).
+    // Stale bindings are never wrongly USED meanwhile: selectSticky re-validates
+    // a binding's expiry/rejection/headroom before returning it.
+    if (now - this.lastStickyCleanup >= STICKY_CLEANUP_INTERVAL_MS) {
+      this.lastStickyCleanup = now;
+      for (const [key, b] of this.sticky) {
+        if (!this.accounts.has(b.alias) || now - b.boundAt > STICKY_TTL_MS) {
+          this.sticky.delete(key);
+        }
       }
     }
+    // Hard size cap always enforced (bounds memory). Batch-evict down to 80% so
+    // the O(n log n) sort amortizes over many inserts rather than firing on every
+    // new conversation at the cap (#642-audit).
     if (this.sticky.size > STICKY_MAX_ENTRIES) {
+      const target = Math.floor(STICKY_MAX_ENTRIES * 0.8);
       const sorted = [...this.sticky.entries()].sort((a, b) => a[1].boundAt - b[1].boundAt);
-      const toDrop = sorted.slice(0, this.sticky.size - STICKY_MAX_ENTRIES);
+      const toDrop = sorted.slice(0, this.sticky.size - target);
       for (const [key] of toDrop) this.sticky.delete(key);
     }
   }
@@ -459,11 +491,7 @@ export class AccountPool {
     );
 
     if (eligible.length > 0) {
-      return eligible.reduce((best, curr) => {
-        const bestHeadroom = computeHeadroom(best.rateLimit, family);
-        const currHeadroom = computeHeadroom(curr.rateLimit, family);
-        return currHeadroom > bestHeadroom ? curr : best;
-      });
+      return pickMaxHeadroom(eligible, family);
     }
 
     if (candidates.length > 0) {

--- a/test/pool-auth-cooldown.mjs
+++ b/test/pool-auth-cooldown.mjs
@@ -75,15 +75,24 @@ header('markAuthFailure — puts account in cooldown');
 }
 
 // ----------------------------------------------------------------------
-header('markAuthFailure — increments counter on consecutive failures');
+header('markAuthFailure — concurrent burst escalates once; spaced re-failures escalate');
 // ----------------------------------------------------------------------
 {
   const pool = makePool(['alpha']);
+  // A burst of concurrent in-flight 401s on the same account escalates the
+  // exponential cool-down ONCE, not once-per-call (#642-audit): after the first
+  // failure the account is already cooling down (and skipped by select), so the
+  // rest of the burst is the same underlying problem, not distinct failures.
   pool.markAuthFailure('alpha');
   pool.markAuthFailure('alpha');
   pool.markAuthFailure('alpha');
   const acc = pool.all().find(a => a.alias === 'alpha');
-  check('counter reaches 3', acc.consecutiveAuthFailures === 3);
+  check('burst of 3 → counter 1 (debounced)', acc.consecutiveAuthFailures === 1);
+  // A genuine re-failure AFTER the cool-down elapsed still escalates. Simulate by
+  // backdating the last failure past the 60s window.
+  acc.lastAuthFailureAt = Date.now() - 10 * 60 * 1000;
+  pool.markAuthFailure('alpha');
+  check('re-failure after cooldown → counter 2', acc.consecutiveAuthFailures === 2);
 }
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
PR C of the audit follow-through: account-pool efficiency & correctness. Ships as v4.8.123. All in `pool.ts`.

## Concurrent-401 over-escalation (correctness)

`markAuthFailure` bumped the consecutive-failure counter on every call. A burst of concurrent in-flight requests that all 401 on the same account (one bad token) escalated the exponential cool-down k times — `authCooldownMs(3)` = 240s instead of 60s — keeping a recoverable account out of rotation ~4× too long (it can't clear via a success while it's being skipped). Now escalation only fires for a genuinely fresh failure: `isInAuthCooldown` reflects the state *before* this failure, so the first of a burst escalates and the rest (already cooling down) don't. Genuine re-failures spaced past the cool-down still escalate.

The existing test asserted the old per-call behavior (3 rapid calls → counter 3); updated to the corrected semantics (burst → 1; a re-failure backdated past the window → 2). In real operation an account in cool-down is skipped by `select()`, so genuine repeated failures are naturally spaced — only a concurrent burst hits `markAuthFailure` rapidly, which is exactly the case that should count once.

## Sticky-cleanup amortization (perf)

`cleanupSticky` ran a full O(n) TTL/orphan scan on every `selectSticky` (i.e. every request with a conversation key) and, at the 2000-entry cap, sorted all entries to evict one on every new conversation. Now the TTL sweep runs at most once per 30s (safe — `selectSticky` re-validates a binding's expiry/rejection/headroom before returning it, so a lingering stale binding is never wrongly used), and the cap batch-evicts down to 80% so the O(n log n) sort amortizes over ~400 inserts instead of firing per new conversation. Memory bound unchanged (still capped at 2000).

## Single-pass selection (perf, low)

`select()` and `selectExcluding()` used a `.reduce()` that recomputed the incumbent's headroom each iteration (~2n `computeHeadroom` calls). Extracted a shared `pickMaxHeadroom` that computes each once.

## Deliberately NOT done

The audit's "`waitForAccount` dead code" item: `waitForAccount`/`drainQueue` are indeed unused, but the `queue` field they use is still read by the live `status()` (`queued: 0` on the `/accounts` response), so removing the cluster would change that API shape for an always-zero field. Rated Informational by the audit; left in place.

## Tests

- `test/pool-auth-cooldown.mjs`: updated for the debounce (+2 assertions), 28/28.
- `test/pool-sticky.mjs` (35), `test/failover-429.mjs` (19), `test/pool-reconcile.mjs` (19) — cover selection + sticky eviction + failover — all green.
- Full suite 102/102.
