### PR TITLE
fix(passthrough): built-in Explore + Plan agent openers — the #678 named-agent residual (v4.8.150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.150] - 2026-07-09
+
+- **Built-in Explore and Plan sub-agents ride the genuine-CC passthrough (#678, the v4.8.148 residual).** The reporter's forced-sub-agent re-run on v4.8.148 still burned ~3x direct per spawn (+17%/3 and +26%/6 spawns vs +7%/4 direct). Cause: CC's built-in *named* agents don't use the general-purpose agent prompt — Explore opens with "You are a file search specialist for Claude Code…" and Plan with "You are a software architect and planning specialist for Claude Code…" (exact bytes in the CC v2.1.205 bundle; a "read every file in parallel" prompt routes to Explore-type agents) — so neither matched the v4.8.148 opener list and every spawn fell onto the template path (~25KB prompt prepend + template tool rebuild, per request shape per cache window). Both openers are now in `CC_ORIGIN_SYSTEM_OPENERS`; anti-replay posture unchanged (billing block at `system[0]` still required, `startsWith` matching). Remaining known gap, now narrower: **custom agents** (`~/.claude/agents`) carry operator-authored definition text with no stable CC marker — there is no universal appended sentinel (the report-instruction sentence is baked into the general-purpose prompt only), so a durable structural discriminator is a follow-up design decision. `test/cc-passthrough.mjs` +3 checks.
+
 ## [4.8.149] - 2026-07-09
 
 - **Template label refresh** — `_version`, `_supportedMaxTested`, and the `user-agent` header bumped to `2.1.205` to track `@anthropic-ai/claude-code@latest`. The live wire shape is unchanged — cc-drift-template-watch ran `capture-and-bake --check` against live CC v2.1.205 and found zero shape drift vs the bundle — so this is a label refresh, not a re-capture (`_captured` stays at the last real capture). Auto-merged; clears the `sdk-drift` early-warning signal.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.148",
+  "version": "4.8.150",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "4.8.148",
+      "version": "4.8.150",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.149",
+  "version": "4.8.150",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -1447,14 +1447,26 @@ export function dedupeToolsByName<T extends { name?: unknown }>(tools: T[]): T[]
  * same anti-replay posture as the main-loop marker: none of them appear at
  * system[1] in any known non-CC framework's wire shape.
  *
- * Known gap: named/custom agents (~/.claude/agents, Explore/Plan) put their
- * operator-authored definition text at system[1] with no stable CC marker —
- * those still ride the template path until a live capture pins a reliable
- * discriminator.
+ * The built-in named agents (Explore, Plan) carry their own specialist
+ * prompts — neither opens with the main-loop or general-purpose markers, so
+ * they missed the v4.8.148 detector and stayed on the template path. That
+ * was the #678 reporter's residual: on v4.8.148, forced parallel sub-agents
+ * (a "read every file" prompt CC routes to Explore-type agents) still burned
+ * ~3x the direct per-spawn cost. Openers are the exact bytes from the CC
+ * v2.1.205 bundle; the drift-watch pipeline is the guard when they move.
+ *
+ * Known gap: CUSTOM agents (~/.claude/agents) put operator-authored
+ * definition text at system[1] with no stable CC marker — those still ride
+ * the template path. There is no universal appended sentinel to key on (the
+ * report-instruction sentence is baked into the general-purpose prompt only),
+ * so a durable structural discriminator (e.g. billing block + claude-cli
+ * user-agent) is a design decision for a follow-up.
  */
 const CC_ORIGIN_SYSTEM_OPENERS = [
   'You are Claude Code',                                        // main loop, cli entrypoint
-  'You are an agent for Claude Code',                           // sub-agents (Task/Agent tool)
+  'You are an agent for Claude Code',                           // general-purpose sub-agent (Task/Agent tool)
+  'You are a file search specialist for Claude Code',           // built-in Explore agent (exact bytes, CC v2.1.205 bundle)
+  'You are a software architect and planning specialist for Claude Code', // built-in Plan agent (exact bytes, CC v2.1.205 bundle)
   'You are a security monitor for autonomous AI coding agents', // auto-mode permission classifier
 ] as const;
 

--- a/test/cc-passthrough.mjs
+++ b/test/cc-passthrough.mjs
@@ -102,6 +102,25 @@ header('isGenuineCCClient — CC-origin non-main-loop shapes (#678 remote re-tes
     { type: 'text', text: 'You are a security monitor for autonomous AI coding agents.\n\n## Context\n\nThe agent you are monitoring is an **autonomous coding agent** with shell access…', cache_control: { type: 'ephemeral' } },
     { type: 'text', text: '\n\n## Session Context\n\n- **User identity**: `user`.' },
   ] }));
+  // Built-in NAMED agents (the #678 reporter's v4.8.148 residual: forced
+  // parallel sub-agents still burned ~3x direct per spawn — CC routes
+  // "read every file" prompts to Explore-type agents). Openers are the
+  // exact bytes from the CC v2.1.205 bundle.
+  check('built-in Explore agent detected', isGenuineCCClient({ system: [
+    { type: 'text', text: 'x-anthropic-billing-header: cc_version=2.1.205.abc; cc_entrypoint=cli;' },
+    { type: 'text', text: 'You are a file search specialist for Claude Code, Anthropic\'s official CLI for Claude. You excel at thoroughly navigating and exploring codebases.' },
+  ] }));
+  check('built-in Plan agent detected', isGenuineCCClient({ system: [
+    { type: 'text', text: 'x-anthropic-billing-header: cc_version=2.1.205.abc; cc_entrypoint=cli;' },
+    { type: 'text', text: 'You are a software architect and planning specialist for Claude Code. Your role is to explore the codebase and design implementation plans.' },
+  ] }));
+  // CUSTOM agents (~/.claude/agents) carry operator-authored text with no CC
+  // marker — the documented remaining gap. Guard that arbitrary agent prose
+  // does NOT slip through on some accidental substring.
+  check('custom-agent definition text still template path', !isGenuineCCClient({ system: [
+    { type: 'text', text: 'x-anthropic-billing-header: cc_version=2.1.205.abc; cc_entrypoint=cli;' },
+    { type: 'text', text: 'You are a meticulous database migration reviewer. Inspect every schema change for backwards compatibility.' },
+  ] }));
   // Anti-replay posture unchanged: openers must be at system[1], must
   // co-occur with the billing block, and are matched with startsWith.
   check('sub-agent opener WITHOUT billing block → not CC', !isGenuineCCClient({ system: [


### PR DESCRIPTION
## What

Adds CC's built-in **Explore** and **Plan** agent prompt openers to the genuine-CC passthrough detector (`CC_ORIGIN_SYSTEM_OPENERS`), and releases as **v4.8.150**.

## Why

The #678 reporter's forced-sub-agent re-run on v4.8.148 still burned ~3× direct per spawn (+17%/3 spawns and +26%/6 spawns via dario, vs +7%/4 spawns direct). His `~/.claude/agents` doesn't exist, so the residual had to be **built-in named agents** — and a "read every file in parallel" prompt is exactly what CC routes to Explore-type agents.

Verified from the CC v2.1.205 bundle (exact bytes):

- **Explore** opens with *"You are a file search specialist for Claude Code, Anthropic's official CLI for Claude."*
- **Plan** opens with *"You are a software architect and planning specialist for Claude Code."*

Neither matches the v4.8.148 opener list (nor mentions the Agent SDK), so every Explore/Plan spawn fell onto the template path: ~25KB template prompt prepended, tool array rebuilt from template defs, re-billed per request shape per cache window.

## How

Two `startsWith` openers added to `CC_ORIGIN_SYSTEM_OPENERS`. Anti-replay posture unchanged: the `x-anthropic-billing-header:` block is still required at `system[0]`.

Also ruled out during investigation: there is **no universal appended sentinel** to key on — the report-instruction sentence ("…the caller will relay this to the user…") is baked into the general-purpose agent prompt only (`Zsy()` in the bundle), not appended to named/custom agent prompts at assembly time. So:

**Known gap (narrower now):** custom agents (`~/.claude/agents`) carry operator-authored definition text at `system[1]` with no stable CC marker and still ride the template path. A durable structural discriminator (e.g. billing block + `claude-cli` user-agent) is a follow-up design decision, deliberately not bundled into this fix.

## Verification

- `test/cc-passthrough.mjs` +3 checks: Explore and Plan fixtures (exact bundle openers) detected; a custom-agent-style prompt correctly stays on the template path.
- Full suite 108/108 (one `issue-29-tool-translation` flake under `--test-concurrency=8` on the first run — passes standalone and on a clean re-run; unrelated to this diff, which touches only the opener list).
- A live wire capture of the sub-agent spawn was attempted but the box's auto-mode monitor blocks scripted-MITM Agent spawns; the binary-extracted openers are the same source of truth the v4.8.148 general-purpose opener was verified against, and the reporter's post-release `-vv` re-test will confirm end-to-end.

Follow-up to #695 for #678.
