### PR TITLE
harden: close spoofable auto-merge gate + scope release token

### DIFF
--- a/.github/workflows/auto-merge-bot-prs.yml
+++ b/.github/workflows/auto-merge-bot-prs.yml
@@ -58,7 +58,10 @@ jobs:
             github.event.pull_request.user.login == 'dependabot[bot]' &&
             steps.dep_meta.outputs.update-type != 'version-update:semver-major'
           ) ||
-          startsWith(github.event.pull_request.head.ref, 'bot/cc-drift-')
+          (
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'bot/cc-drift-')
+          )
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}

--- a/.github/workflows/cc-drift-auto-release.yml
+++ b/.github/workflows/cc-drift-auto-release.yml
@@ -115,6 +115,7 @@ jobs:
         with:
           ref: master
           fetch-depth: 2  # need HEAD^1 for the pull_request fast-exit
+          persist-credentials: false  # no git push in this job (gh CLI + OIDC); don't persist the write-scoped token during npm ci/build
 
       - name: Read package.json version
         id: ver


### PR DESCRIPTION
Two workflow hardening fixes.

## 1. `auto-merge-bot-prs.yml` — spoofable auto-merge gate
This `pull_request_target` workflow (with `contents: write` + `pull-requests: write`) armed native auto-merge in its **Enable auto-merge** step keyed only on the PR head branch name — `startsWith(github.event.pull_request.head.ref, 'bot/cc-drift-')`. A fork PR can name its branch `bot/cc-drift-anything` to satisfy that condition and arm `gh pr merge --auto` on untrusted code.

Added a same-repo guard so only PRs originating from this repo can hit that branch of the condition:

```
(
  github.event.pull_request.head.repo.full_name == github.repository &&
  startsWith(github.event.pull_request.head.ref, 'bot/cc-drift-')
)
```

The Dependabot branch of the logic (keyed on `user.login == 'dependabot[bot]'`, not spoofable) is unchanged.

## 2. `cc-drift-auto-release.yml` — release-token blast radius
The `release` job checked out with a persisted `contents: write` / `packages: write` / `id-token: write` token, then ran `npm ci` / `npm run build` + node scripts. The job never `git push`es (it ships via `gh` CLI + OIDC — verified: no `git push`/`commit`/`tag` in the job), so the persisted credential was unnecessary attack surface during dependency install/build.

Set `persist-credentials: false` on the checkout step. (The checkout uses the `askalf/checkout-with-retry` wrapper, which declares a `persist-credentials` input and forwards it verbatim to the underlying `actions/checkout@v6.0.2` — so the setting takes effect.)

No merge, no settings changes. `cc-drift-watch.yml` intentionally left untouched (it persists a fine-grained PAT it genuinely needs for a later push).
