### PR TITLE
fix(beta): sonnet drops mid-conversation-system on CC 2.1.201 (#667)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.133",
+  "version": "4.8.134",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -332,9 +332,8 @@ function moveBetaBefore(flags: string[], flag: string, anchor: string): string[]
  * it, ORDER included:
  *
  *   opus-4-8    = base                                    (unchanged)
- *   sonnet-5    = base                                    (unchanged — KEEPS
- *                 mid-conversation-system; the old 2.1.170 sonnet-4-6 drop is
- *                 gone: 2.1.199 sonnet == opus)
+ *   sonnet-5    = base − {mid-conversation-system}        (CC 2.1.201 dropped it
+ *                 from sonnet; 2.1.199 sonnet == opus and still kept it — #667)
  *   haiku-4-5   = base − {mid-conversation-system, effort, afk-mode}, and
  *                 claude-code-20250219 MOVED to position 5 (before advisor-tool)
  *   fable-5     = base + fallback-credit-2026-06-01 inserted BEFORE afk-mode
@@ -363,10 +362,14 @@ export function betaForModel(base: string, model: string | null | undefined, ski
     const drop = new Set([MID_CONVERSATION_SYSTEM_BETA, EFFORT_BETA, AFK_MODE_BETA]);
     flags = flags.filter((f) => !drop.has(f));
     flags = moveBetaBefore(flags, CLAUDE_CODE_BETA, ADVISOR_TOOL_BETA);
+  } else if (m.includes('sonnet')) {
+    // CC 2.1.201 dropped mid-conversation-system from sonnet's beta set (2.1.199
+    // sonnet == opus and still carried it — live capture #667). opus + fable keep it.
+    flags = flags.filter((f) => f !== MID_CONVERSATION_SYSTEM_BETA);
   } else if (m.includes('fable')) {
     flags = insertBetaBefore(flags, FABLE_FALLBACK_CREDIT_BETA, AFK_MODE_BETA);
   }
-  // opus + sonnet + unknown families keep the base set unchanged.
+  // opus + unknown families keep the base set unchanged.
 
   if (/\[1m\]$/.test(m) && !skipContext1m) {
     flags = insertBetaAfter(flags, CONTEXT_1M_BETA, CLAUDE_CODE_BETA);

--- a/test/beta-matrix.mjs
+++ b/test/beta-matrix.mjs
@@ -1,7 +1,7 @@
-// betaForModel — full per-model golden matrix vs Claude Code 2.1.199.
+// betaForModel — full per-model golden matrix vs Claude Code 2.1.201.
 //
 // These are the anthropic-beta headers the installed `claude` sends for each
-// model on CC 2.1.199 (`claude --print --model <m> -p hi`), verbatim. Each
+// model on CC 2.1.201 (`claude --print --model <m> -p hi`), verbatim. Each
 // string below is exactly what CC sent for that model.
 // betaForModel(GOLDEN_BASE, <model>) must reproduce it EXACTLY, order included.
 //
@@ -18,9 +18,9 @@ function eq(label, got, want) {
   else { console.log(`  ❌ ${label}\n      got:  ${got}\n      want: ${want}`); fail++; }
 }
 
-// ── verbatim headers from CC 2.1.199 ──
+// ── verbatim headers from CC 2.1.201 ──
 const OPUS   = 'claude-code-20250219,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24,afk-mode-2026-01-31';
-const SONNET = OPUS; // sonnet-5 is identical to opus on 2.1.199
+const SONNET = OPUS.split(',').filter((f) => f !== 'mid-conversation-system-2026-04-07').join(','); // CC 2.1.201 dropped mid-conversation-system from sonnet (#667)
 const HAIKU  = 'interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,claude-code-20250219,advisor-tool-2026-03-01';
 const FABLE  = 'claude-code-20250219,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24,fallback-credit-2026-06-01,afk-mode-2026-01-31';
 // fable[1m]: context-1m inserted at position 2, with fallback-credit before
@@ -29,7 +29,7 @@ const FABLE_1M = 'claude-code-20250219,context-1m-2025-08-07,interleaved-thinkin
 
 const GOLDEN_BASE = OPUS;
 
-console.log('\n=== betaForModel — reproduces the CC 2.1.199 matrix ===');
+console.log('\n=== betaForModel — reproduces the CC 2.1.201 matrix ===');
 eq('opus-4-8',    betaForModel(GOLDEN_BASE, 'claude-opus-4-8'),  OPUS);
 eq('sonnet-5',    betaForModel(GOLDEN_BASE, 'claude-sonnet-5'),  SONNET);
 eq('haiku-4-5',   betaForModel(GOLDEN_BASE, 'claude-haiku-4-5'), HAIKU);
@@ -37,8 +37,8 @@ eq('fable-5',     betaForModel(GOLDEN_BASE, 'claude-fable-5'),   FABLE);
 eq('fable-5[1m]', betaForModel(GOLDEN_BASE, 'claude-fable-5[1m]'), FABLE_1M);
 
 console.log('\n=== membership invariants (the per-model deltas) ===');
-eq('sonnet-5 keeps mid-conversation-system',
-  String(betaForModel(GOLDEN_BASE, 'claude-sonnet-5').includes('mid-conversation-system-2026-04-07')), 'true');
+eq('sonnet-5 drops mid-conversation-system (2.1.201)',
+  String(betaForModel(GOLDEN_BASE, 'claude-sonnet-5').includes('mid-conversation-system-2026-04-07')), 'false');
 eq('haiku drops afk-mode',
   String(betaForModel(GOLDEN_BASE, 'claude-haiku-4-5').includes('afk-mode-2026-01-31')), 'false');
 eq('haiku drops effort',

--- a/test/fable-beta.mjs
+++ b/test/fable-beta.mjs
@@ -43,18 +43,18 @@ check('empty model → unchanged', betaForModel(BASE, '') === BASE);
 check('null model → unchanged',  betaForModel(BASE, null) === BASE);
 check('undefined model → unchanged', betaForModel(BASE, undefined) === BASE);
 
-console.log('\n=== betaForModel — per-model transforms (CC v2.1.199 wire) ===');
-// CC 2.1.199 (live capture 2026-07-03): sonnet-5 == opus (KEEPS
-// mid-conversation-system — the 2.1.170 sonnet-4-6 drop is gone). Haiku drops
+console.log('\n=== betaForModel — per-model transforms (CC v2.1.201 wire) ===');
+// CC 2.1.201 (live capture #667): sonnet-5 = opus − mid-conversation-system
+// (CC dropped it from sonnet; 2.1.199 sonnet still kept it). Haiku drops
 // mid-conversation-system + effort + afk-mode AND emits claude-code-20250219 in
 // position 5 (before advisor-tool), not first. Fable inserts fallback-credit
 // immediately before afk-mode.
 {
   const FULL = 'claude-code-20250219,interleaved-thinking-2025-05-14,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24,afk-mode-2026-01-31';
   const sonnetOut = betaForModel(FULL, 'claude-sonnet-5');
-  check('sonnet-5 → KEEPS mid-conversation-system (2.1.199)', sonnetOut.includes(MID_CONVERSATION_SYSTEM_BETA));
+  check('sonnet-5 → DROPS mid-conversation-system (2.1.201)', !sonnetOut.includes(MID_CONVERSATION_SYSTEM_BETA));
   check('sonnet-5 → keeps effort', sonnetOut.includes(EFFORT_BETA));
-  check('sonnet-5 → identical to base (== opus)', sonnetOut === FULL);
+  check('sonnet-5 → base minus mid-conversation-system', sonnetOut === FULL.split(',').filter((f) => f !== MID_CONVERSATION_SYSTEM_BETA).join(','));
   const haikuOut = betaForModel(FULL, 'claude-haiku-4-5');
   check('haiku → drops mid-conversation-system', !haikuOut.includes(MID_CONVERSATION_SYSTEM_BETA));
   check('haiku → drops effort', !haikuOut.includes(EFFORT_BETA));


### PR DESCRIPTION
`scripts/check-wire-drift.mjs` (self-hosted `dario-drift` runner) flagged a per-model beta divergence from the installed CC 2.1.201 — #667. One finding: `betaForModel` emits sonnet-5's set WITH `mid-conversation-system-2026-04-07`, but CC 2.1.201 dropped it from sonnet (2.1.199 had sonnet == opus and still carried it; opus + fable keep it, haiku already drops it).

Fix: a `sonnet` branch in `betaForModel` that drops `mid-conversation-system`, plus the golden-matrix + fable-beta assertion updates and a 4.8.134 bump to release. cch stays correctly omitted (no seed for 2.1.201); billing block unchanged.

105/105 tests pass locally.

**Unknown surfaced:** the drop is applied family-wide (`m.includes('sonnet')`). sonnet-5 is confirmed by the live capture; sonnet-4-6 isn't in the drift check's captured set, so its 2.1.201 beta is inferred to follow the family. If CC treats sonnet-4-6 differently, it'd be one flag ahead — and the check wouldn't catch it (only the four current models are captured).

Not touched: `SUPPORTED_CC_RANGE.maxTested` — that's the cc-drift bot's lane.
