### PR TITLE
chore(cc-drift): v4.8.153 — maxTested → v2.1.207

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ checklist.
 
 ## [Unreleased]
 
+## [4.8.153] - 2026-07-11
+
+- **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.206` → `2.1.207` for CC v2.1.207. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.
 ## [4.8.152] - 2026-07-10
 
 - **Template label refresh** — `_version`, `_supportedMaxTested`, and the `user-agent` header bumped to `2.1.206` to track `@anthropic-ai/claude-code@latest`. The live wire shape is unchanged — cc-drift-template-watch ran `capture-and-bake --check` against live CC v2.1.206 and found zero shape drift vs the bundle — so this is a label refresh, not a re-capture (`_captured` stays at the last real capture). Auto-merged; clears the `sdk-drift` early-warning signal.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "4.8.152",
+  "version": "4.8.153",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/live-fingerprint.ts
+++ b/src/live-fingerprint.ts
@@ -906,7 +906,7 @@ export function _resetInstalledVersionProbeForTest(): void {
  */
 export const SUPPORTED_CC_RANGE = {
   min: '1.0.0',
-  maxTested: '2.1.206',
+  maxTested: '2.1.207',
 } as const;
 
 /**


### PR DESCRIPTION
## Auto-drafted by cc-drift-watch.yml

The drift watcher flagged CC v2.1.207 as outside the current supported range. This PR:

1. Bumps `SUPPORTED_CC_RANGE.maxTested` from `2.1.206` → `2.1.207` in `src/live-fingerprint.ts`
2. Bumps `package.json` version → `4.8.153`
3. Promotes `## [Unreleased]` in `CHANGELOG.md` to `## [4.8.153] - 2026-07-11` and appends the drift-fix bullet

### Items in the drift report

- **compat.range** (medium) — CC v2.1.207 is beyond SUPPORTED_CC_RANGE.maxTested (v2.1.206). Run the e2e suite against the new CC and bump maxTested in src/live-fingerprint.ts — users on the new CC currently get a soft "untested-above" warning from dario doctor.
- **template.version** (low) — baked cc-template-data.json is v2.1.206; npm latest is v2.1.207. Re-capture the template (MITM a real CC v2.1.207 request) if any fingerprint-sensitive field (system prompt, header order, metadata shape, beta flags) changed.
- **cch.seed** (info) — No cch seed for CC v2.1.207 in src/cch.ts (CCH_SEEDS). dario OMITS the cch token for it — correct while CC v2.1.207 sends none (2.1.199+). Only add a seed if scripts/check-wire-drift.mjs reports CC re-introduced cch; then run `node scripts/cch-calibrate.mjs` on a host with claude v2.1.207. dario#528.

### Fully autonomous — no maintainer action required

This PR validates, merges, and ships itself. Nothing here is a to-do — it is what already happens:

- ✅ **Patched** — `SUPPORTED_CC_RANGE.maxTested` (compat.range), the `package.json` version, and the `CHANGELOG` entry are written by the bot.
- ✅ **Wire-format compat is validated continuously** by `cc-drift-template-watch.yml` — a real CC capture on the self-hosted runner every 30 min. If the bundled template actually drifts against this CC it opens its own `bot/template-rebake-*` PR, independently of this one. (This is the automated equivalent of the old manual "run `dario doctor` against v2.1.207" step — no local run needed.)
- ✅ **Auto-merges** the moment the required CI checks pass (`build (18|20|22)`, `validate-package-json`, `analyze`, `actionlint`). `master` requires no review, so no human approval gates it.
- ✅ **Auto-releases** on merge: `cc-drift-auto-release.yml` tags `v4.8.153`, publishes `@askalf/dario@4.8.153` to npm (`--provenance`) + GHCR inline, and the box autodeploy timer picks it up within ~15 min.

**You only need to look if CI fails** — then auto-merge holds, this PR stays open with the failure visible, and the bot branch is preserved. Otherwise it is already on its way to npm.

### About this auto-draft

Only `compat.range` items are auto-patched by this script. Template re-capture is auto-handled separately by `cc-drift-template-watch.yml`. The remaining categories (scope rotations, URL / clientId / tokenUrl changes) require judgment and stay manual — the bot opens the plain drift-issue for those as before.

---

_Generated by `scripts/auto-draft-drift-fix.mjs`. Closes the detection-latency arc: [#112](https://github.com/askalf/dario/pull/112) (CF bypass), [#113](https://github.com/askalf/dario/pull/113) (hourly cadence), [#114](https://github.com/askalf/dario/pull/114) (auto-draft PR)._
