### PR TITLE
docs(README): drop stale billing-split + pre-4.8.39 callouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,6 @@
 >
 > **Upgrading from v4?** Solo `dario login` + `dario proxy` users: nothing to do — it just works. Full notes → **[MIGRATION.md](MIGRATION.md)** · [CHANGELOG](CHANGELOG.md#500---2026-07-11) · [#701](https://github.com/askalf/dario/issues/701)
 
----
-
-> 🗓️ **The billing split — announced, then paused.** Anthropic announced (2026-05-13) that Agent-SDK and `claude -p` (headless) traffic would leave your subscription pool for a small separate monthly credit ($20 / $100 / $200 by plan), then metered per-token API rates — scheduled for 2026-06-15. It was **paused before that date**: those surfaces still bill subscription today, and Anthropic says it will give advance notice before any revised version. dario already rewrites every request into interactive Claude Code wire-shape, so your traffic sits in the subscription pool whether the split is paused or live — and its daily billing-classifier canary is the tripwire for the day it returns. **[The full timeline, and how to verify on your own machine →](#the-billing-split)**
-
-> ⚠️ Still on a version **before 4.8.39**? Upgrade now — those could silently corrupt code/structured content routed through the proxy (the identifier scrub stripped tokens like the JS `continue` keyword). **[Details →](https://github.com/askalf/dario/issues/457)**
 
 ---
 


### PR DESCRIPTION
Removes the two stale blockquote callouts between the v5 banner and the intro:

- 🗓️ **billing-split "announced, then paused"** — dated news (May announcement, June pause); the substantive `## The billing split` section stays and remains linked from the body, so nothing readers need is lost, just the top-of-page news flash.
- ⚠️ **pre-4.8.39 upgrade notice** — obsolete now that v5.0 is current; the fix shipped 20+ releases ago and #457 stays linked from history.

Docs-only; no version bump on purpose (release gate: nothing ships).
