### PR TITLE
fix: workflow-audit findings (alert-mask, sentinel, teardown, crons)

### DIFF
--- a/.github/workflows/cc-billing-classifier-canary.yml
+++ b/.github/workflows/cc-billing-classifier-canary.yml
@@ -38,12 +38,15 @@ name: CC billing classifier canary (self-hosted)
 # Combined verdict: any signal fail → fail; else any warn → warn; else pass.
 #
 # Cost: ~1 small subscription request per day (opus-4-8, ≤ 16 output tokens).
-# Cron offset to 06:30 UTC so it doesn't coincide with the drift watcher's
-# every-30-min cycles or the hourly auto-release pipeline scans.
+# Cron offset to 05:50 UTC. The old 06:30 slot sat exactly ON the drift
+# watcher's :00/:30 every-30-min grid (contrary to what this comment used
+# to claim) and inside the 06:30–06:37 single-runner pileup with
+# doctor-watch (`37 */6`) and wire-drift. 05:50 is off the :00/:30 grid,
+# the hourly :00/:15 scans, and the repo's other daily cron slots.
 
 on:
   schedule:
-    - cron: '30 6 * * *'
+    - cron: '50 5 * * *'
   workflow_dispatch:
     inputs:
       force_status:

--- a/.github/workflows/cc-drift-watch.yml
+++ b/.github/workflows/cc-drift-watch.yml
@@ -62,9 +62,12 @@ jobs:
           echo "CC latest on npm: $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Cache sentinel (keyed on CC version)
+      - name: Restore cache sentinel (keyed on CC version)
         id: version_cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        # restore-only: the matching SAVE happens at the end of the
+        # `check` job (if: success()), so a failed full check does NOT
+        # mark the version as seen and the next hourly gate retries it.
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           # The path is a tiny marker file; only its presence matters.
           # The cache KEY is what gates: if we've ever saved a cache
@@ -84,11 +87,12 @@ jobs:
             echo "should_run=false" >> "$GITHUB_OUTPUT"
           else
             echo "CC v${{ steps.probe.outputs.version }} is new since the last full check — proceeding."
-            # Write the sentinel so the cache action saves this version
-            # as "seen" at job end. The mark is per-version (key) not
-            # per-run — same version across hours = cache hit.
-            mkdir -p "$(dirname .cc-version-sentinel)"
-            touch .cc-version-sentinel
+            # The sentinel is written and SAVED by the `check` job
+            # (cache/save, if: success()), not here — saving from this
+            # gate job marked a version "seen" even when the downstream
+            # full check failed, so it was never re-checked. The mark is
+            # per-version (key) not per-run — same version across hours
+            # = cache hit.
             echo "should_run=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -317,6 +321,7 @@ jobs:
         # non-zero could be a real drift signal or a Chromium crash;
         # run the fetch-based script so we at least have SOMETHING to
         # compare against (even if it's CF-blocked → inconclusive).
+        id: probe_fallback
         if: steps.probe.outputs.exit_code == '2'
         run: |
           set +e
@@ -328,7 +333,13 @@ jobs:
           cat probe-report.json
 
       - name: Open / update authorize-probe drift issue
-        if: steps.probe.outputs.exit_code != '0'
+        # File only when the headless probe failed AND the fetch fallback
+        # did not pass — i.e. the fallback also failed, or it was skipped
+        # (headless exited non-2 = a real drift signal, not a Playwright
+        # install failure). Keying on the headless exit alone filed false
+        # "authorize-probe drift" issues for every Playwright install
+        # failure (exit 2) even when the fallback passed.
+        if: steps.probe.outputs.exit_code != '0' && (steps.probe_fallback.outcome == 'skipped' || steps.probe_fallback.outputs.exit_code != '0')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -376,3 +387,17 @@ jobs:
             probe-report.json
             probe-log.txt
           retention-days: 30
+
+      - name: Mark CC version as full-checked (write sentinel)
+        # Only on success: a failed full check leaves the version
+        # unmarked, so the hourly gate re-runs it instead of the version
+        # being cached as "seen" by a run that never actually checked it.
+        if: success()
+        run: touch .cc-version-sentinel
+
+      - name: Save cache sentinel (keyed on CC version)
+        if: success()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: .cc-version-sentinel
+          key: cc-drift-checked-${{ needs.version_check.outputs.version }}

--- a/.github/workflows/cc-oauth-health.yml
+++ b/.github/workflows/cc-oauth-health.yml
@@ -48,7 +48,12 @@ jobs:
           # If the container is crash-looping/exited, docker exec fails -> body
           # empty -> oauth=unreachable -> alert fires. That's the intended path.
           body="$(docker exec askalf-dario sh -lc 'wget -qO- http://127.0.0.1:3456/health 2>/dev/null || curl -s --max-time 8 http://127.0.0.1:3456/health' 2>/dev/null || true)"
-          oauth="$(printf '%s' "$body" | grep -o '"oauth":"[^"]*"' | head -1 | cut -d'"' -f4)"
+          # `|| true`: grep exits 1 on no match, and this step runs under
+          # the runner's default `bash -e {0}` plus pipefail — without it,
+          # the empty-body case kills the job RIGHT HERE and the
+          # oauth=unreachable alert below (the whole point of this
+          # watcher) never fires.
+          oauth="$(printf '%s' "$body" | grep -o '"oauth":"[^"]*"' | head -1 | cut -d'"' -f4 || true)"
           [ -z "$oauth" ] && oauth="unreachable"
           echo "dario /health -> oauth=$oauth"
 

--- a/.github/workflows/compat-test-self-hosted.yml
+++ b/.github/workflows/compat-test-self-hosted.yml
@@ -193,7 +193,13 @@ jobs:
           echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
       - name: Stop dario proxy
-        if: always() && env.COMPAT_API_KEY == ''
+        # Unconditional always(): the old `&& env.COMPAT_API_KEY == ''`
+        # guard meant teardown NEVER fired once the secret was set,
+        # leaking the proxy on :3457 — exactly the stale-binary hazard
+        # the Start step warns about. Safe when nothing started:
+        # proxy.pid absent → the kill block is skipped, and every
+        # kill/tail is `|| true`-guarded.
+        if: always()
         run: |
           if [ -f proxy.pid ]; then
             pid=$(cat proxy.pid)

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -55,7 +55,10 @@ jobs:
           #     that are fine sitting open until explicitly closed.
           #   help-wanted / good-first-issue — open-ended by design.
           #   pinned — explicit do-not-stale marker.
-          exempt-issue-labels: cc-drift,review-feedback,help-wanted,good-first-issue,pinned
+          #   bug — user-filed bug reports (e.g. #678) must never be
+          #     auto-closed by housekeeping; they stay open until fixed
+          #     or explicitly triaged away.
+          exempt-issue-labels: cc-drift,review-feedback,help-wanted,good-first-issue,pinned,bug
           exempt-pr-labels: cc-drift,review-feedback,pinned,wip,blocked
           # Conservative counts per run so the bot doesn't mass-close
           # on first activation. Adjust later if the tracker grows.

--- a/.github/workflows/wire-drift-self-hosted.yml
+++ b/.github/workflows/wire-drift-self-hosted.yml
@@ -31,9 +31,12 @@ on:
       - 'scripts/check-wire-drift.mjs'
       - '.github/workflows/wire-drift-self-hosted.yml'
   schedule:
-    # Daily — catches CC-side changes (a new claude on the runner emitting a
-    # different per-model beta set) without waiting for a PR.
-    - cron: '37 6 * * *'
+    # Daily at 07:07 UTC — catches CC-side changes (a new claude on the runner
+    # emitting a different per-model beta set) without waiting for a PR.
+    # The old 06:37 slot collided with doctor-watch's `37 */6` tick on the
+    # same single-slot self-hosted runner; 07:07 shares no minute/hour with
+    # the repo's other crons.
+    - cron: '7 7 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Five audited workflow defects, one commit:

- **cc-oauth-health.yml — alert path died under pipefail (HIGHEST).** The `oauth` extraction (`grep -o ... | cut`) runs under the runner's default `bash -e` + `set -o pipefail`, so an empty/oauth-less `/health` body made grep exit 1 and killed the job *before* the `oauth=unreachable` alert branch — the exact "container down" case this watcher exists to catch just went red unwatched. This is what blinded the 2026-07-12 OAuth-expiry incident class. Fix: `|| true` inside the command substitution; the existing `[ -z "$oauth" ] && oauth="unreachable"` fallback now actually runs.
- **cc-drift-watch.yml — sentinel saved even when the check failed.** The version-sentinel cache was saved by the `version_check` gate job, so a failed `check` run still marked the CC version "seen" and it was never re-checked. Gate now uses `actions/cache/restore`; the sentinel is written and saved (`actions/cache/save`, `if: success()`) at the end of the `check` job, same key/path.
- **cc-drift-watch.yml — false authorize-probe issues on Playwright failures.** The fetch-fallback probe step had no `id:`, so the issue step keyed only on the headless probe's exit code and filed "drift" for every Playwright install failure (exit 2) even when the fallback passed. Fallback now has `id: probe_fallback` and the issue fires only when the fallback also failed or was skipped.
- **compat-test-self-hosted.yml — teardown never ran.** `if: always() && env.COMPAT_API_KEY == ''` never fires with `ANTHROPIC_COMPAT_API_KEY` set, leaking the proxy on :3457 (the stale-binary hazard the file itself warns about). Now plain `if: always()`; the kill block is already safe when nothing started.
- **cron de-collision (single self-hosted runner pileup 06:30–06:37 UTC).** Billing canary `30 6` → `50 5` (its old "offset" comment claimed a separation the :30 grid never had — corrected); wire-drift `37 6` → `7 7` (06:37 collided with doctor-watch's `37 */6`). Both new slots are off every other cron's minute/hour grid.
