### PR TITLE
chore: v5.2.0 — cache-TTL mirroring (#678) + empty-message drop (#744)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ checklist.
 
 ## [Unreleased]
 
+## [5.2.0] - 2026-07-15
+
 ### Fixed
 
 - **`/model` switch mid-session no longer 400s (dario#744).** A mid-session

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## v5.2.0 — two user-facing fixes since 5.1.1

Version bump + changelog promotion. Both fixes already merged and reviewed:

- **#757 — cache-TTL mirroring (#678).** dario was deleting the client's cache `ttl` and re-stamping the 5m default, forcing every proxied subscription session onto a 5m cache. Now mirrors the client's own stamps (real CC decides subscription-1h vs overage-5m itself). Verified by a loopback capture of CC v2.1.209 under subscription OAuth and a replay of that request through the compiled rebuild.
- **#763 — empty-message 400 on `/model` switch (#744).** A mid-session model switch injects a standalone `role:"system"` `<system-reminder>` turn; the scrub emptied it to `content:[]` → upstream 400. Now dropped. Reproduced against the published 5.0.0 artifact.

Diff is `package.json` 5.1.1 → 5.2.0 and the CHANGELOG `[Unreleased]` → `[5.2.0]` promotion (both fix entries + the #756 rebake already written there). No code changes. `extract-release-notes` 30/30, suite 111/0.

Merging triggers the auto-release → npm + GHCR.
