### PR TITLE
fix(effort): default to high, matching CC — fixes #658 zero-text on long prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.130] - 2026-07-03
+
+- **Default `output_config.effort` to `high`, matching real CC — fixes zero-text on long prompts (#658)** — `resolveEffort` defaulted to `max`, the reasoning ceiling. A clean-room capture (fresh HOME, no config) of CC 2.1.199 shows the genuine binary sends `effort: high` on every adaptive-thinking family (opus-4-8, sonnet-5, fable-5, opus-4-6, sonnet-4-6). `max` diverged from CC on two counts: it isn't what CC sends, and `max` effort + unbounded `thinking: {type:"adaptive"}` makes the model reason until it exhausts `max_tokens` — on prompts over ~5K input tokens the thinking phase consumes the entire budget and the stream ends `stop_reason: max_tokens` with **zero text content blocks**. CC at `high` thinks proportionally and leaves room for text, which is why CC works on long prompts and dario didn't. This is a wire-fidelity fix that also resolves the reported failure for every client by default — no opt-out flag needed. `thinking`, `max_tokens`, and `context_management` already matched CC; effort was the only divergence. Operators wanting a higher tier still pin `--effort` / `DARIO_EFFORT` (the prod box already pins `max`, so it is unaffected). The `max`-default regression landed in #470 and outlived the #624 clamp removal.
 ## [4.8.129] - 2026-07-03
 
 - **Wire-tighten the billing block + per-model beta to real CC 2.1.199 (#657)** — live captures of the genuine `claude` 2.1.199 binary (loopback MITM, sdk-cli entrypoint — the entrypoint dario claims) showed three request signals had drifted from what dario emits. None was breaking subscription routing (the classifier isn't hard-validating them today), but each was a clean dario-vs-CC tell. All now match the live binary:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.129",
+  "version": "4.8.130",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -1195,17 +1195,28 @@ function normalizeEffortForWire(effort: string): string {
  * defaulted to `high`; dario special-cased it. A fresh live replay on 2026-07-01
  * through the deployed proxy (CC 2.1.198's verbatim fable body, only
  * output_config.effort mutated) shows the redeployed fable now ANSWERS all three
- * — high/xhigh/max → end_turn, zero refusals — and CC 2.1.198 itself sends
- * `effort: xhigh` on fable (same as opus). So the clamp + the fable-only default
- * are gone: fable now takes the general path (default 'max', no clamp), matching
- * how dario treats opus. `model` is retained in the signature for callers and in
- * case a future model needs per-family effort handling again.
+ * — high/xhigh/max → end_turn, zero refusals. So the clamp + the fable-only
+ * default are gone: fable now takes the general path (no clamp), matching how
+ * dario treats opus. The general default is `high` (see resolveEffort below) —
+ * a clean-room 2.1.199 capture shows CC sends `high` on every family; earlier
+ * `xhigh` sightings were from configured captures. `model` is retained in the
+ * signature in case a future model needs per-family effort handling again.
  *
  * Exported for tests.
  */
 export function resolveEffort(flag: EffortValue | undefined, clientBody: Record<string, unknown>, model?: string): string {
   void model; // no per-family effort handling at present (see FABLE CLAMP note above)
-  const familyDefault = 'max';
+  // Match real CC's wire value. A clean-room capture (fresh HOME, no config) of
+  // CC 2.1.199 sends `effort: high` on every adaptive-thinking model (opus-4-8,
+  // sonnet-5, fable-5, opus-4-6, sonnet-4-6 — verified 2026-07-03). The prior
+  // default `'max'` was the reasoning ceiling and diverged from CC on two
+  // counts: it's not what CC sends, and `max` effort + unbounded adaptive
+  // thinking makes the model reason until it exhausts `max_tokens` — on prompts
+  // over ~5K input tokens the thinking phase consumes the entire budget, so the
+  // stream ends `stop_reason: max_tokens` with ZERO text blocks (dario#658). CC
+  // at `high` thinks proportionally and leaves room for text. Operators who
+  // want a higher tier still pin it via `--effort` / DARIO_EFFORT.
+  const familyDefault = 'high';
   if (flag === undefined) return familyDefault;
   if (flag === 'client') {
     const clientOC = clientBody.output_config as { effort?: unknown } | undefined;

--- a/test/effort-flag.mjs
+++ b/test/effort-flag.mjs
@@ -30,9 +30,10 @@ header('VALID_EFFORT_VALUES — the allowed set');
 // ─────────────────────────────────────────────────────────────
 header('resolveEffort — explicit values pin');
 {
-  // Unset default is 'max' — the highest universally-supported level (Opus +
-  // Sonnet both accept it; 'xhigh' is Opus-only and 400s Sonnet-class).
-  check('undefined → max (default)', resolveEffort(undefined, {}) === 'max');
+  // Unset default is 'high' — the value real CC 2.1.199 sends on every family
+  // (clean-room capture 2026-07-03). `max` (the prior default) diverged from CC
+  // and let adaptive thinking exhaust max_tokens on long prompts (dario#658).
+  check('undefined → high (default)', resolveEffort(undefined, {}) === 'high');
   check('low → low', resolveEffort('low', {}) === 'low');
   check('medium → medium', resolveEffort('medium', {}) === 'medium');
   check('high → high', resolveEffort('high', {}) === 'high');
@@ -44,12 +45,12 @@ header('resolveEffort — fable takes the general path (clamp removed 2026-07-01
 {
   // Fable 5 was suspended 2026-06-12 and redeployed 2026-07-01. A fresh live
   // replay (CC 2.1.198 verbatim body, only effort mutated) shows the redeployed
-  // fable ANSWERS high/xhigh/max (end_turn, no refusal), and CC 2.1.198 sends
-  // effort=xhigh on fable. So the fable-only default ('high') and the max/xhigh
-  // clamp are gone — fable behaves like opus: default 'max', nothing clamped.
-  check('undefined + fable → max (general default)', resolveEffort(undefined, {}, 'claude-fable-5') === 'max');
-  check('undefined + fable[1m] → max', resolveEffort(undefined, {}, 'claude-fable-5[1m]') === 'max');
-  check('undefined + opus → max (unchanged)', resolveEffort(undefined, {}, 'claude-opus-4-8') === 'max');
+  // fable ANSWERS high/xhigh/max (end_turn, no refusal). The clamp is gone —
+  // fable behaves like opus: the general default 'high' (CC's 2.1.199 wire
+  // value on every family), nothing clamped.
+  check('undefined + fable → high (general default)', resolveEffort(undefined, {}, 'claude-fable-5') === 'high');
+  check('undefined + fable[1m] → high', resolveEffort(undefined, {}, 'claude-fable-5[1m]') === 'high');
+  check('undefined + opus → high (general default)', resolveEffort(undefined, {}, 'claude-opus-4-8') === 'high');
   check('max flag + fable → max (no clamp)', resolveEffort('max', {}, 'claude-fable-5') === 'max');
   check('xhigh flag + fable → xhigh (no clamp)', resolveEffort('xhigh', {}, 'claude-fable-5') === 'xhigh');
   check('ultracode + fable → xhigh (no clamp)', resolveEffort('ultracode', {}, 'claude-fable-5') === 'xhigh');
@@ -59,8 +60,8 @@ header('resolveEffort — fable takes the general path (clamp removed 2026-07-01
     resolveEffort('client', { output_config: { effort: 'max' } }, 'claude-fable-5') === 'max');
   check('client xhigh + fable → xhigh (no clamp)',
     resolveEffort('client', { output_config: { effort: 'xhigh' } }, 'claude-fable-5') === 'xhigh');
-  check('client + fable, no client effort → max fallback',
-    resolveEffort('client', {}, 'claude-fable-5') === 'max');
+  check('client + fable, no client effort → high fallback',
+    resolveEffort('client', {}, 'claude-fable-5') === 'high');
   check('client + fable, client effort wins', resolveEffort('client', { output_config: { effort: 'low' } }, 'claude-fable-5') === 'low');
   check('max flag + opus → max', resolveEffort('max', {}, 'claude-opus-4-8') === 'max');
   check('xhigh flag + opus → xhigh', resolveEffort('xhigh', {}, 'claude-opus-4-8') === 'xhigh');
@@ -69,20 +70,20 @@ header('resolveEffort — fable takes the general path (clamp removed 2026-07-01
 
 header('resolveEffort — client passthrough');
 {
-  check('client, no output_config → max fallback',
-    resolveEffort('client', {}) === 'max');
-  check('client, output_config without effort → max fallback',
-    resolveEffort('client', { output_config: {} }) === 'max');
+  check('client, no output_config → high fallback',
+    resolveEffort('client', {}) === 'high');
+  check('client, output_config without effort → high fallback',
+    resolveEffort('client', { output_config: {} }) === 'high');
   check('client, output_config.effort = "low" → low',
     resolveEffort('client', { output_config: { effort: 'low' } }) === 'low');
   check('client, output_config.effort = "xhigh" → xhigh',
     resolveEffort('client', { output_config: { effort: 'xhigh' } }) === 'xhigh');
   check('client, output_config.effort = "max" → max',
     resolveEffort('client', { output_config: { effort: 'max' } }) === 'max');
-  check('client, non-string effort ignored → max',
-    resolveEffort('client', { output_config: { effort: 42 } }) === 'max');
-  check('client, empty string effort ignored → max',
-    resolveEffort('client', { output_config: { effort: '' } }) === 'max');
+  check('client, non-string effort ignored → high',
+    resolveEffort('client', { output_config: { effort: 42 } }) === 'high');
+  check('client, empty string effort ignored → high',
+    resolveEffort('client', { output_config: { effort: '' } }) === 'high');
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -94,7 +95,7 @@ header('buildCCRequest — effort reaches outbound body');
   const clientBody = { model: 'claude-sonnet-4-6', messages: [{ role: 'user', content: 'hi' }], stream: false };
 
   const defaultBuild = buildCCRequest(clientBody, billingTag, cacheControl, identity);
-  check('default outbound effort = max', defaultBuild.body.output_config?.effort === 'max');
+  check('default outbound effort = high', defaultBuild.body.output_config?.effort === 'high');
 
   const lowBuild = buildCCRequest(clientBody, billingTag, cacheControl, identity, { effort: 'low' });
   check('effort=low → outbound low', lowBuild.body.output_config?.effort === 'low');
@@ -111,7 +112,7 @@ header('buildCCRequest — effort reaches outbound body');
   check('effort=client + client body.output_config.effort=xhigh → xhigh', passthroughBuild.body.output_config?.effort === 'xhigh');
 
   const passthroughNoneBuild = buildCCRequest(clientBody, billingTag, cacheControl, identity, { effort: 'client' });
-  check('effort=client + no client output_config → max fallback', passthroughNoneBuild.body.output_config?.effort === 'max');
+  check('effort=client + no client output_config → high fallback', passthroughNoneBuild.body.output_config?.effort === 'high');
 }
 
 header('buildCCRequest — haiku carve-out: no output_config regardless of flag');


### PR DESCRIPTION
Fixes #658.

`resolveEffort` defaulted to `max`, the reasoning ceiling. Combined with unbounded `thinking: {type:"adaptive"}`, that makes the model reason until it exhausts `max_tokens` — on long prompts (~5K+ input tokens) the thinking phase consumes the whole budget and the stream ends `stop_reason: max_tokens` with zero text, exactly the reporter's symptom. `high` — Claude Code's out-of-box default — thinks proportionally and leaves room for the answer.

Change: `resolveEffort` default `'max'` → `'high'`; 11 stale test assertions updated; bumps to v4.8.130. Fixes the failure for every client by default; operators wanting a higher tier still pin `--effort` / `DARIO_EFFORT`. 105 tests green.
