### PR TITLE
release: 5.1.0 — --fast-model, --no-claude-auth, dead-token fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ checklist.
 
 ## [Unreleased]
 
+## [5.1.0] - 2026-07-13
+
+Two new opt-in proxy flags for the "run any model in Claude Code" use case, plus a dead-refresh-token diagnosability fix. No breaking changes; all defaults unchanged.
+
+### Added
+
+- **`--fast-model=MODEL`.** Under a forced `--model`, route Haiku-tier (Claude Code sub-agent / Explore-Task) requests to a cheaper model while the main conversation stays on `--model`. Without it, a forced frontier model silently upgraded the cheap sub-agent turns too, multiplying cost on every fan-out. Opt-in; unset leaves behavior exactly as before. Adds a pure `selectModelOverride()` helper. (#743)
+- **`--no-claude-auth`.** Don't load or refresh the Claude OAuth pool — for OpenAI-only proxies (e.g. `--model=openai:gpt-5.6-sol`). Stops dario rotating the single-use Claude refresh token out from under an interactive Claude Code using the same account on the same machine. The refresh timer becomes a no-op, Claude-bound requests get a clean unauthenticated error, and OpenAI-compatible backends (their own key) are unaffected. Adds a pure `requiresClaudeLogin()` startup-gate helper. (#746)
+
+### Fixed
+
+- **A dead refresh token now fails loud and immediately.** A revoked, expired, or rotated-out refresh token comes back as HTTP 400 `invalid_grant`; previously only 401/403 were treated as terminal, so `invalid_grant` burned three doomed retries and then a vague error, while `getStatus()` kept reporting healthy for the failure-threshold window and every non-Haiku call 401'd behind a green healthcheck. Now classified as terminal via a pure `isTerminalRefreshFailure()` — fail fast with a `dario login` prompt, and `/status`, `/health`, and `dario doctor` report `broken` immediately. (#745)
+
+### Dependencies
+
+- Dev-dependency bumps via Dependabot. (#739, #741)
+
 ## [5.0.1] - 2026-07-12
 
 Supply-chain hardening release — no runtime behavior changes. This is also the first release published tokenless (npm OIDC trusted publishing) and the first to ship attested artifacts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "5.0.1",
+      "version": "5.1.0",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Cuts the accumulated master changes into a minor release (`5.0.1` → `5.1.0`). No breaking changes; two new opt-in flags + a bug fix.

## What ships
- **feat `--fast-model`** (#743) — route Haiku-tier sub-agent requests off a forced `--model` to a cheaper model.
- **feat `--no-claude-auth`** (#746) — OpenAI-only proxies don't load/rotate the Claude OAuth token (stops logging out a local Claude Code).
- **fix** (#745) — `invalid_grant` is now a terminal, loud dead-token state (`broken` reported immediately instead of masking as healthy).
- **deps** (#739, #741) — Dependabot dev-dep bumps.

## Release mechanics
Bumps `package.json` 5.0.1 → 5.1.0 (+ lockfile) and promotes CHANGELOG `[Unreleased]` → `[5.1.0]` with entries for each. On merge, `cc-drift-auto-release.yml` sees the unreleased version and publishes: npm (OIDC trusted publishing), ghcr image, and an attested GitHub release. (`workflow_dispatch` is the manual fallback if the merge event doesn't fire.)

Minor bump per dario semver (new flags = minor). tsc clean; no code changes beyond the version/changelog.