### PR TITLE
feat(logging): per-request cache accounting in verbose logs (#678)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ checklist.
 
 ## [Unreleased]
 
+## [5.2.3] - 2026-07-16
+
+### Added
+
+- **Per-request cache accounting in verbose logs (#678).** `-v` / `-vv` now
+  prints a `usage:` line next to each `billing:` line —
+  `in=… out=… cache_read=… cache_create=… (N% of prompt from cache)` — for
+  both streaming and non-streaming responses. dario already parsed these
+  tokens into `/analytics` and `--log-file` but never to the console, so a
+  plain verbose capture couldn't show whether a repeated prompt was served
+  from cache or re-billed. The cache-read share makes cache-TTL / cold-start
+  burn self-diagnosing from the terminal instead of requiring a log-file run.
+  No wire or billing behavior changes — logging only.
+
 ## [5.2.2] - 2026-07-15
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.210` → `2.1.211` for CC v2.1.211. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -107,6 +107,37 @@ export const SUBSCRIPTION_CLAIMS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * One-line per-request usage summary for verbose (-v / -vv) logs.
+ *
+ * dario already parses `input_tokens` / `cache_read_input_tokens` /
+ * `cache_creation_input_tokens` off every response into analytics and the
+ * `--log-file`, but never printed them to the console — so anyone debugging
+ * subscription burn (dario#678) only ever saw the request body and the
+ * billing *bucket*, never the cache accounting that actually governs cost.
+ * This surfaces it next to the existing `billing:` line so a plain `-vv`
+ * capture is self-diagnosing.
+ *
+ * `cachedPct` = cache_read / (input + cache_read + cache_create): the share of
+ * *prompt* tokens served from cache rather than freshly billed. On a repeated
+ * prompt a LOW value means the prefix is being re-created (a >5-minute gap
+ * expired the 5m TTL, or the cached prefix changed) — the exact signal the
+ * cache-TTL discussion turns on. Output tokens are excluded from the ratio
+ * (they are never cacheable). Pure + total-zero-safe for unit testing.
+ */
+export function formatUsageLogLine(
+  requestCount: number,
+  u: { inputTokens?: number; outputTokens?: number; cacheReadTokens?: number; cacheCreateTokens?: number },
+): string {
+  const inp = u.inputTokens ?? 0;
+  const out = u.outputTokens ?? 0;
+  const cr = u.cacheReadTokens ?? 0;
+  const cc = u.cacheCreateTokens ?? 0;
+  const promptTotal = inp + cr + cc;
+  const pct = promptTotal > 0 ? Math.round((cr / promptTotal) * 100) : 0;
+  return `[dario] #${requestCount} usage: in=${inp} out=${out} cache_read=${cr} cache_create=${cc} (${pct}% of prompt from cache)`;
+}
+
+/**
  * The sentinel `claim` dario assigns when a response carried no rate-limit
  * header at all (non-200s, stream aborts, early rejects — see `pool.ts`
  * `parseRateLimits` / `EMPTY_SNAPSHOT`). It is NOT a billing classification,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -13,7 +13,7 @@ import { buildCCRequest, applyCcPromptCaching, parseEffortSuffix, reverseMapResp
 import { stampCch, hasCchSeed } from './cch.js';
 import { describeTemplate, detectDrift, checkCCCompat } from './live-fingerprint.js';
 import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCooldown, authCooldownMs, reconcilePoolAccounts, type PoolAccount } from './pool.js';
-import { Analytics, billingBucketFromClaim, SUBSCRIPTION_CLAIMS, type RequestRecord } from './analytics.js';
+import { Analytics, billingBucketFromClaim, formatUsageLogLine, SUBSCRIPTION_CLAIMS, type RequestRecord } from './analytics.js';
 import { OverageGuard, buildHaltErrorBody, type HaltState } from './overage-guard.js';
 import { notify as osNotify } from './notify.js';
 import { loadAllAccounts, loadAccount, refreshAccountToken, resyncLoginFromCredentialsIfStale, ensureLoginCredentialsInPool } from './accounts.js';
@@ -3473,6 +3473,11 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           preserve_tools: preserveToolsEffective,
           stream: true,
         });
+
+        if (verbose) console.log(formatUsageLogLine(requestCount, {
+          inputTokens: streamInputTokens, outputTokens: streamOutputTokens,
+          cacheReadTokens: streamCacheReadTokens, cacheCreateTokens: streamCacheCreateTokens,
+        }));
       } else {
         // Buffer and forward
         let responseBody = await upstream.text();
@@ -3537,6 +3542,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           stream: false,
         });
 
+        if (verbose && bufferedUsage) console.log(formatUsageLogLine(requestCount, bufferedUsage));
         if (verbose) console.log(`[dario] #${requestCount} ${upstream.status}`);
       }
     } catch (err) {


### PR DESCRIPTION
## What

Surface dario's per-request **cache accounting** in verbose logs, so a plain `-vv` capture is self-diagnosing for the subscription-burn question in #678.

## Why

dario already parses `input_tokens` / `cache_read_input_tokens` / `cache_creation_input_tokens` off every response — but only into `/analytics` and `--log-file`, **never the console**. The `-vv` logs users attach to #678 therefore show the request body and the billing *bucket* (`subscription, overage 0%`) but not the cache split that actually governs cost. Every round of that issue ends up arguing from confounded session-usage-% deltas because the token-level evidence isn't in the capture.

## Change

- `formatUsageLogLine()` in `analytics.ts` — pure, unit-tested formatter.
- Emitted at `-v` / `-vv` next to the existing `billing:` line, on **both** the streaming and non-streaming response paths:
  ```
  [dario] #42 usage: in=120 out=800 cache_read=26900 cache_create=0 (99% of prompt from cache)
  ```
  The `N% of prompt from cache` share = `cache_read / (input + cache_read + cache_create)`. A low value on a repeated prompt means the prefix is being re-created (a >5-minute gap expired the 5m TTL, or the prefix changed) — the exact signal #678 turns on.

**Logging only — no wire or billing behavior changes.** Ships in `src/` → version bump **5.2.2 → 5.2.3**.

## Testing

- New `test/usage-log-line.mjs` — 11 checks: cache-ratio math (warm ~99% / cold 0% / 50-50 / output excluded), and robustness (all-zero and missing fields → `0%`, no `NaN`, no divide-by-zero).
- Full suite green: **112/112** (111 existing + new).
- `npm run build` clean.

## Follow-up (not in this PR)

With this merged and released, the next step on #678 is to ask the reporter for a `-vv` (or `--log-file`) run so we finally have per-request `cache_read` vs `cache_create` numbers instead of a session-% delta.
