### PR TITLE
chore(release): v4.8.140 — 1h cache TTL fix (#678)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.140] - 2026-07-07
+
 - **Cache TTL is 1h now, matching real CC — stops dario draining the Max window far faster than direct CC (#678).** dario stamped the 5-min ephemeral default (`{type:'ephemeral'}`) on all four cache breakpoints, but real CC caches its system blocks for 1h (documented in `live-fingerprint.ts` extractTemplate). So dario's prefix — system + the entire tool array — expired 12× sooner than CC's: any interactive turn past the 5-min window re-created the whole prefix at cache-creation cost while native CC read it warm for up to an hour. On a heavy MCP config (the reporter forwarded 228 `mcp__*` tools) that cold re-create is what burned ~15%/message through dario vs 1–2% direct — nothing to do with the tool count itself (direct CC sends the same tools), only with how long the prefix stays cached. The emitted cache-control is now a single `CC_CACHE_CONTROL = { type: 'ephemeral', ttl: '1h' }` (`src/cc-template.ts`) consumed by both the system blocks and `applyCcPromptCaching`, so the TTL can't silently drift back to 5m. Live-verified on a bare Max subscription (no Extra Usage): the identical request A/B'd through unpatched vs patched dario returns `ephemeral_5m_input_tokens:1117 / ephemeral_1h:0` vs `ephemeral_5m:0 / ephemeral_1h:1112`, both billed `subscription` — Anthropic honors the 1h TTL on subscription OAuth via the beta set CC already sends, so no `extended-cache-ttl` / Extra Usage is involved. `test/prompt-caching.mjs` +4 (all breakpoints carry `ttl:'1h'`; 17/17, full suite 107/107).
 
 ## [4.8.139] - 2026-07-07

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.137",
+  "version": "4.8.140",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "4.8.137",
+      "version": "4.8.140",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.139",
+  "version": "4.8.140",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Cuts **v4.8.140** to ship the 1h cache-TTL fix to npm. Merging #679 alone didn't release — dario ships on the `package.json` version bump (RELEASING.md), so this is the bump that actually publishes it.

- `package.json` 4.8.139 → 4.8.140 + lockfile
- CHANGELOG entry moved under `## [4.8.140]`
- No code change beyond #679; `npm run build` clean, `npm test` 107/107

Merging fires the inline auto-release (tag `v4.8.140` + GitHub Release + `npm publish --provenance` + GHCR push). Post-publish bin-shim smoke per RELEASING.md to follow.

Addresses #678.
