### PR TITLE
feat(proxy): --fast-model keeps forced-model sub-agents cheap

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -359,6 +359,10 @@ async function proxy() {
   const strictTls = args.includes('--strict-tls');
   const modelArg = args.find(a => a.startsWith('--model='));
   const model = modelArg ? modelArg.split('=')[1] : undefined;
+  // --fast-model=MODEL: route Haiku-tier (CC sub-agent) requests to this
+  // model instead of the forced --model, so sub-agents stay cheap.
+  const fastModelArg = args.find(a => a.startsWith('--fast-model='));
+  const fastModel = fastModelArg ? fastModelArg.split('=')[1] : undefined;
 
   // --pace-min=MS / --pace-jitter=MS (v3.24, direction #6 — behavioral
   // smoothing). Inter-request gap floor + optional uniform-random jitter.
@@ -600,7 +604,7 @@ async function proxy() {
     process.exit(1);
   }
 
-  await startProxy({ port, host, verbose, verboseBodies, model, passthrough, preserveTools, hybridTools, mergeTools, noAutoDetect, strictTls, pacingMinMs, pacingJitterMs, thinkTimeBaseMs, thinkTimePerTokenMs, thinkTimeJitterMs, thinkTimeMaxMs, sessionStartMinMs, sessionStartJitterMs, stealth, drainOnClose, sessionIdleRotateMs, sessionRotateJitterMs, sessionMaxAgeMs, sessionPerClient, preserveOrchestrationTags, noLiveCapture, strictTemplate, maxConcurrent, maxQueued, queueTimeoutMs, effort, maxTokens, logFile, passthroughBetas, skipFields, systemPrompt, overageGuardEnabled, overageGuardBehavior, overageGuardCooldownMs, overageGuardNotifyOs, honorClientThinking, preserveOutputFormat });
+  await startProxy({ port, host, verbose, verboseBodies, model, fastModel, passthrough, preserveTools, hybridTools, mergeTools, noAutoDetect, strictTls, pacingMinMs, pacingJitterMs, thinkTimeBaseMs, thinkTimePerTokenMs, thinkTimeJitterMs, thinkTimeMaxMs, sessionStartMinMs, sessionStartJitterMs, stealth, drainOnClose, sessionIdleRotateMs, sessionRotateJitterMs, sessionMaxAgeMs, sessionPerClient, preserveOrchestrationTags, noLiveCapture, strictTemplate, maxConcurrent, maxQueued, queueTimeoutMs, effort, maxTokens, logFile, passthroughBetas, skipFields, systemPrompt, overageGuardEnabled, overageGuardBehavior, overageGuardCooldownMs, overageGuardNotifyOs, honorClientThinking, preserveOutputFormat });
 }
 
 /**
@@ -1238,6 +1242,10 @@ async function help() {
                              Provider prefix: openai:gpt-4o, groq:llama-3.3-70b,
                              claude:opus, local:qwen-coder (forces backend)
                              Default: passthrough (client decides)
+    --fast-model=MODEL       Route Haiku-tier sub-agent requests to MODEL
+                             instead of --model, so Claude Code's cheap
+                             sub-agents aren't upgraded to the forced model.
+                             Same MODEL forms as --model. No effect unless set.
     --passthrough, --thin    Thin proxy — OAuth swap only, no injection
     --preserve-tools         Forward client tool schemas unchanged
                              Loses subscription routing; use for custom agents

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -240,6 +240,29 @@ export function resolveClaudeAlias(model: string): string {
   return resolveAliasAgainst(model, getCachedBases()) ?? MODEL_ALIASES[model] ?? model;
 }
 
+/**
+ * Pick the per-request model override under a forced `--model`.
+ *
+ * A forced `--model` normally rewrites the model on *every* request. But
+ * Claude Code dispatches its throwaway sub-agent (Explore/Task) turns on the
+ * cheap Haiku tier, so forcing a frontier model silently upgrades those
+ * sub-agents too — quietly multiplying cost. When `--fast-model` is set, a
+ * Haiku-tier inbound request routes there instead, keeping sub-agents cheap
+ * while the main conversation stays on `--model`.
+ *
+ * No-op unless `fastModelOverride` is set: with it null, this returns
+ * `modelOverride` for every request (the pre-existing behavior), so the
+ * change is inert until the operator opts in.
+ */
+export function selectModelOverride(
+  incomingModel: string,
+  modelOverride: string | null,
+  fastModelOverride: string | null,
+): string | null {
+  if (fastModelOverride && /haiku/i.test(incomingModel)) return fastModelOverride;
+  return modelOverride;
+}
+
 // Provider prefix in the `model` field — `<provider>:<model>`. Forces
 // routing regardless of model-name regex. Only recognized prefixes are
 // parsed, so ollama-style `llama3:8b` (without a recognized prefix)
@@ -701,6 +724,7 @@ interface ProxyOptions {
   verbose?: boolean;
   verboseBodies?: boolean; // Dump redacted request bodies on every request (dario#40 -vv / DARIO_LOG_BODIES=1)
   model?: string;  // Override model in all requests
+  fastModel?: string;  // Route Haiku-tier (CC sub-agent) requests here instead of `model` — keeps forced-model sub-agents cheap. No effect unless set.
   passthrough?: boolean;  // Thin proxy — OAuth swap only, no injection
   preserveTools?: boolean;  // Keep client tool schemas (for agents with custom tools)
   hybridTools?: boolean;    // Remap to CC tools but inject request-context fields on return (#33)
@@ -1409,6 +1433,12 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
   const cliModelRaw = modelPrefix ? modelPrefix.model : opts.model;
   const cliProviderOverride: 'openai' | 'claude' | null = modelPrefix ? modelPrefix.provider : null;
   const modelOverride = cliModelRaw ? resolveClaudeAlias(cliModelRaw) : null;
+  // --fast-model: the model that Haiku-tier (Claude Code sub-agent) requests
+  // route to instead of the forced `--model`, so sub-agents stay cheap. Parsed
+  // like --model (alias + optional provider prefix). Null = disabled.
+  const fastModelPrefix = opts.fastModel ? parseProviderPrefix(opts.fastModel) : null;
+  const fastModelRaw = fastModelPrefix ? fastModelPrefix.model : opts.fastModel;
+  const fastModelOverride = fastModelRaw ? resolveClaudeAlias(fastModelRaw) : null;
   const identity = loadClaudeIdentity();
   if (identity.deviceId) {
     console.log('  Device identity: detected');
@@ -2303,7 +2333,13 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           const parsed = parsedBody ?? (JSON.parse(body.toString()) as Record<string, unknown>);
           // Strip orchestration tags from messages (Aider, Cursor, etc.)
           sanitizeMessages(parsed, opts.preserveOrchestrationTags);
-          const result = isOpenAI ? openaiToAnthropic(parsed, modelOverride) : (modelOverride ? { ...parsed, model: modelOverride } : parsed);
+          // Tier-aware routing: under a forced --model, a Haiku-tier sub-agent
+          // request routes to --fast-model (when set) instead of the forced
+          // model, so CC's cheap sub-agents aren't silently upgraded. Inert
+          // when --fast-model is unset (effectiveOverride === modelOverride).
+          const incomingModel = typeof (parsed as { model?: unknown }).model === 'string' ? (parsed as { model: string }).model : '';
+          const effectiveOverride = selectModelOverride(incomingModel, modelOverride, fastModelOverride);
+          const result = isOpenAI ? openaiToAnthropic(parsed, effectiveOverride) : (effectiveOverride ? { ...parsed, model: effectiveOverride } : parsed);
           const r = result as Record<string, unknown>;
           requestModel = (r.model as string || '').toLowerCase();
           // Suspended-model guard. Empty by default (Fable 5 returned globally
@@ -3608,7 +3644,10 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
     const modeLine = passthrough
       ? 'Mode: passthrough (OAuth swap only, no injection)'
       : `OAuth: ${status.status} (expires in ${status.expiresIn})`;
-    const modelLine = modelOverride ? `Model: ${modelOverride} (all requests)` : 'Model: passthrough (client decides)';
+    const fastNote = fastModelOverride ? `, ${fastModelOverride} (Haiku-tier sub-agents)` : '';
+    const modelLine = modelOverride
+      ? `Model: ${modelOverride} (all requests)${fastNote}`
+      : `Model: passthrough (client decides)${fastNote}`;
     // Pool line surfaces the account state on every startup. The pool is the
     // one credential model now (v5.0): a plain `dario login` shows as a pool of
     // one. An empty pool is only reachable in admin-bootstrap / api-key mode.

--- a/test/fast-model-flag.mjs
+++ b/test/fast-model-flag.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// Unit tests for --fast-model tier-aware routing. Under a forced --model,
+// Claude Code's Haiku-tier sub-agent (Explore/Task) requests would be silently
+// upgraded to the forced frontier model — quietly multiplying cost.
+// --fast-model routes those Haiku-tier requests to a cheaper model instead,
+// while the main conversation stays on --model. Covers the pure
+// selectModelOverride() decision function, including the backward-compat
+// no-op when --fast-model is unset.
+
+import { selectModelOverride } from '../dist/proxy.js';
+
+let pass = 0, fail = 0;
+function check(name, cond) {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else      { console.log(`  FAIL ${name}`); fail++; }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+// ─────────────────────────────────────────────────────────────
+header('forced --model with --fast-model set (the fix)');
+{
+  // Haiku sub-agent request → routes to the fast model, not the forced one.
+  check('haiku-tier → fast model',
+    selectModelOverride('claude-haiku-4-5', 'claude-opus-4-8', 'claude-haiku-4-5') === 'claude-haiku-4-5');
+  // Main-conversation model → stays on the forced --model.
+  check('opus request → forced model',
+    selectModelOverride('claude-opus-4-8', 'claude-opus-4-8', 'claude-haiku-4-5') === 'claude-opus-4-8');
+  check('sonnet request → forced model',
+    selectModelOverride('claude-sonnet-4-5', 'claude-opus-4-8', 'claude-haiku-4-5') === 'claude-opus-4-8');
+  check('fable request → forced model',
+    selectModelOverride('claude-fable-5', 'claude-opus-4-8', 'claude-haiku-4-5') === 'claude-opus-4-8');
+}
+
+header('backward compatibility — --fast-model unset (inert)');
+{
+  // With no fast model, every request (incl. Haiku) resolves to the forced
+  // model exactly as before — the change must be a no-op until opted in.
+  check('haiku + no fast → forced model (unchanged behavior)',
+    selectModelOverride('claude-haiku-4-5', 'claude-opus-4-8', null) === 'claude-opus-4-8');
+  check('opus + no fast → forced model',
+    selectModelOverride('claude-opus-4-8', 'claude-opus-4-8', null) === 'claude-opus-4-8');
+  check('passthrough + no fast → null (passthrough preserved)',
+    selectModelOverride('claude-haiku-4-5', null, null) === null);
+}
+
+header('passthrough with --fast-model (downgrade sub-agents only)');
+{
+  // No forced --model, but --fast-model set: Haiku-tier requests route to the
+  // fast model; everything else passes through untouched (null).
+  check('haiku + passthrough + fast → fast model',
+    selectModelOverride('claude-haiku-4-5', null, 'claude-haiku-4-5') === 'claude-haiku-4-5');
+  check('opus + passthrough + fast → passthrough (null)',
+    selectModelOverride('claude-opus-4-8', null, 'claude-haiku-4-5') === null);
+}
+
+header('Haiku detection — matches the tier by name, case-insensitively');
+{
+  check('case-insensitive HAIKU',
+    selectModelOverride('claude-HAIKU-4-5', 'claude-opus-4-8', 'claude-haiku-4-5') === 'claude-haiku-4-5');
+  check('dated 3.5 haiku id matches',
+    selectModelOverride('claude-3-5-haiku-20241022', 'claude-opus-4-8', 'claude-haiku-4-5') === 'claude-haiku-4-5');
+  check('empty model → forced model (no false haiku match)',
+    selectModelOverride('', 'claude-opus-4-8', 'claude-haiku-4-5') === 'claude-opus-4-8');
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Closes #742.

## Problem

Under a forced `--model`, `startProxy`'s handler rewrites the `model` on **every** request:

```js
modelOverride ? { ...parsed, model: modelOverride } : parsed
```

There's no tier check, so Claude Code's Haiku-tier sub-agent (Explore/Task) requests — which CC intentionally runs on the cheap tier — get silently upgraded to the forced frontier model. A single "use subagents" prompt fans out into N such requests, multiplying cost. Passthrough mode is unaffected; this only bites forced-model users.

## Fix

New `--fast-model=MODEL` flag. Under a forced `--model`, a Haiku-tier inbound request routes to `--fast-model` instead of the forced model; the main conversation stays on `--model`.

```
dario proxy --model=opus --fast-model=haiku
# main conversation → Opus, Haiku-tier sub-agents → Haiku
```

The decision is a small pure function, `selectModelOverride(incomingModel, modelOverride, fastModelOverride)`:

- Haiku-tier incoming + `--fast-model` set → fast model
- otherwise → the existing `modelOverride` (unchanged)

`--fast-model` accepts the same MODEL forms as `--model` (alias + optional provider prefix).

## Non-breaking

Inert unless `--fast-model` is set: with it unset, `selectModelOverride` returns `modelOverride` for every request, so forced-model behavior is byte-identical to today. No `@stable` surface changes; this is a new opt-in flag (new `ProxyOptions.fastModel`, new CLI flag, one banner line).

## Testing

- `test/fast-model-flag.mjs` (new) — 12 assertions covering the fix, the backward-compat no-op when unset, passthrough interaction, and case-insensitive Haiku detection. Auto-discovered by `test/all.test.mjs`.
- `npm run build` — clean.
- `npm test` — **108/108 pass**.
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities.
- Zero new runtime dependencies.
