### PR TITLE
refactor(routing): consolidate provider decision into a ProviderAdapter seam

### DIFF
--- a/src/provider-adapter.ts
+++ b/src/provider-adapter.ts
@@ -1,0 +1,119 @@
+/**
+ * Provider routing seam.
+ *
+ * dario's "which backend owns this request" decision used to live inline in the
+ * request handler as a set of interleaved conditions (path class, provider
+ * prefix, GPT-family model test, the openai-backend reroute guard, the pool
+ * fallback guard). This module consolidates that decision into one place: a
+ * small set of `ProviderAdapter`s and a `route()` function that returns the
+ * primary provider plus any exhaustion fallback.
+ *
+ * Scope is deliberately the DECISION, not the request lifecycle. The Claude
+ * path's pool/template/cch/session/overage machinery stays shared below this
+ * seam — it's infrastructure that happens to serve one provider, not per-
+ * provider behaviour, so pushing it behind an adapter interface would make the
+ * Claude adapter the whole proxy and the OpenAI adapter nearly empty. The seam
+ * that pays for itself is routing + request-shaping; the rest is shared.
+ *
+ * The adapters reuse the same primitive proxy.ts uses (`isOpenAIModel`), so this
+ * is a consolidation of the existing decision, not a re-derivation of it.
+ */
+
+import { isOpenAIModel } from './openai-backend.js';
+
+export type ProviderId = 'claude' | 'openai';
+
+/** Inputs the routing decision needs, computed once per request. */
+export interface RouteContext {
+  /** urlPath === '/v1/chat/completions' (OpenAI chat shape). */
+  isOpenAIPath: boolean;
+  /** Model name after provider-prefix stripping (e.g. 'gpt-4o', 'claude-opus-4-8'). */
+  model: string;
+  /** Forced provider from a `<provider>:` prefix or `--model` override; null if unforced. */
+  forcedProvider: ProviderId | null;
+  /** An openai-compat backend is configured (`dario backend add …`). */
+  hasOpenAIBackend: boolean;
+  /** `--pool-fallback=<model>` value, or null when disabled. */
+  poolFallbackModel: string | null;
+  /** Live pool account count. */
+  poolSize: number;
+}
+
+export interface RouteDecision {
+  /** Primary handler for the request. */
+  provider: ProviderId;
+  /** Provider to fall to on primary exhaustion; only claude→openai exists today. */
+  fallback: ProviderId | null;
+  /** Human-readable trace for `--verbose` and tests. */
+  reason: string;
+}
+
+export interface ProviderAdapter {
+  id: ProviderId;
+  /** Higher priority is offered the request first. */
+  priority: number;
+  /** True if this adapter should PRIMARILY handle the request. */
+  claimsPrimary(ctx: RouteContext): boolean;
+}
+
+/**
+ * OpenAI-compat backend adapter. Claims a request under exactly the condition
+ * the request handler reroutes on: a configured backend, an OpenAI-shape
+ * request, not force-routed to Claude, and either force-routed to openai or a
+ * recognized GPT-family model.
+ */
+export const openaiAdapter: ProviderAdapter = {
+  id: 'openai',
+  priority: 100,
+  claimsPrimary(ctx: RouteContext): boolean {
+    if (!ctx.hasOpenAIBackend) return false;
+    if (!ctx.isOpenAIPath) return false;
+    if (ctx.forcedProvider === 'claude') return false;
+    return ctx.forcedProvider === 'openai' || isOpenAIModel(ctx.model);
+  },
+};
+
+/**
+ * Claude adapter — the default owner. Claims anything the openai adapter
+ * doesn't, matching the request handler's fall-through to the template path
+ * (including OpenAI-shape requests with Claude models, which the Claude path
+ * serves via openai→anthropic translation).
+ */
+export const claudeAdapter: ProviderAdapter = {
+  id: 'claude',
+  priority: 0,
+  claimsPrimary(): boolean {
+    return true;
+  },
+};
+
+export const DEFAULT_ADAPTERS: readonly ProviderAdapter[] = [openaiAdapter, claudeAdapter];
+
+/**
+ * Resolve the routing decision. Offers the request to adapters in priority
+ * order and takes the first primary claim; the Claude adapter always claims, so
+ * the result is total. The claude→openai pool fallback is layered on top
+ * because it's a cross-adapter relationship (a Claude-primary request that
+ * spills to openai on pool exhaustion), not a primary claim by either side.
+ */
+export function route(
+  ctx: RouteContext,
+  adapters: readonly ProviderAdapter[] = DEFAULT_ADAPTERS,
+): RouteDecision {
+  const ordered = [...adapters].sort((a, b) => b.priority - a.priority);
+  const primary = ordered.find((a) => a.claimsPrimary(ctx)) ?? claudeAdapter;
+
+  let fallback: ProviderId | null = null;
+  let reason = `${primary.id} primary`;
+  if (
+    primary.id === 'claude' &&
+    ctx.poolFallbackModel !== null &&
+    ctx.hasOpenAIBackend &&
+    ctx.isOpenAIPath &&
+    ctx.poolSize > 0
+  ) {
+    fallback = 'openai';
+    reason = 'claude primary, openai fallback on pool-exhaustion';
+  }
+  return { provider: primary.id, fallback, reason };
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -20,6 +20,7 @@ import { loadAllAccounts, loadAccount, refreshAccountToken, resyncLoginFromCrede
 import { handleAdminRequest, type AdminAccountLive, type AdminAuditEvent } from './admin-api.js';
 import { createTokenBucket } from './rate-limit.js';
 import { getOpenAIBackend, isOpenAIModel, forwardToOpenAI, type BackendCredentials } from './openai-backend.js';
+import { route as routeProvider } from './provider-adapter.js';
 import { RequestQueue, QueueFullError, QueueTimeoutError, DEFAULT_MAX_CONCURRENT, DEFAULT_MAX_QUEUED, DEFAULT_QUEUE_TIMEOUT_MS } from './request-queue.js';
 import { redactSecrets } from './redact.js';
 import { BAKED_BASE_MODELS, withLongContextVariants, buildOpenAIModelsList, getModelCatalog, getCachedBases, resolveAliasAgainst, prewarmModelCatalog, retryModelCatalogNow, isSuspendedModel, type CatalogDeps } from './model-catalog.js';
@@ -2459,11 +2460,26 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
       // through to the backend instead of running it through the Claude
       // template path. Requests on /v1/messages or with Claude-family models
       // fall through to existing behavior.
-      if (openaiBackend && isOpenAI && forcedProvider !== 'claude' && body.length > 0) {
+      //
+      // The decision itself lives in provider-adapter.ts (`route`): `route(...)
+      // .provider === 'openai'` is exactly the prior inline condition
+      // (`openaiBackend && isOpenAI && forcedProvider !== 'claude' &&
+      // (forcedProvider === 'openai' || isOpenAIModel(model))`), consolidated so
+      // the routing rule is testable and lives in one place. `openaiBackend`
+      // stays in the guard for TS narrowing (route already implies it non-null).
+      if (body.length > 0) {
         try {
           const peek = JSON.parse(body.toString()) as { model?: string };
           const rawModel = (peek.model || '').toString();
-          if (rawModel && (forcedProvider === 'openai' || isOpenAIModel(rawModel))) {
+          const decision = routeProvider({
+            isOpenAIPath: isOpenAI,
+            model: rawModel,
+            forcedProvider,
+            hasOpenAIBackend: openaiBackend !== null,
+            poolFallbackModel,
+            poolSize: pool.size,
+          });
+          if (rawModel && openaiBackend && decision.provider === 'openai') {
             if (verbose) {
               console.log(`[dario] #${requestCount} ${req.method} ${urlPath} (model: ${rawModel}) → openai backend`);
             }

--- a/test/provider-adapter.mjs
+++ b/test/provider-adapter.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * test/provider-adapter.mjs
+ *
+ * Truth table for the provider routing seam (`route`). Each row pins an input
+ * context to the provider/fallback the request handler must pick; these lock in
+ * the exact decision proxy.ts made inline before it was consolidated, so a
+ * mismatch means the routing rule drifted.
+ *
+ * The mapping under test:
+ *   - openai backend handles the request iff
+ *       hasOpenAIBackend && isOpenAIPath && forcedProvider !== 'claude'
+ *       && (forcedProvider === 'openai' || isOpenAIModel(model))
+ *   - otherwise Claude handles it (incl. openai-shape + claude model, translated)
+ *   - claude→openai pool fallback iff
+ *       primary === claude && poolFallbackModel && hasOpenAIBackend
+ *       && isOpenAIPath && poolSize > 0
+ *
+ * Runs in-process. No proxy, no OAuth, no network.
+ */
+
+import { route, openaiAdapter, claudeAdapter } from '../dist/provider-adapter.js';
+
+let pass = 0;
+let fail = 0;
+function check(label, cond) {
+  if (cond) { pass++; console.log(`  ✅ ${label}`); }
+  else { fail++; console.log(`  ❌ ${label}`); }
+}
+function header(name) { console.log(`\n${'='.repeat(70)}\n  ${name}\n${'='.repeat(70)}`); }
+
+function ctx(over = {}) {
+  return {
+    isOpenAIPath: false,
+    model: 'claude-opus-4-8',
+    forcedProvider: null,
+    hasOpenAIBackend: false,
+    poolFallbackModel: null,
+    poolSize: 1,
+    ...over,
+  };
+}
+
+// [label, ctx-overrides, expectedProvider, expectedFallback]
+const CASES = [
+  ['anthropic path, claude model, no backend', {}, 'claude', null],
+  ['anthropic path, claude model, backend configured', { hasOpenAIBackend: true }, 'claude', null],
+
+  ['chat path, gpt model, backend', { isOpenAIPath: true, model: 'gpt-4o', hasOpenAIBackend: true }, 'openai', null],
+  ['chat path, o3 model, backend', { isOpenAIPath: true, model: 'o3-mini', hasOpenAIBackend: true }, 'openai', null],
+  ['chat path, gpt model, NO backend → claude (translated)', { isOpenAIPath: true, model: 'gpt-4o', hasOpenAIBackend: false }, 'claude', null],
+  ['chat path, claude model, backend → claude (openai→anthropic)', { isOpenAIPath: true, model: 'claude-opus-4-8', hasOpenAIBackend: true }, 'claude', null],
+
+  ['forced openai on chat path, backend', { isOpenAIPath: true, model: 'gpt-4o', forcedProvider: 'openai', hasOpenAIBackend: true }, 'openai', null],
+  ['forced openai but no backend → claude', { isOpenAIPath: true, model: 'gpt-4o', forcedProvider: 'openai', hasOpenAIBackend: false }, 'claude', null],
+  ['forced claude w/ gpt model + backend → claude', { isOpenAIPath: true, model: 'gpt-4o', forcedProvider: 'claude', hasOpenAIBackend: true }, 'claude', null],
+  ['forced openai on ANTHROPIC path → claude (reroute needs chat path)', { isOpenAIPath: false, model: 'gpt-4o', forcedProvider: 'openai', hasOpenAIBackend: true }, 'claude', null],
+
+  ['fallback armed, chat path, backend, pool>0 → claude+openai', { isOpenAIPath: true, model: 'claude-opus-4-8', hasOpenAIBackend: true, poolFallbackModel: 'gpt-4o-mini', poolSize: 2 }, 'claude', 'openai'],
+  ['fallback armed but anthropic path → no fallback', { isOpenAIPath: false, model: 'claude-opus-4-8', hasOpenAIBackend: true, poolFallbackModel: 'gpt-4o-mini', poolSize: 2 }, 'claude', null],
+  ['fallback armed but empty pool → no fallback (503s)', { isOpenAIPath: true, model: 'claude-opus-4-8', hasOpenAIBackend: true, poolFallbackModel: 'gpt-4o-mini', poolSize: 0 }, 'claude', null],
+  ['fallback armed but no backend → no fallback', { isOpenAIPath: true, model: 'claude-opus-4-8', hasOpenAIBackend: false, poolFallbackModel: 'gpt-4o-mini', poolSize: 2 }, 'claude', null],
+  ['fallback + gpt model on chat path → openai primary (no fallback needed)', { isOpenAIPath: true, model: 'gpt-4o', hasOpenAIBackend: true, poolFallbackModel: 'gpt-4o-mini', poolSize: 2 }, 'openai', null],
+];
+
+header('route() reproduces the routing decision');
+for (const [label, over, expProvider, expFallback] of CASES) {
+  const d = route(ctx(over));
+  const ok = d.provider === expProvider && d.fallback === expFallback;
+  check(`${label}  →  ${d.provider}${d.fallback ? '+' + d.fallback : ''}`, ok);
+  if (!ok) console.log(`      expected ${expProvider}${expFallback ? '+' + expFallback : ''}, got ${d.provider}${d.fallback ? '+' + d.fallback : ''} (${d.reason})`);
+}
+
+header('registry is order-independent (priority, not array order)');
+{
+  const rev = route(ctx({ isOpenAIPath: true, model: 'gpt-4o', hasOpenAIBackend: true }), [claudeAdapter, openaiAdapter]);
+  check('reversed adapter array still routes gpt → openai', rev.provider === 'openai');
+}
+
+console.log(`\n${'='.repeat(70)}\n  ${pass} passed, ${fail} failed\n${'='.repeat(70)}`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## What

Consolidates dario's provider **routing decision** — "which backend owns this request, and what's the exhaustion fallback" — into one place. It used to be spread across ~5 interleaved conditions in `proxy.ts`: the path class (`isOpenAI`), `parseProviderPrefix`, `isOpenAIModel`, the openai-backend reroute guard, and the pool-fallback guard.

New `src/provider-adapter.ts`: a small `ProviderAdapter` registry + `route(ctx)` that returns `{ provider, fallback, reason }`. The openai-backend reroute in `proxy.ts` now calls `route(...)` instead of re-deriving the condition inline.

## Behavior-preserving

`route(...).provider === 'openai'` is exactly the prior inline condition:
`hasOpenAIBackend && isOpenAIPath && forcedProvider !== 'claude' && (forcedProvider === 'openai' || isOpenAIModel(model))`. The `body.length > 0` guard and `openaiBackend` narrowing are unchanged.

- `test/provider-adapter.mjs` — a 15-row truth table pinning the full decision matrix (paths, models, forced-provider, backend on/off, fallback armed / empty-pool / no-backend), plus an order-independence check.
- Full suite green (116 files), which is the real guarantee since it exercises openai routing and pool fallback end to end.

## Deliberately scoped: the decision, not the lifecycle

This adapts the routing **decision** and stops there. The Claude path's pool / template / cch / session-rotation / overage machinery stays shared below the seam. That's intentional: a measurement of the request handler shows Claude touches **17 distinct `pool.*` methods** plus ~80 template/overage/effort/tool references, versus the OpenAI path's **4 calls** to one 211-line function. A "fat" adapter owning the whole lifecycle would make the Claude adapter ≈ the entire proxy and the OpenAI adapter nearly empty — an asymmetry that doesn't pay for itself. The seam that pays is routing + request-shaping; the rest is shared infrastructure that happens to serve one provider.

Follow-up candidates (not in this PR, to keep it behavior-preserving and reviewable): route the two pool-fallback viability checks through the same `route(...).fallback` where the full context is available.
