### PR TITLE
fix(login): OAuth callback timeout no longer hangs the CLI (v4.8.126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.126] - 2026-07-02
+
+- **`dario login` no longer hangs the terminal for up to 5 minutes after a successful login (#642-audit)** — the OAuth callback flow's 5-minute timeout was neither `.unref()`'d nor cleared, so after login completed the timer kept the Node process alive until it fired. It is now `unref`'d (so a completed login can't pin the process) and cleared on the success path. Matches the sibling `accounts.ts` add-account flow.
+
 ## [4.8.125] - 2026-07-02
 
 - **Harden the template scrubber against CRLF captures + strip failures (#642-audit)** — `removeSection` (which strips host-context sections like `# claudeMd` / `# userEmail` from the baked prompt) matched an LF-only `\n# name\n` heading, so a CRLF capture or a heading with trailing whitespace would leave the whole section — including host CLAUDE.md contents and the capturing email — in the shipped template. It now tolerates `\r?\n` and trailing whitespace (identical behavior on the normal LF path); `removeGitStatusBlock` got the same CRLF tolerance. Additionally, `findUserPathHits` (the release drift-gate detector) now flags any host-context section that survived stripping, so a strip failure fails the release instead of shipping the leak silently. Verified: the current shipped template still yields zero hits.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.125",
+  "version": "4.8.126",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -519,8 +519,8 @@ export async function startAutoOAuthFlow(): Promise<OAuthTokens> {
       // Exchange the code for tokens
       server.close();
       exchangeCodeWithRedirect(code, codeVerifier, state, port)
-        .then(resolve)
-        .catch(reject);
+        .then((tokens) => { clearTimeout(loginTimeout); resolve(tokens); })
+        .catch((e) => { clearTimeout(loginTimeout); reject(e); });
     });
 
     let port = 0;
@@ -559,11 +559,14 @@ export async function startAutoOAuthFlow(): Promise<OAuthTokens> {
       reject(new Error(`Failed to start OAuth callback server: ${err.message}`));
     });
 
-    // Timeout after 5 minutes
-    setTimeout(() => {
+    // Timeout after 5 minutes. unref so a completed login (server already
+    // closed, promise resolved on the success path) does not pin the process
+    // for 5 min — the #642-audit CLI hang. Also cleared on success below.
+    const loginTimeout = setTimeout(() => {
       server.close();
       reject(new Error('OAuth flow timed out. Try again with `dario login`.'));
     }, 300_000);
+    loginTimeout.unref();
   });
 }
 


### PR DESCRIPTION
PR F — the final audit follow-through, covering the LOW batch. Ships as v4.8.126.

## Fixed

**`dario login` terminal hang.** The OAuth callback flow's 5-minute timeout was never `.unref()`'d or cleared, so after a *successful* login the timer kept the Node process alive until it fired — the CLI wouldn't return for up to 5 minutes. Now `unref`'d (a completed login can't pin the process) and cleared on the success path, matching the sibling `accounts.ts` add-account flow the audit cited as correct.

This is startup/login wiring (a real server + browser round-trip), so it's verified by build + inspection against the known-good `accounts.ts` pattern rather than a new unit test. Full suite 102/102.

## Consciously NOT done (with reasons)

Working through the rest of the LOW batch, several turned out to be not worth the risk/change — recording them so the audit is fully accounted for:

- **Analytics buffer amortization** — the audit suggested letting the rolling buffer grow a 25% slack before trimming, to avoid a full-array re-slice on every push at the cap. But `analytics-stream.mjs` asserts a *strict* ring-buffer contract (exactly `maxRecords`), which the slack relaxes; the semantics-preserving alternative (a true fixed-size ring buffer) is a real rewrite of `record`/`recent`/`summary`/filters. Not worth it for GC churn on a not-high-QPS proxy. **Dropped.**
- **`/status` + `/health` method guards** — read-only endpoints; the audit itself rated the impact "inconsistency only, no state change." Restricting `/health`'s methods also risks breaking a HEAD-based probe. Zero benefit, small risk. **Skipped.**
- **Failed-auth throttle on the main proxy key gate** — `timingSafeEqual` already blocks the timing channel, and the bind guard requires a key on any non-loopback bind, so this only helps against brute-forcing a weak key on an exposed proxy; it also risks throttling legit clients that send a transiently-wrong key. **Skipped** (marginal, some risk).
- **Re-gate `/admin/resume` behind the admin token** — it currently sits behind the proxy key. Moving it would break existing callers, and resetting the overage halt is within the trust already granted to a proxy-key holder. **Skipped** (behavior change, marginal).
- **Skip the keychain subprocess on the single-account hot path** — the "pick freshest" keychain probe exists deliberately (keychain may hold fresher tokens than disk); skipping it when disk is merely unexpired could serve a staler token. **Skipped** (correctness risk > perf gain; single-account mode only, prod uses the pool).

This completes the audit follow-through (PRs A–F, v4.8.119–126). Of the 10 ranked findings + LOW batch: the load-bearing ones are fixed and released; the rest are either fixed or documented-skipped with a verified reason (including audit #2, which was a false positive — the guard already existed).
