### PR TITLE
fix(accounts): don't clobber a newer pool token from stale credentials.json (#805)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [5.2.10] - 2026-07-18
+
+- **Fix: a container recreate could clobber a freshly-refreshed pool token, causing a fleet-wide auth outage (#805).** `resyncLoginFromCredentialsIfStale` overwrote the pool's `login` account from `credentials.json` on *any* token divergence, assuming the legacy file was always the newer source (#235's single-account case). In pool mode the reverse happens — the pool's own refresh loop advances `accounts/login.json` while `credentials.json` stays frozen — so a recreate replaced the live pool token with the stale legacy one, whose refresh token Anthropic had already rotated → `invalid_grant` on every startup → every request 503s until a manual re-auth. The resync now reconciles by freshness: it only overwrites when `credentials.json` is newer-or-equal, and leaves a strictly-newer pool token untouched (`creds-stale`).
+
 ## [5.2.9] - 2026-07-18
 
 - **Template label refresh** — `_version`, `_supportedMaxTested`, and the `user-agent` header bumped to `2.1.214` to track `@anthropic-ai/claude-code@latest`. The live wire shape is unchanged — cc-drift-template-watch ran `capture-and-bake --check` against live CC v2.1.214 and found zero shape drift vs the bundle — so this is a label refresh, not a re-capture (`_captured` stays at the last real capture). Auto-merged; clears the `sdk-drift` early-warning signal.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.2.9",
+  "version": "5.2.10",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -644,6 +644,9 @@ export async function ensureLoginCredentialsInPool(
  *   - 'in-sync'      : tokens match; no action
  *   - 'resynced'     : login.json was stale; overwrote with current
  *                       credentials. Caller should reload pool state
+ *   - 'creds-stale'  : login.json is STRICTLY NEWER than credentials.json
+ *                       (the pool refreshed it; the legacy file is stale) —
+ *                       left login.json untouched. dario#805.
  *
  * Why: the single-account path keeps refreshing `credentials.json` in
  * the background (proxy startup auth check, periodic refresh in oauth.ts).
@@ -653,13 +656,21 @@ export async function ensureLoginCredentialsInPool(
  * says "healthy" so the selector keeps picking it. Detect this at startup
  * and overwrite with the current canonical content. dario#235.
  *
+ * BUT the divergence runs BOTH ways. In pool mode the pool's own refresh
+ * loop advances `login.json` while `credentials.json` stays frozen (the
+ * pool never writes it). Blindly overwriting login.json from credentials.json
+ * would then clobber a live token with the stale legacy one whose refresh
+ * Anthropic already rotated → invalid_grant on every startup → fleet-wide
+ * auth outage. So we reconcile by FRESHNESS, not by assuming credentials.json
+ * wins. dario#805 (the second outage of this class within 12h).
+ *
  * Runs at any pool size ≥ 1: a lone `login` entry is a live pool member
  * since pool-at-one (dario#618) and can go stale exactly the same way —
  * e.g. after `accounts remove` shrinks a migrated pool back to just the
  * back-filled snapshot.
  */
 export async function resyncLoginFromCredentialsIfStale(): Promise<
-  'no-pool' | 'no-login' | 'no-creds' | 'in-sync' | 'resynced'
+  'no-pool' | 'no-login' | 'no-creds' | 'in-sync' | 'resynced' | 'creds-stale'
 > {
   const aliases = await listAccountAliases();
   if (aliases.length === 0) return 'no-pool';
@@ -679,9 +690,20 @@ export async function resyncLoginFromCredentialsIfStale(): Promise<
     return 'in-sync';
   }
 
-  // Tokens diverged — credentials.json has refreshed since last back-fill.
-  // Overwrite the snapshot, preserving deviceId/accountUuid (they don't
-  // rotate with token refresh; they're pool-internal identity).
+  // Tokens diverged. Reconcile by FRESHNESS — a strictly-newer login.json is
+  // the pool having refreshed it (credentials.json is the stale legacy copy),
+  // and overwriting it from credentials.json would swap a live token for one
+  // whose refresh Anthropic already rotated → invalid_grant → outage (#805).
+  // Only the strict case is skipped; equal expiresAt keeps the #235 behaviour
+  // (overwrite), since a real refresh always advances expiresAt.
+  if (loginAcc.expiresAt > tok.expiresAt) {
+    return 'creds-stale';
+  }
+
+  // credentials.json is the newer (or equal-age) token — the #235 case: the
+  // single-account path refreshed it and the pool snapshot is stale. Overwrite,
+  // preserving deviceId/accountUuid (they don't rotate with token refresh;
+  // they're pool-internal identity).
   await saveAccount({
     alias: MIGRATED_LOGIN_ALIAS,
     accessToken: tok.accessToken,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1436,6 +1436,8 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
   const resyncResult = await resyncLoginFromCredentialsIfStale();
   if (resyncResult === 'resynced') {
     console.log('[dario] re-synced pool `login` account from current credentials.json (was stale; dario#235)');
+  } else if (resyncResult === 'creds-stale') {
+    console.log('[dario] kept the newer pool `login` token; credentials.json is stale — NOT overwriting (dario#805)');
   }
 
   // Admin mode (#599) manages the pool over HTTP: it may legitimately start

--- a/test/resync-login-stale.mjs
+++ b/test/resync-login-stale.mjs
@@ -278,6 +278,48 @@ header('only access-token diverges → still resyncs');
 }
 
 // ----------------------------------------------------------------------
+header('dario#805 — login.json STRICTLY newer than credentials.json is NOT clobbered');
+// ----------------------------------------------------------------------
+{
+  // Pool mode: the pool's refresh loop advanced login.json, credentials.json
+  // is the stale legacy copy whose refresh_token Anthropic already rotated.
+  // Overwriting login.json from it would strand the fleet on invalid_grant.
+  await resetAccounts();
+  const poolAccess = 'pool-fresh-access';
+  const poolRefresh = 'pool-fresh-refresh';
+  const staleAccess = 'legacy-stale-access';
+  const staleRefresh = 'legacy-stale-refresh-rotated-away';
+
+  // credentials.json is OLDER (expired an hour ago).
+  await writeCredentials({
+    accessToken: staleAccess,
+    refreshToken: staleRefresh,
+    expiresAt: Date.now() - 3600_000,
+    scopes: ['user:inference'],
+  });
+  // login.json is NEWER (fresh ~8h token the pool just minted).
+  await saveAccount({
+    alias: 'login',
+    accessToken: poolAccess,
+    refreshToken: poolRefresh,
+    expiresAt: Date.now() + 8 * 3600_000,
+    scopes: ['user:inference'],
+    deviceId: 'pool-device', accountUuid: 'pool-uuid',
+  });
+  await saveAccount({
+    alias: 'personal', accessToken: 'at2', refreshToken: 'rt2',
+    expiresAt: Date.now() + 3600_000, scopes: [],
+    deviceId: 'd2', accountUuid: 'u2',
+  });
+
+  const result = await resyncLoginFromCredentialsIfStale();
+  check('newer login.json → creds-stale (not resynced)', result === 'creds-stale');
+  const after = await loadAccount('login');
+  check('login.json access token NOT clobbered', after.accessToken === poolAccess);
+  check('login.json refresh token NOT clobbered', after.refreshToken === poolRefresh);
+}
+
+// ----------------------------------------------------------------------
 //  Cleanup
 // ----------------------------------------------------------------------
 await rm(tmpHome, { recursive: true, force: true });


### PR DESCRIPTION
Fixes #805.

## The bug

`resyncLoginFromCredentialsIfStale()` (src/accounts.ts) overwrote the pool's `login` account from `credentials.json` on **any** token divergence, assuming the legacy file is always the newer source — correct for #235 (single-account path refreshes `credentials.json`, pool snapshot goes stale) but **inverted in pool mode**, where the pool's own refresh loop advances `accounts/login.json` while `credentials.json` stays frozen (the pool never writes it).

So a container **recreate** replaced the live, freshly-refreshed pool token with the stale legacy one — whose refresh token Anthropic had already rotated when the pool refreshed. Result: `invalid_grant` on every startup, the account stuck in auth-cooldown, `/accounts` 503, and every fleet LLM request failing until a manual `--force-reauth`.

**Two fleet-wide outages in ~12h** on the self-hosted deployment: 2026-07-17 ~16:01Z and 2026-07-18 03:51→12:12Z (168 auth-fails, **2 of 187 executions completed**). Both traced to a `credentials.json`/`accounts/login.json` `expiresAt` that had gone *backwards* to a byte-identical stale value right after a recreate.

## The fix

Reconcile by **freshness**, not by assuming `credentials.json` wins:

- `credentials.json` newer-or-equal → overwrite the stale snapshot (`resynced`, the #235 behaviour — unchanged).
- pool token **strictly newer** → leave it untouched, return `creds-stale`. Proxy startup logs the protective skip.

Only the strict case is skipped; equal `expiresAt` keeps the old overwrite, since a real refresh always advances `expiresAt` (so equal-but-different is an anomaly, not a pool refresh).

## Tests

New regression case in `test/resync-login-stale.mjs`: a strictly-newer `login.json` is **not** clobbered (`creds-stale`, tokens preserved). Existing #235 tests — creds-newer overwrite, and the equal-expiry access-only divergence — still pass. `tsc` clean, **suite 117/117**.

## Shipping

Bumped **5.2.10** so this deploys on merge — the box stays exposed to a re-clobber on its next pool refresh + recreate until it lands. The deploy-recreate itself is safe: after the 12:12Z re-auth both credential files hold the same fresh token (`in-sync`), so nothing is clobbered on the way in.

Follow-up (separate, not blocking): the pool refresh could also **mirror** the new token into `credentials.json` so `dario doctor`'s OAuth row (which reads the legacy file) stops falsely reporting `expired` in pool mode.
