### PR TITLE
feat(proxy): --no-claude-auth — stop OpenAI-only proxies rotating the Claude token

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -357,6 +357,10 @@ async function proxy() {
   // proxy presents to Anthropic is Bun's BoringSSL ClientHello, not
   // Node's OpenSSL one. v3.23 (direction #3).
   const strictTls = args.includes('--strict-tls');
+  // --no-claude-auth: don't load/refresh the Claude OAuth pool (OpenAI-only
+  // proxies). Stops dario rotating a shared refresh token out from under an
+  // interactive Claude Code on the same machine.
+  const noClaudeAuth = args.includes('--no-claude-auth');
   const modelArg = args.find(a => a.startsWith('--model='));
   const model = modelArg ? modelArg.split('=')[1] : undefined;
   // --fast-model=MODEL: route Haiku-tier (CC sub-agent) requests to this
@@ -604,7 +608,7 @@ async function proxy() {
     process.exit(1);
   }
 
-  await startProxy({ port, host, verbose, verboseBodies, model, fastModel, passthrough, preserveTools, hybridTools, mergeTools, noAutoDetect, strictTls, pacingMinMs, pacingJitterMs, thinkTimeBaseMs, thinkTimePerTokenMs, thinkTimeJitterMs, thinkTimeMaxMs, sessionStartMinMs, sessionStartJitterMs, stealth, drainOnClose, sessionIdleRotateMs, sessionRotateJitterMs, sessionMaxAgeMs, sessionPerClient, preserveOrchestrationTags, noLiveCapture, strictTemplate, maxConcurrent, maxQueued, queueTimeoutMs, effort, maxTokens, logFile, passthroughBetas, skipFields, systemPrompt, overageGuardEnabled, overageGuardBehavior, overageGuardCooldownMs, overageGuardNotifyOs, honorClientThinking, preserveOutputFormat });
+  await startProxy({ port, host, verbose, verboseBodies, model, fastModel, noClaudeAuth, passthrough, preserveTools, hybridTools, mergeTools, noAutoDetect, strictTls, pacingMinMs, pacingJitterMs, thinkTimeBaseMs, thinkTimePerTokenMs, thinkTimeJitterMs, thinkTimeMaxMs, sessionStartMinMs, sessionStartJitterMs, stealth, drainOnClose, sessionIdleRotateMs, sessionRotateJitterMs, sessionMaxAgeMs, sessionPerClient, preserveOrchestrationTags, noLiveCapture, strictTemplate, maxConcurrent, maxQueued, queueTimeoutMs, effort, maxTokens, logFile, passthroughBetas, skipFields, systemPrompt, overageGuardEnabled, overageGuardBehavior, overageGuardCooldownMs, overageGuardNotifyOs, honorClientThinking, preserveOutputFormat });
 }
 
 /**
@@ -1246,6 +1250,12 @@ async function help() {
                              instead of --model, so Claude Code's cheap
                              sub-agents aren't upgraded to the forced model.
                              Same MODEL forms as --model. No effect unless set.
+    --no-claude-auth         Don't load or refresh the Claude OAuth token —
+                             for OpenAI-only proxies (e.g. --model=openai:...).
+                             Prevents dario rotating a shared refresh token out
+                             from under an interactive Claude Code on the same
+                             machine. Claude-bound requests then return a clean
+                             unauthenticated error.
     --passthrough, --thin    Thin proxy — OAuth swap only, no injection
     --preserve-tools         Forward client tool schemas unchanged
                              Loses subscription routing; use for custom agents

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -718,6 +718,21 @@ export function createOpenAIStreamTranslator(): (line: string) => string | null 
 // the one shared long-context rule, never hand-listed per model.
 export const OPENAI_MODELS_LIST = buildOpenAIModelsList(withLongContextVariants(BAKED_BASE_MODELS));
 
+/**
+ * Whether dario must have a Claude login to start. False (an empty pool is
+ * expected, not a fatal "run dario login") for the modes that serve requests
+ * without the Claude OAuth pool: admin-bootstrap, upstream-api-key, and
+ * --no-claude-auth. Pure so the startup gate is unit-testable.
+ */
+export function requiresClaudeLogin(
+  poolSize: number,
+  adminEnabled: boolean,
+  hasUpstreamApiKey: boolean,
+  noClaudeAuth: boolean,
+): boolean {
+  return poolSize === 0 && !adminEnabled && !hasUpstreamApiKey && !noClaudeAuth;
+}
+
 interface ProxyOptions {
   port?: number;
   host?: string;  // Bind address (default: 127.0.0.1)
@@ -725,6 +740,7 @@ interface ProxyOptions {
   verboseBodies?: boolean; // Dump redacted request bodies on every request (dario#40 -vv / DARIO_LOG_BODIES=1)
   model?: string;  // Override model in all requests
   fastModel?: string;  // Route Haiku-tier (CC sub-agent) requests here instead of `model` — keeps forced-model sub-agents cheap. No effect unless set.
+  noClaudeAuth?: boolean;  // Don't load or refresh the Claude OAuth pool — for OpenAI-only proxies. Stops dario rotating a shared refresh token out from under an interactive Claude Code on the same machine. Claude-bound requests then get a clean unauthenticated error.
   passthrough?: boolean;  // Thin proxy — OAuth swap only, no injection
   preserveTools?: boolean;  // Keep client tool schemas (for agents with custom tools)
   hybridTools?: boolean;    // Remap to CC tools but inject request-context fields on return (#33)
@@ -1343,17 +1359,27 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
   });
 
   let status: Awaited<ReturnType<typeof getStatus>>;
-  for (const acc of accountsList) {
-    pool.add(acc.alias, {
-      accessToken: acc.accessToken,
-      refreshToken: acc.refreshToken,
-      expiresAt: acc.expiresAt,
-      deviceId: acc.deviceId,
-      accountUuid: acc.accountUuid,
-    });
+  // --no-claude-auth: don't populate the Claude OAuth pool. An empty pool makes
+  // the background refresh a no-op, so dario never touches (and never rotates)
+  // the shared Claude refresh token — the fix for a local OpenAI-only proxy
+  // logging out an interactive Claude Code on the same machine (dario#737 class,
+  // locally). OpenAI-compat requests use their own backend key, unaffected.
+  if (opts.noClaudeAuth) {
+    console.error('[dario] --no-claude-auth: Claude OAuth pool NOT loaded — serving OpenAI-compatible backends only; the Claude refresh token is never touched. Claude-bound requests return an unauthenticated error.');
+  } else {
+    for (const acc of accountsList) {
+      pool.add(acc.alias, {
+        accessToken: acc.accessToken,
+        refreshToken: acc.refreshToken,
+        expiresAt: acc.expiresAt,
+        deviceId: acc.deviceId,
+        accountUuid: acc.accountUuid,
+      });
+    }
   }
   // Background refresh — keep every account's token fresh without blocking requests
   const refreshInterval = setInterval(async () => {
+    if (opts.noClaudeAuth) return; // never touch the Claude token in OpenAI-only mode
     for (const acc of pool.all()) {
       if (acc.expiresAt < Date.now() + 45 * 60 * 1000) {
         try {
@@ -1380,7 +1406,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
   // dead-but-refreshable token (a container restarted right after a normal
   // expiry, gap #1) is refreshed, then back-filled so the recovered login
   // becomes the pool-of-one it should be — rather than crash-looping on exit(1).
-  if (pool.size === 0 && !adminEnabled && !upstreamApiKey) {
+  if (requiresClaudeLogin(pool.size, adminEnabled, !!upstreamApiKey, opts.noClaudeAuth ?? false)) {
     const single = await resolveSingleAccountStartupStatus();
     if (!single.authenticated) {
       console.error('[dario] Not authenticated. Run `dario login` first.');
@@ -3671,6 +3697,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
     console.log('');
     console.log(`  ${modeLine}`);
     console.log(`  ${modelLine}`);
+    if (opts.noClaudeAuth) console.log('  Claude auth: disabled (--no-claude-auth) — OpenAI-compatible backends only; Claude token untouched');
     console.log(`  ${poolLine}`);
     if (!isLoopbackHost(host)) {
       console.log('');

--- a/test/no-claude-auth-flag.mjs
+++ b/test/no-claude-auth-flag.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// Unit tests for --no-claude-auth via the requiresClaudeLogin startup gate.
+// The flag lets an OpenAI-only proxy start WITHOUT a Claude login, so it never
+// loads or rotates the shared Claude refresh token (which otherwise logs out an
+// interactive Claude Code on the same machine — dario#737 class, locally).
+// requiresClaudeLogin === false means "an empty pool is fine, don't fatally
+// demand `dario login`". It must be false for --no-claude-auth exactly like the
+// existing admin-bootstrap and upstream-api-key empty-pool modes.
+
+import { requiresClaudeLogin } from '../dist/proxy.js';
+
+let pass = 0, fail = 0;
+function check(name, cond) {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else      { console.log(`  FAIL ${name}`); fail++; }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+header('default (no flags, empty pool) — must demand login');
+{
+  // poolSize, adminEnabled, hasUpstreamApiKey, noClaudeAuth
+  check('empty pool, nothing set → requires login',
+    requiresClaudeLogin(0, false, false, false) === true);
+}
+
+header('--no-claude-auth — empty pool is expected, do NOT demand login');
+{
+  check('empty pool + noClaudeAuth → no login required',
+    requiresClaudeLogin(0, false, false, true) === false);
+}
+
+header('existing empty-pool modes still bypass the login demand');
+{
+  check('admin-bootstrap → no login required',
+    requiresClaudeLogin(0, true, false, false) === false);
+  check('upstream-api-key → no login required',
+    requiresClaudeLogin(0, false, true, false) === false);
+}
+
+header('a populated pool never demands login (any flags)');
+{
+  check('pool has an account, default',
+    requiresClaudeLogin(1, false, false, false) === false);
+  check('pool has an account + noClaudeAuth',
+    requiresClaudeLogin(2, false, false, true) === false);
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## Problem

A dario started to route to an OpenAI-compatible backend — e.g. `dario proxy --model=openai:gpt-5.6-sol`, the "run GPT/Sol in Claude Code" use case — **still loads the Claude OAuth pool and runs the 15-minute background refresh timer** at startup, even though it never makes a Claude call.

Anthropic refresh tokens are single-use rotating. So that background refresh **rotates the token**, and an interactive Claude Code using the same account on the same machine is left holding the old, now-invalid refresh token → `invalid_grant` → surprise `/login`. It's the exact dario#737 dead-token mechanism, happening locally between an OpenAI-only dario and a live Claude Code.

## Fix

`--no-claude-auth` (opt-in): don't load the Claude OAuth pool at all.

- The pool stays empty, so the background refresh timer is a no-op — **dario never touches, and never rotates, the Claude refresh token.**
- Claude-bound requests return a clean unauthenticated error (empty pool), same as the existing admin-bootstrap / upstream-api-key modes.
- OpenAI-compatible backends use their own key and are completely unaffected.
- Startup no longer fatally demands `dario login` — handled by a new pure `requiresClaudeLogin()` gate that treats `--no-claude-auth` as an expected empty-pool mode (alongside admin-bootstrap and upstream-api-key).

Usage:

```
dario proxy --model=openai:gpt-5.6-sol --no-claude-auth
# routes to OpenAI, never rotates your Claude token, no more logouts
```

## Non-breaking

Opt-in. Unset (the default) = current behavior exactly — the pool loads, the timer runs, everything as before. No `@stable` surface change; a new boolean flag + `ProxyOptions.noClaudeAuth` + one exported gate helper + a banner line.

Does **not** affect a passthrough fleet dario (it serves Claude requests, needs the pool, won't set the flag).

## Testing

- `test/no-claude-auth-flag.mjs` (new) — 6 assertions on `requiresClaudeLogin` (default demands login; `--no-claude-auth` / admin / api-key don't; a populated pool never does).
- `npm run build` clean · `npm test` **110/110 pass** · zero new runtime deps.
