### PR TITLE
fix(doctor-watch): don't file OAuth drift when obedience proves it's serving

### DIFF
--- a/scripts/check-doctor-drift.mjs
+++ b/scripts/check-doctor-drift.mjs
@@ -35,6 +35,7 @@
 // NOT a false drift issue). Mirrors scripts/check-sdk-drift.mjs's contract.
 
 import { execFileSync } from 'node:child_process';
+import { classifyDoctorOutput } from './doctor-drift-classify.mjs';
 
 /**
  * Synchronous sleep between retries — this script runs as a top-level sync
@@ -97,63 +98,15 @@ for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
   }
 }
 
-// Rows render as:  [ OK ]  OAuth   healthy (...)   /   [INFO]  Template   bundled capture, ...
-function findRow(labelRe) {
-  for (const line of raw.split('\n')) {
-    const m = line.match(/^\s*\[\s*(OK|INFO|WARN|FAIL|ERROR)\s*\]\s+(.*\S)\s*$/i);
-    if (!m) continue;
-    const status = m[1].toUpperCase();
-    const rest = m[2];
-    if (labelRe.test(rest)) return { status, detail: rest };
-  }
-  return null;
-}
-
-// Like findRow but collects every match — the obedience probe emits one
-// row PER model family.
-function findRows(labelRe) {
-  const rows = [];
-  for (const line of raw.split('\n')) {
-    const m = line.match(/^\s*\[\s*(OK|INFO|WARN|FAIL|ERROR)\s*\]\s+(.*\S)\s*$/i);
-    if (!m) continue;
-    const status = m[1].toUpperCase();
-    const rest = m[2];
-    if (labelRe.test(rest)) rows.push({ status, detail: rest });
-  }
-  return rows;
-}
-
-const oauth = findRow(/^OAuth\b/i);
-const template = findRow(/^Template\b(?!\s+drift)/i); // the capture row, NOT "Template drift"
-const identity = findRow(/^Identity\b/i);
-const obedience = findRows(/^Obedience\b/i);
+const { oauth, template, identity, obedience, drift, parsedAnchors } = classifyDoctorOutput(raw);
 
 // If neither anchor row parsed, doctor's format changed — treat as infra/format
 // error rather than silently reporting "clean".
-if (!oauth && !template) {
+if (!parsedAnchors) {
   process.stderr.write(
     'check-doctor-drift: could not parse OAuth or Template rows — dario doctor output format may have changed\n',
   );
   process.exit(3);
-}
-
-const drift = [];
-if (oauth && oauth.status !== 'OK') {
-  drift.push({ check: 'OAuth', status: oauth.status, detail: oauth.detail });
-}
-if (template && /\blive capture\b/i.test(template.detail)) {
-  drift.push({ check: 'Template', status: template.status, detail: template.detail });
-}
-if (identity && identity.status === 'WARN') {
-  drift.push({ check: 'Identity', status: identity.status, detail: identity.detail });
-}
-// Only FAIL is drift: WARN = probe couldn't complete (infra flake), INFO =
-// probe skipped (proxy not running — the container would be unhealthy and
-// caught elsewhere). No rows at all = deployed dario predates --obedience.
-for (const row of obedience) {
-  if (row.status === 'FAIL') {
-    drift.push({ check: 'Obedience', status: row.status, detail: row.detail });
-  }
 }
 
 const report = { checkedAt: new Date().toISOString(), oauth, template, identity, obedience, drift };

--- a/scripts/doctor-drift-classify.mjs
+++ b/scripts/doctor-drift-classify.mjs
@@ -1,0 +1,84 @@
+// Pure parse + classify half of check-doctor-drift.mjs. Split out so the drift
+// logic is unit-testable without a docker exec — the runner script execs into
+// askalf-dario at module load, which a `node --test` subprocess can't do.
+// Takes a `dario doctor --obedience` stdout dump and returns the parsed status
+// rows plus the drift set. Zero dependencies; behaviour-identical to the
+// inline version it replaced except for the OAuth gate documented below.
+
+// Rows render as:  [ OK ]  OAuth   healthy (...)   /   [INFO]  Template   bundled capture, ...
+function findRow(raw, labelRe) {
+  for (const line of raw.split('\n')) {
+    const m = line.match(/^\s*\[\s*(OK|INFO|WARN|FAIL|ERROR)\s*\]\s+(.*\S)\s*$/i);
+    if (!m) continue;
+    const status = m[1].toUpperCase();
+    const rest = m[2];
+    if (labelRe.test(rest)) return { status, detail: rest };
+  }
+  return null;
+}
+
+// Like findRow but collects every match — the obedience probe emits one
+// row PER model family.
+function findRows(raw, labelRe) {
+  const rows = [];
+  for (const line of raw.split('\n')) {
+    const m = line.match(/^\s*\[\s*(OK|INFO|WARN|FAIL|ERROR)\s*\]\s+(.*\S)\s*$/i);
+    if (!m) continue;
+    const status = m[1].toUpperCase();
+    const rest = m[2];
+    if (labelRe.test(rest)) rows.push({ status, detail: rest });
+  }
+  return rows;
+}
+
+/**
+ * Parse a `dario doctor --obedience` dump and classify the runtime drifts no
+ * other watcher catches.
+ *
+ * @param {string} raw doctor stdout
+ * @returns {{oauth, template, identity, obedience, drift, parsedAnchors: boolean}}
+ *   `parsedAnchors` is false when neither the OAuth nor the Template anchor row
+ *   parsed — the caller treats that as an infra/format error (exit 3), NOT a
+ *   clean run.
+ */
+export function classifyDoctorOutput(raw) {
+  const oauth = findRow(raw, /^OAuth\b/i);
+  const template = findRow(raw, /^Template\b(?!\s+drift)/i); // the capture row, NOT "Template drift"
+  const identity = findRow(raw, /^Identity\b/i);
+  const obedience = findRows(raw, /^Obedience\b/i);
+
+  const drift = [];
+
+  // OAuth is gated on the obedience ground truth. The non-Haiku obedience
+  // probes (Sonnet / Opus / Fable) each require a live bearer to answer;
+  // Haiku can fall back. So when they all PONG, OAuth is serving regardless
+  // of the stored-token expiry the doctor reads: dario refreshes the bearer
+  // in-memory per request in single-account mode and does NOT write the fresh
+  // expiry back to the on-disk credential doctor inspects, so a cosmetic
+  // "OAuth expired" row coexists with a fully-serving fleet (dario#721).
+  // Only file OAuth drift when serving is NOT proven — obedience missing (a
+  // deployed dario predating --obedience) or a non-Haiku probe not OK (a
+  // genuinely dead bearer 401s and FAILs the probe anyway, so it still trips).
+  const nonHaiku = obedience.filter((o) => /\b(sonnet|opus|fable)\b/i.test(o.detail));
+  const oauthServes = nonHaiku.length > 0 && nonHaiku.every((o) => o.status === 'OK');
+  if (oauth && oauth.status !== 'OK' && !oauthServes) {
+    drift.push({ check: 'OAuth', status: oauth.status, detail: oauth.detail });
+  }
+
+  if (template && /\blive capture\b/i.test(template.detail)) {
+    drift.push({ check: 'Template', status: template.status, detail: template.detail });
+  }
+  if (identity && identity.status === 'WARN') {
+    drift.push({ check: 'Identity', status: identity.status, detail: identity.detail });
+  }
+  // Only FAIL is drift: WARN = probe couldn't complete (infra flake), INFO =
+  // probe skipped (proxy not running — the container would be unhealthy and
+  // caught elsewhere). No rows at all = deployed dario predates --obedience.
+  for (const row of obedience) {
+    if (row.status === 'FAIL') {
+      drift.push({ check: 'Obedience', status: row.status, detail: row.detail });
+    }
+  }
+
+  return { oauth, template, identity, obedience, drift, parsedAnchors: !!(oauth || template) };
+}

--- a/test/doctor-drift-classify.mjs
+++ b/test/doctor-drift-classify.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+// Unit tests for scripts/doctor-drift-classify.mjs — the pure parse + drift
+// classifier behind the dario-doctor-watch. The headline case is dario#721:
+// an "OAuth expired" row that coexists with fully-passing obedience probes
+// (dario refreshes the bearer in-memory and doesn't persist the fresh expiry
+// to the on-disk credential doctor reads) must NOT file OAuth drift — the
+// non-Haiku obedience PONGs prove OAuth is serving. Everything else the
+// watcher flags (a genuinely dead bearer, a stale live-capture template, an
+// identity WARN, an obedience FAIL) must still trip.
+
+import { classifyDoctorOutput } from '../scripts/doctor-drift-classify.mjs';
+
+let pass = 0, fail = 0;
+function check(name, cond) {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else      { console.log(`  FAIL ${name}`); fail++; }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+// Build a doctor dump from [status, detail] rows.
+const dump = (rows) => rows.map(([st, txt]) => `  [${st}]  ${txt}`).join('\n') + '\n';
+const has = (drift, name) => drift.some((d) => d.check === name);
+
+const OAUTH_OK = ['OK', 'OAuth               healthy (expires in 3h 12m)'];
+const OAUTH_EXPIRED = ['WARN', 'OAuth               expired'];
+const TEMPLATE_BUNDLED = ['INFO', 'Template            bundled capture, CC v2.1.207 (13h old) (schema v3)'];
+const TEMPLATE_LIVE = ['INFO', 'Template            live capture, CC v2.1.207 (2h old) (schema v3)'];
+const IDENTITY_OK = ['OK', 'Identity            1/1 pool account match ~/.claude.json (userID=798b515a…)'];
+const IDENTITY_WARN = ['WARN', 'Identity            bearer/userID mismatch (userID drift)'];
+const OB = (fam, st = 'OK', d = '"PONG" (attempt 1/3)') => [st, `Obedience (${fam})  ${d}`];
+const OB_ALL_OK = [OB('haiku'), OB('sonnet'), OB('opus'), OB('fable')];
+
+// ─────────────────────────────────────────────────────────────
+header('dario#721 — OAuth expired but all obedience PONG → NO OAuth drift');
+{
+  const r = classifyDoctorOutput(dump([OAUTH_EXPIRED, TEMPLATE_BUNDLED, IDENTITY_OK, ...OB_ALL_OK]));
+  check('OAuth parsed as WARN/expired', r.oauth && r.oauth.status === 'WARN');
+  check('4 obedience rows parsed', r.obedience.length === 4);
+  check('no OAuth drift (non-Haiku serves)', !has(r.drift, 'OAuth'));
+  check('drift is empty overall', r.drift.length === 0);
+  check('parsedAnchors true', r.parsedAnchors === true);
+}
+
+header('dead bearer — OAuth expired + non-Haiku FAIL → OAuth drift fires');
+{
+  const r = classifyDoctorOutput(dump([
+    OAUTH_EXPIRED, TEMPLATE_BUNDLED, IDENTITY_OK,
+    OB('haiku'), OB('sonnet', 'FAIL', 'ignored system prompt'),
+    OB('opus', 'FAIL', 'ignored system prompt'), OB('fable', 'FAIL', 'ignored system prompt'),
+  ]));
+  check('OAuth drift present', has(r.drift, 'OAuth'));
+  check('obedience FAIL also drifts', has(r.drift, 'Obedience'));
+}
+
+header('predates --obedience — OAuth expired + no obedience rows → OAuth drift fires');
+{
+  const r = classifyDoctorOutput(dump([OAUTH_EXPIRED, TEMPLATE_BUNDLED, IDENTITY_OK]));
+  check('no obedience rows', r.obedience.length === 0);
+  check('OAuth drift present (serving unproven)', has(r.drift, 'OAuth'));
+}
+
+header('partial non-Haiku not OK — OAuth expired + opus WARN → OAuth drift fires');
+{
+  const r = classifyDoctorOutput(dump([
+    OAUTH_EXPIRED, TEMPLATE_BUNDLED, IDENTITY_OK,
+    OB('haiku'), OB('sonnet'), OB('opus', 'WARN', 'probe timed out'), OB('fable'),
+  ]));
+  check('OAuth drift present (not every non-Haiku OK)', has(r.drift, 'OAuth'));
+}
+
+header('healthy fleet → no drift');
+{
+  const r = classifyDoctorOutput(dump([OAUTH_OK, TEMPLATE_BUNDLED, IDENTITY_OK, ...OB_ALL_OK]));
+  check('drift empty', r.drift.length === 0);
+}
+
+header('other drifts still fire (behaviour preserved)');
+{
+  const live = classifyDoctorOutput(dump([OAUTH_OK, TEMPLATE_LIVE, IDENTITY_OK, ...OB_ALL_OK]));
+  check('live-capture template → Template drift', has(live.drift, 'Template'));
+
+  const idw = classifyDoctorOutput(dump([OAUTH_OK, TEMPLATE_BUNDLED, IDENTITY_WARN, ...OB_ALL_OK]));
+  check('identity WARN → Identity drift', has(idw.drift, 'Identity'));
+
+  const obf = classifyDoctorOutput(dump([
+    OAUTH_OK, TEMPLATE_BUNDLED, IDENTITY_OK,
+    OB('haiku'), OB('sonnet', 'FAIL', 'ignored system prompt'), OB('opus'), OB('fable'),
+  ]));
+  check('obedience FAIL (OAuth OK) → Obedience drift, no OAuth drift', has(obf.drift, 'Obedience') && !has(obf.drift, 'OAuth'));
+}
+
+header('format error — neither anchor row → parsedAnchors false');
+{
+  const r = classifyDoctorOutput('some unrelated output\nwith no doctor rows\n');
+  check('parsedAnchors false', r.parsedAnchors === false);
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Closes #721.

## The false positive

`dario-doctor-watch` opened #721 on this row:

```
[WARN]  OAuth               expired
```

But the same doctor run — and a second one 2h later — showed every obedience probe passing, including the non-Haiku families that need a live bearer to answer at all:

```
[ OK ]  Obedience (haiku)   "PONG"      [ OK ]  Obedience (sonnet)  "PONG"
[ OK ]  Obedience (opus)    "PONG"      [ OK ]  Obedience (fable)   "PONG"
[ OK ]  Identity            1/1 pool account match
```

A dead bearer 401s every non-Haiku call; these PONG'd twice. In single-account mode dario refreshes the bearer in-memory per request and doesn't write the fresh expiry back to the on-disk credential `doctor` reads, so a cosmetic `expired` row coexists with a fully-serving fleet. `check-doctor-drift.mjs` flagged OAuth on `status !== 'OK'` unconditionally, without consulting the obedience rows that are the real liveness signal — so it filed a drift issue for a healthy fleet, and would keep re-filing every ~8h as the access token re-expires.

## The change

Gate the OAuth drift on the obedience ground truth: file it only when serving is **unproven**.

```js
const nonHaiku = obedience.filter(o => /\b(sonnet|opus|fable)\b/i.test(o.detail));
const oauthServes = nonHaiku.length > 0 && nonHaiku.every(o => o.status === 'OK');
if (oauth && oauth.status !== 'OK' && !oauthServes) { /* drift */ }
```

Trade-offs, both fail-toward-flagging:

- A deployed dario **predating `--obedience`** emits no obedience rows, so `oauthServes` is false and OAuth drift still fires — unchanged for old containers.
- A **genuinely dead bearer** FAILs the non-Haiku probes (401), so `oauthServes` is false and it still trips. This only suppresses the exact expired-but-serving case (#721).

Template / Identity / Obedience-FAIL classification is untouched.

## Testing

The parse + classify half moves to `scripts/doctor-drift-classify.mjs` so it's unit-testable without a `docker exec` (the runner script execs into `askalf-dario` at module load). `test/doctor-drift-classify.mjs` adds 15 assertions: the #721 case (expired + all-PONG → no drift), dead-bearer (expired + non-Haiku FAIL → drift), predates-`--obedience` (expired + no obedience → drift), partial non-Haiku not-OK → drift, healthy → clean, and the preserved template/identity/obedience/format-error paths. All 15 pass; both files `node --check` clean.
