### PR TITLE
docs: refresh SECURITY/CONTRIBUTING/COC for v5

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,19 +1,132 @@
-# Code of Conduct
+# Contributor Covenant Code of Conduct
 
 ## Our Pledge
 
-We are committed to making participation in this project a harassment-free experience for everyone.
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-- Be respectful and constructive
-- Focus on what is best for the community
-- Show empathy toward others
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive behavior may be reported to **conduct@askalf.org**. All complaints will be reviewed and acted upon.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**support@askalf.org**. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,13 +15,13 @@ npm run dev   # runs with tsx, no build needed
 
 | File | Purpose |
 |------|---------|
-| `src/proxy.ts` | HTTP proxy server, request dispatch, rate governor, billing tag, multi-account pool routing, OpenAI-compat backend routing, SSE streaming forwarder |
+| `src/proxy.ts` | HTTP proxy server, request dispatch, rate governor, billing tag, account-pool routing (the one credential path since v5.0 — pool-as-primitive), OpenAI-compat backend routing, SSE streaming forwarder |
 | `src/cc-template.ts` | CC request template engine, forward tool mapping (`translateArgs`), reverse tool mapping (`translateBack`), `reverseMapResponse` for non-streaming responses, `createStreamingReverseMapper` for SSE streaming tool_use blocks, framework/orchestration scrubbing |
 | `src/cc-template-data.json` | CC request template data (25 tools, 25KB system prompt) |
 | `src/cc-oauth-detect.ts` | Auto-detect OAuth config from the installed Claude Code binary (v3.4.3+), anchored on `BASE_API_URL:"https://api.anthropic.com"` |
-| `src/oauth.ts` | Single-account token storage, refresh, credential detection, macOS keychain fallback (v3.7.0+) |
-| `src/accounts.ts` | Multi-account credential storage for pool mode (v3.5.0+) |
-| `src/pool.ts` | Account pool, headroom-aware selection, failover-target selection, request queueing (v3.5.0+) |
+| `src/oauth.ts` | `dario login` token storage, refresh, credential detection, macOS keychain fallback (v3.7.0+); since v5.0 the login credential is back-filled into the pool under the reserved `login` alias |
+| `src/accounts.ts` | Per-account credential storage at `~/.dario/accounts/<alias>.json` (v3.5.0+) — the backing store for the account pool, the one credential model since v5.0 |
+| `src/pool.ts` | Account pool, headroom-aware selection, failover-target selection, request queueing (v3.5.0+); always constructed since v5.0 — a plain `dario login` is a pool of one |
 | `src/analytics.ts` | Rolling request history, per-account / per-model stats, burn-rate, exhaustion predictions (v3.5.0+) |
 | `src/openai-backend.ts` | OpenAI-compat backend credential storage and request forwarder (v3.6.0+) |
 | `src/cli.ts` | CLI entry point, command routing (`login`, `proxy`, `accounts`, `backend`, `status`, `refresh`, `logout`), Bun auto-relaunch |
@@ -59,13 +59,13 @@ PRs that don't meet the bar get comments explaining why, not a silent block. If 
 
 ## Release cadence
 
-For the actual release mechanics (how auto-release works, the pre-merge checklist, and the **post-publish bin-shim smoke** added after dario#143), see [RELEASING.md](RELEASING.md).
+For the actual release mechanics — the inline auto-release chain in `cc-drift-auto-release.yml` (build → smoke → GHCR push → GitHub release with attested artifacts → tokenless npm publish via OIDC trusted publishing), the pre-merge checklist, and the **post-publish smoke against the installed npm bin** added after dario#143 (that's npm's bin stub, unrelated to the `dario shim` transport removed in v5.0) — see [RELEASING.md](RELEASING.md).
 
 See [STABILITY.md](STABILITY.md) for the full policy. Summary:
 
-- **Patch** (`3.30.x`) — bug fixes, review-feedback, drift patches. Often multiple per day during active cycles.
-- **Minor** (`3.31.0`) — new flags, new exports, new endpoints. Ships when accumulated new surface justifies it.
-- **Major** (`4.0.0`) — removes `@deprecated` APIs, changes `@stable` behavior. Every major carries `docs/migrate-vX.md`.
+- **Patch** (`5.0.x`) — bug fixes, review-feedback, drift patches. Often multiple per day during active cycles.
+- **Minor** (`5.1.0`) — new flags, new exports, new endpoints. Ships when accumulated new surface justifies it.
+- **Major** (`5.0.0`) — removes `@deprecated` APIs, changes `@stable` behavior. v5.0 made the account pool the one credential model (a plain `dario login` is a pool of one) and deleted the deprecated shim transport. Every major carries a migration guide — see [MIGRATION.md](MIGRATION.md).
 
 New features default to `@experimental` for at least one minor before being promoted to `@stable`. The promotion is a CHANGELOG entry, not a code change — the JSDoc tag moves and the `CHANGELOG.md` notes the graduation.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,9 @@
 
 | Version | Supported |
 |---------|-----------|
-| 3.x     | Yes       |
-| 2.x     | No        |
-| 1.x     | No        |
+| 5.x     | Yes       |
+| 4.x     | Best effort — critical security fixes only. Upgrade to 5.x (see [MIGRATION.md](./MIGRATION.md); zero-effort for most setups). |
+| 3.x and earlier | No |
 
 ## Reporting a Vulnerability
 
@@ -25,11 +25,11 @@ If you discover a security vulnerability in dario, please report it responsibly:
 The following are in scope for security reports:
 
 - Token leakage (Claude OAuth access/refresh tokens, OpenAI-compat backend API keys, or any other stored credential exposed in logs, errors, or network responses)
-- Credential file permission issues across `~/.dario/credentials.json`, `~/.dario/accounts/<alias>.json` (pool mode), and `~/.dario/backends/<name>.json` (OpenAI-compat backends)
+- Credential file permission issues across `~/.dario/credentials.json`, `~/.dario/accounts/<alias>.json` (account pool), and `~/.dario/backends/<name>.json` (OpenAI-compat backends)
 - Proxy authentication bypass (`DARIO_API_KEY`)
 - Proxy path traversal (accessing non-allowlisted paths)
 - OpenAI-compat translation / routing exploits (injection via model names, system prompts, or backend `baseUrl` construction)
-- Multi-account pool routing exploits (cross-account token leakage, rate-limit headroom poisoning)
+- Account-pool routing exploits (cross-account token leakage, rate-limit headroom poisoning)
 - SSE streaming payload parse / framing exploits in the reverse-mapper
 - Man-in-the-middle vulnerabilities
 - Denial of service via the proxy
@@ -42,8 +42,8 @@ The following are in scope for security reports:
 - Supports both `x-api-key` header and `Authorization: Bearer` header.
 
 ### Credential Storage
-- **Single-account Claude backend**: reads from Claude Code (`~/.claude/.credentials.json`) or its own store (`~/.dario/credentials.json`). On macOS with modern Claude Code (v3.7.0+), also reads from the OS keychain via `security find-generic-password -s "Claude Code-credentials"`.
-- **Multi-account pool mode (v3.5.0+)**: per-account credentials at `~/.dario/accounts/<alias>.json`, one file per Claude subscription. Each account has its own independent OAuth refresh lifecycle.
+- **Account pool — the one credential model (v5.0+)**: per-account credentials at `~/.dario/accounts/<alias>.json`, one file per Claude subscription (per-account storage since v3.5.0). Each account has its own independent OAuth refresh lifecycle. A plain `dario login` is a pool of one under the reserved `login` alias: its credentials live at `~/.dario/credentials.json` and are back-filled (copy-only) into `accounts/login.json` at startup, so a single account rides the same selection, failover, and rate-limit path as a pool of many.
+- **Claude Code credential detection**: dario also reads Claude Code's own store (`~/.claude/.credentials.json`) as a credential source. On macOS with modern Claude Code (v3.7.0+), also reads from the OS keychain via `security find-generic-password -s "Claude Code-credentials"`.
 - **OpenAI-compat backends (v3.6.0+)**: API keys stored at `~/.dario/backends/<name>.json`. Supports OpenAI, OpenRouter, Groq, local LiteLLM, and any OpenAI-compat endpoint via configurable `baseUrl`.
 - All dario-managed credential files stored with `0600` permissions (owner-only).
 - Atomic file writes (temp + rename) prevent corruption.
@@ -67,7 +67,7 @@ The following are in scope for security reports:
 - **Binds to `127.0.0.1` by default** — loopback-only and unreachable from other machines.
 - `--host` / `DARIO_HOST` (v3.4.3+) can bind to a specific non-loopback interface for deliberate mesh/LAN use (e.g. a Tailscale interface, a LAN address). **When bound to anything non-loopback, `DARIO_API_KEY` is required** — dario prints a warning at startup and operators who ignore it and run `--host=0.0.0.0` without a key are explicitly exposing their OAuth session to anything that can reach the port.
 - Hardcoded **upstream-proxy path allowlist**: `/v1/messages`, `/v1/complete` (Anthropic format), and `/v1/chat/completions` (OpenAI-compat format, routed by model name to either the Claude backend or the configured OpenAI-compat backend). These are the only paths that forward requests upstream.
-- Local-only endpoints (no upstream forwarding): `/health`, `/status`, `/v1/models`, `/accounts` (pool mode only), `/analytics` (pool mode only).
+- Local-only endpoints (no upstream forwarding): `/health`, `/status`, `/v1/models`, `/accounts`, `/analytics`.
 - All other paths return 403.
 - Only `GET` and `POST` methods allowed.
 - 10 MB request body size limit.
@@ -93,3 +93,8 @@ The following are in scope for security reports:
 - Claude OAuth token traffic is sent only to `api.anthropic.com` and `platform.claude.com`.
 - OpenAI-compat backend traffic goes to whatever `baseUrl` the operator configured for that backend (typically `api.openai.com`, `api.groq.com`, `openrouter.ai/api/v1`, or a local LiteLLM / vLLM / Ollama endpoint). **The operator is the trust anchor for that URL** — dario does no domain reputation or cert pinning beyond standard Node.js HTTPS verification.
 - No telemetry, analytics, or external data collection.
+
+### Release Integrity (v5.0.1+)
+- Every GitHub release ships the exact npm tarball plus a keyless Sigstore provenance bundle (`<tarball>.sigstore.json`). Verify with `gh attestation verify --owner askalf <tarball>`.
+- npm publishes are tokenless via OIDC trusted publishing — there is no long-lived npm token to steal.
+- ClusterFuzzLite continuously fuzzes the wire boundaries: the OpenAI-compat SSE stream translator, the upstream-rejection parsers, and the cch stamp algorithm.


### PR DESCRIPTION
Three community docs had gone stale against the v5 reality. This PR refreshes them — docs only, no code or workflow changes.

**What was stale**
- `SECURITY.md` still claimed 3.x as the supported line, described a "single-account Claude backend" plus a separate "multi-account pool mode", and marked `/accounts` / `/analytics` as pool-mode-only — all falsified by v5.0's pool-as-primitive (the pool is the one credential model; a plain `dario login` is a pool of one under the reserved `login` alias).
- `CONTRIBUTING.md` carried single-account/pool-mode wording in its src table, a release pointer whose "post-publish bin-shim smoke" parenthetical reads ambiguously now that the `dario shim` transport is deleted, and 3.x/4.0.0 version examples.
- `CODE_OF_CONDUCT.md` was a 528-byte stub.

**What changed**
- `SECURITY.md` — Supported Versions: 5.x supported, 4.x best-effort critical fixes only (see MIGRATION.md), 3.x and earlier unsupported. Credential Storage rewritten to pool-as-primitive with the surviving paths (`~/.dario/credentials.json`, `~/.dario/accounts/<alias>.json`, CC store + macOS keychain read) and their original vintage annotations kept. Dropped the "(pool mode only)" endpoint qualifiers (verified unconditional in `src/proxy.ts`). Added a short Release Integrity section for 5.0.1: attested release artifacts (tarball + `.sigstore.json`, `gh attestation verify`), tokenless npm publish via OIDC trusted publishing, ClusterFuzzLite on the wire parsers.
- `CONTRIBUTING.md` — every src-table file verified present in the current tree (no shim rows existed; none removed); `proxy.ts`/`oauth.ts`/`accounts.ts`/`pool.ts` rows annotated for pool-as-primitive. Release pointer now names the inline `cc-drift-auto-release.yml` chain (build → smoke → GHCR → release + attestation → npm OIDC) and clarifies the post-publish smoke targets npm's bin stub, not the removed shim transport. Version examples moved to the 5.x era, with v5.0.0 (pool-as-primitive + shim removal, MIGRATION.md) as the real major example.
- `CODE_OF_CONDUCT.md` — replaced with Contributor Covenant v2.1, byte-identical to askalf/truecopy's copy (contact: support@askalf.org).
