### PR TITLE
fix: mirror the client's cache TTL instead of overwriting it (#678)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,32 @@ checklist.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Client cache TTL is now mirrored, not overwritten (dario#678).** Real CC on
+  included subscription usage sends `ttl:'1h'` on every cache breakpoint plus
+  `extended-cache-ttl-2025-04-11` in `anthropic-beta`, and itself falls back to
+  bare 5m stamps in overage (verified by loopback capture of CC v2.1.209 under
+  subscription OAuth). dario deleted those stamps and re-placed bare 5m ones,
+  and stripped the beta as "requires Extra Usage" (stale — the 1h TTL is
+  included on subscription per the prompt-caching docs), so every proxied
+  subscription session ran a 5m cache: any >5-minute pause re-paid cache
+  creation on the full prefix. dario now derives the request's cache control
+  from the client's own stamps (`effectiveCacheControl`) — mirrored only when
+  the client also sent the enabling beta, exactly the pair real CC produces —
+  and forwards `extended-cache-ttl-*`. Clients that stamp nothing are
+  unchanged. Escape hatch: `DARIO_CACHE_TTL_5M=1` restores the old behavior.
+
+### Changed
+
+- **Template rebake** — re-captured `src/cc-template-data.json` after
+  cc-drift-template-watch detected wire-fingerprint drift against a live CC
+  capture (#756). Merged 15 minutes after the v5.1.1 auto-release fired, so it
+  ships here rather than in 5.1.1 as originally listed.
+
 ## [5.1.1] - 2026-07-14
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.207` → `2.1.209` for CC v2.1.209. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.
-- **Template rebake** — re-captured `src/cc-template-data.json` after cc-drift-template-watch detected wire-fingerprint drift against a live CC capture. Bundled fallback template now matches the current CC wire shape.
 ## [5.1.0] - 2026-07-13
 
 Two new opt-in proxy flags for the "run any model in Claude Code" use case, plus a dead-refresh-token diagnosability fix. No breaking changes; all defaults unchanged.
@@ -71,7 +93,6 @@ The `pool ? … : single-account` fork is gone from `src/proxy.ts`. A plain `dar
 
 ## [4.8.154] - 2026-07-11
 
-- **Template rebake** — re-captured `src/cc-template-data.json` after cc-drift-template-watch detected wire-fingerprint drift against a live CC capture. Bundled fallback template now matches the current CC wire shape.
 ## [4.8.153] - 2026-07-11
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.206` → `2.1.207` for CC v2.1.207. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ The `pool ? … : single-account` fork is gone from `src/proxy.ts`. A plain `dar
 
 ## [4.8.154] - 2026-07-11
 
+- **Template rebake** — re-captured `src/cc-template-data.json` after cc-drift-template-watch detected wire-fingerprint drift against a live CC capture. Bundled fallback template now matches the current CC wire shape.
 ## [4.8.153] - 2026-07-11
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.206` → `2.1.207` for CC v2.1.207. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -1335,6 +1335,53 @@ export type CacheControl = { type: 'ephemeral'; ttl?: '5m' | '1h' };
 export const CC_CACHE_CONTROL: CacheControl = { type: 'ephemeral' };
 
 /**
+ * The cache control the CLIENT asked for, read from its own stamps — or
+ * CC_CACHE_CONTROL when it stamped nothing.
+ *
+ * Real CC implements the subscription-vs-overage TTL selection itself:
+ * on included subscription usage it sends `ttl:'1h'` on every breakpoint
+ * plus `extended-cache-ttl-2025-04-11` in `anthropic-beta`, and drops to
+ * bare 5m stamps when drawing on usage credits (loopback capture of CC
+ * v2.1.209 under subscription OAuth, 2026-07-14 — dario#678; docs:
+ * code.claude.com/docs/en/prompt-caching#cache-lifetime). The client's
+ * stamps are therefore the billing-correct answer, and dario mirrors them
+ * instead of overwriting with the 5m default — deleting them forced every
+ * proxied subscription session onto a 5m cache, so any >5-minute pause
+ * re-paid cache creation on the full prefix.
+ *
+ * The ttl is mirrored only when the client's `anthropic-beta` also carries
+ * `extended-cache-ttl-` (CC always sends the pair together); a ttl stamp
+ * without the enabling beta is not a shape real CC produces, and forwarding
+ * half of it risks an upstream 400. DARIO_CACHE_TTL_5M=1 restores the
+ * pre-fix behavior (always bare 5m) as the operator escape hatch.
+ */
+export function effectiveCacheControl(
+  clientBody: Record<string, unknown>,
+  clientBeta?: string,
+): CacheControl {
+  if (process.env['DARIO_CACHE_TTL_5M'] === '1') return CC_CACHE_CONTROL;
+  if (!clientBeta || !clientBeta.includes('extended-cache-ttl-')) return CC_CACHE_CONTROL;
+  const scan = (blocks: unknown): CacheControl | null => {
+    if (!Array.isArray(blocks)) return null;
+    for (const b of blocks) {
+      const cc = (b as Record<string, unknown> | null)?.cache_control as CacheControl | undefined;
+      if (cc && (cc.ttl === '1h' || cc.ttl === '5m')) return { type: 'ephemeral', ttl: cc.ttl };
+    }
+    return null;
+  };
+  const fromSystem = scan(clientBody.system);
+  if (fromSystem) return fromSystem;
+  const msgs = clientBody.messages;
+  if (Array.isArray(msgs)) {
+    for (const m of msgs) {
+      const hit = scan((m as Record<string, unknown> | null)?.content);
+      if (hit) return hit;
+    }
+  }
+  return CC_CACHE_CONTROL;
+}
+
+/**
  * Place CC-style prompt-cache breakpoints on the conversation. The system
  * prompt is already cached at build time (2 system breakpoints); this adds a
  * rolling breakpoint on the last user message plus an anchor on the previous

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -9,7 +9,7 @@ import { arch, platform } from 'node:process';
 import { getAccessToken, getStatus } from './oauth.js';
 import { buildHealthResponse, derivePoolStatus, shouldDiscloseHealthInternals } from './health-response.js';
 import { darioVersion } from './version.js';
-import { buildCCRequest, applyCcPromptCaching, parseEffortSuffix, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, isMcpToolName, CC_TEMPLATE, CC_CACHE_CONTROL, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
+import { buildCCRequest, applyCcPromptCaching, parseEffortSuffix, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, isMcpToolName, CC_TEMPLATE, CC_CACHE_CONTROL, effectiveCacheControl, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
 import { stampCch, hasCchSeed } from './cch.js';
 import { describeTemplate, detectDrift, checkCCCompat } from './live-fingerprint.js';
 import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCooldown, authCooldownMs, reconcilePoolAccounts, type PoolAccount } from './pool.js';
@@ -292,10 +292,13 @@ export function parseProviderPrefix(model: string): { provider: 'openai' | 'clau
 // Beta prefixes that require Extra Usage to be ENABLED on the account.
 // context-management and prompt-caching-scope are safe — billing is determined
 // solely by the OAuth token's subscription type, not by beta flags.
-// Only extended-cache-ttl actually requires Extra Usage availability.
-const BILLABLE_BETA_PREFIXES = [
-  'extended-cache-ttl-',   // Extended cache TTLs — requires Extra Usage enabled
-];
+// extended-cache-ttl- was listed here until v5.1.1 on the assumption it needed
+// Extra Usage — wrong per code.claude.com/docs/en/prompt-caching#cache-lifetime
+// (the 1h TTL is included on subscription usage; real CC sends the flag on
+// every main request there — dario#678 capture, CC v2.1.209). It is forwarded
+// now; the per-account rejected-beta cache below remains the guard for any
+// account state where the upstream refuses it.
+const BILLABLE_BETA_PREFIXES: string[] = [];
 
 /** Filter out billable betas from client-provided beta header. */
 function filterBillableBetas(betas: string): string {
@@ -2402,8 +2405,13 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
             // current Claude Code, which sends none. dario#528.
             const cch = hasCchSeed(cliVersion) ? computeCch() : null;
             const billingTag = buildBillingTag(cliVersion, cch);
-            // Plain 5m ephemeral, matching real CC (see CC_CACHE_CONTROL / dario#678).
-            const CACHE_EPHEMERAL = CC_CACHE_CONTROL;
+            // Mirror the CLIENT's cache TTL (real CC sends ttl:'1h' + the
+            // extended-cache-ttl beta on included subscription usage and
+            // decides overage/API fallback itself — see effectiveCacheControl
+            // / dario#678). Bare 5m when the client stamped nothing or
+            // DARIO_CACHE_TTL_5M=1.
+            const CACHE_EPHEMERAL = effectiveCacheControl(
+              r, req.headers['anthropic-beta'] as string | undefined);
 
             // Session stickiness: rebind the pre-selected pool account to
             // whatever the sticky-key resolver picks. If this is a new

--- a/test/cache-ttl.mjs
+++ b/test/cache-ttl.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+// Client cache-TTL mirroring — dario#678 round 3.
+//
+// Ground truth (loopback capture, CC v2.1.209 under subscription OAuth,
+// 2026-07-14): real CC sends `ttl:'1h'` on every breakpoint plus
+// `extended-cache-ttl-2025-04-11` in anthropic-beta on included subscription
+// usage, and decides the overage/API fallback (bare 5m stamps) itself.
+// dario used to DELETE those stamps and re-place bare 5m ones, forcing every
+// proxied subscription session onto a 5m cache. These tests pin the mirror:
+// the client's ttl survives the rebuild, on exactly the client's terms.
+import { buildCCRequest, applyCcPromptCaching, effectiveCacheControl, CC_CACHE_CONTROL, isGenuineCCClient } from '../dist/cc-template.js';
+
+let pass = 0, fail = 0;
+function check(label, cond) {
+  if (cond) { console.log(`  ✅ ${label}`); pass++; }
+  else { console.log(`  ❌ ${label}`); fail++; }
+}
+
+const BETA_1H = 'claude-code-20250219,oauth-2025-04-20,extended-cache-ttl-2025-04-11';
+const BETA_NO_TTL = 'claude-code-20250219,oauth-2025-04-20';
+
+/** A minimal genuine-CC-shaped request, mirroring the captured wire shape. */
+function ccBody(cacheControl) {
+  const cc = cacheControl ? { cache_control: cacheControl } : {};
+  return {
+    model: 'claude-sonnet-5',
+    stream: true,
+    system: [
+      { type: 'text', text: 'x-anthropic-billing-header: cc-version=2.1.209' },
+      { type: 'text', text: "You are Claude Code, Anthropic's official CLI for Claude.", ...cc },
+      { type: 'text', text: 'Long system prompt '.repeat(50), ...cc },
+    ],
+    messages: [
+      { role: 'user', content: [
+        { type: 'text', text: 'context' },
+        { type: 'text', text: 'hi', ...cc },
+      ] },
+    ],
+    metadata: { user_id: 'u' },
+    max_tokens: 32000,
+  };
+}
+
+const TTL_1H = { type: 'ephemeral', ttl: '1h' };
+
+// ── effectiveCacheControl derivation ──────────────────────────────────
+{
+  const got = effectiveCacheControl(ccBody(TTL_1H), BETA_1H);
+  check('1h stamps + extended-cache-ttl beta -> mirrored 1h', got.ttl === '1h');
+}
+{
+  const got = effectiveCacheControl(ccBody(TTL_1H), BETA_NO_TTL);
+  check('1h stamps WITHOUT the enabling beta -> bare 5m (never forward half the pair)', got.ttl === undefined);
+}
+{
+  const got = effectiveCacheControl(ccBody({ type: 'ephemeral' }), BETA_1H);
+  check('bare client stamps (CC in overage) -> bare 5m', got.ttl === undefined);
+}
+{
+  const got = effectiveCacheControl(ccBody(null), BETA_1H);
+  check('no client stamps at all -> bare 5m', got.ttl === undefined);
+}
+{
+  const got = effectiveCacheControl(ccBody(TTL_1H), undefined);
+  check('no client beta header -> bare 5m', got.ttl === undefined);
+}
+{
+  process.env.DARIO_CACHE_TTL_5M = '1';
+  const got = effectiveCacheControl(ccBody(TTL_1H), BETA_1H);
+  delete process.env.DARIO_CACHE_TTL_5M;
+  check('DARIO_CACHE_TTL_5M=1 escape hatch -> bare 5m despite client 1h', got.ttl === undefined);
+}
+{
+  // conversation-only stamps (no system stamps) still count
+  const body = ccBody(null);
+  body.messages[0].content[1].cache_control = TTL_1H;
+  const got = effectiveCacheControl(body, BETA_1H);
+  check('ttl found on a conversation breakpoint alone -> mirrored', got.ttl === '1h');
+}
+
+// ── end-to-end through the real rebuild ───────────────────────────────
+function collectCC(body) {
+  const out = [];
+  for (const b of body.system ?? []) if (b.cache_control) out.push(b.cache_control);
+  for (const m of body.messages ?? [])
+    if (Array.isArray(m.content))
+      for (const b of m.content) if (b && b.cache_control) out.push(b.cache_control);
+  return out;
+}
+
+{
+  const client = ccBody(TTL_1H);
+  check('fixture is detected as genuine CC', isGenuineCCClient(client) === true);
+  const control = effectiveCacheControl(client, BETA_1H);
+  const { body, genuineCC } = buildCCRequest(client, 'x-anthropic-billing-header: tag', control,
+    { deviceId: 'd', accountUuid: 'a', sessionId: 's' });
+  applyCcPromptCaching(body, control);
+  const stamps = collectCC(body);
+  check('passthrough took the genuine-CC path', genuineCC === true);
+  check('outbound has breakpoints', stamps.length > 0);
+  check('EVERY outbound breakpoint carries the client 1h ttl',
+    stamps.length > 0 && stamps.every((s) => s.ttl === '1h'));
+}
+{
+  // client in overage (bare stamps): outbound must stay bare — no invented 1h
+  const client = ccBody({ type: 'ephemeral' });
+  const control = effectiveCacheControl(client, BETA_1H);
+  const { body } = buildCCRequest(client, 'x-anthropic-billing-header: tag', control,
+    { deviceId: 'd', accountUuid: 'a', sessionId: 's' });
+  applyCcPromptCaching(body, control);
+  const stamps = collectCC(body);
+  check('overage-shaped client -> outbound breakpoints stay ttl-less',
+    stamps.length > 0 && stamps.every((s) => s.ttl === undefined));
+}
+{
+  // default export unchanged: CC_CACHE_CONTROL itself is still bare
+  check('CC_CACHE_CONTROL stays bare (non-CC clients unchanged)', CC_CACHE_CONTROL.ttl === undefined);
+}
+
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## The bug (#678, round 3)

Captured what CC v2.1.209 actually sends under **subscription OAuth** (loopback recorder as `ANTHROPIC_BASE_URL`, credentials redacted at ingest): every main conversation request carries `ttl:"1h"` on **all** cache breakpoints plus `extended-cache-ttl-2025-04-11` in `anthropic-beta` — confirming the [prompt-caching docs](https://code.claude.com/docs/en/prompt-caching#cache-lifetime). CC also implements the fallback itself: bare 5m stamps when in overage.

dario deleted those stamps (the genuine-CC passthrough re-stamped bare 5m) and stripped the beta on a stale Extra-Usage assumption. Fed the real captured request through compiled `buildCCRequest`:

```
client:   system[1] {"ttl":"1h"}  system[2] {"ttl":"1h"}  messages[0][1] {"ttl":"1h"}
outbound: system[1] {}            system[2] {}            (no ttl anywhere)
```

Every proxied subscription session ran a 5m cache where bare CC runs 1h — a >5-minute pause re-paid cache creation on the full prefix. Direct contributor to this issue's gap-pattern burn.

## The fix

`effectiveCacheControl(clientBody, clientBeta)`: derive the request's cache control from the **client's own stamps** — the client already made the billing-correct choice. Mirrored only when the client also sent the enabling beta (exactly the pair real CC produces; never forward half of it). `extended-cache-ttl-*` removed from `BILLABLE_BETA_PREFIXES` (docs: included on subscription; the per-account rejected-beta cache stays as the guard). Clients that stamp nothing → unchanged bare-5m behavior. Escape hatch: `DARIO_CACHE_TTL_5M=1`.

Same bake after the fix: outbound mirrors all three 1h stamps byte-for-byte.

## Why the v4.8.140 history doesn't block this

That attempt stamped `1h` **unconditionally** — including for API-key/overage traffic where 1h writes bill 2× — and in the era when dario duplicated the ~25KB system prompt per request shape, doubling every cache write. This fix stamps nothing the client didn't ask for. Before any release ships it as default behavior, the #678 >5-min-gap test gets re-run on both settings and posted to the thread.

## Tests

`test/cache-ttl.mjs` — 13 checks: derivation gates (beta required, overage-shaped stays bare, no stamps stays bare), escape hatch, genuine-CC detection of the fixture, and end-to-end rebuild asserting every outbound breakpoint carries the client ttl. Full suite green (fail 0).

Also relocates the template-rebake CHANGELOG entry — #756 merged 15 minutes after the v5.1.1 auto-release fired on #754's bump, so the rebake actually ships with the next release, not 5.1.1.

Fixes the dario side of #678's cache story.
