### PR TITLE
chore(cc-drift): v4.8.143 — maxTested → v2.1.204

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.143] - 2026-07-08
+
+- **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.203` → `2.1.204` for CC v2.1.204. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.
 ## [4.8.142] - 2026-07-08
 
 - **TUI Status tab shows the advertised model catalog.** New `Models` panel sourced live from the proxy's `/v1/models` (the upstream-autodetected catalog with the baked fallback), so the current families — Sonnet 5 and Fable 5 included — are visible at a glance and future models appear without a TUI change. `[1m]` long-context variants fold onto their base id as a `+[1m]` marker instead of doubling the list. Renders nothing when the proxy is unreachable. Core Sonnet 5 / Fable 5 support was audited as part of this release and is current everywhere it lives: baked catalog + autodetection, adaptive-thinking gating (any 5+ major), per-family beta matrix, the Fable system-prompt variant and tool-less guard, and date-modeled Sonnet 5 intro pricing in `/analytics`. `test/tui-tabs.mjs` +10 checks.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.142",
+  "version": "4.8.143",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/live-fingerprint.ts
+++ b/src/live-fingerprint.ts
@@ -885,7 +885,7 @@ export function _resetInstalledVersionProbeForTest(): void {
  */
 export const SUPPORTED_CC_RANGE = {
   min: '1.0.0',
-  maxTested: '2.1.203',
+  maxTested: '2.1.204',
 } as const;
 
 /**


### PR DESCRIPTION
## Auto-drafted by cc-drift-watch.yml

The drift watcher flagged CC v2.1.204 as outside the current supported range. This PR:

1. Bumps `SUPPORTED_CC_RANGE.maxTested` from `2.1.203` → `2.1.204` in `src/live-fingerprint.ts`
2. Bumps `package.json` version → `4.8.143`
3. Promotes `## [Unreleased]` in `CHANGELOG.md` to `## [4.8.143] - 2026-07-08` and appends the drift-fix bullet

### Items in the drift report

- **compat.range** (medium) — CC v2.1.204 is beyond SUPPORTED_CC_RANGE.maxTested (v2.1.203). Run the e2e suite against the new CC and bump maxTested in src/live-fingerprint.ts — users on the new CC currently get a soft "untested-above" warning from dario doctor.
- **template.version** (low) — baked cc-template-data.json is v2.1.202; npm latest is v2.1.204. Re-capture the template (MITM a real CC v2.1.204 request) if any fingerprint-sensitive field (system prompt, header order, metadata shape, beta flags) changed.
- **cch.seed** (info) — No cch seed for CC v2.1.204 in src/cch.ts (CCH_SEEDS). dario OMITS the cch token for it — correct while CC v2.1.204 sends none (2.1.199+). Only add a seed if scripts/check-wire-drift.mjs reports CC re-introduced cch; then run `node scripts/cch-calibrate.mjs` on a host with claude v2.1.204. dario#528.

### Fully autonomous — no maintainer action required

This PR validates, merges, and ships itself. Nothing here is a to-do — it is what already happens:

- ✅ **Patched** — `SUPPORTED_CC_RANGE.maxTested` (compat.range), the `package.json` version, and the `CHANGELOG` entry are written by the bot.
- ✅ **Wire-format compat is validated continuously** by `cc-drift-template-watch.yml` — a real CC capture on the self-hosted runner every 30 min. If the bundled template actually drifts against this CC it opens its own `bot/template-rebake-*` PR, independently of this one. (This is the automated equivalent of the old manual "run `dario doctor` against v2.1.204" step — no local run needed.)
- ✅ **Auto-merges** the moment the required CI checks pass (`build (18|20|22)`, `validate-package-json`, `analyze`, `actionlint`). `master` requires no review, so no human approval gates it.
- ✅ **Auto-releases** on merge: `cc-drift-auto-release.yml` tags `v4.8.143`, publishes `@askalf/dario@4.8.143` to npm (`--provenance`) + GHCR inline, and the box autodeploy timer picks it up within ~15 min.

**You only need to look if CI fails** — then auto-merge holds, this PR stays open with the failure visible, and the bot branch is preserved. Otherwise it is already on its way to npm.

### About this auto-draft

Only `compat.range` items are auto-patched by this script. Template re-capture is auto-handled separately by `cc-drift-template-watch.yml`. The remaining categories (scope rotations, URL / clientId / tokenUrl changes) require judgment and stay manual — the bot opens the plain drift-issue for those as before.

---

_Generated by `scripts/auto-draft-drift-fix.mjs`. Closes the detection-latency arc: [#112](https://github.com/askalf/dario/pull/112) (CF bypass), [#113](https://github.com/askalf/dario/pull/113) (hourly cadence), [#114](https://github.com/askalf/dario/pull/114) (auto-draft PR)._
