### PR TITLE
docs: reframe the 2026-06-15 billing split as announced-then-paused

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ---
 
-> 🗓️ **2026-06-15 — Anthropic splits Claude billing.** Agent-SDK and `claude -p` (headless) traffic stops counting against your subscription pool and moves to a small separate monthly credit ($20 / $100 / $200 by plan), then metered per-token API rates. Most proxies forward your requests in exactly the shape that gets reclassified into that bucket. dario rewrites every request into interactive Claude Code wire-shape before it leaves your machine, so your traffic stays in the subscription pool you already pay for — same install, no config change for the cliff. **[What changes, and how to verify it on your own machine →](#the-deadline-2026-06-15)**
+> 🗓️ **The billing split — announced, then paused.** Anthropic announced (2026-05-13) that Agent-SDK and `claude -p` (headless) traffic would leave your subscription pool for a small separate monthly credit ($20 / $100 / $200 by plan), then metered per-token API rates — scheduled for 2026-06-15. It was **paused before that date**: those surfaces still bill subscription today, and Anthropic says it will give advance notice before any revised version. dario already rewrites every request into interactive Claude Code wire-shape, so your traffic sits in the subscription pool whether the split is paused or live — and its daily billing-classifier canary is the tripwire for the day it returns. **[The full timeline, and how to verify on your own machine →](#the-billing-split)**
 
 > ⚠️ Still on a version **before 4.8.39**? Upgrade now — those could silently corrupt code/structured content routed through the proxy (the identifier scrub stripped tokens like the JS `continue` keyword). **[Details →](https://github.com/askalf/dario/issues/457)**
 
@@ -85,28 +85,28 @@ Type `dario` with no args (in another terminal) to open a full-screen control pa
 
 ---
 
-## The deadline: 2026-06-15
+## The billing split
 
-On **2026-06-15**, Anthropic splits Claude billing in two. Agentic traffic — Agent SDK, `claude -p` headless — stops counting against your subscription pool and gets a separate small monthly credit. [Announced 2026-05-13](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan) via Claude's Help Center and a [@ClaudeDevs X post](https://x.com/ClaudeDevs/status/2054610152817619388) — no anthropic.com blog post, no email to most subscribers, no mention in CC release notes.
+On **2026-05-13**, Anthropic [announced](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan) — via the Claude Help Center and a [@ClaudeDevs X post](https://x.com/ClaudeDevs/status/2054610152817619388), with no anthropic.com blog post, no email to most subscribers, no mention in CC release notes — that on **2026-06-15**, Agentic traffic (Agent SDK, `claude -p` headless) would stop counting against your subscription pool and move to a separate small monthly credit, then metered per-token API rates. The announced terms:
 
-| Plan | New Agent-SDK / `claude -p` credit | When it runs out |
+| Plan | Announced Agent-SDK / `claude -p` credit | When it would run out |
 |---|---|---|
 | Pro | $20/mo | extra-usage at API rates **only if enabled**; otherwise suspended until renewal |
 | Max 5x | $100/mo | same |
 | Max 20x | $200/mo | same |
 
-A sustained Cline or Aider session burns $100 of API-rate tokens in an evening. **Any proxy that forwards requests in their original `claude -p` / Agent-SDK shape — which is most of them — dumps your agentic traffic into that small credit bucket, then onto metered pricing.**
+**Then Anthropic paused it before 2026-06-15.** The Help Center now states Agent-SDK and `claude -p` usage continue drawing from your existing subscription pool unchanged; Anthropic said it's reworking the proposal and will give advance notice before any revised version. No credits were issued; no split took effect.
 
-dario doesn't. Every outbound request is rebuilt into **interactive Claude Code wire-shape** before it leaves your machine — headers, body key order, TLS stack, session-id lifecycle, and (`--stealth`) the temporal axis: response-correlated think-time and session-start latency. Anthropic's billing classifier sees an interactive Claude Code session. Your traffic stays in the subscription pool you already pay for.
+So the cliff isn't live — but it was announced once, on short public notice, and can return. dario is built around that fact, split or no split. Every outbound request is rebuilt into **interactive Claude Code wire-shape** before it leaves your machine — headers, body key order, TLS stack, session-id lifecycle, and (`--stealth`) the temporal axis: response-correlated think-time and session-start latency. Anthropic's billing classifier sees an interactive Claude Code session, so your traffic sits in the subscription pool whether the classifier is checking today or after a revival.
 
-| Your setup | After 2026-06-15 |
-|---|---|
-| Any tool → Anthropic API direct | per-token API |
-| Any tool → proxy that forwards requests as-is | **$20–200/mo credit, then per-token (or suspended)** |
-| **Any tool → dario** | **subscription pool — unchanged** |
-| Claude Code, interactive | subscription pool — unchanged |
+| Your setup | Today (split paused) | If the split returns |
+|---|---|---|
+| Any tool → Anthropic API direct | per-token API | per-token API |
+| Any tool → proxy that forwards requests as-is | subscription pool | **$20–200/mo credit, then per-token (or suspended)** |
+| **Any tool → dario** | **subscription pool** | **subscription pool — rewritten to interactive-CC shape** |
+| Claude Code, interactive | subscription pool | subscription pool |
 
-Same install, same `localhost:3456`, no config change for the cliff. Verify on your own machine: `dario doctor --usage` fires one request and surfaces the rate-limit headers — `representative-claim` should read `five_hour` or `seven_day` (subscription buckets). Full breakdown: [`docs/why-now-2026-06.md`](./docs/why-now-2026-06.md).
+(A sustained Cline or Aider session can burn $100 of API-rate tokens in an evening — the "if it returns" column is what that credit cap would meter.) The [daily billing-classifier canary](#how-it-works-and-how-it-stays-working) is the tripwire: it fires one live request a day and asserts the bucket is still subscription, so a revived split surfaces within a day, not on a surprise invoice. Verify on your own machine right now: `dario doctor --usage` fires one request and surfaces the rate-limit headers — `representative-claim` should read `five_hour` or `seven_day` (subscription buckets). Full timeline: [`docs/why-now-2026-06.md`](./docs/why-now-2026-06.md).
 
 ---
 
@@ -156,7 +156,7 @@ dario doesn't *guess* Claude Code's request shape — it captures it live from y
 
 [Discussion #178](https://github.com/askalf/dario/discussions/178) reproduces a ninth fingerprint operating on commit metadata: the classifier fires on the literal namespaced string `openclaw.inbound_meta.v1` in recent git commits. dario's template replay protects you because that git context never reaches `api.anthropic.com` — only dario's captured CC template does.
 
-**Why this needs constant maintenance.** The 2026-06-15 split is announced; the wire-shape changes that arrive between releases are not. CC v2.1.142 ([changelog](https://code.claude.com/docs/en/changelog), 2026-05-14) itemized a Fast-mode tweak and some fixes — and said **nothing** about three wire-shape changes in the same release. That's the rule, not the exception; a running ledger of silent changes dario caught and shipped:
+**Why this needs constant maintenance.** The billing split got a public announcement (then a pause); the wire-shape changes that arrive between releases never do. CC v2.1.142 ([changelog](https://code.claude.com/docs/en/changelog), 2026-05-14) itemized a Fast-mode tweak and some fixes — and said **nothing** about three wire-shape changes in the same release. That's the rule, not the exception; a running ledger of silent changes dario caught and shipped:
 
 | Silent wire-shape change (no subscriber changelog) | Effect on subscribers | dario shipped |
 |---|---|---|
@@ -234,7 +234,7 @@ Three things it does that a round-robin doesn't:
 
 A subscriber should never see a single response billed outside their subscription pool during normal operation. One means something is wrong — wire-shape drift, a classifier change, an account misconfig — and continuing to forward requests in the same shape bleeds real money (accounts with extra-usage enabled) or returns a wall of rejections (accounts without it). The first hit is the signal; the second through hundredth are damage.
 
-So the moment any upstream response bills to something other than your subscription pool — `representative-claim: overage`, `api`, or a new credit/SDK bucket like the one the 2026-06-15 Agent-SDK split introduces — dario **halts the proxy**. The check is an allow-list, not a match on `overage`: anything that isn't a known subscription claim (`five_hour`/`seven_day` and their fallbacks) and isn't the `unknown` no-header sentinel trips it, so a credit-bucket claim dario has never seen still halts. Every subsequent request returns `503` with an Anthropic-shaped error body the client surfaces verbatim, until you run `dario resume`, press `R` on the TUI, or the cooldown clears (default 30 min). The halt is visible across the TUI's Status, Hits, and Analytics tabs, fires a best-effort native OS notification, and emits named SSE events. (In upstream-API-key passthrough mode — set `ANTHROPIC_UPSTREAM_API_KEY` — the guard is off; `api` billing is the point there, not a failure.)
+So the moment any upstream response bills to something other than your subscription pool — `representative-claim: overage`, `api`, or a new credit/SDK bucket like the one a revived Agent-SDK split would introduce — dario **halts the proxy**. The check is an allow-list, not a match on `overage`: anything that isn't a known subscription claim (`five_hour`/`seven_day` and their fallbacks) and isn't the `unknown` no-header sentinel trips it, so a credit-bucket claim dario has never seen still halts. Every subsequent request returns `503` with an Anthropic-shaped error body the client surfaces verbatim, until you run `dario resume`, press `R` on the TUI, or the cooldown clears (default 30 min). The halt is visible across the TUI's Status, Hits, and Analytics tabs, fires a best-effort native OS notification, and emits named SSE events. (In upstream-API-key passthrough mode — set `ANTHROPIC_UPSTREAM_API_KEY` — the guard is off; `api` billing is the point there, not a failure.)
 
 ```
 ┌─ dario ─────────────────────────────[ q quit · Tab next · ? help ]──┐
@@ -293,7 +293,7 @@ cd $(npm root -g)/@askalf/dario && npm ls --production
 
 ## Project status — stable surface, automated defense
 
-dario's surface is feature-complete and stable: the proxy, the TUI, the multi-account pool, the overage guard, the 2026-06-15 cliff protection. What *isn't* stable is the thing it defends against. Anthropic ships wire-shape and classifier changes with no subscriber changelog, on no schedule — so the part of dario that runs unattended is the part that keeps your subscription routing the day they do, and it runs every day.
+dario's surface is feature-complete and stable: the proxy, the TUI, the multi-account pool, the overage guard, the billing-split tripwire. What *isn't* stable is the thing it defends against. Anthropic ships wire-shape and classifier changes with no subscriber changelog, on no schedule — so the part of dario that runs unattended is the part that keeps your subscription routing the day they do, and it runs every day.
 
 That defense is live: [three drift watchers](#how-it-works-and-how-it-stays-working) (npm-release hourly, remote-config every 30 min, classifier-rule daily — cron schedules; GitHub coalesces scheduled runs, so effective intervals run longer), a PR-time compat gate that runs the full suite against a live proxy before any wire-shape change merges, a liveness alarm if a watcher goes quiet, a daily NPM_TOKEN health check, and an auto-release pipeline that ships a fix within hours of a CC release. When Anthropic moves, the watchers catch it within a release cycle, the bot opens the PR, the maintainer reviews and merges — the receipt log above is that machinery doing its job. Residual manual cases — OAuth rotation, runner re-registration, ghcr backfill — live in the [recovery runbook](./docs/recovery.md).
 
@@ -334,8 +334,8 @@ Yes. Skip `dario login`, run `dario backend add openai --key=…`, and you have 
 **`representative-claim: seven_day` in my headers — am I downgraded?**
 No. `five_hour` and `seven_day` are both subscription billing — different accounting buckets, same mode. `overage` is the one that flips you to per-token. [Discussion #1](https://github.com/askalf/dario/discussions/1).
 
-**Will the 2026-06-15 split break my setup? / What if Anthropic ships another silent change?**
-No, and it's caught automatically — see [The deadline](#the-deadline-2026-06-15) and [How it stays working](#how-it-works-and-how-it-stays-working). dario rewrites every request to interactive-CC shape before it reaches `api.anthropic.com`, and the three-class drift watcher picks up new changes (npm-release hourly, remote-config every 30 min, classifier-rule daily). v3.38.5 + v3.38.6 — 13 minutes apart, same day as v2.1.142's silent drops — are the prior art.
+**Will the billing split break my setup? / What if Anthropic ships another silent change?**
+The split was announced, then paused before it took effect — today nothing changed, and your traffic still bills subscription. If it returns (Anthropic promised advance notice) or if Anthropic ships another silent wire change, it's caught automatically — see [The billing split](#the-billing-split) and [How it stays working](#how-it-works-and-how-it-stays-working). dario rewrites every request to interactive-CC shape before it reaches `api.anthropic.com`, and the three-class drift watcher picks up new changes (npm-release hourly, remote-config every 30 min, classifier-rule daily). v3.38.5 + v3.38.6 — 13 minutes apart, same day as v2.1.142's silent drops — are the prior art.
 
 **Used dario before and bounced off a drift / capacity / tool-compat wall?**
 The 5-minute path back — what changed, what's automated now, and the one command to re-verify — is in [`docs/returning.md`](./docs/returning.md).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,21 +12,23 @@ On 2026-04-21 Anthropic temporarily removed Claude Code from new Pro signups, pe
 **Does it work with Team / Enterprise?**
 Yes — tested and confirmed working as long as your plan includes Claude Code access.
 
-**Anthropic announced that `claude -p` and Agent SDK usage moves to a separate credit pool on 2026-06-15. Will dario's Claude backend keep working?**
-Yes. The Claude backend was designed to send requests as **interactive Claude Code** wire-shape — full template replay of headers, body key order, TLS ClientHello, session-id lifecycle, inter-request timing. The upstream billing classifier sees an interactive CC session regardless of which local tool (claude -p subprocess, Agent SDK app, Cline, Aider, your own scripts) originated the call. That's the entire point of the wire-fidelity work in [`wire-fidelity.md`](./wire-fidelity.md), and it predates the 2026-06-15 announcement.
+**Anthropic announced that `claude -p` and Agent SDK usage would move to a separate credit pool on 2026-06-15. Did that break dario's Claude backend?**
+No — and the split itself was **paused before it took effect**. Anthropic announced it 2026-05-13, scheduled it for 2026-06-15, then paused it before that date; the Help Center now states Agent-SDK and `claude -p` usage continue drawing from your existing subscription pool unchanged, with a promise of advance notice before any revised version. So today `claude -p` and the Agent SDK still bill subscription whether or not you use dario.
+
+dario is built to hold either way. The Claude backend sends every request as **interactive Claude Code** wire-shape — full template replay of headers, body key order, TLS ClientHello, session-id lifecycle, inter-request timing. The upstream billing classifier sees an interactive CC session regardless of which local tool (claude -p subprocess, Agent SDK app, Cline, Aider, your own scripts) originated the call. That's the entire point of the wire-fidelity work in [`wire-fidelity.md`](./wire-fidelity.md), and it predates the announcement.
 
 What that means in practice:
 
-- Workloads that route through dario continue billing against your **subscription pool** (Pro $20, Max 5x $100, Max 20x $200) post-2026-06-15, same as before.
-- Workloads that bypass dario and call `claude -p` directly will count against the **new separate credit pool** (same dollar amounts, but a fixed monthly grant rather than the rolling subscription bucket — and once exhausted, those calls flip to metered API pricing).
-- Workloads that bypass dario and use the Agent SDK with API keys are unaffected (they were already metered API and remain so).
+- Workloads that route through dario bill against your **subscription pool** (Pro $20, Max 5x $100, Max 20x $200) — the same today as before the announcement, and the same if a revised split ships later.
+- If the split does return, workloads that bypass dario and call `claude -p` directly would count against the **separate credit pool** (a fixed monthly grant rather than the rolling subscription bucket — and once exhausted, metered API pricing). Right now, paused, they bill subscription like everything else.
+- Workloads that use the Agent SDK with API keys are unaffected either way (already metered API).
 
-Two questions to verify after 2026-06-15 lands:
+Two questions to verify at any time — and the exact check to run the day a revived split lands:
 
-1. **Did Anthropic add a new fingerprint to `claude -p` that dario doesn't yet strip?** Run `claude -p "hi"` directly (no dario), check `representative-claim` and related rate-limit headers — that tells you what bucket Anthropic put the direct call in. Then run the same prompt through dario and check the same headers. If both show the same bucket (interactive subscription), the wire-rewrite is still doing its job. If dario's path shows the new agent-credit bucket, file an issue — that's the kind of CC drift the live template extractor and the [drift detector](./../scripts/capture-full-body.mjs) exist to catch.
-2. **Did Anthropic tighten OAuth-token classification?** If access-token bearer alone now signals "non-interactive," dario would have to add session affinity or a re-auth dance. Same diagnostic via the rate-limit headers will surface it. None of this is observed today (verified 2026-05-14 on v3.37.15).
+1. **Is dario's traffic still landing in the subscription bucket?** Run `claude -p "hi"` directly (no dario), check `representative-claim` and related rate-limit headers — that tells you the bucket Anthropic put the direct call in. Then run the same prompt through dario and check the same headers. Both should show a subscription bucket (`five_hour` / `seven_day`). If dario's path ever shows an agent-credit or `overage` bucket, file an issue — that's the drift the live template extractor, the [drift detector](./../scripts/capture-full-body.mjs), and the daily billing-classifier canary exist to catch (the canary runs this exact check automatically and opens an issue on a bad bucket).
+2. **Did Anthropic tighten OAuth-token classification?** If access-token bearer alone ever signals "non-interactive," dario would have to add session affinity or a re-auth dance. The same rate-limit-header diagnostic surfaces it. None of this is observed today.
 
-No config change is needed on the user side for the 2026-06-15 transition — same install, same `localhost:3456`, same `ANTHROPIC_BASE_URL=http://localhost:3456` env var.
+No config change is needed on the user side, split or no split — same install, same `localhost:3456`, same `ANTHROPIC_BASE_URL=http://localhost:3456` env var.
 
 **Do I need Claude Code installed?**
 Recommended for the Claude backend, not strictly required. With CC installed, `dario login` picks up your credentials automatically, and the live template extractor reads your CC binary on every startup so the template stays current. Without CC, dario runs its own OAuth flow and falls back to the bundled template snapshot (scrubbed of host context at bake time as of v3.21). Drift detection warns you if your installed CC doesn't match the captured template, so upgrade windows don't silently ship stale templates.

--- a/docs/why-now-2026-06.md
+++ b/docs/why-now-2026-06.md
@@ -1,8 +1,8 @@
-# What changes 2026-06-15
+# The 2026 billing split: announced, paused, watched
 
-Anthropic [announced on 2026-05-13](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan) — via the Claude Help Center and a [@ClaudeDevs post](https://x.com/ClaudeDevs/status/2054610152817619388), with no anthropic.com blog post and no email to most subscribers — that starting **2026-06-15**, Claude Agent SDK and `claude -p` (Claude Code headless mode) usage will no longer count toward Claude plan usage limits. Instead, eligible plans receive a fixed monthly Agent-SDK credit:
+Anthropic [announced on 2026-05-13](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan) — via the Claude Help Center and a [@ClaudeDevs post](https://x.com/ClaudeDevs/status/2054610152817619388), with no anthropic.com blog post and no email to most subscribers — that starting **2026-06-15**, Claude Agent SDK and `claude -p` (Claude Code headless mode) usage would no longer count toward Claude plan usage limits. Instead, eligible plans would receive a fixed monthly Agent-SDK credit. The announced terms:
 
-| Plan | Subscription pool (interactive Claude Code, Claude Cowork, Claude.ai) | Separate Agent-SDK / `claude -p` credit (new) |
+| Plan | Subscription pool (interactive Claude Code, Claude Cowork, Claude.ai) | Announced Agent-SDK / `claude -p` credit |
 |---|---|---|
 | Pro | $20/mo | $20/mo |
 | Max 5x | $100/mo | $100/mo |
@@ -10,91 +10,84 @@ Anthropic [announced on 2026-05-13](https://support.claude.com/en/articles/15036
 | Team Premium | $100/mo | $100/mo |
 | Enterprise (seat-based) | included | $200/mo |
 
-Once the Agent-SDK credit is exhausted, those calls flip to **metered per-token API pricing**. The subscription pool stays reserved for interactive use.
+Once the Agent-SDK credit was exhausted, those calls would flip to **metered per-token API pricing**, with the subscription pool reserved for interactive use.
 
-For autonomous workloads — sustained coding agents, background scripts, anything that calls Anthropic unattended — the new credit is small. A long Cline or Aider session can chew $100 of API-rate tokens in an evening; sustained agentic loops blow past $200 in days.
+## What actually happened: it was paused
 
-## Why dario isn't affected
+**Anthropic paused the change before 2026-06-15, and it never took effect.** The Help Center now states that Agent-SDK usage, `claude -p`, and third-party app usage continue drawing from your existing subscription pool, unchanged. Anthropic said it is reworking the proposal "to better support how users build with Claude subscriptions" and pledged advance notice before implementing any revised version. No credits were issued; no subscription limits changed.
 
-Dario's Claude backend was designed to make every outbound request look like an **interactive Claude Code session** at the wire level. That predates the 2026-06-15 announcement — it's the same mechanism that's been routing your traffic through your Pro / Max 5x / Max 20x subscription pool since v3.22.
+So as of this writing, the split is **not live**. A `claude -p` run or an Agent SDK app bills your subscription pool today whether or not it goes through dario. The reason this document still exists — and the reason dario's daily billing-classifier canary still runs — is that the change was announced once, on short public notice, and Anthropic has explicitly reserved the right to bring back a revised version.
 
-The relevant property: Anthropic's billing classifier identifies traffic by what arrives at `api.anthropic.com`, not by what initiated it locally. A `claude -p` invocation that talks to dario gets rewritten into an interactive Claude Code request shape before it leaves your machine. The classifier sees interactive CC, applies the subscription pool, doesn't apply the new Agent-SDK bucket.
+## Why dario holds either way
 
-This is the entire point of the wire-fidelity work in [`wire-fidelity.md`](./wire-fidelity.md). Six axes — body key order, TLS ClientHello, inter-request timing, stream-consumption shape, session-ID lifecycle, request headers — were closed between v3.22 and v3.28 specifically so the upstream classifier has no observable signal that the request originated outside an interactive CC session. The work was scoped around subscription-billing recognition, which is now what the 2026-06-15 split tests.
+Dario's Claude backend was designed to make every outbound request look like an **interactive Claude Code session** at the wire level. That predates the 2026-05-13 announcement — it's the same mechanism that's routed traffic through your Pro / Max 5x / Max 20x subscription pool since v3.22.
+
+The relevant property: Anthropic's billing classifier identifies traffic by what arrives at `api.anthropic.com`, not by what initiated it locally. A `claude -p` invocation that talks to dario gets rewritten into an interactive Claude Code request shape before it leaves your machine. The classifier sees interactive CC and applies the subscription pool — today, with the split paused, and equally if a revised split ever makes the entrypoint billable.
+
+This is the entire point of the wire-fidelity work in [`wire-fidelity.md`](./wire-fidelity.md). Axes — body key order, TLS ClientHello, inter-request timing, stream-consumption shape, session-ID lifecycle, request headers — were closed specifically so the upstream classifier has no observable signal that the request originated outside an interactive CC session.
 
 ## What this means concretely
 
-| Setup | Pre-2026-06-15 | Post-2026-06-15 |
+| Setup | Today (split paused) | If a revised split ships |
 |---|---|---|
 | Direct Anthropic API with API key (Cline default, Aider default, your scripts) | Per-token API billing | Per-token API billing (unchanged) |
 | Proxy that forwards `claude -p` / Agent SDK request shape unchanged | Subscription pool | **Separate $20–200/mo Agent-SDK credit, then per-token API** |
-| **dario** | **Subscription pool** | **Subscription pool (unchanged — request is rewritten as interactive CC)** |
+| **dario** | **Subscription pool** | **Subscription pool (request rewritten as interactive CC)** |
 | Claude Code itself (you, sitting at a terminal) | Subscription pool | Subscription pool (unchanged) |
 
-No config change is needed on the user side for the 2026-06-15 transition. Same install. Same `localhost:3456`. Same `ANTHROPIC_BASE_URL=http://localhost:3456` env var. The wire-rewrite has been doing this job in production for months.
+No config change is needed on the user side, split or no split — same install, same `localhost:3456`, same `ANTHROPIC_BASE_URL=http://localhost:3456` env var. The wire-rewrite has been doing this job in production for months.
 
-## How to verify on your own setup (after 2026-06-15 lands)
+## The tripwire: how you'd know the day it returns
 
-Two diagnostics will tell you the classification is still working as expected.
+You don't have to watch Anthropic's Help Center. dario runs a **daily billing-classifier canary** ([`cc-billing-classifier-canary.yml`](../.github/workflows/cc-billing-classifier-canary.yml)) that fires one live request and asserts the `representative-claim` header still maps to a subscription bucket. A revived split — or any silent classifier change that reclassifies dario's traffic — surfaces as a canary failure and an auto-opened issue within a day, not on a surprise invoice. It's one of [three drift watchers](../README.md#how-it-works-and-how-it-stays-working) that keep the wire-rewrite current against a moving target.
+
+You can run the same check by hand at any time:
 
 ### Verify the rate-limit headers
 
-Every response from `api.anthropic.com` includes rate-limit metadata. The bucket the request was charged against is visible in the response headers. After 2026-06-15, run:
-
 ```bash
-# 1. Direct claude -p, no dario. This is the new Agent-SDK credit bucket.
+# 1. Direct claude -p, no dario.
 unset ANTHROPIC_BASE_URL ANTHROPIC_API_KEY
 claude -p "say hi" 2>&1 | grep -i 'rate-limit\|representative'
 
-# 2. The same prompt through dario. Should land in the subscription bucket.
+# 2. The same prompt through dario.
 export ANTHROPIC_BASE_URL=http://localhost:3456
 export ANTHROPIC_API_KEY=dario
 claude -p "say hi" 2>&1 | grep -i 'rate-limit\|representative'
 ```
 
 What to look for:
-- The direct call should reference an Agent-SDK / claude-agent / claude-headless bucket (Anthropic's exact header names will land alongside the 2026-06-15 rollout; today's name is `representative-claim`).
-- The dario call should reference `five_hour` or `seven_day` — both subscription-billing accounting buckets. See [Discussion #1](https://github.com/askalf/dario/discussions/1) for the full breakdown of subscription rate-limit headers.
-
-If both calls land in the same bucket as dario, the wire-rewrite is doing its job. If dario's path lands in the new Agent-SDK bucket, file an issue — that's the kind of upstream classifier drift the live template extractor and the [drift detector](../scripts/capture-full-body.mjs) exist to catch.
+- Both calls should reference `five_hour` or `seven_day` — subscription-billing accounting buckets — because the split is paused and `claude -p` bills subscription directly too. See [Discussion #1](https://github.com/askalf/dario/discussions/1) for the full breakdown of subscription rate-limit headers.
+- If a revised split ships, the **direct** call would move to an Agent-SDK / credit bucket while the **dario** call should stay in `five_hour` / `seven_day`. If dario's path ever lands in an agent-credit or `overage` bucket, file an issue — that's the upstream classifier drift the live template extractor and the [drift detector](../scripts/capture-full-body.mjs) exist to catch.
 
 ### Verify via dario doctor
 
 ```bash
-dario doctor
+dario doctor          # template drift + OAuth + runtime/TLS
+dario doctor --usage  # also fires one request and prints the live billing bucket
 ```
 
-The output includes:
-- **Template source + age + drift status** — confirms the bundled wire template matches your installed CC binary
-- **OAuth status** — confirms the access token is healthy (broken tokens 401 regardless of wire fidelity)
-- **Runtime / TLS class** — confirms `bun-match` (or surfaces the divergence with a hint)
-
-A clean `dario doctor` report is the per-machine equivalent of running the rate-limit-header check above. Run it before you assume dario is correctly classified.
+A clean `dario doctor` report is the per-machine equivalent of the rate-limit-header check above.
 
 ## What this doesn't promise
 
-A few things worth being precise about:
-
-1. **No verified post-2026-06-15 behavior yet.** The split lands 2026-06-15; until it does, there's no post-cliff data to point to. The wire-rewrite has been classified as interactive subscription billing every day for months — but Anthropic could add a new signal on 2026-06-15 that none of the six current axes covers. If that happens, the live template extractor and drift detector will surface it on your first call, and the fix follows the same pattern as every other CC drift event the project has shipped.
-2. **No claim about competitor products specifically.** The table above refers to architectural patterns (`proxy that forwards request shape unchanged`), not named tools. If a particular tool also implements wire-fidelity replay, it gets the same outcome dario does. The reason this doc exists is that most subscription-billing proxies don't — they extract OAuth tokens and forward the raw client request, which is exactly the request shape that's about to be reclassified.
-3. **Beyond the subscription cap, Anthropic still rate-limits.** Dario doesn't multiply your subscription — it routes through the plan you have. Multi-account pool mode ([`multi-account-pool.md`](./multi-account-pool.md)) is the answer for hitting the cap on a single account; the 2026-06-15 work is orthogonal to it.
-4. **Anthropic terms of service still apply.** This project is independent, unofficial, third-party — see [DISCLAIMER.md](../DISCLAIMER.md). Whether any particular use complies with Anthropic's current terms is between you and Anthropic.
+1. **dario doesn't multiply your subscription.** It routes through the plan you have. Beyond the subscription cap, Anthropic still rate-limits; [multi-account pool mode](./multi-account-pool.md) is the answer for hitting the cap on a single account, and it's orthogonal to the billing-split question.
+2. **No claim about competitor products specifically.** The tables above refer to architectural patterns (`proxy that forwards request shape unchanged`), not named tools. If a particular tool also implements wire-fidelity replay, it gets the same outcome dario does. This doc exists because most subscription-billing proxies don't — they extract OAuth tokens and forward the raw client request, which is exactly the shape a revived split would reclassify.
+3. **Anthropic terms of service still apply.** This project is independent, unofficial, third-party — see [DISCLAIMER.md](../DISCLAIMER.md). Whether any particular use complies with Anthropic's current terms is between you and Anthropic.
 
 ## If you're coming from another proxy
 
-The migration is roughly:
-
 1. `npm install -g @askalf/dario` (or pull `ghcr.io/askalf/dario:latest` — see [`docker.md`](./docker.md))
-2. `dario login` — if you have Claude Code already installed and logged in, this picks up existing credentials. Otherwise it runs its own OAuth flow. For SSH / headless setups, `dario login --manual`.
+2. `dario login` — if you have Claude Code installed and logged in, this picks up existing credentials. Otherwise it runs its own OAuth flow. For SSH / headless setups, `dario login --manual`.
 3. `dario proxy` — starts the local proxy on `localhost:3456`
-4. Update your tools' `ANTHROPIC_BASE_URL` env var to `http://localhost:3456` and `ANTHROPIC_API_KEY` to `dario` (literal string `dario` if you bind to loopback; a real `DARIO_API_KEY` if you bind to `0.0.0.0`)
+4. Point your tools' `ANTHROPIC_BASE_URL` at `http://localhost:3456` and `ANTHROPIC_API_KEY` at `dario` (literal string `dario` on loopback; a real `DARIO_API_KEY` if you bind to `0.0.0.0`)
 5. `dario doctor` — confirms everything is wired correctly
 
-Backends other than the Claude subscription (OpenAI, Groq, OpenRouter, Ollama, etc.) are configured separately via `dario backend add` — see the [README's 30-seconds section](../README.md#30-seconds).
+Backends other than the Claude subscription (OpenAI, Groq, OpenRouter, Ollama, etc.) are configured separately via `dario backend add` — see the [README](../README.md).
 
 ## Related reading
 
-- [`wire-fidelity.md`](./wire-fidelity.md) — the six wire-rewrite axes that make this possible
+- [`wire-fidelity.md`](./wire-fidelity.md) — the wire-rewrite axes that make this possible
 - [`returning.md`](./returning.md) — if you used dario before and are coming back
 - [`multi-account-pool.md`](./multi-account-pool.md) — running multiple subscriptions in a pool
 - [Discussion #1](https://github.com/askalf/dario/discussions/1) — rate-limit header reference for subscription billing


### PR DESCRIPTION
## What

Corrects the stale 2026-06-15 billing-split narrative across the docs. The README + docs presented the Agent-SDK / `claude -p` split as an upcoming/effected cliff, but that date has passed and Anthropic **paused the change before it took effect** — SDK and `claude -p` still bill subscription today. Docs-only; no version bump.

## Reframe

From "here's the deadline, here's the cliff" → **"announced, then paused — and here's the tripwire for its return."** This is a stronger honest story than a deadline that quietly didn't happen: the threat was real and announced on short public notice, Anthropic reserved the right to ship a revised version with advance notice, and dario's daily billing-classifier canary is the early-warning system for the day it does.

Consistent thread across every surface: the split is **not live today**; dario's standing value (route every tool through your subscription) is unchanged and never depended on the deadline; the canary + drift watchers catch a revival within a day.

## Files

- **README.md** — top banner and `## The deadline: 2026-06-15` → `## The billing split` rewritten (announced/paused timeline, "Today (paused) vs If it returns" table, canary-as-tripwire). Anchor renamed `#the-deadline-2026-06-15` → `#the-billing-split`; both inbound links updated. Tense fixes in the drift note, overage-guard bullet, project-status line, and the FAQ entry.
- **docs/faq.md** — the `claude -p` / Agent-SDK Q&A reframed to paused reality + the exact verify check for a revival (now naming the canary).
- **docs/why-now-2026-06.md** — retitled "The 2026 billing split: announced, paused, watched" and rewritten throughout: paused-status section, "Today vs if a revised split ships" table, a dedicated tripwire section, verify steps reframed from "after it lands" to "at any time / the day it returns." Filename kept so inbound links don't break.

## Verification

- No dangling references to the old `#the-deadline-2026-06-15` anchor (grep clean); both inbound links point to `#the-billing-split`.
- All 7 residual `2026-06-15` mentions are in correct announced/scheduled/paused context.
- Announced/paused facts sourced from Anthropic's Help Center article (linked in-doc) and the @ClaudeDevs announcement; consistent with the current live behavior (subscription buckets on `claude -p`).
