### PR TITLE
fix(drift-watch): stop stale drift-summary.md poisoning rebake PR/issue bodies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,11 @@ dist/
 *.tgz
 .env
 credentials.json
+
+# drift-watch scratch artifacts — written to the repo root on the runner by
+# capture-and-bake.mjs --check / cc-drift-template-watch.yml; never commit
+# (a tracked drift-summary.md gets embedded into rebake PR bodies as if it
+# described the current run — see the once-committed copy from #669)
+drift-summary.md
+drift-output.txt
+label-target.txt

--- a/drift-summary.md
+++ b/drift-summary.md
@@ -1,4 +1,0 @@
-**Verdict:** 🟡 Moderate — worth a closer read
-
-- **anthropic_beta added:** `fallback-credit-2026-06-01`, `afk-mode-2026-01-31` (CC opted into a feature flag)
-- **system_prompt:** +3993 chars net (text-content drift — see unified diff below)

--- a/scripts/capture-and-bake.mjs
+++ b/scripts/capture-and-bake.mjs
@@ -39,7 +39,7 @@
  *       version is written to `label-target.txt` for the workflow to consume.
  */
 
-import { writeFileSync, readFileSync } from 'node:fs';
+import { writeFileSync, readFileSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -216,6 +216,14 @@ if (fableVariant) scrubbed.system_prompt_fable = fableVariant;
 
 // ── --check mode: diff and exit; do not write ────────────────────────
 if (CHECK_MODE) {
+  // Remove any leftover drift-summary.md BEFORE diffing. The watch workflow
+  // embeds the file into issue/PR bodies whenever it exists, but this run
+  // only writes it for the drift it actually found — so a stale copy (from
+  // a previous run on the persistent self-hosted runner workdir, or the
+  // once-tracked copy that #669 accidentally committed) gets embedded as if
+  // it described THIS run's drift.
+  const summaryPath = join(repoRoot, 'drift-summary.md');
+  rmSync(summaryPath, { force: true });
   const diff = computeDrift(prev, scrubbed);
   const variantDrift = (prev.system_prompt_fable ?? '') !== (scrubbed.system_prompt_fable ?? '');
   if (diff.length === 0 && !variantDrift) {
@@ -239,7 +247,6 @@ if (CHECK_MODE) {
   // v4.7.0: lead with a one-line verdict + per-axis breakdown so the
   // workflow embedding this output (and any human reading the log)
   // sees the ship/investigate signal before the line-by-line detail.
-  const summaryPath = join(repoRoot, 'drift-summary.md');
   if (diff.length > 0) {
     const interp = interpretDrift(diff);
     log(`check: drift detected — ${diff.length} differing slot${diff.length === 1 ? '' : 's'} (verdict: ${interp.verdict}):`);
@@ -252,6 +259,18 @@ if (CHECK_MODE) {
   }
   if (variantDrift) {
     log(`check: fable system-prompt variant drift (${(prev.system_prompt_fable ?? '').length} → ${(scrubbed.system_prompt_fable ?? '').length} chars).`);
+    if (diff.length === 0) {
+      // The slot diff is empty, so the drift-detected branch above wrote no
+      // summary — give the workflow embed an accurate variant-only one
+      // instead of leaving the body summary-less (or, before the rmSync
+      // above, stale).
+      writeFileSync(summaryPath, [
+        '**Verdict:** 🟡 Moderate — fable system-prompt variant only',
+        '',
+        `- **system_prompt_fable:** ${(prev.system_prompt_fable ?? '').length} → ${(scrubbed.system_prompt_fable ?? '').length} chars (base system prompt, tools, and anthropic_beta unchanged)`,
+      ].join('\n') + '\n');
+      log('wrote drift-summary.md (variant-only) for workflow embedding');
+    }
   }
   log('check: bundled template is stale relative to live CC. Run `node scripts/capture-and-bake.mjs` to re-bake.');
 


### PR DESCRIPTION
## Problem — every rebake PR/issue body carries a stale drift Summary

`cc-drift-template-watch.yml` builds the rebake-PR / drift-issue body with:

```sh
if [ -f drift-summary.md ]; then
  echo "### Summary"
  cat drift-summary.md
fi
```

but `capture-and-bake.mjs --check` only **writes** `drift-summary.md` when `computeDrift` finds slot-level drift (`diff.length > 0`). A variant-only or label-only run writes nothing — so whatever `drift-summary.md` happens to exist gets embedded as if it described the current run.

And one *does* exist: a stale copy was accidentally committed to the repo root in #669, so it is present in **every checkout**. Concrete damage, visible right now:

- **#711 (rebake PR) and #712 (drift issue)** lead with `anthropic_beta added: fallback-credit-2026-06-01, afk-mode-2026-01-31 … system_prompt: +3993 chars net` — **none of which is in the 2026-07-11 capture**. The baked template in #711 carries zero beta changes, and the `[bake]` log in those same bodies shows no `drift detected — N differing slots` line (i.e. `computeDrift` was empty; the only real drift is the fable variant 8783 → 8841 chars + version pins).
- A reviewer deciding ship-or-investigate from the Summary — its stated purpose — is reading a different, older drift event.

Even after untracking the file, the **persistent self-hosted runner workdir** could leak a summary written by a real slot-drift run into a later variant-only run's body.

## Fix — three layers

1. **Untrack `drift-summary.md`** and gitignore it, plus `drift-output.txt` / `label-target.txt` (same class: scratch artifacts the check writes to the repo root on the runner; one accidental `git add -A` away from recommitting).
2. **`--check` now `rm`s any leftover `drift-summary.md` before diffing** — the file present at embed time is exactly what *this* run wrote, regardless of what a previous run or a tracked copy left behind.
3. **Variant-only drift now writes its own accurate Summary** (`fable system-prompt variant only, N → M chars, base/tools/beta unchanged`) so those PR bodies lead with a correct verdict instead of nothing.

No version bump — CI/tooling only; the watch runs the script from the master checkout, so this is effective on merge without a release.

## Test plan

- `node --check scripts/capture-and-bake.mjs` clean; full CI on this PR.
- Next scheduled `cc-drift-template-watch` run (every 30 min, while #711 is still open): its issue-comment body should show the **variant-only** Summary (fable 8783 → 8841) instead of the stale beta claims — that's the live confirmation, no manual step needed.

Note for #711 reviewers: this PR does **not** change what #711 bakes — that bake is correct (verification comment on #711). It fixes the misleading description around it.
