### PR TITLE
fix(catalog): timeout covers token acquisition + prompt-strip memo (v4.8.124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.124] - 2026-07-02
+
+- **Model-catalog refresh timeout now bounds token acquisition (#642-audit)** — the 4s abort timer was armed *after* `await deps.getToken()`, so it only covered the `fetch`, not the token step. A hung single-account OAuth refresh in `getToken` never settled, leaving the catalog `inflight` guard non-null forever and wedging every future refresh on the baked model list. The timer is now armed first and token acquisition is raced against the same deadline, so a stuck refresh falls back to the baked list (and retries after the normal backoff) instead of wedging. Unit-tested with a never-resolving `getToken`.
+
+- **Memoize the stripped system prompt under `--system-prompt=partial|aggressive`** — `resolveSystemPrompt` ran ~12 regex passes over the ~25KB prompt on every request when that (non-default) flag was set; the result is now memoized by (base, level), keyed on the base string so a runtime template re-capture correctly re-strips. Default (`verbatim`) path is unchanged.
+
 ## [4.8.123] - 2026-07-02
 
 - **Concurrent 401s no longer over-escalate an account cool-down (#642-audit)** — `markAuthFailure` incremented the consecutive-failure counter on every call, so a burst of concurrent in-flight requests that all 401 on the same account (one bad token) jumped the exponential window to e.g. `authCooldownMs(3)` = 240s instead of 60s, keeping a recoverable account out of rotation ~4x too long. It now escalates only for a genuinely fresh failure (the account is already cooling down after the first of a burst); genuine re-failures spaced past the cool-down still escalate.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.123",
+  "version": "4.8.124",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -168,11 +168,26 @@ export const CLIENT_SYSTEM_PREFACE =
   'task-specific instructions. For this conversation they OVERRIDE any ' +
   'conflicting general behavior described above. Follow them exactly:\n\n';
 
+// Memoize the stripped prompt by (base, level) (#642-audit): resolveSystemPrompt
+// runs per request and stripBehavioralConstraints does ~12 regex passes over the
+// ~25KB prompt. Keyed on the base STRING so a runtime template re-capture (a new
+// base) correctly misses and re-strips. Bounded to a few bases; cleared if it
+// somehow grows past a small cap.
+const _stripCache = new Map<string, Map<string, string>>();
+function stripBehavioralConstraintsMemo(base: string, level: 'partial' | 'aggressive'): string {
+  if (_stripCache.size > 8) _stripCache.clear();
+  let byLevel = _stripCache.get(base);
+  if (!byLevel) { byLevel = new Map(); _stripCache.set(base, byLevel); }
+  let v = byLevel.get(level);
+  if (v === undefined) { v = stripBehavioralConstraints(base, level); byLevel.set(level, v); }
+  return v;
+}
+
 export function resolveSystemPrompt(arg: string | undefined, model?: string): string {
   const base = systemPromptForModel(model);
   if (!arg || arg === 'verbatim') return base;
-  if (arg === 'partial') return stripBehavioralConstraints(base, 'partial');
-  if (arg === 'aggressive') return stripBehavioralConstraints(base, 'aggressive');
+  if (arg === 'partial') return stripBehavioralConstraintsMemo(base, 'partial');
+  if (arg === 'aggressive') return stripBehavioralConstraintsMemo(base, 'aggressive');
   return arg;
 }
 

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -268,20 +268,33 @@ function envInt(name: string, dflt: number): number {
 
 async function fetchUpstreamBases(deps: CatalogDeps): Promise<string[]> {
   const f = deps.fetchImpl ?? fetch;
-  const headers: Record<string, string> = {
-    accept: 'application/json',
-    'anthropic-version': ANTHROPIC_VERSION,
-  };
-  if (deps.upstreamApiKey) {
-    headers['x-api-key'] = deps.upstreamApiKey;
-  } else {
-    if (!deps.getToken) throw new Error('no token source for catalog fetch');
-    headers['authorization'] = `Bearer ${await deps.getToken()}`;
-    headers['anthropic-beta'] = OAUTH_BETA;
-  }
+  // Arm the timeout FIRST so it bounds token acquisition too, not just the
+  // fetch (#642-audit): a hung getToken() (e.g. a stuck single-account OAuth
+  // refresh) would otherwise never settle, leaving the catalog `inflight` guard
+  // non-null forever and wedging every future refresh on the baked list.
   const ctl = new AbortController();
   const timer = setTimeout(() => ctl.abort(), deps.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS);
   try {
+    const headers: Record<string, string> = {
+      accept: 'application/json',
+      'anthropic-version': ANTHROPIC_VERSION,
+    };
+    if (deps.upstreamApiKey) {
+      headers['x-api-key'] = deps.upstreamApiKey;
+    } else {
+      if (!deps.getToken) throw new Error('no token source for catalog fetch');
+      // Race token acquisition against the same abort deadline as the fetch.
+      const token = await Promise.race([
+        deps.getToken(),
+        new Promise<never>((_, reject) => {
+          const onAbort = () => reject(new Error('catalog token acquisition timed out'));
+          if (ctl.signal.aborted) onAbort();
+          else ctl.signal.addEventListener('abort', onAbort, { once: true });
+        }),
+      ]);
+      headers['authorization'] = `Bearer ${token}`;
+      headers['anthropic-beta'] = OAUTH_BETA;
+    }
     const res = await f(`${ANTHROPIC_API}/v1/models?limit=100`, { headers, signal: ctl.signal });
     if (!res.ok) throw new Error(`upstream /v1/models ${res.status}`);
     const json = (await res.json()) as { data?: Array<{ id?: unknown }> };

--- a/test/model-catalog.mjs
+++ b/test/model-catalog.mjs
@@ -322,6 +322,21 @@ console.log('  suspended models — none by default (Fable 5 returned globally 2
   else process.env.DARIO_SUSPENDED_MODELS = ORIG;
 }
 
+// #8 (#642-audit): a hung getToken() must NOT wedge the catalog. The fetch
+// timeout now bounds token acquisition too, so getModelCatalog falls back to
+// the baked list instead of hanging on a never-resolving refresh.
+_resetModelCatalogForTest();
+{
+  let t = 9_000_000;
+  const neverToken = () => new Promise(() => {}); // never resolves
+  const deps = { getToken: neverToken, timeoutMs: 50, now: () => t };
+  const cat = await getModelCatalog(deps);
+  check('hung getToken → baked fallback (no hang)', cat.source === 'baked');
+  t += 6 * 60 * 1000; // past the retry backoff
+  const cat2 = await getModelCatalog(deps);
+  check('not wedged — second call still returns', cat2.source === 'baked');
+}
+
 // suspendedFamilies memoization (#642-audit): same env value returns the cached
 // Set (no per-call rebuild); a changed env value re-parses.
 {


### PR DESCRIPTION
PR D of the audit follow-through: model-catalog robustness + template perf. Ships as v4.8.124.

## #8 — catalog refresh timeout didn't cover token acquisition (robustness)

In `fetchUpstreamBases`, the 4s `AbortController` timer was armed *after* `await deps.getToken()`, so it bounded only the `fetch`, not the token step. On the single-account path `getToken` is a network OAuth refresh; if it hangs, the promise never settles. Since `refresh()` clears the `inflight` guard only in `.finally()`, `inflight` stays non-null forever and `maybeRefreshInBackground` early-returns permanently — the catalog is wedged on the baked model list with no further retries. Fix: arm the timer first and race token acquisition against the same abort deadline, so a stuck refresh falls back to baked (and retries after the normal 5-min backoff) instead of wedging.

**Test**: a never-resolving `getToken` with a 50ms timeout → `getModelCatalog` returns the baked list promptly (doesn't hang) and a later call still returns (not wedged).

## `resolveSystemPrompt` memo (perf, non-default flag)

Under `--system-prompt=partial|aggressive`, `resolveSystemPrompt` ran ~12 regex passes over the ~25KB prompt every request. Now memoized by (base, level), keyed on the base *string* so a runtime template re-capture (new base) correctly misses and re-strips; bounded to a few bases (cleared if it grows past a small cap). The default `verbatim` path is untouched.

## Not done here

The shim's per-request `filterToolsForPlatform` (audit's trivial nit): the shim's `tmpl` provenance wasn't clearly process-invariant, and the filter is cheap, so memoizing it isn't worth the risk. Left as-is.

## Verification

- `test/model-catalog.mjs` +2 (the #8 no-wedge test), 98 assertions.
- `test/system-prompt-modes` / `strict-template-flags` (the partial/aggressive paths) green; full suite 102/102.
