### PR TITLE
fix(ci): oauth-health monitor was blind — probe /health via docker exec (loopback)

### DIFF
--- a/.github/workflows/cc-oauth-health.yml
+++ b/.github/workflows/cc-oauth-health.yml
@@ -2,7 +2,8 @@ name: dario OAuth health alert (self-hosted)
 
 # Independent OAuth-health watcher. The fleet itself can't alert when dario's
 # OAuth dies — every agent routes through dario — so this runs on the box's own
-# self-hosted runner and curls the LOCAL /health every 5 minutes. On
+# self-hosted runner and probes the LOCAL /health (via `docker exec`, so it
+# reads the loopback-only detailed body — see the step comment) every 5 min. On
 # `oauth != healthy` it opens a GH issue (label `dario-oauth`) with the
 # split-credential diagnostic; it closes the issue on recovery.
 #
@@ -36,7 +37,15 @@ jobs:
         run: |
           set -uo pipefail
 
-          body="$(curl -s --max-time 8 http://127.0.0.1:3456/health || true)"
+          # Probe /health via `docker exec` (true 127.0.0.1 INSIDE the container),
+          # NOT host-side curl. Since dario #636, /health returns the detailed body
+          # (incl. the "oauth" field) only to genuine loopback callers and strips it
+          # to a bare {"status":"ok"} for the published-port path (a docker-gateway
+          # source IP) — so host-side curl can never read oauth status and this
+          # monitor was silently blind (missed the 2026-07-02 token-death outage).
+          # If the container is crash-looping/exited, docker exec fails -> body
+          # empty -> oauth=unreachable -> alert fires. That's the intended path.
+          body="$(docker exec askalf-dario sh -lc 'wget -qO- http://127.0.0.1:3456/health 2>/dev/null || curl -s --max-time 8 http://127.0.0.1:3456/health' 2>/dev/null || true)"
           oauth="$(printf '%s' "$body" | grep -o '"oauth":"[^"]*"' | head -1 | cut -d'"' -f4)"
           [ -z "$oauth" ] && oauth="unreachable"
           echo "dario /health -> oauth=$oauth"


### PR DESCRIPTION
The self-hosted OAuth-health watcher (`cc-oauth-health.yml`) has been **silently blind** — it curled host-side `127.0.0.1:3456/health`, but since **#636** dario returns the detailed body (with the `oauth` field) **only to genuine loopback callers** and strips it to a bare `{"status":"ok"}` for the published-port path (docker-gateway source IP). So the monitor's `grep '"oauth":"…"'` always came back empty → it could neither confirm health (**false failures** when dario is fine) nor detect a real outage.

**Confirmed live 2026-07-02:** dario was healthy (`oauth:healthy` inside the container, `/v1/models` proxying end-to-end) yet this workflow kept failing every 5 min; and during the **actual token-death outage** earlier that day it **never opened a `dario-oauth` issue** — the exact gap noted in the recovery docs.

**Fix:** probe via `docker exec askalf-dario` (true `127.0.0.1` inside the container) → full oauth-bearing body. If the container is crash-looping/exited, `docker exec` fails → body empty → `oauth=unreachable` → alert fires (the desired outage path). Runner is `root`, so `docker exec` is available. Verified: `docker exec askalf-dario … /health` returns `"oauth":"healthy"`. YAML validated.

After merge, the `*/5` schedule will pick it up and this workflow should go green (dario is currently healthy).