### PR TITLE
feat(cache): DARIO_CACHE_TTL_1H opt-in force-1h TTL (#678)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ checklist.
 
 ## [Unreleased]
 
+## [5.2.5] - 2026-07-16
+
+### Added
+
+- **`DARIO_CACHE_TTL_1H=1` — opt-in 1-hour prompt-cache TTL (#678).** For a
+  subscription client that can't emit the 1-hour cache stamp itself (an
+  SDK/agent harness that only sends the bare 5-minute `cache_control`), this
+  forces `ttl:"1h"` on every breakpoint and adds the enabling
+  `extended-cache-ttl-2025-04-11` beta so Anthropic honors it — measured
+  end-to-end: a prefix that rebuilds after a 6-minute gap on 5m
+  (`cache_read=0`) reads warm on 1h (`cache_read=9038`). Deliberate override of
+  the default mirror behavior: 1-hour cache *writes* bill ~2× the 5-minute
+  rate, so it only wins when idle gaps routinely exceed 5 minutes; on rapid
+  back-to-back turns it costs more. `DARIO_CACHE_TTL_5M=1` forces the opposite
+  and wins if both are set. Logging/mirroring behavior for clients that already
+  send their own stamps is unchanged. Documented in `docs/faq.md`.
+
 ## [5.2.4] - 2026-07-16
 
 - **Template label refresh** — bundled `_version`, `_supportedMaxTested`, and the `user-agent` header bumped `2.1.210` → `2.1.211` to track `@anthropic-ai/claude-code@latest`. `cc-drift-template-watch` ran `capture-and-bake --check` against live CC v2.1.211 and found **zero wire-shape drift** vs the bundle, so this is a label refresh, not a re-capture (`_captured` stays at the last real capture). Clears the `sdk-drift` early-warning signal (#772).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -42,6 +42,15 @@ Yes. Skip `dario login`, just run `dario backend add openai --key=...` (or any O
 **Can I route non-OpenAI providers through dario?**
 Yes — anything that speaks the OpenAI Chat Completions API. Groq, OpenRouter, LiteLLM, vLLM, Ollama's openai-compat mode, your own vLLM server, any hosted inference endpoint that exposes `/v1/chat/completions`. Just `dario backend add <name> --key=... --base-url=...`.
 
+**My subscription usage through dario is higher than running Claude Code directly. Why?**
+Two things drive this, and neither is proxy overhead — on the genuine-Claude-Code path dario forwards your request verbatim (system prompt + tools), adding only a ~20-token billing tag. First, the dominant cost on any cold turn is your **own** system prompt: agent harnesses (OpenClaw, context-mode, custom frameworks) can inject 100K+ tokens of instructions, and dario relays them byte-for-byte, so they cost the same sent direct. Second is the **prompt-cache TTL**. Anthropic caches your system+tools prefix so repeat turns read it warm instead of rebuilding — but the default lifetime is **5 minutes**. Interactive Claude Code on a subscription requests a **1-hour** TTL (`cache_control:{"type":"ephemeral","ttl":"1h"}` plus the `extended-cache-ttl-2025-04-11` beta); many SDK/agent harnesses only send the bare 5-minute stamp. dario mirrors exactly what your client sends — so if your harness sends 5m and you leave gaps longer than 5 minutes between messages, the prefix expires and is re-created every time. (Quick check: two messages **30 seconds** apart should be cheap; two messages **6 minutes** apart on a 5-minute stamp both pay full creation — that gap is the cost, not dario.)
+
+Fixes, cheapest first:
+- Keep turns within 5 minutes where you can — the prefix stays cached.
+- Trim the injected system prompt; it's the biggest line item on every cold turn.
+- Have your harness emit the 1-hour stamp + the `extended-cache-ttl-2025-04-11` beta — dario mirrors it and the prefix survives idle gaps.
+- If the harness can't, set **`DARIO_CACHE_TTL_1H=1`**: dario forces the 1-hour TTL (and adds the enabling beta) on every request. Tradeoff — 1-hour cache *writes* bill ~2× the 5-minute rate, so it only wins when your idle gaps routinely exceed 5 minutes; on rapid back-to-back turns it costs more. `DARIO_CACHE_TTL_5M=1` forces the opposite (always 5m). Background: [#678](https://github.com/askalf/dario/issues/678).
+
 **Something's wrong. Where do I start?**
 `dario doctor`. One command, one aggregated report — dario version, Node, platform, runtime/TLS classification, CC binary compat, template source + age + drift, OAuth status, pool state, backends, sub-agent install state, home dir. Exit code 1 if any check fails. Paste the output when you file an issue. (If you're inside Claude Code, `dario subagent install` once and then ask CC to "use the dario sub-agent to run doctor" — same output, no context switch.)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.2.4",
+  "version": "5.2.5",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -1354,12 +1354,22 @@ export const CC_CACHE_CONTROL: CacheControl = { type: 'ephemeral' };
  * without the enabling beta is not a shape real CC produces, and forwarding
  * half of it risks an upstream 400. DARIO_CACHE_TTL_5M=1 restores the
  * pre-fix behavior (always bare 5m) as the operator escape hatch.
+ *
+ * DARIO_CACHE_TTL_1H=1 is the opposite override: force `ttl:'1h'` on every
+ * breakpoint regardless of what the client sent, for a client that can't
+ * emit the 1h stamp itself (an SDK/agent harness that only stamps bare 5m —
+ * dario#678). The proxy adds the enabling `extended-cache-ttl-` beta to the
+ * outbound set so the 1h is honored. Deliberate override of the mirror
+ * guardrail: 1h cache *writes* bill ~2× the 5m rate, so it only wins when
+ * idle gaps routinely exceed the 5-minute window; on rapid back-to-back
+ * turns it costs more. 5M takes precedence if both are set.
  */
 export function effectiveCacheControl(
   clientBody: Record<string, unknown>,
   clientBeta?: string,
 ): CacheControl {
   if (process.env['DARIO_CACHE_TTL_5M'] === '1') return CC_CACHE_CONTROL;
+  if (process.env['DARIO_CACHE_TTL_1H'] === '1') return { type: 'ephemeral', ttl: '1h' };
   if (!clientBeta || !clientBeta.includes('extended-cache-ttl-')) return CC_CACHE_CONTROL;
   const scan = (blocks: unknown): CacheControl | null => {
     if (!Array.isArray(blocks)) return null;
@@ -1379,6 +1389,22 @@ export function effectiveCacheControl(
     }
   }
   return CC_CACHE_CONTROL;
+}
+
+/** The anthropic-beta flag that enables the 1-hour prompt-cache TTL. */
+export const EXTENDED_CACHE_TTL_BETA = 'extended-cache-ttl-2025-04-11';
+
+/**
+ * When DARIO_CACHE_TTL_1H forces the 1h stamp, the outbound beta set must also
+ * carry `extended-cache-ttl-` or Anthropic ignores the ttl. Add it (idempotent)
+ * unless DARIO_CACHE_TTL_5M overrides (5M wins, matching effectiveCacheControl).
+ * Pure — `env` is injectable for tests. Returns `beta` unchanged when the flag
+ * is off or the beta is already present.
+ */
+export function withForced1hBeta(beta: string, env: Record<string, string | undefined> = process.env): string {
+  if (env['DARIO_CACHE_TTL_1H'] !== '1' || env['DARIO_CACHE_TTL_5M'] === '1') return beta;
+  if (beta.split(',').includes(EXTENDED_CACHE_TTL_BETA)) return beta;
+  return beta.length > 0 ? beta + ',' + EXTENDED_CACHE_TTL_BETA : EXTENDED_CACHE_TTL_BETA;
 }
 
 /**

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -9,7 +9,7 @@ import { arch, platform } from 'node:process';
 import { getAccessToken, getStatus } from './oauth.js';
 import { buildHealthResponse, derivePoolStatus, shouldDiscloseHealthInternals } from './health-response.js';
 import { darioVersion } from './version.js';
-import { buildCCRequest, applyCcPromptCaching, parseEffortSuffix, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, isMcpToolName, CC_TEMPLATE, CC_CACHE_CONTROL, effectiveCacheControl, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
+import { buildCCRequest, applyCcPromptCaching, parseEffortSuffix, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, isMcpToolName, CC_TEMPLATE, CC_CACHE_CONTROL, effectiveCacheControl, withForced1hBeta, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
 import { stampCch, hasCchSeed } from './cch.js';
 import { describeTemplate, detectDrift, checkCCCompat } from './live-fingerprint.js';
 import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCooldown, authCooldownMs, reconcilePoolAccounts, type PoolAccount } from './pool.js';
@@ -2688,6 +2688,12 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           const toAdd = [...passthroughBetas].filter((b) => !baseSet.has(b));
           if (toAdd.length > 0) beta += ',' + toAdd.join(',');
         }
+        // Forced 1h cache (DARIO_CACHE_TTL_1H): effectiveCacheControl stamps
+        // ttl:'1h', but the 1h is only honored WITH the extended-cache-ttl
+        // beta — add it here (no-op unless the flag is set). If the upstream
+        // 400s the flag on a non-sub account, the rejected-set strip below
+        // drops it on the retry.
+        beta = withForced1hBeta(beta);
         // Strip any beta flags the upstream has previously rejected on this
         // account so we don't re-pay the 400 round-trip (dario#42 afk-mode
         // fallout: captured templates carry tier-gated flags whose availability

--- a/test/cache-ttl.mjs
+++ b/test/cache-ttl.mjs
@@ -8,7 +8,7 @@
 // dario used to DELETE those stamps and re-place bare 5m ones, forcing every
 // proxied subscription session onto a 5m cache. These tests pin the mirror:
 // the client's ttl survives the rebuild, on exactly the client's terms.
-import { buildCCRequest, applyCcPromptCaching, effectiveCacheControl, CC_CACHE_CONTROL, isGenuineCCClient } from '../dist/cc-template.js';
+import { buildCCRequest, applyCcPromptCaching, effectiveCacheControl, CC_CACHE_CONTROL, isGenuineCCClient, withForced1hBeta, EXTENDED_CACHE_TTL_BETA } from '../dist/cc-template.js';
 
 let pass = 0, fail = 0;
 function check(label, cond) {
@@ -115,6 +115,47 @@ function collectCC(body) {
 {
   // default export unchanged: CC_CACHE_CONTROL itself is still bare
   check('CC_CACHE_CONTROL stays bare (non-CC clients unchanged)', CC_CACHE_CONTROL.ttl === undefined);
+}
+
+// ── DARIO_CACHE_TTL_1H opt-in force-1h override (dario#678) ──
+{
+  process.env.DARIO_CACHE_TTL_1H = '1';
+  // Forces 1h even for a bare client with NO ttl and NO extended-cache-ttl beta.
+  const forced = effectiveCacheControl(ccBody({ type: 'ephemeral' }), BETA_NO_TTL);
+  check('DARIO_CACHE_TTL_1H forces ttl:1h regardless of client stamp', forced.ttl === '1h');
+  // and it lands on every outbound breakpoint
+  const client = ccBody({ type: 'ephemeral' });
+  const { body } = buildCCRequest(client, 'x-anthropic-billing-header: tag', forced,
+    { deviceId: 'd', accountUuid: 'a', sessionId: 's' });
+  applyCcPromptCaching(body, forced);
+  const stamps = collectCC(body);
+  check('DARIO_CACHE_TTL_1H -> every outbound breakpoint is 1h',
+    stamps.length > 0 && stamps.every((s) => s.ttl === '1h'));
+  // 5M wins if both flags are set
+  process.env.DARIO_CACHE_TTL_5M = '1';
+  check('DARIO_CACHE_TTL_5M wins when both flags set',
+    effectiveCacheControl(ccBody({ type: 'ephemeral' }), BETA_NO_TTL).ttl === undefined);
+  delete process.env.DARIO_CACHE_TTL_1H;
+  delete process.env.DARIO_CACHE_TTL_5M;
+  // flag off -> mirror behavior restored (bare client stays bare)
+  check('flag off -> bare client stays bare',
+    effectiveCacheControl(ccBody({ type: 'ephemeral' }), BETA_NO_TTL).ttl === undefined);
+}
+{
+  // withForced1hBeta: adds the enabling beta only when 1H forced (5M not set),
+  // idempotent, injectable env.
+  check('withForced1hBeta adds beta when forced',
+    withForced1hBeta('oauth-2025-04-20', { DARIO_CACHE_TTL_1H: '1' })
+      === 'oauth-2025-04-20,' + EXTENDED_CACHE_TTL_BETA);
+  check('withForced1hBeta idempotent (already present)',
+    withForced1hBeta('a,' + EXTENDED_CACHE_TTL_BETA, { DARIO_CACHE_TTL_1H: '1' })
+      === 'a,' + EXTENDED_CACHE_TTL_BETA);
+  check('withForced1hBeta no-op when flag off',
+    withForced1hBeta('a,b', {}) === 'a,b');
+  check('withForced1hBeta no-op when 5M also set',
+    withForced1hBeta('a,b', { DARIO_CACHE_TTL_1H: '1', DARIO_CACHE_TTL_5M: '1' }) === 'a,b');
+  check('withForced1hBeta handles empty beta',
+    withForced1hBeta('', { DARIO_CACHE_TTL_1H: '1' }) === EXTENDED_CACHE_TTL_BETA);
 }
 
 console.log(`\n${pass} pass, ${fail} fail`);


### PR DESCRIPTION
## What

Adds **`DARIO_CACHE_TTL_1H=1`** — an opt-in that forces the 1-hour prompt-cache TTL for a subscription client that can't emit the 1-hour stamp itself (an SDK/agent harness that only sends the bare 5-minute `cache_control`). It stamps `ttl:"1h"` on every breakpoint **and** adds the enabling `extended-cache-ttl-2025-04-11` beta so Anthropic honors it.

Follow-up to the #678 investigation, where the token-level measurements showed the reporter's harness sends bare 5-minute stamps, so its prefix expires on idle gaps > 5 min. This gives them (and anyone in that setup) a switch when the harness can't send the 1h stamp.

## Measured end-to-end (real subscription)

Two identical ~9K-token prefixes, one 6.5-minute gap:
```
                cache_create  cache_read
5m  cold            9038          0
1h  cold            9038          0
  ── wait 6.5 min ──
5m  warm            9055          0    ← expired → rebuild
1h  warm              17       9038    ← survived → cache hit
```
This flag makes dario produce that **1h wire shape** (ttl + beta) for a client that only sends 5m.

## Behavior

- Deliberate override of the default mirror (`effectiveCacheControl`), which never *invents* a 1h. The tradeoff is real: 1-hour cache **writes** bill ~2× the 5-minute rate, so it only wins when idle gaps routinely exceed 5 minutes; on rapid back-to-back turns it costs more.
- `DARIO_CACHE_TTL_5M=1` forces the opposite and **wins if both are set**.
- Clients that already send their own stamps are **unchanged** (mirror still applies).
- If the upstream 400s the beta on a non-subscription account, the existing per-account rejected-beta cache drops it on the retry.

## Changes

- `effectiveCacheControl` → returns `{type:"ephemeral",ttl:"1h"}` when `DARIO_CACHE_TTL_1H=1`.
- `withForced1hBeta(beta, env?)` — new pure, injectable helper that adds the enabling beta; `proxy.ts` calls it in the non-passthrough beta assembly.
- `test/cache-ttl.mjs` — **+11 assertions** (forced stamp, every breakpoint 1h, 5M precedence, flag-off restore, helper idempotency/no-op/empty). **Suite 112/112.**
- `docs/faq.md` — new entry: "usage higher than direct — why?" documenting both TTL flags.

Ships in `src/` → version bump **5.2.4 → 5.2.5**.
