### PR TITLE
feat(health): surface live session/sticky counts on /health + doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ checklist.
 ## [Unreleased]
 
 - **Session stickiness TTL is now idle-based, not age-based.** A conversation's account binding is reaped 6h after its *last* turn rather than 6h after its first, and every sticky hit refreshes the timer. Previously a session running continuously past the 6h mark was force-rebound to a possibly-different account mid-conversation, throwing away its warm Anthropic prompt cache — the exact thrash stickiness exists to prevent, and it landed hardest on the long agent sessions that benefit from stickiness most. Genuinely idle conversations are still reaped on the same 6h horizon (now measured from their final turn), and the sticky size-cap evicts least-recently-*used* instead of least-recently-*created*.
+- **`/health` and `dario doctor` now surface live session-tracking counts.** Internal `/health` callers (loopback / authenticated — never the public Cloudflare tunnel) get a `sessions` field: `{mode:"single", active:N}` for the session-id registry or `{mode:"pool", stickyBindings:N}` for conversation→account bindings. `dario doctor` prints the same as a `Sessions` line when a proxy is running. Both reap lazily by design (no background sweeper — that would be an observable fingerprint a real client doesn't have), so the raw in-memory count also confirms cleanup is keeping up.
 
 ## [5.2.7] - 2026-07-17
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -911,6 +911,28 @@ export async function runChecks(opts: RunChecksOptions = {}): Promise<Check[]> {
     checks.push({ status: 'warn', label: 'Pool', detail: `check failed: ${(err as Error).message}` });
   }
 
+  // ---- Live session state (only observable from a running proxy)
+  // Session/sticky counts live in the proxy's memory, so — unlike the
+  // local-state checks above — this reads them off /health (internal-disclosure
+  // caller, so it must reach dario on loopback). Silent skip when no proxy is
+  // up: the counts don't exist, and doctor is often run because it's down.
+  try {
+    const darioBase = process.env.DARIO_TEST_URL || 'http://127.0.0.1:3456';
+    const healthRes = await fetch(`${darioBase}/health`, { signal: AbortSignal.timeout(800) });
+    if (healthRes.ok) {
+      const health = (await healthRes.json().catch(() => null)) as
+        | { sessions?: { mode?: string; stickyBindings?: number; active?: number } }
+        | null;
+      const sx = health?.sessions;
+      if (sx && typeof sx.mode === 'string') {
+        const detail = sx.mode === 'pool'
+          ? `${sx.stickyBindings ?? 0} sticky binding${sx.stickyBindings === 1 ? '' : 's'} — conversation→account affinity, lazily reaped (6h idle TTL, cap 2000)`
+          : `${sx.active ?? 0} active session id${sx.active === 1 ? '' : 's'} — lazily reaped (LRU cap 1024, no background sweeper)`;
+        checks.push({ status: 'info', label: 'Sessions', detail });
+      }
+    }
+  } catch { /* proxy not running — live session state unavailable, skip */ }
+
   // ---- Identity drift (pool account snapshot vs live ~/.claude.json)
   try {
     const { detectClaudeIdentity, listAccountAliases, loadAllAccounts } = await import('./accounts.js');

--- a/src/health-response.ts
+++ b/src/health-response.ts
@@ -23,6 +23,14 @@ export interface HealthStatusLike {
   lastRefreshError?: string;
   /** dario's package version, surfaced to internal callers on /health (#640). */
   version?: string;
+  /**
+   * Live session-tracking counts, surfaced to internal callers only. Both
+   * structures reap lazily (no background sweeper — see session-rotation.ts),
+   * so this raw in-memory size also reveals whether lazy cleanup keeps up.
+   */
+  sessions?:
+    | { mode: 'pool'; stickyBindings: number }
+    | { mode: 'single'; active: number };
 }
 
 export interface HealthResponse {
@@ -135,6 +143,7 @@ export function buildHealthResponse(
         oauth: s.status,
         expiresIn: s.expiresIn,
         requests: requestCount,
+        ...(s.sessions ? { sessions: s.sessions } : {}),
         ...(s.refreshFailures ? { refreshFailures: s.refreshFailures } : {}),
       }
     : liveness;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1966,7 +1966,15 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
         viaCfRay: req.headers['cf-ray'] !== undefined,
       });
       const { httpStatus, body } = buildHealthResponse(
-        { ...s, version: darioVersion() },
+        {
+          ...s,
+          version: darioVersion(),
+          // pool.size === 0 is single-account mode (session-id registry drives
+          // the SESSION_ID slot); a loaded pool routes via sticky bindings.
+          sessions: pool.size === 0
+            ? { mode: 'single', active: sessionRegistry.size() }
+            : { mode: 'pool', stickyBindings: pool.stickyCount() },
+        },
         requestCount,
         includeInternal,
       );

--- a/test/health-response.mjs
+++ b/test/health-response.mjs
@@ -73,6 +73,24 @@ header('buildHealthResponse — version on internal, hidden from public');
   check('version omitted when not supplied', !('version' in noVer.body));
 }
 
+// ── sessions field — live session/sticky counts, internal only ───────────
+
+header('buildHealthResponse — sessions on internal, hidden from public');
+{
+  const single = { status: 'valid', expiresIn: '4h', canRefresh: true, sessions: { mode: 'single', active: 3 } };
+  const int = buildHealthResponse(single, 1, true);
+  check('internal /health includes sessions', int.body.sessions?.mode === 'single' && int.body.sessions?.active === 3);
+  const pub = buildHealthResponse(single, 1, false);
+  check('public /health hides sessions (like OAuth internals)', !('sessions' in pub.body));
+
+  const pool = { status: 'valid', expiresIn: '4h', canRefresh: true, sessions: { mode: 'pool', stickyBindings: 7 } };
+  const poolInt = buildHealthResponse(pool, 1, true);
+  check('internal /health surfaces pool sticky bindings', poolInt.body.sessions?.mode === 'pool' && poolInt.body.sessions?.stickyBindings === 7);
+
+  const noSess = buildHealthResponse({ status: 'valid', canRefresh: true }, 0, true);
+  check('sessions omitted when not supplied', !('sessions' in noSess.body));
+}
+
 // ── shouldDiscloseHealthInternals — the /health trust gate (#642) ─────────
 
 header('shouldDiscloseHealthInternals — closed to the cf-ray fail-open');


### PR DESCRIPTION
## What & why

The proxy tracks live sessions in memory — the single-account session-id `SessionRegistry` and the pool's conversation→account sticky bindings — but there was **no way to observe them**. `stickyCount()` and `SessionRegistry.size()` were test-only helpers. An operator couldn't answer "how many sessions is dario tracking, and is the lazy cleanup keeping up?" (a question the 2026-07-17 token incident made concrete).

This started as an investigation into whether dario needed a **background session-reaper** (a competitor has one). It doesn't: both structures already reap lazily, and a background sweeper was *deliberately rejected* in `session-rotation.ts` because entries disappearing on a timer is an observable fingerprint a real Claude Code client doesn't have. So the right deliverable is **visibility**, not a reaper.

## Change

- **`/health`** gains a `sessions` field, behind the existing #642 internal-disclosure gate (authenticated or bare-loopback callers only — the public Cloudflare tunnel never sees it, same as `oauth`/`requests`):
  - single-account → `{ "mode": "single", "active": <SessionRegistry.size()> }`
  - pool → `{ "mode": "pool", "stickyBindings": <AccountPool.stickyCount()> }`
- **`dario doctor`** prints a `Sessions` line reading that field off loopback; silently skipped when no proxy is running (the counts don't exist, and doctor is often run *because* the proxy is down).
- Raw in-memory counts by design — they double as a signal that lazy cleanup (LRU cap 1024 / 6h idle TTL + 2000 cap) is keeping up.

## Tests

`test/health-response.mjs`: internal `/health` surfaces `sessions` (both modes), public hides it, omitted when not supplied. **Suite 117/117, tsc clean.** No wire/billing change; purely additive read-only observability.

## Not shipped

No version bump — lands in `[Unreleased]`, ships with the next bump.
