### PR TITLE
fix(ci-deps): bump playwright 1.49.0 → 1.55.1 (GHSA-7mvr-c777-76hp)

### DIFF
--- a/.github/drift-probe-deps/package-lock.json
+++ b/.github/drift-probe-deps/package-lock.json
@@ -8,7 +8,7 @@
       "name": "dario-drift-probe-deps",
       "version": "0.0.0",
       "dependencies": {
-        "playwright": "1.49.0"
+        "playwright": "1.55.1"
       }
     },
     "node_modules/fsevents": {
@@ -26,12 +26,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
-      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.49.0"
+        "playwright-core": "1.55.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
-      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/.github/drift-probe-deps/package.json
+++ b/.github/drift-probe-deps/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "description": "CI-only dependencies for the cc-drift-watch headless authorize probe. Kept out of dario's own package.json (zero-runtime-dependency policy); the lockfile here gives the install integrity hashes (Scorecard Pinned-Dependencies).",
   "dependencies": {
-    "playwright": "1.49.0"
+    "playwright": "1.55.1"
   }
 }


### PR DESCRIPTION
Clears **Dependabot #3 (high)** — `playwright < 1.55.1` downloads browsers without verifying the SSL certificate ([GHSA-7mvr-c777-76hp](https://github.com/advisories/GHSA-7mvr-c777-76hp)).

**Scope:** CI-only. The dep lives in `.github/drift-probe-deps` (the cc-drift-watch headless authorize probe) and is **not** in dario's published npm tarball (`package.json` `files` = `dist/README/LICENSE`), so there is **zero exposure to npm users** — CI runners only.

**Change:** exact pin `1.49.0` → `1.55.1` (the patched floor; conservative minor bump, and the probe has a fetch fallback if headless ever fails). Exact pin retained for Scorecard Pinned-Dependencies; lockfile regenerated with integrity hashes (`npm audit` on the sub-package → 0 vulnerabilities).

Also clears **code-scanning #42** (Scorecard "Vulnerabilities"), which is osv-scanner surfacing this same advisory.

Not addressed here: **code-scanning #37** (Scorecard "CII-Best-Practices", low) — informational, reflects dario not yet enrolled in the OpenSSF Best Practices badge program (operator task, not a code fix).