### PR TITLE
Wire tightening for CC 2.1.199 (cch, beta matrix, build suffix, drift check)

### DIFF
--- a/.github/workflows/wire-drift-self-hosted.yml
+++ b/.github/workflows/wire-drift-self-hosted.yml
@@ -1,0 +1,145 @@
+name: Wire drift (self-hosted)
+
+# Runs `node scripts/check-wire-drift.mjs` against the real `claude` binary on
+# the self-hosted runner. This is the RUNTIME counterpart to cc-drift-watch.yml
+# (which statically scans the npm binary and so can't see per-request wire
+# decisions): it spawns claude for opus/sonnet/haiku/fable, reads each live
+# anthropic-beta header + billing block, and fails if
+#
+#   - betaForModel no longer reproduces CC's per-model beta set (the 2.1.170 ->
+#     2.1.199 drift that shipped silently: sonnet keeping mid-conversation-
+#     system, haiku dropping afk-mode + reordering, fable/[1m] positions), or
+#   - dario's cch gate disagrees with the live billing block (CC emits a cch we
+#     have no seed for, or we hold a seed for a version CC no longer stamps).
+#
+# The capture is the safe loopback-MITM path (stub key, fresh HOME, no OAuth) —
+# no real Anthropic call, so this needs only `claude` on PATH, not a
+# subscription. The `dario-drift` runner already has claude installed (it hosts
+# the template drift watcher). GH-hosted runners have no claude, so they can't
+# host this.
+#
+# Fork PRs are skipped — a self-hosted runner must never run fork code.
+
+on:
+  pull_request:
+    paths:
+      # The wire-shape surface this check guards.
+      - 'src/proxy.ts'
+      - 'src/cch.ts'
+      - 'src/cc-template.ts'
+      - 'src/cc-template-data.json'
+      - 'scripts/check-wire-drift.mjs'
+      - '.github/workflows/wire-drift-self-hosted.yml'
+  schedule:
+    # Daily — catches CC-side changes (a new claude on the runner emitting a
+    # different per-model beta set) without waiting for a PR.
+    - cron: '37 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: wire-drift-${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  wire-drift:
+    # Fork-PR guard: only the source repo runs on the self-hosted runner.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, dario-drift]
+    timeout-minutes: 10
+    steps:
+      - uses: askalf/checkout-with-retry@744195501c3e2b794c50370b753a7b8c93d084f5  # v1.0.0
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Install + build
+        run: |
+          npm ci --no-audit --no-fund
+          npm run build
+
+      - name: Report claude version
+        run: claude --version || echo "::warning::claude not on PATH — the capture step will report a high-severity 'capture' finding"
+
+      - name: Run wire-drift check
+        id: drift
+        run: |
+          set +e
+          node scripts/check-wire-drift.mjs > wire-drift-report.json 2> wire-drift-log.txt
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          echo "=== wire-drift-log.txt ==="
+          cat wire-drift-log.txt
+          echo "=== wire-drift-report.json ==="
+          cat wire-drift-report.json
+
+      - name: Comment on PR with result
+        if: github.event_name == 'pull_request' && always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pr=${{ github.event.pull_request.number }}
+          marker='<!-- dario-wire-drift -->'
+          existing=$(gh api "repos/${{ github.repository }}/issues/$pr/comments" --jq ".[] | select(.body | startswith(\"$marker\")) | .id" | head -1)
+
+          status_emoji="❌"; status_text="DRIFT"
+          if [ "${{ steps.drift.outputs.exit_code }}" = "0" ]; then status_emoji="✅"; status_text="CLEAN"; fi
+
+          body_file=$(mktemp)
+          {
+            echo "$marker"
+            echo "## Wire drift: $status_emoji $status_text"
+            echo ""
+            echo "Ran \`node scripts/check-wire-drift.mjs\` against the runner's \`claude\` for commit \`${{ github.event.pull_request.head.sha }}\` — per-model \`anthropic-beta\` (betaForModel) + billing-block cch gate vs the live binary."
+            echo ""
+            echo "<details><summary>Report</summary>"
+            echo ""
+            echo '```json'
+            cat wire-drift-report.json 2>/dev/null || echo "(no report captured)"
+            echo '```'
+            echo ""
+            echo "</details>"
+            echo ""
+            echo "[Full workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+          } > "$body_file"
+
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/${{ github.repository }}/issues/comments/$existing" -f body="$(cat "$body_file")" > /dev/null
+          else
+            gh pr comment "$pr" --body-file "$body_file"
+          fi
+
+      - name: Open / update drift issue (scheduled runs)
+        if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && steps.drift.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CC_VERSION=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('wire-drift-report.json','utf-8')).ccVersion||'unknown')}catch(e){console.log('unknown')}")
+          TITLE="Wire drift detected: CC v${CC_VERSION}"
+          EXISTING=$(gh issue list --label cc-drift --state open --search "in:title \"${TITLE}\"" --json number --jq '.[0].number')
+          body_file=$(mktemp)
+          {
+            echo "\`scripts/check-wire-drift.mjs\` found a per-model beta or cch-gate divergence from the live \`claude\` binary (CC v${CC_VERSION})."
+            echo ""
+            echo '```json'
+            cat wire-drift-report.json 2>/dev/null || echo "(no report)"
+            echo '```'
+            echo ""
+            echo "Fix: update \`betaForModel\` (src/proxy.ts) to the captured matrix, and/or run \`npm run cch:calibrate\` if the report shows a cch-gate finding. [Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+          } > "$body_file"
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body-file "$body_file"
+          else
+            gh issue create --title "$TITLE" --body-file "$body_file" --label cc-drift
+          fi
+
+      - name: Set job status
+        if: always()
+        env:
+          DRIFT_EXIT_CODE: ${{ steps.drift.outputs.exit_code }}
+        run: exit "$DRIFT_EXIT_CODE"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lint:pkg": "node scripts/check-package-json.mjs",
     "drift:sdk": "node scripts/check-sdk-drift.mjs",
     "drift:wire": "node scripts/check-wire-drift.mjs",
+    "check:overage": "node scripts/check-overage-live.mjs",
     "cch:calibrate": "node scripts/cch-calibrate.mjs",
     "fix:pkg": "node -e \"const fs=require('fs');fs.writeFileSync('package.json',JSON.stringify(JSON.parse(fs.readFileSync('package.json','utf-8')),null,2)+'\\n')\""
   },

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "compat": "node test/compat.mjs",
     "lint:pkg": "node scripts/check-package-json.mjs",
     "drift:sdk": "node scripts/check-sdk-drift.mjs",
+    "drift:wire": "node scripts/check-wire-drift.mjs",
     "cch:calibrate": "node scripts/cch-calibrate.mjs",
     "fix:pkg": "node -e \"const fs=require('fs');fs.writeFileSync('package.json',JSON.stringify(JSON.parse(fs.readFileSync('package.json','utf-8')),null,2)+'\\n')\""
   },

--- a/scripts/check-cc-drift.mjs
+++ b/scripts/check-cc-drift.mjs
@@ -297,17 +297,20 @@ try {
     });
   }
 
-  // cch seed coverage (dario#528). The cch integrity-hash seed rotates between
-  // CC releases. If we have no seed for the latest version, dario ships a
-  // RANDOM cch for it — a safe fallback, not a failure — but we want to close
-  // that gap ourselves, not wait for someone to report it. Surface it so the
-  // maintainer runs the owned calibration step.
+  // cch seed coverage (dario#528). This static scan can't see whether the
+  // latest CC actually emits a cch (that's a REQUEST-time decision) — CC
+  // dropped the token entirely between 2.1.177 and 2.1.199, and dario now OMITS
+  // cch unless a seed exists (hasCchSeed), which MATCHES current CC. So a
+  // missing seed is no longer a gap by itself; it's the correct state whenever
+  // CC emits no cch. Surface it only as INFO, and defer the authoritative call
+  // to scripts/check-wire-drift.mjs (self-hosted; it runs the real binary and
+  // fails if CC emits a cch while we hold no seed, or vice-versa).
   if (ccVersion && !CCH_SEEDS[ccVersion]) {
     items.push({
       category: 'cch.seed',
-      severity: 'low',
+      severity: 'info',
       message:
-        `No cch seed for CC v${ccVersion} in src/cch.ts (CCH_SEEDS) — dario sends a random cch for it (safe fallback). Run \`node scripts/cch-calibrate.mjs\` on a host with claude v${ccVersion}: it confirms whether an existing seed still applies (just add the version → seed line) or whether the seed rotated (saves the live capture so we extract the new seed ourselves). dario#528.`,
+        `No cch seed for CC v${ccVersion} in src/cch.ts (CCH_SEEDS). dario OMITS the cch token for it — correct while CC v${ccVersion} sends none (2.1.199+). Only add a seed if scripts/check-wire-drift.mjs reports CC re-introduced cch; then run \`node scripts/cch-calibrate.mjs\` on a host with claude v${ccVersion}. dario#528.`,
     });
   }
 
@@ -377,8 +380,13 @@ try {
   try { rmSync(scratch, { recursive: true, force: true }); } catch { /* best-effort */ }
 }
 
+// `info` items are notes, not drift — they must not open an issue or trigger
+// the auto-drafter (e.g. cch.seed, which reports the correct omit state). Only
+// actionable (low/medium/high) items flip `drift` and the exit code.
+const actionable = items.filter((i) => i.severity !== 'info');
+
 const report = {
-  drift: items.length > 0,
+  drift: actionable.length > 0,
   checkedAt: new Date().toISOString(),
   ccVersion,
   pinned: {
@@ -393,4 +401,4 @@ const report = {
 };
 
 console.log(JSON.stringify(report, null, 2));
-process.exit(items.length > 0 ? 1 : 0);
+process.exit(actionable.length > 0 ? 1 : 0);

--- a/scripts/check-overage-live.mjs
+++ b/scripts/check-overage-live.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+/**
+ * Live subscription-routing check — sends a sustained, multi-model load THROUGH
+ * a dario proxy against real api.anthropic.com and confirms every response
+ * bills to the SUBSCRIPTION pool (five_hour / seven_day [_fallback]), never
+ * overage / api, and that the Max pool ACCEPTS dario's wire shape (no
+ * "429 rejected"). It is the billing-bucket + wire-acceptance counterpart to
+ * scripts/check-wire-drift.mjs.
+ *
+ * ⚠ MAKES REAL subscription calls — needs a live Pro/Max OAuth credential and
+ * egress to api.anthropic.com. Run it yourself (operator / self-hosted), never
+ * in GH-hosted CI. On the ALF-PROD-DOCKER box the agent firewall (warden)
+ * blocks agent-driven OAuth-read + egress, so this is an operator-run harness
+ * by design: launch it from your own shell (or `! node scripts/…`).
+ *
+ * It starts its OWN short-lived dario from the local build (dist/cli.js) on a
+ * SPARE port with the overage-guard ENABLED, so a single non-subscription hit
+ * halts the run immediately. It reads the per-response
+ * `anthropic-ratelimit-unified-representative-claim` + `-status` headers and
+ * classifies each with dario's own billingBucketFromClaim. Small max_tokens +
+ * short prompts keep the token burn minimal.
+ *
+ *   npm run build && node scripts/check-overage-live.mjs
+ *   COUNT=10 CONCURRENCY=3 node scripts/check-overage-live.mjs      # heavier soak
+ *   MODELS=claude-opus-4-8,claude-haiku-4-5 node scripts/check-overage-live.mjs
+ *
+ * OAuth note: this spins up a SECOND dario using your default credentials. If a
+ * box dario is already running and the access token is near expiry, both may
+ * refresh and race the refresh-token family. Run it when the token is fresh; it
+ * is short-lived (~a minute) to keep that window small. Override the port with
+ * PORT= if 3466 is taken.
+ *
+ * Exit 0 = every request billed to subscription and the pool accepted the wire
+ * shape. Exit 1 = an overage/api hit, a "429 rejected" (non-CC shape), or the
+ * overage-guard halted.
+ */
+import { spawn } from 'node:child_process';
+import { mkdtempSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { billingBucketFromClaim, SUBSCRIPTION_CLAIMS } from '../dist/analytics.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..');
+
+const PORT = Number(process.env.PORT || 3466);
+const COUNT = Number(process.env.COUNT || 5);          // requests per model
+const CONCURRENCY = Number(process.env.CONCURRENCY || 2);
+const MAX_TOKENS = Number(process.env.MAX_TOKENS || 32);
+const PROMPT = process.env.PROMPT || 'reply with the single word: ok';
+const MODELS = (process.env.MODELS
+  || 'claude-opus-4-8,claude-sonnet-5,claude-haiku-4-5,claude-fable-5,claude-opus-4-8[1m],claude-sonnet-5[1m],claude-fable-5[1m]'
+).split(',').map((s) => s.trim()).filter(Boolean);
+
+const BASE = `http://127.0.0.1:${PORT}`;
+const logFile = join(mkdtempSync(join(tmpdir(), 'overage-live-')), 'dario.log');
+const cliPath = join(repoRoot, 'dist', 'cli.js');
+const log = (m) => console.error(`[overage-live] ${m}`);
+
+if (!existsSync(cliPath)) {
+  log(`dist/cli.js missing — run \`npm run build\` first.`);
+  process.exit(2);
+}
+
+// ── start a short-lived dario from the local build ──
+log(`starting dario (build under test) on :${PORT} with overage-guard on, log-file=${logFile}`);
+const proxy = spawn(process.execPath, [cliPath, 'proxy', `--port=${PORT}`, `--log-file=${logFile}`], {
+  cwd: repoRoot,
+  stdio: ['ignore', 'pipe', 'pipe'],
+  env: { ...process.env },
+});
+let proxyOut = '';
+proxy.stdout.on('data', (d) => { proxyOut += d.toString(); });
+proxy.stderr.on('data', (d) => { proxyOut += d.toString(); });
+
+function shutdown() { try { proxy.kill('SIGTERM'); } catch {} }
+process.on('exit', shutdown);
+process.on('SIGINT', () => { shutdown(); process.exit(130); });
+
+async function waitHealth(timeoutMs = 30000) {
+  const t0 = Date.now();
+  while (Date.now() - t0 < timeoutMs) {
+    try {
+      const r = await fetch(`${BASE}/health`, { signal: AbortSignal.timeout(2000) });
+      if (r.ok) return true;
+    } catch { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  return false;
+}
+
+async function oneRequest(model) {
+  try {
+    const res = await fetch(`${BASE}/v1/messages`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ model, max_tokens: MAX_TOKENS, messages: [{ role: 'user', content: PROMPT }] }),
+      signal: AbortSignal.timeout(120000),
+    });
+    const claim = res.headers.get('anthropic-ratelimit-unified-representative-claim');
+    const rlStatus = res.headers.get('anthropic-ratelimit-unified-status');
+    let bodyErrType = null;
+    if (!res.ok) { try { bodyErrType = (JSON.parse(await res.text()).error || {}).type || null; } catch {} }
+    return { httpStatus: res.status, claim, rlStatus, bodyErrType };
+  } catch (e) {
+    return { httpStatus: 0, claim: null, rlStatus: null, error: String(e && e.message || e) };
+  }
+}
+
+function classify(r) {
+  // Guard halted (dario returned its own 503) — a breach was already seen.
+  if (r.bodyErrType === 'dario_overage_guard') return 'HALTED';
+  // Max pool rejected the wire shape as non-CC.
+  if (r.httpStatus === 429 && (r.rlStatus === 'rejected' || r.bodyErrType === 'dario_overage_guard')) return 'REJECTED';
+  const bucket = billingBucketFromClaim(r.claim);
+  if (bucket === 'extra_usage' || bucket === 'api') return 'BREACH';
+  if (SUBSCRIPTION_CLAIMS.has(r.claim || '')) return r.httpStatus === 429 ? 'WINDOW' : 'OK';
+  if (r.httpStatus === 429) return r.rlStatus === 'rejected' ? 'REJECTED' : 'WINDOW';
+  if (r.httpStatus >= 200 && r.httpStatus < 300) return 'OK?'; // 2xx but no claim header (unknown) — inconclusive
+  return 'ERROR';
+}
+
+async function runModel(model) {
+  const results = [];
+  let i = 0;
+  async function worker() {
+    while (i < COUNT) {
+      const n = i++;
+      // stop early if the guard already halted the proxy
+      if (results.some((r) => classify(r) === 'HALTED' || classify(r) === 'BREACH')) return;
+      const r = await oneRequest(model);
+      r.n = n;
+      results.push(r);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, COUNT) }, worker));
+  return results;
+}
+
+(async () => {
+  if (!(await waitHealth())) {
+    log('dario never reached /health within 30s. Proxy output:');
+    console.error(proxyOut.slice(-2000));
+    process.exit(2);
+  }
+  log(`health OK. Sending ${COUNT}×${MODELS.length} requests (concurrency ${CONCURRENCY}, max_tokens ${MAX_TOKENS})…`);
+
+  const perModel = {};
+  let breached = false;
+  for (const model of MODELS) {
+    const rs = await runModel(model);
+    const tally = {};
+    for (const r of rs) { const c = classify(r); tally[c] = (tally[c] || 0) + 1; }
+    perModel[model] = { count: rs.length, tally, sampleClaim: rs.map((r) => r.claim).find(Boolean) || null };
+    if (tally.BREACH || tally.HALTED || tally.REJECTED) breached = true;
+    // If the guard halted, every later model would just 503 — stop the soak.
+    if (tally.HALTED) { log('overage-guard HALTED — stopping the soak.'); break; }
+  }
+
+  console.log('\n=== live subscription-routing report ===');
+  console.log(`dario build: local dist  | port ${PORT} | ${COUNT}/model × ${MODELS.length} models`);
+  const pad = (s, n) => String(s).padEnd(n);
+  console.log(pad('model', 26), pad('n', 3), pad('claim', 14), 'outcome');
+  for (const [m, v] of Object.entries(perModel)) {
+    const outcome = Object.entries(v.tally).map(([k, n]) => `${k}:${n}`).join(' ');
+    console.log(pad(m, 26), pad(v.count, 3), pad(v.sampleClaim || '-', 14), outcome);
+  }
+  // Cross-check against dario's own per-request log (claim/bucket), if present.
+  try {
+    const lines = readFileSync(logFile, 'utf8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
+    const nonSub = lines.filter((e) => e.bucket && !['subscription', 'subscription_fallback', 'unknown'].includes(e.bucket));
+    console.log(`\ndario log: ${lines.length} request records; non-subscription buckets: ${nonSub.length}`);
+    if (nonSub.length) console.log('  ' + nonSub.slice(0, 5).map((e) => `${e.model}:${e.bucket}`).join(', '));
+  } catch { /* no log or unreadable */ }
+
+  console.log(`\nOutcome legend: OK=subscription 2xx  WINDOW=subscription 429 (rate cap, not a breach)`);
+  console.log(`  BREACH=overage/api  REJECTED=Max pool rejected wire shape (non-CC)  HALTED=overage-guard tripped`);
+  const verdict = breached ? '❌ BREACH — non-subscription billing or wire-shape rejection detected' : '✅ CLEAN — all traffic on the subscription pool, wire shape accepted';
+  console.log(`\n${verdict}`);
+  shutdown();
+  process.exit(breached ? 1 : 0);
+})();

--- a/scripts/check-wire-drift.mjs
+++ b/scripts/check-wire-drift.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+/**
+ * Capture-based wire-drift watcher — the runtime counterpart to
+ * scripts/check-cc-drift.mjs (which statically scans the npm binary and so
+ * can't see anything CC only decides at REQUEST time).
+ *
+ * Two wire signals drifted silently between CC 2.1.170 and 2.1.199 because
+ * nothing ran the real binary and compared its live request to what dario
+ * emits (dario#528 follow-up, 2026-07-03):
+ *
+ *   1. Per-model `anthropic-beta` set. betaForModel encodes CC's per-family
+ *      add/drop/reorder rules; those moved (sonnet-5 keeps mid-conversation-
+ *      system, haiku drops afk-mode + reorders, fable/[1m] positions). This
+ *      check spawns the real `claude` for opus/sonnet/haiku/fable, reads each
+ *      anthropic-beta header, and asserts betaForModel reproduces it from the
+ *      captured opus base — EXACTLY, order included.
+ *
+ *   2. `cch` billing-integrity token. CC dropped it entirely (sdk-cli); dario
+ *      now omits it unless a calibrated seed exists (hasCchSeed). This check
+ *      reads whether the live billing block still carries `cch=` and asserts
+ *      dario's gate agrees: CC-emits-cch XOR we-have-a-seed is a drift.
+ *
+ * Capture path is the safe one live-fingerprint / cch-calibrate use: a loopback
+ * MITM with a STUB api key + a fresh HOME (no CLAUDE.md / memory leaking into
+ * the body). No OAuth, no real Anthropic call — the beta header and billing
+ * block are built into the request before it leaves the process.
+ *
+ * Run on the self-hosted `dario-drift` runner (it has `claude`); GH-hosted
+ * runners don't. Exits non-zero on any HARD drift (empty findings => clean).
+ *
+ *   node scripts/check-wire-drift.mjs
+ *   DARIO_CLAUDE_BIN=/path/to/claude node scripts/check-wire-drift.mjs
+ */
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import { gunzipSync } from 'node:zlib';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { betaForModel } from '../dist/proxy.js';
+import { hasCchSeed } from '../dist/cch.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..');
+const CC_BIN = process.env.DARIO_CLAUDE_BIN || 'claude';
+const useShell = process.platform === 'win32' && !/[\\/]/.test(CC_BIN);
+const cleanHome = mkdtempSync(join(tmpdir(), 'wire-drift-'));
+
+// The families dario transforms betaForModel for. Opus is the base.
+const MODELS = ['claude-opus-4-8', 'claude-sonnet-5', 'claude-haiku-4-5', 'claude-fable-5'];
+
+function log(m) { console.error(`[wire-drift] ${m}`); }
+
+function capture(model) {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      const chunks = [];
+      req.on('data', (c) => chunks.push(c));
+      req.on('end', () => {
+        if (req.url.includes('/v1/messages') && req.method === 'POST' && !server._cap) {
+          server._cap = { headers: req.headers, buf: Buffer.concat(chunks) };
+        }
+        res.writeHead(200, { 'content-type': 'text/event-stream' });
+        res.end('event: message_start\ndata: {"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"x","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}}}\n\nevent: message_stop\ndata: {"type":"message_stop"}\n\n');
+      });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const port = server.address().port;
+      const env = {
+        ...process.env,
+        HOME: cleanHome, USERPROFILE: cleanHome,
+        ANTHROPIC_BASE_URL: `http://127.0.0.1:${port}`,
+        ANTHROPIC_API_KEY: 'sk-capture-stub',
+        CLAUDE_NONINTERACTIVE: '1',
+      };
+      const cc = spawn(CC_BIN, ['--print', '--model', model, '-p', 'hi'], {
+        env, stdio: ['ignore', 'ignore', 'ignore'], windowsHide: true, shell: useShell,
+      });
+      const done = () => {
+        try { server.close(); } catch {}
+        const cap = server._cap;
+        if (!cap) return resolve(null);
+        let buf = cap.buf;
+        if ((cap.headers['content-encoding'] || '').includes('gzip')) { try { buf = gunzipSync(buf); } catch {} }
+        const text = buf.toString('utf8');
+        const beta = typeof cap.headers['anthropic-beta'] === 'string' ? cap.headers['anthropic-beta'] : null;
+        const billing = (/x-anthropic-billing-header:[^"]*/.exec(text) || [])[0] || null;
+        const version = (/cc_version=([0-9]+\.[0-9]+\.[0-9]+)/.exec(text) || [])[1] || null;
+        const cchEmitted = /cch=[0-9a-fA-F]{5}/.test(text);
+        resolve({ model, beta, billing, version, cchEmitted });
+      };
+      cc.on('exit', () => setTimeout(done, 200));
+      cc.on('error', (e) => { log(`spawn error for ${model}: ${e.message}`); resolve(null); });
+      setTimeout(() => { try { cc.kill(); } catch {}; done(); }, 40000);
+    });
+  });
+}
+
+const findings = [];
+const caps = {};
+for (const m of MODELS) {
+  const c = await capture(m);
+  if (!c || !c.beta) {
+    findings.push({ severity: 'high', category: 'capture', message: `Failed to capture a /v1/messages request for ${m} (is claude installed and runnable?).` });
+    continue;
+  }
+  caps[m] = c;
+}
+
+const opus = caps['claude-opus-4-8'];
+if (opus && opus.beta) {
+  // ── (1) per-model beta transform vs live CC ──
+  // Opus IS the base; assert betaForModel reproduces every other family from it.
+  for (const m of MODELS) {
+    const c = caps[m];
+    if (!c || !c.beta) continue;
+    const derived = betaForModel(opus.beta, m);
+    if (derived !== c.beta) {
+      findings.push({
+        severity: 'high',
+        category: 'beta.transform',
+        model: m,
+        message: `betaForModel drift for ${m}: dario would emit a beta set that does not match live CC ${c.version || ''}.`,
+        expected: c.beta,
+        got: derived,
+      });
+    }
+  }
+
+  // Informational: is the BAKED base still current (modulo the OAuth flag dario
+  // appends only in production and afk-mode's remote-config volatility)?
+  try {
+    const tmpl = JSON.parse(readFileSync(join(repoRoot, 'src/cc-template-data.json'), 'utf-8'));
+    const norm = (s) => s.split(',').filter((f) => f && f !== 'oauth-2025-04-20' && f !== 'afk-mode-2026-01-31').join(',');
+    if (tmpl.anthropic_beta && norm(tmpl.anthropic_beta) !== norm(opus.beta)) {
+      findings.push({
+        severity: 'low',
+        category: 'beta.base',
+        message: 'Baked template anthropic_beta differs from the live opus base (ignoring oauth-2025-04-20 + volatile afk-mode). Re-run capture-and-bake; on a CC-equipped host the live-fingerprint refresh heals this automatically.',
+        expected: opus.beta,
+        got: tmpl.anthropic_beta,
+      });
+    }
+  } catch { /* template unreadable — the static drift check covers that */ }
+}
+
+// ── (2) cch gate vs live billing block ──
+for (const m of MODELS) {
+  const c = caps[m];
+  if (!c || !c.version) continue;
+  const weWouldEmit = hasCchSeed(c.version);
+  if (c.cchEmitted && !weWouldEmit) {
+    findings.push({
+      severity: 'high', category: 'cch.gate', model: m,
+      message: `CC ${c.version} emits a cch token but dario has no seed for it (hasCchSeed=false) — dario would OMIT cch while CC sends one. Run scripts/cch-calibrate.mjs to add the seed.`,
+    });
+  } else if (!c.cchEmitted && weWouldEmit) {
+    findings.push({
+      severity: 'high', category: 'cch.gate', model: m,
+      message: `CC ${c.version} emits NO cch token but dario holds a seed (hasCchSeed=true) — dario would emit a cch CC no longer sends. Drop ${c.version} from CCH_SEEDS.`,
+    });
+  }
+}
+
+const report = {
+  drift: findings.some((f) => f.severity === 'high'),
+  checkedAt: new Date().toISOString(),
+  ccVersion: opus?.version ?? null,
+  captured: Object.fromEntries(Object.entries(caps).map(([m, c]) => [m, { beta: c.beta, cchEmitted: c.cchEmitted, billing: c.billing }])),
+  findings,
+};
+console.log(JSON.stringify(report, null, 2));
+process.exit(report.drift ? 1 : 0);

--- a/src/cch.ts
+++ b/src/cch.ts
@@ -21,14 +21,32 @@
 // The seed rotates per Claude Code release and is keyed on major.minor.patch
 // (the build-tag suffix, e.g. ".e2d" vs ".dd9", does NOT change it — verified
 // against two captures with different suffixes, same 2.1.177 seed). An unknown
-// version returns null so the caller falls back to a random value (the
-// pre-dario#528 behavior) rather than emitting a confident-but-wrong hash that
-// a validating server could single out.
+// version returns null; the caller then OMITS the cch token entirely rather
+// than stamping a random one (see hasCchSeed below).
+//
+// ⚠ Claude Code DROPPED the cch token between 2.1.177 and 2.1.199 (live
+// capture 2026-07-03, sdk-cli entrypoint — the entrypoint dario claims): the
+// billing block is now `cc_version=…; cc_entrypoint=sdk-cli;` with no `cch=`.
+// So "no seed" and "CC emits no cch" currently coincide, and gating cch
+// emission on seed availability keeps dario byte-aligned with real CC: we emit
+// cch only when we can emit the CORRECT deterministic value, and otherwise
+// send nothing — which is exactly what current CC sends. A random cch never
+// validates AND is a field genuine CC no longer carries: a 100%-vs-0% tell.
 
 /** Verified per-release seeds, keyed on `major.minor.patch`. */
 export const CCH_SEEDS: Record<string, bigint> = {
   '2.1.177': 0x4d659218e32a3268n,
 };
+
+/**
+ * Whether a calibrated cch seed exists for `version`. The proxy gates cch
+ * EMISSION on this: with a seed it stamps the deterministic value, without
+ * one it omits the token (matching CC 2.1.199+, which sends no cch). Keyed on
+ * `major.minor.patch` — same key space as CCH_SEEDS.
+ */
+export function hasCchSeed(version: string): boolean {
+  return CCH_SEEDS[version] !== undefined;
+}
 
 const MASK = 0xfffffn;
 const U64 = (1n << 64n) - 1n;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -54,14 +54,34 @@ function isLoopbackAddr(addr: string | undefined): boolean {
 // Concurrency control: see src/request-queue.ts for the bounded queue
 // (replaced the v3.30.x-and-earlier simple unbounded semaphore in dario#80).
 
-// Billing tag hash seed — matches Claude Code's value
+// Deterministic seed for the cc_version build suffix. Once reverse-engineered
+// as Claude Code's own value; it is now just dario's stable constant — CC's
+// real suffix algorithm has moved (see computeVersionSuffix).
 const BILLING_SEED = '59cf53e54c78';
 
-// Compute per-request build tag:
-// SHA-256(seed + chars[4,7,20] of user message + version).slice(0,3)
-function computeBuildTag(userMessage: string, version: string): string {
-  const chars = [4, 7, 20].map(i => userMessage[i] || '0').join('');
-  return createHash('sha256').update(`${BILLING_SEED}${chars}${version}`).digest('hex').slice(0, 3);
+// The `.<suffix>` on cc_version (e.g. `2.1.199.ef3`). A clean-room capture
+// (2026-07-03, fresh HOME with no CLAUDE.md / memory / project context) proved
+// this is NOT a function of the user message: every prompt — any content, any
+// length, bytes flipped at positions 0/4/7/20/29 — returned the SAME suffix,
+// and it shifted only when the injected SYSTEM CONTEXT changed. So CC derives
+// it from the system payload and it is STABLE for a given config. dario's old
+// `chars[4,7,20]`-of-user-message hash was doubly wrong: wrong input, and
+// per-request-varying where real CC is stable across requests.
+//
+// We can't reproduce CC's exact algorithm (it lives in the compiled binary,
+// same as the cch seed) and the value isn't population-discriminating — every
+// CC machine's suffix differs by its own context — so a STABLE, plausible 3-hex
+// derived from the template we replay is the faithful choice: it matches CC's
+// observable property (one stable suffix per config, like a single real
+// install) and changes only when the system payload changes (a template
+// rebake). Memoized — the inputs don't change within a process.
+let _versionSuffixCache: { key: string; value: string } | null = null;
+function computeVersionSuffix(version: string): string {
+  if (_versionSuffixCache && _versionSuffixCache.key === version) return _versionSuffixCache.value;
+  const sys = (CC_TEMPLATE as { system_prompt?: string }).system_prompt ?? '';
+  const value = createHash('sha256').update(`${BILLING_SEED}${version}${sys}`).digest('hex').slice(0, 3);
+  _versionSuffixCache = { key: version, value };
+  return value;
 }
 
 // Per-request cch PLACEHOLDER. Claude Code's cch is a deterministic xxHash64
@@ -91,10 +111,11 @@ function computeCch(): string {
  * computeCch() (a placeholder stampCch later overwrites with the deterministic
  * value) when a seed exists, or null when it doesn't. Passing null omits the
  * token — never emit a cch we can't stand behind, and never emit one current
- * CC doesn't send. Exported for tests.
+ * CC doesn't send. The cc_version build suffix is stable per config
+ * (computeVersionSuffix), independent of the request. Exported for tests.
  */
-export function buildBillingTag(cliVersion: string, userMsg: string, cch: string | null): string {
-  const fullVersion = `${cliVersion}.${computeBuildTag(userMsg, cliVersion)}`;
+export function buildBillingTag(cliVersion: string, cch: string | null): string {
+  const fullVersion = `${cliVersion}.${computeVersionSuffix(cliVersion)}`;
   const base = `x-anthropic-billing-header: cc_version=${fullVersion}; cc_entrypoint=sdk-cli;`;
   return cch === null ? base : `${base} cch=${cch};`;
 }
@@ -2290,7 +2311,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
             // CC (2.1.199+) sends none, so a random placeholder would be a
             // fingerprint rather than cover. dario#528 + 2026-07-03 drift.
             const cch = hasCchSeed(cliVersion) ? computeCch() : null;
-            const billingTag = buildBillingTag(cliVersion, userMsg, cch);
+            const billingTag = buildBillingTag(cliVersion, cch);
             const CACHE_EPHEMERAL = { type: 'ephemeral' as const };
 
             // Session stickiness: rebind the pre-selected pool account to

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -10,7 +10,7 @@ import { getAccessToken, getStatus } from './oauth.js';
 import { buildHealthResponse, derivePoolStatus, shouldDiscloseHealthInternals } from './health-response.js';
 import { darioVersion } from './version.js';
 import { buildCCRequest, applyCcPromptCaching, parseEffortSuffix, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, CC_TEMPLATE, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
-import { stampCch } from './cch.js';
+import { stampCch, hasCchSeed } from './cch.js';
 import { describeTemplate, detectDrift, checkCCCompat } from './live-fingerprint.js';
 import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCooldown, authCooldownMs, reconcilePoolAccounts, type PoolAccount } from './pool.js';
 import { Analytics, billingBucketFromClaim, type RequestRecord } from './analytics.js';
@@ -68,14 +68,35 @@ function computeBuildTag(userMessage: string, version: string): string {
 // over a projection of the request body (see src/cch.ts, dario#528). We can
 // only compute the real value once the final body is assembled, so we seed the
 // billing tag with a random 5-hex token here and overwrite it in place with the
-// deterministic value at serialize time (the `cchForBody` call near the
-// JSON.stringify of the outbound body). For Claude Code versions whose seed we
-// haven't reverse-engineered, `cchForBody` returns null and this random value
-// is what ships — same behavior as before dario#528, and a better tell than a
-// confident-but-wrong deterministic hash. Operators can force the random path
-// on every request with DARIO_CCH=random.
+// deterministic value at serialize time (the `stampCch` call near the
+// JSON.stringify of the outbound body).
+//
+// This placeholder is only emitted for CC versions we hold a calibrated seed
+// for — see buildBillingTag / hasCchSeed. Versions without a seed omit the cch
+// token entirely: current CC (2.1.199+) sends no cch at all, so a random
+// value would be a fingerprint, not cover. Operators can force the random
+// path on every seeded request with DARIO_CCH=random.
 function computeCch(): string {
   return randomBytes(3).toString('hex').slice(0, 5);
+}
+
+/**
+ * Assemble the `x-anthropic-billing-header` system-block text, tracking real
+ * Claude Code's wire shape:
+ *   with cch:    `…; cc_entrypoint=sdk-cli; cch=<5hex>;`   (CC ≤ 2.1.177)
+ *   without cch: `…; cc_entrypoint=sdk-cli;`               (CC 2.1.199+)
+ *
+ * `cch` is passed in rather than generated here so this stays a pure, testable
+ * string builder: the caller gates on hasCchSeed(cliVersion) and passes
+ * computeCch() (a placeholder stampCch later overwrites with the deterministic
+ * value) when a seed exists, or null when it doesn't. Passing null omits the
+ * token — never emit a cch we can't stand behind, and never emit one current
+ * CC doesn't send. Exported for tests.
+ */
+export function buildBillingTag(cliVersion: string, userMsg: string, cch: string | null): string {
+  const fullVersion = `${cliVersion}.${computeBuildTag(userMsg, cliVersion)}`;
+  const base = `x-anthropic-billing-header: cc_version=${fullVersion}; cc_entrypoint=sdk-cli;`;
+  return cch === null ? base : `${base} cch=${cch};`;
 }
 
 // Detect installed Claude Code version for the build-tag computation.
@@ -2232,10 +2253,13 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
             // The upstream sees a genuine CC request structure.
 
             const userMsg = extractFirstUserMessage(r);
-            const buildTag = computeBuildTag(userMsg, cliVersion);
-            const cch = computeCch();
-            const fullVersion = `${cliVersion}.${buildTag}`;
-            const billingTag = `x-anthropic-billing-header: cc_version=${fullVersion}; cc_entrypoint=sdk-cli; cch=${cch};`;
+            // Emit a cch token only for CC versions we hold a calibrated seed
+            // for (stampCch overwrites this placeholder with the deterministic
+            // value at serialize time). Uncalibrated versions omit cch: current
+            // CC (2.1.199+) sends none, so a random placeholder would be a
+            // fingerprint rather than cover. dario#528 + 2026-07-03 drift.
+            const cch = hasCchSeed(cliVersion) ? computeCch() : null;
+            const billingTag = buildBillingTag(cliVersion, userMsg, cch);
             const CACHE_EPHEMERAL = { type: 'ephemeral' as const };
 
             // Session stickiness: rebind the pre-selected pool account to
@@ -2404,10 +2428,12 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           // reverse-engineered. stampCch hashes a projection of THIS final body
           // (so it must run after every mutation above) and replaces the cch
           // anchored to the billing tag — never a cch quoted in conversation
-          // content. No-op for unknown versions (keep the random placeholder).
-          // Only the template-replay path is stamped — passthrough /
-          // count_tokens forward the client's body (and its own cch) verbatim.
-          // Reversible kill-switch: DARIO_CCH=random.
+          // content. No-op for uncalibrated versions — but those also carry no
+          // cch token to begin with (buildBillingTag omits it without a seed,
+          // matching CC 2.1.199+), so there is nothing to stamp and nothing
+          // stale is shipped. Only the template-replay path is stamped —
+          // passthrough / count_tokens forward the client's body (and its own
+          // cch) verbatim. Reversible kill-switch: DARIO_CCH=random.
           let outboundText = JSON.stringify(r);
           if (!passthrough && !isCountTokens && process.env.DARIO_CCH !== 'random') {
             outboundText = stampCch(outboundText, cliVersion);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -279,59 +279,90 @@ export const FABLE_FALLBACK_CREDIT_BETA = 'fallback-credit-2026-06-01';
 export const CONTEXT_1M_BETA = 'context-1m-2025-08-07';
 export const MID_CONVERSATION_SYSTEM_BETA = 'mid-conversation-system-2026-04-07';
 export const EFFORT_BETA = 'effort-2025-11-24';
+export const AFK_MODE_BETA = 'afk-mode-2026-01-31';
+export const ADVISOR_TOOL_BETA = 'advisor-tool-2026-03-01';
+export const CLAUDE_CODE_BETA = 'claude-code-20250219';
 
 /**
- * Model-conditional beta flags, mirroring real CC (live captures
- * 2026-06-09, CC v2.1.170 — same binary/account, `--print -p hi`, identical
- * request shape, deterministic across repeat trials):
+ * Insert `flag` immediately before the first `anchor`, deduped. If `flag` is
+ * already present the list is returned unchanged; if `anchor` is absent `flag`
+ * is appended at the tail. Used to place model-conditional betas at the exact
+ * position real CC emits them, rather than always appending.
+ */
+function insertBetaBefore(flags: string[], flag: string, anchor: string): string[] {
+  if (flags.includes(flag)) return flags;
+  const i = flags.indexOf(anchor);
+  return i < 0 ? [...flags, flag] : [...flags.slice(0, i), flag, ...flags.slice(i)];
+}
+
+/** As insertBetaBefore, but places `flag` immediately AFTER the first `anchor`. */
+function insertBetaAfter(flags: string[], flag: string, anchor: string): string[] {
+  if (flags.includes(flag)) return flags;
+  const i = flags.indexOf(anchor);
+  return i < 0 ? [...flags, flag] : [...flags.slice(0, i + 1), flag, ...flags.slice(i + 1)];
+}
+
+/**
+ * Move an already-present `flag` to immediately before the first `anchor`.
+ * No-op when either is absent. Used for haiku, where CC emits
+ * claude-code-20250219 mid-list rather than first.
+ */
+function moveBetaBefore(flags: string[], flag: string, anchor: string): string[] {
+  if (!flags.includes(flag)) return flags;
+  const without = flags.filter((f) => f !== flag);
+  const i = without.indexOf(anchor);
+  return i < 0 ? flags : [...without.slice(0, i), flag, ...without.slice(i)];
+}
+
+/**
+ * Model-conditional anthropic-beta set, mirroring real CC 2.1.199 (live
+ * captures 2026-07-03, this box, `--print --model <m> -p hi` — same
+ * binary/account, deterministic across repeat trials). `base` is the captured
+ * opus/sonnet order (TEMPLATE.anthropic_beta); each family is a transform of
+ * it, ORDER included:
  *
- *   model            betas  effort-body  notable beta set
- *   ---------------  -----  -----------  ------------------------------------
- *   claude-opus-4-8     9   xhigh        baked base (all flags)
- *   claude-sonnet-4-6   8   high         base − mid-conversation-system
- *   claude-haiku-4-5    6   (none)       base − mid-conversation-system − effort
+ *   opus-4-8    = base                                    (unchanged)
+ *   sonnet-5    = base                                    (unchanged — KEEPS
+ *                 mid-conversation-system; the old 2.1.170 sonnet-4-6 drop is
+ *                 gone: 2.1.199 sonnet == opus)
+ *   haiku-4-5   = base − {mid-conversation-system, effort, afk-mode}, and
+ *                 claude-code-20250219 MOVED to position 5 (before advisor-tool)
+ *   fable-5     = base + fallback-credit-2026-06-01 inserted BEFORE afk-mode
  *
- * APPENDS (CC adds for these families):
- *  - `fallback-credit-2026-06-01` rides on FABLE requests only (without it,
- *    subscription fable traffic is soft-refused upstream).
- *  - `context-1m-2025-08-07` rides on `[1m]`-labelled requests only (CC does
- *    NOT send it for plain models). `skipContext1m` (dario#36) suppresses the
- *    [1m] append when the account's long-context billing was rejected.
+ * `[1m]`-labelled models additionally carry context-1m-2025-08-07 at POSITION 2
+ * (immediately after claude-code-20250219), not appended at the tail. CC does
+ * NOT send it for plain models. `skipContext1m` (dario#36) suppresses it when
+ * the account's long-context billing was rejected.
  *
- * OMISSIONS (CC drops for these families; the baked base is opus's full set):
- *  - `mid-conversation-system-2026-04-07` — sonnet + haiku omit it. All three
- *    models still send the SAME 3 system blocks, so this is a capability
- *    advertisement, not load-bearing for the system shape — safe to drop.
- *  - `effort-2025-11-24` — haiku omits it (and sends no `output_config.effort`
- *    body field either; dario already strips that field for haiku, so dropping
- *    the beta just restores consistency).
+ * afk-mode-2026-01-31 is REMOTE-CONFIG controlled and flips within a CC version
+ * (memory: rolled off 7/2, back on 7/3), so its presence is a property of the
+ * captured `base`, not of this function — the live capture heals it. haiku
+ * drops it regardless. The per-family shape here is correct whether or not the
+ * base carries afk-mode: the anchor-relative inserts/moves degrade gracefully
+ * (append / no-op) when an anchor is absent.
  *
  * Removing a beta can never provoke an upstream 400 (the runtime rejection
- * cache only ever needs to ADD strips), so the omissions are strictly safe.
- * Only the two families measured to omit them are touched; opus / fable /
- * unknown models keep the full baked set unchanged.
+ * cache only ever needs to ADD strips), so the haiku omissions are safe; the
+ * position fixes are pure wire-shape fidelity.
  */
 export function betaForModel(base: string, model: string | null | undefined, skipContext1m = false): string {
-  let beta = base;
   const m = (model ?? '').toLowerCase();
-  const append = (flag: string) => {
-    if (beta.split(',').includes(flag)) return;
-    beta = beta ? `${beta},${flag}` : flag;
-  };
-  if (m.includes('fable')) append(FABLE_FALLBACK_CREDIT_BETA);
-  if (/\[1m\]$/.test(m) && !skipContext1m) append(CONTEXT_1M_BETA);
+  let flags = base.split(',').map((s) => s.trim()).filter(Boolean);
 
-  const drop = new Set<string>();
   if (m.includes('haiku')) {
-    drop.add(MID_CONVERSATION_SYSTEM_BETA);
-    drop.add(EFFORT_BETA);
-  } else if (m.includes('sonnet')) {
-    drop.add(MID_CONVERSATION_SYSTEM_BETA);
+    const drop = new Set([MID_CONVERSATION_SYSTEM_BETA, EFFORT_BETA, AFK_MODE_BETA]);
+    flags = flags.filter((f) => !drop.has(f));
+    flags = moveBetaBefore(flags, CLAUDE_CODE_BETA, ADVISOR_TOOL_BETA);
+  } else if (m.includes('fable')) {
+    flags = insertBetaBefore(flags, FABLE_FALLBACK_CREDIT_BETA, AFK_MODE_BETA);
   }
-  if (drop.size > 0) {
-    beta = beta.split(',').filter((b) => !drop.has(b.trim())).join(',');
+  // opus + sonnet + unknown families keep the base set unchanged.
+
+  if (/\[1m\]$/.test(m) && !skipContext1m) {
+    flags = insertBetaAfter(flags, CONTEXT_1M_BETA, CLAUDE_CODE_BETA);
   }
-  return beta;
+
+  return flags.join(',');
 }
 
 /**

--- a/test/beta-matrix.mjs
+++ b/test/beta-matrix.mjs
@@ -1,0 +1,60 @@
+// betaForModel — full per-model golden matrix vs real CC 2.1.199.
+//
+// Live capture 2026-07-03 (this box, `claude --print --model <m> -p hi`,
+// CC 2.1.199, sdk-cli entrypoint — the entrypoint dario claims). Each string
+// below is the verbatim anthropic-beta header CC emitted for that model.
+// betaForModel(GOLDEN_BASE, <model>) must reproduce it EXACTLY, order included.
+//
+// GOLDEN_BASE is the opus/sonnet-5 capture — the same set dario bakes into
+// TEMPLATE.anthropic_beta. Every other family is a transform of it, so a single
+// base drives the whole matrix (the live-capture auto-heal keeps the base
+// current; these transforms hold regardless of afk-mode's remote-config state).
+
+import { betaForModel } from '../dist/proxy.js';
+
+let pass = 0, fail = 0;
+function eq(label, got, want) {
+  if (got === want) { console.log(`  ✅ ${label}`); pass++; }
+  else { console.log(`  ❌ ${label}\n      got:  ${got}\n      want: ${want}`); fail++; }
+}
+
+// ── verbatim live captures (CC 2.1.199) ──
+const OPUS   = 'claude-code-20250219,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24,afk-mode-2026-01-31';
+const SONNET = OPUS; // sonnet-5 is byte-identical to opus on 2.1.199
+const HAIKU  = 'interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,claude-code-20250219,advisor-tool-2026-03-01';
+const FABLE  = 'claude-code-20250219,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24,fallback-credit-2026-06-01,afk-mode-2026-01-31';
+// fable[1m]: context-1m at position 2, fallback-credit before afk-mode (the
+// original default-model capture on this box).
+const FABLE_1M = 'claude-code-20250219,context-1m-2025-08-07,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24,fallback-credit-2026-06-01,afk-mode-2026-01-31';
+
+const GOLDEN_BASE = OPUS;
+
+console.log('\n=== betaForModel — reproduces the live CC 2.1.199 matrix ===');
+eq('opus-4-8',    betaForModel(GOLDEN_BASE, 'claude-opus-4-8'),  OPUS);
+eq('sonnet-5',    betaForModel(GOLDEN_BASE, 'claude-sonnet-5'),  SONNET);
+eq('haiku-4-5',   betaForModel(GOLDEN_BASE, 'claude-haiku-4-5'), HAIKU);
+eq('fable-5',     betaForModel(GOLDEN_BASE, 'claude-fable-5'),   FABLE);
+eq('fable-5[1m]', betaForModel(GOLDEN_BASE, 'claude-fable-5[1m]'), FABLE_1M);
+
+console.log('\n=== membership invariants (the classifier-relevant deltas) ===');
+eq('sonnet-5 keeps mid-conversation-system',
+  String(betaForModel(GOLDEN_BASE, 'claude-sonnet-5').includes('mid-conversation-system-2026-04-07')), 'true');
+eq('haiku drops afk-mode',
+  String(betaForModel(GOLDEN_BASE, 'claude-haiku-4-5').includes('afk-mode-2026-01-31')), 'false');
+eq('haiku drops effort',
+  String(betaForModel(GOLDEN_BASE, 'claude-haiku-4-5').includes('effort-2025-11-24')), 'false');
+eq('fable has fallback-credit',
+  String(betaForModel(GOLDEN_BASE, 'claude-fable-5').includes('fallback-credit-2026-06-01')), 'true');
+
+console.log('\n=== afk-mode-agnostic: transforms hold when the base lacks afk-mode ===');
+// Remote config can flip afk-mode off within a version; when the bake captured
+// it off, the base is 8 flags. The per-family shape must still be correct.
+const BASE_NO_AFK = OPUS.split(',').filter(f => f !== 'afk-mode-2026-01-31').join(',');
+eq('opus (no afk base) unchanged', betaForModel(BASE_NO_AFK, 'claude-opus-4-8'), BASE_NO_AFK);
+eq('fable (no afk base) → fallback-credit at tail',
+  betaForModel(BASE_NO_AFK, 'claude-fable-5'), `${BASE_NO_AFK},fallback-credit-2026-06-01`);
+eq('haiku (no afk base) → same 6-flag reorder',
+  betaForModel(BASE_NO_AFK, 'claude-haiku-4-5'), HAIKU);
+
+console.log(`\n${fail === 0 ? '✅ PASS' : '❌ FAIL'} — ${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/test/billing-tag.mjs
+++ b/test/billing-tag.mjs
@@ -1,0 +1,76 @@
+// Billing-tag shape + cch-gating tests (src/proxy.ts buildBillingTag,
+// src/cch.ts hasCchSeed).
+//
+// Claude Code DROPPED the cch integrity token between 2.1.177 and 2.1.199
+// (live capture 2026-07-03, sdk-cli entrypoint — the entrypoint dario claims).
+// Real CC 2.1.199 emits `cc_version=2.1.199.<suffix>; cc_entrypoint=sdk-cli;`
+// with no `cch=`. dario must match: emit cch ONLY for versions we hold a
+// calibrated seed for (so stampCch can write the correct deterministic value),
+// and omit it otherwise — a random cch never validates and is a field genuine
+// CC no longer carries (a 100%-vs-0% tell).
+
+import { buildBillingTag } from '../dist/proxy.js';
+import { hasCchSeed, CCH_SEEDS } from '../dist/cch.js';
+
+let pass = 0, fail = 0;
+function check(label, cond) {
+  if (cond) { console.log(`  ✅ ${label}`); pass++; }
+  else { console.log(`  ❌ ${label}`); fail++; }
+}
+function header(label) {
+  console.log(`\n======================================================================`);
+  console.log(`  ${label}`);
+  console.log(`======================================================================`);
+}
+
+// ── hasCchSeed: gate keyed on CCH_SEEDS coverage ──
+header('hasCchSeed — only calibrated versions report a seed');
+check("'2.1.177' has a seed", hasCchSeed('2.1.177') === true);
+check("'2.1.199' has NO seed (CC dropped cch)", hasCchSeed('2.1.199') === false);
+check("'2.1.198' has NO seed", hasCchSeed('2.1.198') === false);
+check("unknown '9.9.9' has NO seed", hasCchSeed('9.9.9') === false);
+check('hasCchSeed agrees with CCH_SEEDS membership',
+  Object.keys(CCH_SEEDS).every(v => hasCchSeed(v)) && !hasCchSeed('nope'));
+
+// ── buildBillingTag: cch omitted when null, present when supplied ──
+header('buildBillingTag — cch token gated by the caller');
+{
+  const withoutCch = buildBillingTag('2.1.199', 'hi', null);
+  const withCch = buildBillingTag('2.1.177', 'hi', 'a82da');
+
+  check('null cch -> no `cch=` token at all', !withoutCch.includes('cch='));
+  check('null cch -> block ends at `cc_entrypoint=sdk-cli;`',
+    withoutCch.endsWith('; cc_entrypoint=sdk-cli;'));
+  check('supplied cch -> `cch=<value>;` appended after entrypoint',
+    withCch.endsWith('; cc_entrypoint=sdk-cli; cch=a82da;'));
+  check('both keep cc_version first, then cc_entrypoint',
+    /^x-anthropic-billing-header: cc_version=[^;]+; cc_entrypoint=sdk-cli;/.test(withoutCch)
+    && /^x-anthropic-billing-header: cc_version=[^;]+; cc_entrypoint=sdk-cli;/.test(withCch));
+}
+
+// ── golden vector: matches real CC 2.1.199 for the `hi` prompt ──
+// Live capture 2026-07-03: `claude --print -p hi` on CC 2.1.199 emitted
+//   x-anthropic-billing-header: cc_version=2.1.199.ef3; cc_entrypoint=sdk-cli;
+// computeBuildTag('hi', '2.1.199') === 'ef3' (the degenerate empty-chars case),
+// so dario's output for this prompt is byte-identical to genuine CC. The value
+// of the suffix for OTHER prompts is a separate concern (build-suffix drift);
+// this vector pins the SHAPE: cc_version-first, sdk-cli, and no cch.
+header('buildBillingTag — golden vector vs real CC 2.1.199 (`hi`)');
+check('byte-matches the live 2.1.199 `hi` capture',
+  buildBillingTag('2.1.199', 'hi', null)
+    === 'x-anthropic-billing-header: cc_version=2.1.199.ef3; cc_entrypoint=sdk-cli;');
+
+// ── composition: the production gating expression ──
+// proxy.ts builds cch as `hasCchSeed(v) ? computeCch() : null`. Simulate it
+// with a fixed placeholder and assert cch presence tracks seed availability.
+header('gating composition — cch presence tracks the seed');
+for (const v of ['2.1.177', '2.1.199', '2.1.198', '9.9.9']) {
+  const cch = hasCchSeed(v) ? 'xxxxx' : null;
+  const tag = buildBillingTag(v, 'hello world', cch);
+  const expectCch = hasCchSeed(v);
+  check(`${v}: cch ${expectCch ? 'present' : 'absent'} in billing tag`,
+    tag.includes('cch=') === expectCch);
+}
+
+console.log(`\n${fail === 0 ? '✅ PASS' : '❌ FAIL'} — ${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/test/billing-tag.mjs
+++ b/test/billing-tag.mjs
@@ -35,8 +35,8 @@ check('hasCchSeed agrees with CCH_SEEDS membership',
 // ── buildBillingTag: cch omitted when null, present when supplied ──
 header('buildBillingTag — cch token gated by the caller');
 {
-  const withoutCch = buildBillingTag('2.1.199', 'hi', null);
-  const withCch = buildBillingTag('2.1.177', 'hi', 'a82da');
+  const withoutCch = buildBillingTag('2.1.199', null);
+  const withCch = buildBillingTag('2.1.177', 'a82da');
 
   check('null cch -> no `cch=` token at all', !withoutCch.includes('cch='));
   check('null cch -> block ends at `cc_entrypoint=sdk-cli;`',
@@ -48,17 +48,25 @@ header('buildBillingTag — cch token gated by the caller');
     && /^x-anthropic-billing-header: cc_version=[^;]+; cc_entrypoint=sdk-cli;/.test(withCch));
 }
 
-// ── golden vector: matches real CC 2.1.199 for the `hi` prompt ──
-// Live capture 2026-07-03: `claude --print -p hi` on CC 2.1.199 emitted
-//   x-anthropic-billing-header: cc_version=2.1.199.ef3; cc_entrypoint=sdk-cli;
-// computeBuildTag('hi', '2.1.199') === 'ef3' (the degenerate empty-chars case),
-// so dario's output for this prompt is byte-identical to genuine CC. The value
-// of the suffix for OTHER prompts is a separate concern (build-suffix drift);
-// this vector pins the SHAPE: cc_version-first, sdk-cli, and no cch.
-header('buildBillingTag — golden vector vs real CC 2.1.199 (`hi`)');
-check('byte-matches the live 2.1.199 `hi` capture',
-  buildBillingTag('2.1.199', 'hi', null)
-    === 'x-anthropic-billing-header: cc_version=2.1.199.ef3; cc_entrypoint=sdk-cli;');
+// ── build suffix: stable per config, NOT request-derived ──
+// Clean-room capture (2026-07-03, fresh HOME): CC's cc_version suffix is
+// CONSTANT across every prompt — content, length, byte position all irrelevant.
+// It is a hash of the SYSTEM context, stable for a given config. dario matches
+// that observable property: one stable 3-hex suffix per (version, template),
+// independent of the request. (The exact value is CC's binary-internal algo —
+// unreproducible, unvalidated in practice, and different on every CC machine.)
+header('buildBillingTag — cc_version suffix is stable per config');
+{
+  const shape = /^x-anthropic-billing-header: cc_version=2\.1\.199\.[0-9a-f]{3}; cc_entrypoint=sdk-cli;$/;
+  const a = buildBillingTag('2.1.199', null);
+  const b = buildBillingTag('2.1.199', null);
+  check('suffix is exactly 3 lowercase hex, cc_version-first, no cch', shape.test(a));
+  check('stable across calls (no per-request variance)', a === b);
+  const suffix = /cc_version=2\.1\.199\.([0-9a-f]{3})/.exec(a)?.[1] ?? '';
+  check('a different CC version yields its own stable suffix',
+    /\.[0-9a-f]{3};/.test(buildBillingTag('2.1.177', null)));
+  check('suffix is deterministic hex', /^[0-9a-f]{3}$/.test(suffix));
+}
 
 // ── composition: the production gating expression ──
 // proxy.ts builds cch as `hasCchSeed(v) ? computeCch() : null`. Simulate it
@@ -66,7 +74,7 @@ check('byte-matches the live 2.1.199 `hi` capture',
 header('gating composition — cch presence tracks the seed');
 for (const v of ['2.1.177', '2.1.199', '2.1.198', '9.9.9']) {
   const cch = hasCchSeed(v) ? 'xxxxx' : null;
-  const tag = buildBillingTag(v, 'hello world', cch);
+  const tag = buildBillingTag(v, cch);
   const expectCch = hasCchSeed(v);
   check(`${v}: cch ${expectCch ? 'present' : 'absent'} in billing tag`,
     tag.includes('cch=') === expectCch);

--- a/test/fable-beta.mjs
+++ b/test/fable-beta.mjs
@@ -9,7 +9,7 @@
 // while opus/sonnet answer normally (isolated on the live proxy 2026-06-09).
 // dario therefore mirrors CC: append for the fable family, never for others.
 
-import { betaForModel, FABLE_FALLBACK_CREDIT_BETA, CONTEXT_1M_BETA, MID_CONVERSATION_SYSTEM_BETA, EFFORT_BETA, stripContext1mTag } from '../dist/proxy.js';
+import { betaForModel, FABLE_FALLBACK_CREDIT_BETA, CONTEXT_1M_BETA, MID_CONVERSATION_SYSTEM_BETA, EFFORT_BETA, CLAUDE_CODE_BETA, stripContext1mTag } from '../dist/proxy.js';
 import { buildCCRequest } from '../dist/cc-template.js';
 
 let pass = 0;
@@ -43,44 +43,45 @@ check('empty model → unchanged', betaForModel(BASE, '') === BASE);
 check('null model → unchanged',  betaForModel(BASE, null) === BASE);
 check('undefined model → unchanged', betaForModel(BASE, undefined) === BASE);
 
-console.log('\n=== betaForModel — per-model beta OMISSIONS (CC v2.1.170 wire) ===');
-// Real CC drops betas for lesser models: sonnet omits mid-conversation-system;
-// haiku omits mid-conversation-system AND effort-2025-11-24. The baked base is
-// opus's full set, so dario must subtract per model.
+console.log('\n=== betaForModel — per-model transforms (CC v2.1.199 wire) ===');
+// CC 2.1.199 (live capture 2026-07-03): sonnet-5 == opus (KEEPS
+// mid-conversation-system — the 2.1.170 sonnet-4-6 drop is gone). Haiku drops
+// mid-conversation-system + effort + afk-mode AND emits claude-code-20250219 in
+// position 5 (before advisor-tool), not first. Fable inserts fallback-credit
+// immediately before afk-mode.
 {
-  const FULL = 'claude-code-20250219,interleaved-thinking-2025-05-14,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24';
-  const sonnetOut = betaForModel(FULL, 'claude-sonnet-4-6');
-  check('sonnet → drops mid-conversation-system', !sonnetOut.includes(MID_CONVERSATION_SYSTEM_BETA));
-  check('sonnet → keeps effort', sonnetOut.includes(EFFORT_BETA));
+  const FULL = 'claude-code-20250219,interleaved-thinking-2025-05-14,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24,afk-mode-2026-01-31';
+  const sonnetOut = betaForModel(FULL, 'claude-sonnet-5');
+  check('sonnet-5 → KEEPS mid-conversation-system (2.1.199)', sonnetOut.includes(MID_CONVERSATION_SYSTEM_BETA));
+  check('sonnet-5 → keeps effort', sonnetOut.includes(EFFORT_BETA));
+  check('sonnet-5 → identical to base (== opus)', sonnetOut === FULL);
   const haikuOut = betaForModel(FULL, 'claude-haiku-4-5');
   check('haiku → drops mid-conversation-system', !haikuOut.includes(MID_CONVERSATION_SYSTEM_BETA));
   check('haiku → drops effort', !haikuOut.includes(EFFORT_BETA));
-  check('opus → keeps both', betaForModel(FULL, 'claude-opus-4-8') === FULL);
-  check('fable → keeps both (unmeasured, left as opus-class)',
-    betaForModel(FULL, 'claude-fable-5').includes(MID_CONVERSATION_SYSTEM_BETA) &&
-    betaForModel(FULL, 'claude-fable-5').includes(EFFORT_BETA));
-  check('sonnet[1m] → drops mid-conv, keeps effort, appends context-1m',
-    (() => { const o = betaForModel(FULL, 'claude-sonnet-4-6[1m]'); return !o.includes(MID_CONVERSATION_SYSTEM_BETA) && o.includes(EFFORT_BETA) && o.includes(CONTEXT_1M_BETA); })());
-  check('haiku omission does not corrupt unrelated flags',
-    haikuOut === 'claude-code-20250219,interleaved-thinking-2025-05-14,advisor-tool-2026-03-01');
+  check('haiku → drops afk-mode', !haikuOut.includes('afk-mode-2026-01-31'));
+  check('opus → keeps everything', betaForModel(FULL, 'claude-opus-4-8') === FULL);
+  check('fable → fallback-credit inserted BEFORE afk-mode',
+    betaForModel(FULL, 'claude-fable-5') === 'claude-code-20250219,interleaved-thinking-2025-05-14,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24,fallback-credit-2026-06-01,afk-mode-2026-01-31');
+  check('haiku → claude-code-20250219 moved to position 5 (before advisor-tool)',
+    haikuOut === 'interleaved-thinking-2025-05-14,claude-code-20250219,advisor-tool-2026-03-01');
 }
 
-console.log('\n=== betaForModel — context-1m rides on [1m] requests only (CC v2.1.170 wire) ===');
-// Real CC sends context-1m ONLY for [1m]-labelled models; the v2.1.170 baked
-// base set carries neither model-conditional flag.
+console.log('\n=== betaForModel — context-1m rides on [1m] requests at position 2 (CC v2.1.199 wire) ===');
+// Real CC sends context-1m ONLY for [1m]-labelled models, and at POSITION 2 —
+// immediately after claude-code-20250219, not appended at the tail.
 {
-  const LEAN = 'claude-code-20250219,effort-2025-11-24'; // base without context-1m (v2.1.170 bake shape)
-  check('[1m] request → context-1m appended',
-    betaForModel(LEAN, 'claude-sonnet-4-6[1m]') === `${LEAN},${CONTEXT_1M_BETA}`);
+  const LEAN = 'claude-code-20250219,effort-2025-11-24'; // base without context-1m
+  check('[1m] request → context-1m at position 2 (after claude-code)',
+    betaForModel(LEAN, 'claude-sonnet-5[1m]') === `${CLAUDE_CODE_BETA},${CONTEXT_1M_BETA},effort-2025-11-24`);
   check('plain model → no context-1m',
-    betaForModel(LEAN, 'claude-sonnet-4-6') === LEAN);
-  check('fable[1m] → fallback-credit AND context-1m',
-    betaForModel(LEAN, 'claude-fable-5[1m]') === `${LEAN},${FABLE_FALLBACK_CREDIT_BETA},${CONTEXT_1M_BETA}`);
-  check('skipContext1m suppresses the [1m] append (billing-cache fallback)',
-    betaForModel(LEAN, 'claude-sonnet-4-6[1m]', true) === LEAN);
+    betaForModel(LEAN, 'claude-sonnet-5') === LEAN);
+  check('fable[1m] → context-1m at position 2, fallback-credit at tail',
+    betaForModel(LEAN, 'claude-fable-5[1m]') === `${CLAUDE_CODE_BETA},${CONTEXT_1M_BETA},effort-2025-11-24,${FABLE_FALLBACK_CREDIT_BETA}`);
+  check('skipContext1m suppresses the [1m] insert (billing-cache fallback)',
+    betaForModel(LEAN, 'claude-sonnet-5[1m]', true) === LEAN);
   check('skipContext1m does NOT suppress fable fallback-credit',
     betaForModel(LEAN, 'claude-fable-5[1m]', true) === `${LEAN},${FABLE_FALLBACK_CREDIT_BETA}`);
-  check('legacy base already carrying context-1m → no dup',
+  check('base already carrying context-1m → no dup / no move',
     betaForModel(`${LEAN},${CONTEXT_1M_BETA}`, 'claude-opus-4-7[1m]') === `${LEAN},${CONTEXT_1M_BETA}`);
 }
 


### PR DESCRIPTION
Keeps dario's request format in step with current Claude Code — three fields had gone stale:

- **`cch` billing-header token dropped** — current Claude Code no longer sends it; dario was still appending one. Now gated on a known value via `hasCchSeed()` and otherwise omitted.
- **Per-model `anthropic-beta` refreshed** — updated the per-model sets in `betaForModel` (sonnet-5 keeps `mid-conversation-system`; haiku drops `afk-mode` and orders `claude-code-20250219` at position 5; fable/`[1m]` positions), order and membership.
- **`cc_version` build suffix now stable per config** — derived from the loaded template rather than per-request.
- **Drift guard** — `scripts/check-wire-drift.mjs` + `wire-drift-self-hosted.yml` flag per-model beta / billing-header drift; `scripts/check-overage-live.mjs` checks all models bill to the subscription plan.

105 tests green.
