### PR TITLE
fix(pool): idle-based sticky TTL so long sessions aren't rebound mid-conversation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ checklist.
 
 ## [Unreleased]
 
+- **Session stickiness TTL is now idle-based, not age-based.** A conversation's account binding is reaped 6h after its *last* turn rather than 6h after its first, and every sticky hit refreshes the timer. Previously a session running continuously past the 6h mark was force-rebound to a possibly-different account mid-conversation, throwing away its warm Anthropic prompt cache — the exact thrash stickiness exists to prevent, and it landed hardest on the long agent sessions that benefit from stickiness most. Genuinely idle conversations are still reaped on the same 6h horizon (now measured from their final turn), and the sticky size-cap evicts least-recently-*used* instead of least-recently-*created*.
+
 ## [5.2.7] - 2026-07-17
 
 - **OAuth token persistence** — refreshed tokens are now durably written back to disk (`credentials.json` + pool account files, atomic write) instead of living only in memory; current tokens are also flushed on SIGTERM, and startup now refreshes an expired-but-refreshable token instead of marking the account expired. Fixes the class of outage where any container recreate after >8h of uptime loaded a rotated-away refresh token. (#790, #791)

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -264,15 +264,21 @@ export function computeHeadroom(snapshot: RateLimitSnapshot, family?: string | n
  *
  * Stickiness: bind the conversation's stickyKey to an account for the life
  * of that conversation, and fall off only when the bound account is
- * exhausted / rejected. The 6-hour TTL matches the Max plan's five-hour
- * rate-limit window plus a buffer — past that point a "same" conversation
- * would be starting a fresh window anyway, so rebinding is free.
+ * exhausted / rejected. The 6-hour TTL is measured from a binding's LAST
+ * use, not its creation: an actively-running session refreshes the timer on
+ * every turn (see selectSticky), so it is never rebound out from under a
+ * warm prompt cache — agent sessions routinely run past 6h, and an age-based
+ * TTL would force such a session onto a cold account mid-conversation. A
+ * conversation that goes quiet is reaped 6h after its final turn; by then
+ * its cache has long expired (Anthropic prompt cache lives at most 1h) and a
+ * "same" conversation returning would start fresh anyway, so rebinding is free.
  */
 interface StickyBinding {
   alias: string;
-  boundAt: number;
+  boundAt: number;    // creation time — retained for observability/debugging
+  lastUsedAt: number; // last time this binding was returned; drives the idle TTL and LRU eviction
 }
-const STICKY_TTL_MS = 6 * 60 * 60 * 1000; // 6h
+const STICKY_IDLE_TTL_MS = 6 * 60 * 60 * 1000; // reap a binding 6h after its LAST use, not its creation
 const STICKY_MAX_ENTRIES = 2_000;          // lazy cleanup cap
 const STICKY_CLEANUP_INTERVAL_MS = 30_000; // amortize the O(n) TTL/orphan sweep
 
@@ -460,27 +466,30 @@ export class AccountPool {
    *
    * Also performs lazy cleanup of expired bindings (TTL or size cap).
    */
-  selectSticky(stickyKey: string | null, family?: string | null): PoolAccount | null {
+  selectSticky(stickyKey: string | null, family?: string | null, now: number = Date.now()): PoolAccount | null {
     if (!stickyKey) return this.select(family);
-    this.cleanupSticky();
+    this.cleanupSticky(now);
 
     const binding = this.sticky.get(stickyKey);
     if (binding) {
       const bound = this.accounts.get(binding.alias);
-      const now = Date.now();
       if (bound
         && bound.rateLimit.status !== 'rejected'
         && bound.expiresAt > now + 30_000
         && !isInAuthCooldown(bound, now)
         && computeHeadroom(bound.rateLimit, family) > POOL_HEADROOM_FLOOR
       ) {
+        // Refresh the idle timer. A session that keeps taking turns must never
+        // be reaped or rebound while active — that would strand its warm prompt
+        // cache — so the TTL is re-based to now on every hit.
+        binding.lastUsedAt = now;
         return bound;
       }
     }
 
     const picked = this.select(family);
     if (picked) {
-      this.sticky.set(stickyKey, { alias: picked.alias, boundAt: Date.now() });
+      this.sticky.set(stickyKey, { alias: picked.alias, boundAt: now, lastUsedAt: now });
     }
     return picked;
   }
@@ -494,7 +503,8 @@ export class AccountPool {
   rebindSticky(stickyKey: string | null, alias: string): void {
     if (!stickyKey) return;
     if (!this.accounts.has(alias)) return;
-    this.sticky.set(stickyKey, { alias, boundAt: Date.now() });
+    const now = Date.now();
+    this.sticky.set(stickyKey, { alias, boundAt: now, lastUsedAt: now });
   }
 
   /**
@@ -503,8 +513,7 @@ export class AccountPool {
    * entries until we're back under. O(n) but n is small (capped at 2k)
    * and this only runs on selectSticky, not on every method.
    */
-  private cleanupSticky(): void {
-    const now = Date.now();
+  private cleanupSticky(now: number = Date.now()): void {
     // TTL/orphan sweep is O(n); amortize it — run at most once per
     // STICKY_CLEANUP_INTERVAL_MS instead of on every selectSticky (#642-audit).
     // Stale bindings are never wrongly USED meanwhile: selectSticky re-validates
@@ -512,17 +521,22 @@ export class AccountPool {
     if (now - this.lastStickyCleanup >= STICKY_CLEANUP_INTERVAL_MS) {
       this.lastStickyCleanup = now;
       for (const [key, b] of this.sticky) {
-        if (!this.accounts.has(b.alias) || now - b.boundAt > STICKY_TTL_MS) {
+        // Reap orphans (account gone) and bindings idle past the TTL. Idle is
+        // measured from lastUsedAt, which selectSticky refreshes every turn, so
+        // an actively-running conversation is never reaped here.
+        if (!this.accounts.has(b.alias) || now - b.lastUsedAt > STICKY_IDLE_TTL_MS) {
           this.sticky.delete(key);
         }
       }
     }
     // Hard size cap always enforced (bounds memory). Batch-evict down to 80% so
     // the O(n log n) sort amortizes over many inserts rather than firing on every
-    // new conversation at the cap (#642-audit).
+    // new conversation at the cap (#642-audit). Evict least-recently-USED first
+    // (true LRU): a binding's only value is its warm prompt cache, and the ones
+    // untouched longest are the coldest — least worth keeping.
     if (this.sticky.size > STICKY_MAX_ENTRIES) {
       const target = Math.floor(STICKY_MAX_ENTRIES * 0.8);
-      const sorted = [...this.sticky.entries()].sort((a, b) => a[1].boundAt - b[1].boundAt);
+      const sorted = [...this.sticky.entries()].sort((a, b) => a[1].lastUsedAt - b[1].lastUsedAt);
       const toDrop = sorted.slice(0, this.sticky.size - target);
       for (const [key] of toDrop) this.sticky.delete(key);
     }

--- a/test/pool-sticky.mjs
+++ b/test/pool-sticky.mjs
@@ -251,6 +251,85 @@ header('multi-conversation — distinct keys bind to distinct accounts');
 }
 
 // ======================================================================
+//  idle-based TTL — the binding timer measures time since LAST use, not
+//  creation, so a long-running active session is never rebound out from
+//  under its warm prompt cache. `now` is injected (same convention as the
+//  auth-cooldown tests tampering lastAuthFailureAt) since we can't sleep 6h.
+//  Tokens are given a far-future expiry so the synthetic clock doesn't trip
+//  the 30s token-expiry guard inside selectSticky.
+// ======================================================================
+const HOUR = 3600_000;
+const FAR = 72 * HOUR; // token expiry well past the synthetic timeline
+
+header('idle TTL — an actively-used binding survives past the 6h AGE mark');
+{
+  const pool = new AccountPool();
+  addAccount(pool, 'alpha', { util5h: 0.1, expiresInMs: FAR });
+  addAccount(pool, 'beta', { util5h: 0.5, expiresInMs: FAR });
+  const key = computeStickyKey('a very long agent session');
+  const t0 = Date.now();
+
+  check('binds to alpha at t0', pool.selectSticky(key, null, t0)?.alias === 'alpha');
+  // Keep taking turns across many hours — each hit refreshes the idle timer,
+  // so the binding never crosses 6h of *idleness* even though its age does.
+  check('turn at t0+5h still alpha', pool.selectSticky(key, null, t0 + 5 * HOUR)?.alias === 'alpha');
+  check('turn at t0+9h still alpha (age > 6h, idle never > 6h)', pool.selectSticky(key, null, t0 + 9 * HOUR)?.alias === 'alpha');
+  check('turn at t0+14h still alpha', pool.selectSticky(key, null, t0 + 14 * HOUR)?.alias === 'alpha');
+  check('exactly one binding throughout (never rebound)', pool.stickyCount() === 1);
+}
+
+header('idle TTL — a binding idle past 6h is reaped and re-picks the current best');
+{
+  const pool = new AccountPool();
+  addAccount(pool, 'alpha', { util5h: 0.1, expiresInMs: FAR }); // best at t0
+  addAccount(pool, 'beta', { util5h: 0.5, expiresInMs: FAR });
+  const key = computeStickyKey('a session that goes quiet');
+  const t0 = Date.now();
+
+  check('binds to alpha at t0', pool.selectSticky(key, null, t0)?.alias === 'alpha');
+  // alpha drains so a FRESH selection would now prefer beta — but alpha still
+  // has 0.4 headroom, above the 2% floor, so stickiness holds it within the TTL.
+  pool.updateRateLimits('alpha', { ...EMPTY_SNAPSHOT, util5h: 0.6, status: 'ok', updatedAt: Date.now() });
+  check('return at t0+3h stays on alpha (within idle TTL)', pool.selectSticky(key, null, t0 + 3 * HOUR)?.alias === 'alpha');
+  // That t0+3h hit re-based the timer; 7h later (idle > 6h) the binding is reaped
+  // and the returning conversation re-picks the current best, which is now beta.
+  check('return at t0+10h reaped → re-picks beta', pool.selectSticky(key, null, t0 + 10 * HOUR)?.alias === 'beta');
+  check('still one binding after reap+rebind', pool.stickyCount() === 1);
+  check('binding now points at beta', pool.stickyAliasFor(key) === 'beta');
+}
+
+// ======================================================================
+//  size cap — evicts least-recently-USED, not least-recently-created
+// ======================================================================
+header('size cap — LRU eviction keeps recently-used bindings over old-but-idle');
+{
+  const pool = new AccountPool();
+  addAccount(pool, 'alpha', { util5h: 0.1, expiresInMs: FAR });
+  const t0 = Date.now();
+  const keys = [];
+  // Fill to the 2000 cap, each binding stamped 1ms apart so lastUsedAt is a
+  // strict total order (created-order == used-order at this point).
+  for (let i = 0; i < 2000; i++) {
+    const k = computeStickyKey(`conversation number ${i}`);
+    keys.push(k);
+    pool.selectSticky(k, null, t0 + i);
+  }
+  check('at the cap (2000 bindings)', pool.stickyCount() === 2000);
+
+  // Re-touch the OLDEST-created binding so it becomes the newest-USED one.
+  pool.selectSticky(keys[0], null, t0 + 100_000);
+  // Overflow the cap, then trigger the cleanup pass that evicts down to 80%.
+  const overflow = computeStickyKey('conversation number 2000');
+  pool.selectSticky(overflow, null, t0 + 100_001);
+  pool.selectSticky(overflow, null, t0 + 100_002);
+
+  check('evicted down to 80% of cap (1600)', pool.stickyCount() === 1600);
+  check('key 0 SURVIVED — recently used despite being created first', pool.stickyAliasFor(keys[0]) === 'alpha');
+  check('key 1 EVICTED — oldest lastUsedAt', pool.stickyAliasFor(keys[1]) === null);
+  check('overflow key survived (just inserted)', pool.stickyAliasFor(overflow) === 'alpha');
+}
+
+// ======================================================================
 //  Summary
 // ======================================================================
 console.log(`\n${'='.repeat(70)}`);


### PR DESCRIPTION
## Problem

Session-stickiness bindings had their TTL keyed on `boundAt` (creation time), and `selectSticky` never refreshed it on a hit. So a conversation running continuously past `STICKY_TTL_MS` (6h) got reaped by `cleanupSticky` and re-picked via `select()` on its next turn — usually landing on a *different* account and discarding the warm Anthropic prompt cache the binding exists to preserve. Long agent sessions are precisely the ones that cross the 6h mark, so they took the worst of it — the opposite of what stickiness is for.

The design comment even stated the intent ("past that point a same conversation would be starting a fresh window anyway, so rebinding is free"), but as written the TTL measured age, not idleness, so it fired on active sessions too.

## Fix

Make the TTL idle-based:

- `StickyBinding` gains `lastUsedAt` (`boundAt` stays, for observability).
- `selectSticky` refreshes `lastUsedAt` on every hit, so an active session re-bases the timer each turn and is never reaped/rebound.
- `cleanupSticky` reaps on `now - lastUsedAt > STICKY_IDLE_TTL_MS`. A conversation that goes quiet is still reaped 6h after its *final* turn.
- The size-cap eviction now sorts by `lastUsedAt` — true LRU rather than least-recently-*created*.

No capacity is freed by this (a binding never reserved any — headroom is computed from live rate-limit snapshots), and there's no downside for the paused-then-resumed case: a session idle >6h is reaped under both the old and new rules. The only behavioral change is that a *continuously active* >6h session is no longer rebound out from under its cache.

`selectSticky`/`cleanupSticky` take an optional injected `now` (same pattern as `isInAuthCooldown(account, now)`) so the 6h behavior is deterministically testable without sleeping. The single proxy call site uses the 2-arg form; the new param defaults to `Date.now()`.

## Tests

New `pool-sticky` cases (full suite 117/117):
- active binding survives past the 6h **age** mark (turns at t0+5h/+9h/+14h all stay on the same account, one binding throughout);
- binding idle past 6h is reaped and re-picks the current best account;
- size-cap eviction keeps a recently-used-but-old binding and drops the idle ones (LRU, not LRC).

## Open question (tuning, not blocking)

I kept the idle horizon at the existing 6h to minimize behavioral change. But Anthropic's prompt cache lives at most 1h, so a conversation resuming after >1h idle already has a cold cache — sticking it to its old account past that point gives no cache benefit and only forgoes re-picking the least-drained seat. A shorter idle TTL (~1h, matching max cache lifetime) would arguably load-spread better on resume with zero cache cost. Happy to change the constant if you'd prefer that; left at 6h here since it's the conservative, single-concept change (age → idle).
