### PR TITLE
harden(scrub): CRLF-tolerant section strip + gate catches strip failures (v4.8.125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.125] - 2026-07-02
+
+- **Harden the template scrubber against CRLF captures + strip failures (#642-audit)** — `removeSection` (which strips host-context sections like `# claudeMd` / `# userEmail` from the baked prompt) matched an LF-only `\n# name\n` heading, so a CRLF capture or a heading with trailing whitespace would leave the whole section — including host CLAUDE.md contents and the capturing email — in the shipped template. It now tolerates `\r?\n` and trailing whitespace (identical behavior on the normal LF path); `removeGitStatusBlock` got the same CRLF tolerance. Additionally, `findUserPathHits` (the release drift-gate detector) now flags any host-context section that survived stripping, so a strip failure fails the release instead of shipping the leak silently. Verified: the current shipped template still yields zero hits.
+
 ## [4.8.124] - 2026-07-02
 
 - **Model-catalog refresh timeout now bounds token acquisition (#642-audit)** — the 4s abort timer was armed *after* `await deps.getToken()`, so it only covered the `fetch`, not the token step. A hung single-account OAuth refresh in `getToken` never settled, leaving the catalog `inflight` guard non-null forever and wedging every future refresh on the baked model list. The timer is now armed first and token acquisition is raced against the same deadline, so a stuck refresh falls back to the baked list (and retries after the normal backoff) instead of wedging. Unit-tested with a never-resolving `getToken`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.124",
+  "version": "4.8.125",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/scrub-template.ts
+++ b/src/scrub-template.ts
@@ -149,7 +149,7 @@ function removeHostContextSections(systemPrompt: string): string {
  * drift signals and leaks the bake host's repo state.
  */
 function removeGitStatusBlock(systemPrompt: string): string {
-  return systemPrompt.replace(/\ngitStatus:[\s\S]*?(?=\n# |$)/, '');
+  return systemPrompt.replace(/\r?\ngitStatus:[\s\S]*?(?=\r?\n# |$)/, '');
 }
 
 /**
@@ -159,14 +159,16 @@ function removeGitStatusBlock(systemPrompt: string): string {
  */
 function removeSection(systemPrompt: string, name: string): string {
   const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const heading = new RegExp(`\\n# ${escaped}\\n`);
+  // \r?\n tolerates a CRLF capture; [ \t]* tolerates trailing whitespace on the
+  // heading line — either would otherwise leave a host-context section unstripped.
+  const heading = new RegExp(`\\r?\\n# ${escaped}[ \\t]*\\r?\\n`);
   let out = systemPrompt;
   while (true) {
     const m = heading.exec(out);
     if (!m) return out;
     const sectionStart = m.index;
     const afterHeading = out.slice(sectionStart + m[0].length);
-    const nextHeading = /\n# /.exec(afterHeading);
+    const nextHeading = /\r?\n# /.exec(afterHeading);
     const sectionEnd = nextHeading
       ? sectionStart + m[0].length + nextHeading.index
       : out.length;
@@ -209,6 +211,15 @@ export function findUserPathHits(text: string): string[] {
   for (const re of detectors) {
     const matches = text.match(re);
     if (matches) hits.push(...matches);
+  }
+  // A host-context section still present here means removeSection failed to
+  // strip it (e.g. a CRLF capture or a renamed heading). Flag it so the drift-
+  // gate fails the release rather than shipping the leak (#642-audit).
+  for (const name of HOST_CONTEXT_SECTION_HEADINGS) {
+    const esc = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    if (new RegExp(`\\r?\\n# ${esc}[ \\t]*\\r?\\n`).test(text)) {
+      hits.push(`# ${name} (host-context section not stripped)`);
+    }
   }
   return hits;
 }

--- a/test/scrub-template.mjs
+++ b/test/scrub-template.mjs
@@ -332,5 +332,28 @@ header('14. scrubTemplate — gitStatus stripping is idempotent');
 const scrubbedTwiceGit = scrubTemplate(scrubbedEof);
 check('scrub(scrub(gitStatus-prompt)) === scrub(gitStatus-prompt)', scrubbedTwiceGit.system_prompt === scrubbedEof.system_prompt);
 
+// ────────────────────────────────────────────────────────────────────
+header('15. removeSection — strips a CRLF-delimited host-context section (#642-audit)');
+// A CRLF capture used to slip past the LF-only section regex, leaving
+// # claudeMd / # userEmail contents in the shipped template.
+const crlfPrompt = ['# Static intro', 'Keep me.', '# claudeMd', 'SECRET host CLAUDE.md contents', '# currentDate', 'today'].join('\r\n');
+const crlfScrubbed = scrubTemplate({ ...sampleTemplate, system_prompt: crlfPrompt });
+check('CRLF: # claudeMd contents stripped', !crlfScrubbed.system_prompt.includes('SECRET host CLAUDE.md contents'));
+check('CRLF: # currentDate section stripped', !crlfScrubbed.system_prompt.includes('# currentDate'));
+check('CRLF: static content preserved', crlfScrubbed.system_prompt.includes('Keep me.'));
+check('CRLF: scrubbed prompt has no residual host-context hits', findUserPathHits(crlfScrubbed.system_prompt).length === 0);
+
+// ────────────────────────────────────────────────────────────────────
+header('16. removeSection — tolerates trailing whitespace on the heading');
+const twPrompt = ['# Static', 'keep', '# claudeMd  ', 'leak-content', '# currentDate', 'd'].join('\n');
+const twScrubbed = scrubTemplate({ ...sampleTemplate, system_prompt: twPrompt });
+check('trailing-whitespace heading section stripped', !twScrubbed.system_prompt.includes('leak-content'));
+
+// ────────────────────────────────────────────────────────────────────
+header('17. findUserPathHits — flags a host-context section that survived stripping');
+const leaked = 'intro\n# userEmail\nsomeone@example.com\n# next\nx';
+check('unstripped # userEmail flagged by the drift-gate detector', findUserPathHits(leaked).some((h) => h.includes('userEmail')));
+check('clean text yields no false residual-section hit', findUserPathHits('just some static prose\n# Tone\nbe nice').length === 0);
+
 console.log(`\n${pass} pass, ${fail} fail`);
 process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
PR E of the audit follow-through: template-scrubber hardening (security). Ships as v4.8.125.

The scrubber strips host-specific data (paths, host `CLAUDE.md` contents, the capturing user's email, git status) from the baked CC template before it ships. The audit (#9) found the section-strip was LF-brittle.

## Fixes

- **`removeSection` tolerates CRLF + trailing whitespace.** It matched an LF-only `\n# <name>\n` heading, so a CRLF capture (`\r\n# claudeMd\r\n`) or a heading with a trailing space silently *failed to strip* the section — leaking host `CLAUDE.md` contents / the capturing email into the shipped template. Now `\r?\n# <name>[ \t]*\r?\n`, with `\r?\n# ` for the next-heading terminator. On the normal LF capture this is byte-for-byte identical behavior. `removeGitStatusBlock` got the same CRLF tolerance.
- **The release drift-gate now catches a strip failure.** `findUserPathHits` (run by `check-cc-drift` before a release) additionally flags any `HOST_CONTEXT_SECTION_HEADINGS` section still present in the scrubbed text. Previously the detector only looked for path patterns, so a section that survived stripping shipped silently with "gate passed" confidence. Now it fails the gate.

Deliberately **not** adding an email/secret *masker* to `scrubText`: the host-context sections are removed wholesale (that's the real defense), and a broad email masker risks mangling legitimate example emails in tool docs. The residual-section *detector* covers the straggler case without that risk.

## Verification

- **The current shipped template yields zero `findUserPathHits`** — the new residual-section detector does not false-positive on the clean bundle, so the release gate stays green. (Checked directly against `dist/cc-template-data.json`.)
- `test/scrub-template.mjs` +3 groups: CRLF `# claudeMd` section stripped + no residual hits, trailing-whitespace heading stripped, and `findUserPathHits` flags an unstripped `# userEmail` while clean prose yields none. 73/73.
- Full suite 102/102.

(This finding is directly relevant to our own bake host, which runs `$HOME=/root`.)
