### PR TITLE
feat: ClusterFuzzLite fuzzing of wire-boundary parsers

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,9 @@
+# ClusterFuzzLite build image — OpenSSF Scorecard detects fuzzing via this file.
+# Uses the OSS-Fuzz JavaScript base builder (Jazzer.js), which provides
+# `compile_javascript_fuzzer`. See build.sh for the fuzz targets.
+# Base pinned by digest (Scorecard Pinned-Dependencies). OSS-Fuzz rolls this
+# image, so bump the digest periodically if the weekly fuzz build breaks.
+FROM gcr.io/oss-fuzz-base/base-builder-javascript@sha256:717f88cd72ee85ab295debf1272eed85590621d6ba9d70d6c59133a61f3f3acf
+COPY . $SRC/dario
+WORKDIR $SRC/dario
+COPY .clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -eu
+# Build the Jazzer.js fuzz targets for ClusterFuzzLite / OSS-Fuzz.
+#
+# dario sits between untrusted parties on both sides of the wire: clients hand
+# it arbitrary /v1/messages and /v1/chat/completions bodies, and the upstream
+# hands back SSE streams and rejection bodies that dario parses, translates,
+# and rewrites. Each target feeds hostile bytes into one of those parsers and
+# asserts its fail-safe contract — see the header of each fuzz/*.fuzz.js.
+
+cd "$SRC/dario"
+
+# npm ci verifies every integrity hash in the committed lockfile
+# (Scorecard Pinned-Dependencies).
+npm ci --no-audit --no-fund
+
+# Jazzer.js is installed build-side rather than as a devDependency so the
+# published package's dependency tree stays exactly as committed; --no-save
+# leaves package.json and package-lock.json untouched.
+npm install --no-save --no-audit --no-fund "@jazzer.js/core@^4.0.0"
+
+# The fuzz targets exercise the compiled output (dist/), same as the test
+# suite — build it first.
+npm run build
+
+for target in sse_translate reject_parsers cch_stamp; do
+  compile_javascript_fuzzer dario "fuzz/${target}.fuzz.js" --sync
+done

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,2 @@
+# ClusterFuzzLite project config — targets are built by build.sh (Jazzer.js).
+language: javascript

--- a/.github/workflows/cflite.yml
+++ b/.github/workflows/cflite.yml
@@ -1,0 +1,47 @@
+# ClusterFuzzLite — continuous fuzzing of dario's wire-boundary parsers: the
+# Anthropic-SSE → OpenAI-SSE stream translator, the upstream-rejection parsers
+# (effort tiers, max_tokens caps) plus the client model-string router, and the
+# deterministic cch request-integrity stamp. Both sides of the wire hand dario
+# input it does not control — clients send arbitrary request bodies and model
+# strings, the upstream sends SSE streams and rejection bodies — and a crash in
+# any of these parsers kills a live stream or the error-recovery path. Runs
+# weekly + on demand; a discovered crash fails the job and is uploaded as an
+# artifact. Fuzz targets live in ./fuzz, built by .clusterfuzzlite/build.sh
+# (Jazzer.js). OpenSSF Scorecard credits the Fuzzing check from the
+# .clusterfuzzlite/ config.
+name: ClusterFuzzLite
+
+on:
+  schedule:
+    - cron: '53 5 * * 2' # weekly, Tuesday 05:53 UTC (staggered off the :00 grid and this repo's other watchers)
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # JavaScript (Jazzer.js) has no native sanitizer — OSS-Fuzz rejects
+        # address/memory/undefined for JS ("cannot be fuzzed with sanitizers"),
+        # and the action's config rejects `none`. `coverage` is the value real
+        # JS ClusterFuzzLite projects use with this action version.
+        sanitizer: [coverage]
+    steps:
+      - name: Build fuzzers (${{ matrix.sanitizer }})
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          language: javascript
+          sanitizer: ${{ matrix.sanitizer }}
+      - name: Run fuzzers (${{ matrix.sanitizer }})
+        id: run
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: 300
+          mode: 'batch'
+          language: javascript
+          sanitizer: ${{ matrix.sanitizer }}

--- a/fuzz/cch_stamp.fuzz.js
+++ b/fuzz/cch_stamp.fuzz.js
@@ -1,0 +1,63 @@
+// Fuzz the deterministic cch request-integrity stamp — the anchored-regex
+// projection + xxHash64 that dario recomputes over every outbound /v1/messages
+// body so its model/fallback rewrites stay consistent with the billing
+// header's cch token. The body text embeds client-supplied conversation
+// content, which may itself quote cch-lookalikes. Contracts: xxh64 never
+// throws and stays in the u64 domain on arbitrary bytes/seeds; on a valid-JSON
+// body the stamp is 5 lowercase hex chars, stamping is idempotent, keeps the
+// body valid JSON, and only ever rewrites the anchored billing token (a
+// mis-anchored match silently corrupts the user's own text — dario#528). On
+// garbage that merely LOOKS like it carries a billing token, JSON.parse's
+// SyntaxError is the documented garbage-in contract (callers stamp bodies they
+// just serialized), so SyntaxError is expected; anything else is a finding.
+import { xxh64, cchWithSeed, cchForBody, stampCch } from '../dist/cch.js';
+
+const U64 = (1n << 64n) - 1n;
+
+export function fuzz(data) {
+  const s = data.toString('utf8');
+
+  // 1. The hash core on raw bytes with a fuzz-derived seed.
+  const seed = data.length >= 8 ? data.readBigUInt64LE(0) : BigInt(data.length);
+  const h = xxh64(data, seed);
+  if (typeof h !== 'bigint' || h < 0n || h > U64) {
+    throw new Error(`xxh64 left the u64 domain: ${h}`);
+  }
+
+  // 2. A guaranteed-valid-JSON body carrying a real billing tag, with the fuzz
+  //    string as conversation content AFTER it (which may quote cch=xxxxx —
+  //    the anchored rewrite must never touch it).
+  const body = JSON.stringify({
+    model: 'claude-opus-4-6',
+    max_tokens: 32000,
+    system: [{ type: 'text', text: 'x-anthropic-billing-header: cc_version=2.1.177; cc_entrypoint=cli; cch=abc12;' }],
+    messages: [{ role: 'user', content: s }],
+    metadata: { user_id: s.slice(0, 64) },
+  });
+  const cch = cchWithSeed(body, seed);
+  if (cch !== null && !/^[0-9a-f]{5}$/.test(cch)) {
+    throw new Error(`cchWithSeed produced a non-5-hex token: ${JSON.stringify(cch)}`);
+  }
+  const stamped = stampCch(body, '2.1.177');
+  JSON.parse(stamped); // the stamp must never break the body's JSON
+  if (stamped.length !== body.length) {
+    // 5-hex → 5-hex anchored replacement: anything else means the rewrite
+    // escaped the billing tag and rewrote conversation content.
+    throw new Error('stampCch changed the body length');
+  }
+  if (stampCch(stamped, '2.1.177') !== stamped) {
+    throw new Error('stampCch is not idempotent');
+  }
+
+  // 3. Raw fuzz text as the body: past the billing-token gate, a JSON.parse
+  //    SyntaxError is the documented contract for non-JSON input — only that
+  //    error class is expected.
+  for (const raw of [s, `{"a":"cc_entrypoint=cli; cch=00000;${s}"}`]) {
+    try {
+      cchForBody(raw, '2.1.177');
+      stampCch(raw, '2.1.177');
+    } catch (e) {
+      if (!(e instanceof SyntaxError)) throw e;
+    }
+  }
+}

--- a/fuzz/reject_parsers.fuzz.js
+++ b/fuzz/reject_parsers.fuzz.js
@@ -1,0 +1,59 @@
+// Fuzz the upstream-rejection parsers — the regexes dario runs over RAW 400
+// bodies from the upstream API to learn a model's supported effort tiers and
+// max_tokens cap — plus the provider-prefix parser that routes on the
+// client-supplied `model` field. Rejection bodies and model strings are both
+// wire input from a party dario does not control. Contracts: never throw,
+// never hang (a super-linear regex here is a denial-of-service on the
+// error-recovery path), and return only the documented shapes —
+// parseEffortRejection null or a rejected tier + non-empty supported list,
+// parseMaxTokensRejection null or a positive finite cap, parseProviderPrefix
+// null or a known provider + non-empty model.
+import {
+  parseEffortRejection,
+  isEffortParamUnsupported,
+  parseMaxTokensRejection,
+  bestSupportedEffort,
+  parseProviderPrefix,
+} from '../dist/proxy.js';
+
+export function fuzz(data) {
+  const s = data.toString('utf8');
+
+  // The raw fuzz body, plus variants seeded with the real upstream anchors so
+  // the regexes' interesting paths run on adversarial surroundings.
+  const bodies = [
+    s,
+    `does not support effort level '${s.slice(0, 32)}'. Supported levels: ${s.slice(0, 64)}`,
+    `${s} does not support the effort parameter ${s}`,
+    `max_tokens: ${s.slice(0, 24)} > ${s.slice(0, 24)}, which is the maximum allowed ${s}`,
+  ];
+  for (const body of bodies) {
+    const eff = parseEffortRejection(body);
+    if (eff !== null) {
+      if (typeof eff.rejected !== 'string' || !Array.isArray(eff.supported) || eff.supported.length === 0) {
+        throw new Error(`parseEffortRejection returned a malformed shape: ${JSON.stringify(eff)}`);
+      }
+      // Whatever tiers came off the wire, the clamp target must come out usable.
+      if (typeof bestSupportedEffort(eff.supported) !== 'string') {
+        throw new Error('bestSupportedEffort returned a non-string');
+      }
+    }
+    if (typeof isEffortParamUnsupported(body) !== 'boolean') {
+      throw new Error('isEffortParamUnsupported returned a non-boolean');
+    }
+    const cap = parseMaxTokensRejection(body);
+    if (cap !== null && (!Number.isFinite(cap) || cap <= 0)) {
+      throw new Error(`parseMaxTokensRejection returned a non-positive cap: ${cap}`);
+    }
+  }
+
+  // Client-supplied model strings: raw, correctly prefixed, and colon-riddled.
+  for (const model of [s, `openai:${s}`, `claude:${s}`, `:${s}`, `${s}:${s}`]) {
+    const route = parseProviderPrefix(model);
+    if (route !== null) {
+      if ((route.provider !== 'openai' && route.provider !== 'claude') || typeof route.model !== 'string' || route.model.length === 0) {
+        throw new Error(`parseProviderPrefix returned a malformed route: ${JSON.stringify(route)}`);
+      }
+    }
+  }
+}

--- a/fuzz/sse_translate.fuzz.js
+++ b/fuzz/sse_translate.fuzz.js
@@ -1,0 +1,48 @@
+// Fuzz the Anthropic-SSE → OpenAI-SSE stream translator — the per-request
+// closure that turns each upstream `data: {...}` line into an OpenAI
+// chat.completion.chunk for /v1/chat/completions clients. The upstream stream
+// is wire input dario does not control; the contract: NEVER throw on a hostile
+// line (broken JSON, events whose content_block / delta fields are missing,
+// primitives, or prototype-named junk), and every non-null return is a
+// well-formed `data: <json>\n\n` frame (or the [DONE] sentinel). A throw here
+// kills a client's live stream mid-response.
+import { createOpenAIStreamTranslator } from '../dist/proxy.js';
+
+function checkOutput(out) {
+  if (out === null) return;
+  if (typeof out !== 'string' || !out.startsWith('data: ')) {
+    throw new Error(`translator returned a non-SSE frame: ${JSON.stringify(String(out).slice(0, 80))}`);
+  }
+  for (const frame of out.split('\n\n')) {
+    if (frame === '' || frame === 'data: [DONE]') continue;
+    JSON.parse(frame.slice(6)); // a non-JSON frame breaks the client's SSE parser
+  }
+}
+
+export function fuzz(data) {
+  const s = data.toString('utf8');
+  const translate = createOpenAIStreamTranslator();
+
+  // Raw fuzz input, as-is and forced through the `data: ` gate.
+  checkOutput(translate(s));
+  checkOutput(translate(`data: ${s}`));
+
+  // Hostile-but-parseable events: real event types with fuzz-derived fields,
+  // so the translator's property access runs on adversarial shapes.
+  const types = ['content_block_start', 'content_block_delta', 'content_block_stop', 'message_stop', s.slice(0, 24)];
+  const hostiles = [
+    { type: types[data.length % types.length], content_block: { type: 'tool_use', name: s.slice(0, 16), id: s.slice(0, 8) } },
+    { type: 'content_block_start', content_block: s },
+    { type: 'content_block_start', content_block: { type: 'tool_use', name: s.slice(0, 16) } },
+    { type: 'content_block_delta', delta: { type: 'text_delta', text: s } },
+    { type: 'content_block_delta', delta: { type: 'input_json_delta', partial_json: s } },
+    { type: 'content_block_delta', delta: s.length },
+    { type: 'message_stop', ['__proto__']: { polluted: true } },
+  ];
+  for (const e of hostiles) checkOutput(translate(`data: ${JSON.stringify(e)}`));
+
+  // A multi-line stream split on newlines — the closure is stateful across
+  // lines (tool-call index/id), so interleavings matter.
+  const streamed = createOpenAIStreamTranslator();
+  for (const line of s.split('\n')) checkOutput(streamed(line));
+}


### PR DESCRIPTION
Adds ClusterFuzzLite continuous fuzzing (Jazzer.js), fixing the OpenSSF Scorecard **Fuzzing** check (currently 0). Scorecard credits the check from the `.clusterfuzzlite/` config; the workflow makes the fuzzing real rather than decorative. New files only — no existing file is touched.

## What's fuzzed and why

dario sits between two parties it does not control: clients hand it arbitrary `/v1/messages` and `/v1/chat/completions` bodies and model strings, and the upstream hands back SSE streams and rejection bodies that dario parses, translates, and rewrites. A crash in any of these parsers kills a live stream or the error-recovery path. Three targets, each asserting a fail-safe contract on hostile bytes:

- **`fuzz/sse_translate.fuzz.js`** — `createOpenAIStreamTranslator` (`dist/proxy.js`): the per-request closure translating upstream Anthropic SSE lines into OpenAI `chat.completion.chunk` frames. Must never throw on broken JSON, type-confused `content_block`/`delta` fields, or prototype-named junk; every non-null return must be a well-formed `data: <json>\n\n` frame (or the `[DONE]` sentinel). Exercises both stateless lines and stateful multi-line streams (tool-call index/id).
- **`fuzz/reject_parsers.fuzz.js`** — `parseEffortRejection`, `isEffortParamUnsupported`, `parseMaxTokensRejection`, `bestSupportedEffort`, `parseProviderPrefix` (`dist/proxy.js`): regexes over raw upstream 400 bodies (learn-once effort tiers / max_tokens caps) and the client-supplied `model` router. Must never throw or hang (a super-linear regex here is a DoS on the error path) and must return only the documented shapes.
- **`fuzz/cch_stamp.fuzz.js`** — `xxh64`, `cchWithSeed`, `cchForBody`, `stampCch` (`dist/cch.js`): the request-integrity stamp recomputed over every outbound body. `xxh64` must stay in the u64 domain on arbitrary bytes/seeds; on valid-JSON bodies the stamp must be 5-hex, idempotent, JSON-preserving, and anchored to the billing tag only (a mis-anchored match rewrites the user's own text — the dario#528 hazard). `JSON.parse` `SyntaxError` on non-JSON input is the documented garbage-in contract and is caught as expected; any other exception propagates as a finding.

Targets import the compiled `dist/` output, same as the test suite; `.clusterfuzzlite/build.sh` runs `npm ci`, installs `@jazzer.js/core` with `--no-save` (so `package.json`/`package-lock.json` stay exactly as committed), builds, and compiles the three targets.

## Cadence and plumbing

- Weekly (`53 5 * * 2`, staggered off the `:00` grid and off every minute this repo's other schedules use) + `workflow_dispatch` for on-demand runs.
- `permissions: read-all` at top level; both `google/clusterfuzzlite` actions SHA-pinned; base builder image pinned by digest.
- `sanitizer: [coverage]` — JS/Jazzer has no native sanitizer; `coverage` is the value the action accepts for JavaScript.

Mirrors the org's working setup on truecopy / redstamp / strongroom, adapted to dario's own trust boundaries.
