### PR TITLE
fix(doctor-watch): retry transient docker-exec miss instead of false red CI

### DIFF
--- a/scripts/check-doctor-drift.mjs
+++ b/scripts/check-doctor-drift.mjs
@@ -36,21 +36,57 @@
 
 import { execFileSync } from 'node:child_process';
 
+/**
+ * Synchronous sleep between retries — this script runs as a top-level sync
+ * flow with no event loop to await. Mirrors scripts/check-sdk-drift.mjs.
+ */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+// Run `docker exec askalf-dario dario doctor --obedience`, retrying ONLY the
+// transient "container momentarily unreachable" case. The askalf-dario
+// container is bounced during a deploy (image pull + recreate); a doctor run
+// that lands in that window fails INSTANTLY with empty stdout — docker exits
+// non-zero before dario prints a row. Un-retried, that surfaces as a false red
+// CI run (exit 3) even though nothing drifted, and the container is back
+// seconds later. Same transient-blip guard scripts/check-sdk-drift.mjs already
+// wraps around its npm calls.
+//
+// What is deliberately NOT retried:
+//   - a run that produced output, even on a non-zero exit: `dario doctor`
+//     prints its rows and THEN exits 1 on a [FAIL], so non-empty stdout is a
+//     real run carrying drift — parse it, never retry it away.
+//   - a timeout-kill (err.killed): doctor genuinely hung, not a fast container
+//     miss. Retrying 3×180s would blow the job's 8-min budget — surface it now.
+const ATTEMPTS = 3;
 let raw = '';
-try {
-  // 180s: the obedience probe is up to 3 serial attempts × 30s per family
-  // (families run in parallel) on top of doctor's local checks.
-  raw = execFileSync('docker', ['exec', 'askalf-dario', 'dario', 'doctor', '--obedience'], {
-    encoding: 'utf8',
-    timeout: 180_000,
-  });
-} catch (err) {
-  // `dario doctor` may exit non-zero while still printing its rows — keep that
-  // output and parse it. Only a truly empty result is an infra error.
-  raw = (err.stdout || '').toString();
-  if (!raw.trim()) {
+for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
+  try {
+    // 180s: the obedience probe is up to 3 serial attempts × 30s per family
+    // (families run in parallel) on top of doctor's local checks.
+    raw = execFileSync('docker', ['exec', 'askalf-dario', 'dario', 'doctor', '--obedience'], {
+      encoding: 'utf8',
+      timeout: 180_000,
+    });
+    break;
+  } catch (err) {
+    // `dario doctor` may exit non-zero while still printing its rows — keep that
+    // output and parse it. Only a truly empty result is an infra error.
+    raw = (err.stdout || '').toString();
+    if (raw.trim()) break;
+    // Empty output. Retry a fast container miss (mid-deploy bounce); surface a
+    // timeout-kill or the exhausted final attempt as exit 3 (infra error — the
+    // workflow shows red but files NO false drift issue).
+    if (!err.killed && attempt < ATTEMPTS) {
+      process.stderr.write(
+        `check-doctor-drift: docker exec produced no output (attempt ${attempt}/${ATTEMPTS}: ${err.message}) — retrying, askalf-dario may be mid-deploy\n`,
+      );
+      sleepSync(400 * attempt);
+      continue;
+    }
     process.stderr.write(
-      `check-doctor-drift: \`docker exec askalf-dario dario doctor\` produced no output: ${err.message}\n`,
+      `check-doctor-drift: \`docker exec askalf-dario dario doctor\` produced no output after ${attempt} attempt(s): ${err.message}\n`,
     );
     process.exit(3);
   }

--- a/scripts/check-doctor-drift.mjs
+++ b/scripts/check-doctor-drift.mjs
@@ -82,7 +82,12 @@ for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
       process.stderr.write(
         `check-doctor-drift: docker exec produced no output (attempt ${attempt}/${ATTEMPTS}: ${err.message}) — retrying, askalf-dario may be mid-deploy\n`,
       );
-      sleepSync(400 * attempt);
+      // Seconds-scale backoff (5s, then 10s), not check-sdk-drift's ms-scale:
+      // an image pull + container recreate takes seconds, and a ~1s retry
+      // window would still land inside the same bounce. Worst case adds 15s
+      // of sleep — far inside the job's 8-min budget even with one 180s
+      // timeout attempt on top.
+      sleepSync(5_000 * attempt);
       continue;
     }
     process.stderr.write(


### PR DESCRIPTION
## Problem

`dario-doctor-watch` (job `doctor-drift-check`) failed with **exit code 3** ("check-doctor-drift.mjs could not run dario doctor — infra/format error, not drift") on scheduled runs [28729798134](https://github.com/askalf/dario/actions/runs/28729798134) (2026-07-05) and [28618247914](https://github.com/askalf/dario/actions/runs/28618247914) (2026-07-02).

## Root cause (evidenced, not the obedience-timeout or format-parse suspects)

Both failures were **near-instant**: the "Run dario doctor drift check" step failed in **6s** and **0s** respectively. That rules out:
- the obedience-probe timeout path — it needs up to 180s (`execFileSync` timeout) and would show a multi-minute step;
- the format-parse path — `dario doctor` would actually run and print rows, taking real time.

A 0–6s failure with empty stdout means `docker exec askalf-dario dario doctor` failed *immediately*: the **askalf-dario container was transiently unavailable** — bounced mid-deploy (image pull + recreate; `v4.8.134` was tagged in-window). `check-doctor-drift.mjs` did a single `execFileSync` with no retry, so the empty result hit `if (!raw.trim()) process.exit(3)` → false-red CI. Pattern is intermittent: **2 failures in the last 15 scheduled runs, all surrounded by green** — a classic transient blip, correctly NOT filing a drift issue.

## Fix

Wrap the `docker exec` in the **same 3-attempt retry-with-backoff guard** that sibling `scripts/check-sdk-drift.mjs` already uses for transient npm-registry blips. Semantics preserved exactly:
- **Retries only** a fast empty-output miss (container mid-deploy), with seconds-scale backoff (5s, then 10s) — wide enough to bridge a real container recreate.
- **Never retries** a run that produced output — `dario doctor` prints its rows and *then* exits 1 on a `[FAIL]`, so non-empty stdout is a real result carrying drift; it's parsed, not retried away.
- **Never retries** a timeout-kill (`err.killed`) — doctor genuinely hung; 3×180s would blow the job's 8-min budget, so it surfaces red immediately.
- Exit-code contract (0 clean / 1 drift / 3 infra) and `dario-doctor-watch.yml` are **unchanged**. Script-only.

## Test plan

- `node --check scripts/check-doctor-drift.mjs` passes (syntax).
- Retry path mirrors the proven `sh(cmd, attempts=3)` idiom in `check-sdk-drift.mjs` (`sleepSync` via `Atomics.wait`).
- No behavior change on the happy path (first attempt succeeds → `break`) or on real drift (`[FAIL]`/non-zero-with-output → parsed on attempt 1).
- Next scheduled `dario-doctor-watch` run (every 6h at :37) will exercise it; a mid-deploy bounce now retries instead of going red.

Refs source ticket `00MR7BAT5X78A5D68F015C7E6C`.

