### PR TITLE
fix: drop messages emptied by the orchestration scrub (#744)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ checklist.
 
 ### Fixed
 
+- **`/model` switch mid-session no longer 400s (dario#744).** A mid-session
+  model switch makes CC (v2.1.209, `mid-conversation-system`) inject a
+  standalone `role:"system"` turn whose entire content is a
+  `<system-reminder>` block. The orchestration scrub emptied that block, the
+  dario#54 filter dropped it, and the message went upstream as `content: []` —
+  rejected with `messages.N: system content must contain at least one block`.
+  `sanitizeMessages` now drops a message whose content emptied out entirely
+  (array or string form): it carried nothing but orchestration tags, so
+  removing it is the block filter's own decision applied one level up.
+  Reproduced against the published 5.0.0 artifact and pinned by tests.
+
 - **Client cache TTL is now mirrored, not overwritten (dario#678).** Real CC on
   included subscription usage sends `ttl:'1h'` on every cache breakpoint plus
   `extended-cache-ttl-2025-04-11` in `anthropic-beta`, and itself falls back to

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -610,6 +610,20 @@ export function sanitizeMessages(body: Record<string, unknown>, preserveTags?: S
       });
     }
   }
+  // Drop messages whose content emptied out entirely. A message that was
+  // NOTHING but orchestration tags — CC's standalone `<system-reminder>`
+  // injections, e.g. the model-switch notice a mid-session `/model sonnet`
+  // adds as its own role:"system" turn — leaves the block filter above as
+  // `content: []`, and the upstream rejects the whole request with
+  // "messages.N: … content must contain at least one block" (dario#744).
+  // The message carried nothing for the model, so removing it is the same
+  // decision the block filter already made, applied one level up. String
+  // content scrubbed to '' is the same case in its other shape.
+  body.messages = messages.filter((m) => {
+    if (Array.isArray(m.content)) return m.content.length > 0;
+    if (typeof m.content === 'string') return m.content !== '';
+    return true;
+  });
 }
 
 /**

--- a/test/sanitize-messages.mjs
+++ b/test/sanitize-messages.mjs
@@ -109,8 +109,11 @@ header('All-reminder message content collapses to empty array');
     ],
   };
   sanitizeMessages(body);
-  check('content array emptied when every block scrubbed away', body.messages[0].content.length === 0);
-  // Note: buildCCRequest pops empty trailing turns; this shape flows through to that layer.
+  // Pre-#744 this asserted `content.length === 0` and relied on downstream
+  // layers to cope — but a NON-trailing empty message reached the upstream as
+  // content:[] and 400'd ("must contain at least one block"). The contract is
+  // now: a message emptied entirely by the scrub is dropped here.
+  check('message emptied by the scrub is dropped, not sent as content:[]', body.messages.length === 0);
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -213,5 +216,47 @@ header('dario#78 — resolvePreserveOrchestrationTags parses CLI + env');
 }
 
 // ─────────────────────────────────────────────────────────────
+// dario#744 - a message that is NOTHING but orchestration tags must be
+// DROPPED, not left as content:[] (upstream 400 "must contain at least one
+// block"). Trigger shape: mid-session /model switch injects a standalone
+// role:"system" <system-reminder> turn (CC 2.1.209, mid-conversation-system).
+{
+  const body = { messages: [
+    { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+    { role: 'system', content: [{ type: 'text', text: '<system-reminder>The user selected the model claude-sonnet-5.</system-reminder>' }] },
+    { role: 'user', content: [{ type: 'text', text: '<system-reminder>note</system-reminder>' }, { type: 'text', text: 'real question' }] },
+  ] };
+  sanitizeMessages(body);
+  check('all-orchestration system message is dropped entirely (#744)',
+    body.messages.length === 2 && body.messages.every(m => !Array.isArray(m.content) || m.content.length > 0));
+  check('mixed message keeps its real block (#744)',
+    Array.isArray(body.messages[1].content) && body.messages[1].content.length === 1 && body.messages[1].content[0].text === 'real question');
+}
+{
+  const body = { messages: [
+    { role: 'user', content: '<system-reminder>only tags</system-reminder>' },
+    { role: 'user', content: [{ type: 'text', text: 'kept' }] },
+  ] };
+  sanitizeMessages(body);
+  check('string content scrubbed to empty drops the message too (#744)',
+    body.messages.length === 1 && body.messages[0].content[0].text === 'kept');
+}
+{
+  const body = { messages: [
+    { role: 'assistant', content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: {} }] },
+    { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }] },
+  ] };
+  sanitizeMessages(body);
+  check('tool_use/tool_result messages untouched by the drop (#744)', body.messages.length === 2);
+}
+{
+  const body = { messages: [
+    { role: 'user', content: [{ type: 'text', text: '<system-reminder>x</system-reminder>' }] },
+  ] };
+  sanitizeMessages(body, new Set(['system-reminder']));
+  check('preserved tag -> message survives intact (#744)',
+    body.messages.length === 1 && body.messages[0].content[0].text.includes('system-reminder'));
+}
+
 console.log(`\n${pass} pass, ${fail} fail`);
 process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
**Root cause of #744**, reproduced against the published 5.0.0 artifact: a mid-session `/model sonnet` makes CC v2.1.209 (`mid-conversation-system` beta) inject a standalone `role:"system"` turn whose entire content is one `<system-reminder>` block. The orchestration scrub empties the block, the #54 filter drops it, and the message reaches the upstream as `content: []` → `400 messages.1: system content must contain at least one block` — the reporter's exact error, and why it only shows on a model *switch*.

```
before: messages[1] role=system content=[]   → upstream 400
after:  message dropped (it was pure orchestration; nothing for the model)
```

Scope: `sanitizeMessages` only — drops a message whose content emptied out entirely (array or string form). Messages with surviving non-text blocks (tool_use/tool_result/image) are untouched; `--preserve-orchestration-tags` keeps such messages intact. One pre-existing test pinned the old `content:[]` shape and relied on downstream layers to cope — updated to the new contract. +5 checks including the exact trigger shape; suite 111/0.

Addresses #744 � leaving the issue open for the reporter to confirm.
