### PR TITLE
fix(accounts): mirror pool-refreshed login token to credentials.json (#808)

### DIFF
--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -23,7 +23,7 @@ import { homedir } from 'node:os';
 import { randomUUID, randomBytes, createHash } from 'node:crypto';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { detectCCOAuthConfig } from './cc-oauth-detect.js';
-import { loadCredentials, buildManualAuthorizeUrl, parseManualPaste, readLineFromStdin, enumerateKeychainCredentials, type KeychainEntry } from './oauth.js';
+import { loadCredentials, saveCredentialsTokens, buildManualAuthorizeUrl, parseManualPaste, readLineFromStdin, enumerateKeychainCredentials, type KeychainEntry } from './oauth.js';
 import { openBrowser } from './open-browser.js';
 import { redactSecrets } from './redact.js';
 import { durableWriteFile } from './durable-write.js';
@@ -714,4 +714,57 @@ export async function resyncLoginFromCredentialsIfStale(): Promise<
     accountUuid: loginAcc.accountUuid,
   });
   return 'resynced';
+}
+
+/**
+ * Mirror the pool's freshly-refreshed `login` account token back into the
+ * legacy `~/.dario/credentials.json` store. dario#808.
+ *
+ * The divergence #805 fixed runs one way (credentials.json stale, login.json
+ * fresh) but left the two files diverged: the pool's refresh loop advances
+ * accounts/login.json while nothing ever writes credentials.json, so the
+ * legacy file stays frozen at the last `dario login`. Consequences:
+ *   - `dario doctor` reads credentials.json for its OAuth row and prints
+ *     'expired'/'expiring' in pool-of-1 mode even when the live pool token is
+ *     fresh and the fleet is 200-healthy — an alarm-inducing false positive.
+ *   - any other reader of credentials.json (a co-resident Claude Code, an ops
+ *     script) sees a stale token indefinitely.
+ *
+ * Fix: whenever the pool refreshes the `login` account, mirror the new token
+ * into credentials.json so the legacy file tracks the pool store. Only the
+ * `login` alias is mirrored — it's the one back-filled FROM credentials.json
+ * (ensureLoginCredentialsInPool), so it's the only account whose canonical
+ * home is that file; `work`/`personal` accounts have no legacy counterpart.
+ *
+ * Freshness-guarded, symmetric with #805: mirror only when the refreshed login
+ * token is strictly NEWER than the current credentials.json (by `expiresAt`).
+ * A newer-or-equal credentials.json means another process (e.g. a concurrent
+ * `dario login --force-reauth`) just wrote a fresher family — never clobber it;
+ * resyncLoginFromCredentialsIfStale pulls that direction on next startup.
+ *
+ * Best-effort: a mirror failure must never fail the refresh that produced the
+ * live token. Returns one of:
+ *   - 'skip-not-login' : alias isn't the reserved `login` — nothing to mirror
+ *   - 'mirrored'       : credentials.json updated to the pool token
+ *   - 'creds-newer'    : credentials.json is newer-or-equal — left untouched
+ */
+export async function mirrorLoginToCredentials(
+  refreshed: AccountCredentials,
+): Promise<'skip-not-login' | 'mirrored' | 'creds-newer'> {
+  if (refreshed.alias !== MIGRATED_LOGIN_ALIAS) return 'skip-not-login';
+
+  const creds = await loadCredentials();
+  const currentExpiry = creds?.claudeAiOauth?.expiresAt ?? 0;
+  // Only mirror a strictly-newer pool token. Equal expiry means the files
+  // already agree (or a same-second write elsewhere); newer credentials.json
+  // is another process's fresher family we must not overwrite (#805 direction).
+  if (currentExpiry >= refreshed.expiresAt) return 'creds-newer';
+
+  await saveCredentialsTokens({
+    accessToken: refreshed.accessToken,
+    refreshToken: refreshed.refreshToken,
+    expiresAt: refreshed.expiresAt,
+    scopes: refreshed.scopes ?? creds?.claudeAiOauth?.scopes ?? [],
+  });
+  return 'mirrored';
 }

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -484,6 +484,18 @@ async function saveCredentials(creds: CredentialsFile): Promise<void> {
 }
 
 /**
+ * Mirror a set of OAuth tokens into the legacy `~/.dario/credentials.json`
+ * store. Thin durable-write wrapper over `saveCredentials` for callers outside
+ * this module — specifically the pool's login-account mirror (dario#808), which
+ * keeps credentials.json tracking the pool store after a background/startup
+ * refresh advanced `accounts/login.json`. Shares saveCredentials' durability
+ * (fsync temp + dir, #790), cache invalidation, and refresh-dead-flag clear.
+ */
+export async function saveCredentialsTokens(tokens: OAuthTokens): Promise<void> {
+  await saveCredentials({ claudeAiOauth: tokens });
+}
+
+/**
  * Automatic OAuth flow using a local callback server (same as Claude Code).
  * Opens browser, captures the authorization code automatically.
  */

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -16,7 +16,7 @@ import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCo
 import { Analytics, billingBucketFromClaim, formatUsageLogLine, SUBSCRIPTION_CLAIMS, type RequestRecord } from './analytics.js';
 import { OverageGuard, buildHaltErrorBody, type HaltState } from './overage-guard.js';
 import { notify as osNotify } from './notify.js';
-import { loadAllAccounts, loadAccount, saveAccount, refreshAccountToken, resyncLoginFromCredentialsIfStale, ensureLoginCredentialsInPool } from './accounts.js';
+import { loadAllAccounts, loadAccount, saveAccount, refreshAccountToken, resyncLoginFromCredentialsIfStale, ensureLoginCredentialsInPool, mirrorLoginToCredentials } from './accounts.js';
 import { handleAdminRequest, type AdminAccountLive, type AdminAuditEvent } from './admin-api.js';
 import { createTokenBucket } from './rate-limit.js';
 import { getOpenAIBackend, isOpenAIModel, forwardToOpenAI, type BackendCredentials } from './openai-backend.js';
@@ -1530,6 +1530,11 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           if (!saved) return;
           const refreshed = await refreshAccountToken(saved);
           pool.updateTokens(acc.alias, refreshed.accessToken, refreshed.refreshToken, refreshed.expiresAt);
+          // Mirror a refreshed `login` token back to credentials.json so the
+          // legacy file (and `dario doctor`) tracks the pool store (#808).
+          await mirrorLoginToCredentials(refreshed).catch((err) => {
+            console.error(`[dario] login→credentials.json mirror failed (startup) for ${acc.alias}: ${err instanceof Error ? err.message : err}`);
+          });
           console.error(`[dario] Startup refresh recovered account ${acc.alias} (was expired/expiring).`);
         } catch (err) {
           console.error(`[dario] Startup refresh failed for ${acc.alias}: ${err instanceof Error ? err.message : err}. Account left as-is; auth gate will surface it.`);
@@ -1547,6 +1552,11 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           if (!saved) continue;
           const refreshed = await refreshAccountToken(saved);
           pool.updateTokens(acc.alias, refreshed.accessToken, refreshed.refreshToken, refreshed.expiresAt);
+          // Mirror a refreshed `login` token back to credentials.json so the
+          // legacy file (and `dario doctor`) tracks the pool store (#808).
+          await mirrorLoginToCredentials(refreshed).catch((err) => {
+            console.error(`[dario] login→credentials.json mirror failed (background) for ${acc.alias}: ${err instanceof Error ? err.message : err}`);
+          });
         } catch (err) {
           console.error(`[dario] Background refresh failed for ${acc.alias}: ${err instanceof Error ? err.message : err}`);
         }

--- a/test/mirror-login-to-credentials.mjs
+++ b/test/mirror-login-to-credentials.mjs
@@ -1,0 +1,148 @@
+// dario#808 — mirror the pool-refreshed `login` token back into the legacy
+// credentials.json store.
+//
+// After #805 stopped the pool→credentials clobber, the two files stayed
+// diverged: the pool's refresh loop advances accounts/login.json while nothing
+// writes credentials.json, so the legacy file stays frozen at the last
+// `dario login`. `dario doctor` reads credentials.json and prints
+// 'expired'/'expiring' even when the live pool token is fresh (false alarm),
+// and any other reader of credentials.json sees a stale token indefinitely.
+//
+// mirrorLoginToCredentials(refreshed) writes a strictly-newer `login` token
+// back to credentials.json, freshness-guarded so it never clobbers a
+// newer-or-equal legacy family (symmetric with #805). These tests cover the
+// contract without any network.
+
+import { mkdtemp, writeFile, mkdir, rm, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let pass = 0, fail = 0;
+function check(label, cond) {
+  if (cond) { console.log(`  ✅ ${label}`); pass++; }
+  else { console.log(`  ❌ ${label}`); fail++; }
+}
+function header(label) {
+  console.log(`\n======================================================================`);
+  console.log(`  ${label}`);
+  console.log(`======================================================================`);
+}
+
+// Temp home + env override must happen BEFORE importing accounts/oauth.
+const tmpHome = await mkdtemp(join(tmpdir(), 'dario-mirror-test-'));
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+const dariDir = join(tmpHome, '.dario');
+const credentialsPath = join(dariDir, 'credentials.json');
+await mkdir(dariDir, { recursive: true });
+
+const { mirrorLoginToCredentials, MIGRATED_LOGIN_ALIAS } = await import('../dist/accounts.js');
+const { _clearCredentialsCacheForTest } = await import('../dist/oauth.js');
+
+async function writeCredentials(tokens) {
+  await writeFile(credentialsPath, JSON.stringify({ claudeAiOauth: tokens }, null, 2));
+  _clearCredentialsCacheForTest();
+}
+async function readCredentials() {
+  try { return JSON.parse(await readFile(credentialsPath, 'utf-8')).claudeAiOauth; }
+  catch { return null; }
+}
+async function deleteCredentials() {
+  try { await rm(credentialsPath); } catch { /* not there */ }
+  _clearCredentialsCacheForTest();
+}
+function acct(overrides = {}) {
+  return {
+    alias: MIGRATED_LOGIN_ALIAS,
+    accessToken: 'at-fresh',
+    refreshToken: 'rt-fresh',
+    expiresAt: Date.now() + 3600_000,
+    scopes: ['user:inference'],
+    deviceId: 'dev', accountUuid: 'uuid',
+    ...overrides,
+  };
+}
+
+// ----------------------------------------------------------------------
+header('non-login alias is never mirrored');
+// ----------------------------------------------------------------------
+{
+  await deleteCredentials();
+  const result = await mirrorLoginToCredentials(acct({ alias: 'work' }));
+  check('alias "work" → skip-not-login', result === 'skip-not-login');
+  check('credentials.json not created', (await readCredentials()) === null);
+}
+
+// ----------------------------------------------------------------------
+header('mirrors a strictly-newer login token into credentials.json');
+// ----------------------------------------------------------------------
+{
+  // Legacy file frozen at the last login (older expiry).
+  const oldExpiry = Date.now() + 600_000;
+  await writeCredentials({
+    accessToken: 'at-stale', refreshToken: 'rt-stale',
+    expiresAt: oldExpiry, scopes: ['user:inference'],
+  });
+  // Pool refreshed the login account — strictly newer expiry.
+  const newExpiry = Date.now() + 8 * 3600_000;
+  const result = await mirrorLoginToCredentials(acct({
+    accessToken: 'at-new', refreshToken: 'rt-new', expiresAt: newExpiry,
+    scopes: ['user:inference', 'org:create_api_key'],
+  }));
+  check('newer pool token → mirrored', result === 'mirrored');
+  const after = await readCredentials();
+  check('accessToken written', after.accessToken === 'at-new');
+  check('refreshToken written', after.refreshToken === 'rt-new');
+  check('expiresAt written', after.expiresAt === newExpiry);
+  check('scopes written from pool token', after.scopes.length === 2 && after.scopes.includes('org:create_api_key'));
+}
+
+// ----------------------------------------------------------------------
+header('does NOT clobber a newer-or-equal credentials.json (#805 direction)');
+// ----------------------------------------------------------------------
+{
+  const credExpiry = Date.now() + 8 * 3600_000;
+  await writeCredentials({
+    accessToken: 'at-cred-fresh', refreshToken: 'rt-cred-fresh',
+    expiresAt: credExpiry, scopes: ['user:inference'],
+  });
+  // Pool token is OLDER — another process (e.g. `dario login --force-reauth`)
+  // just wrote a fresher family; must not overwrite it.
+  const older = await mirrorLoginToCredentials(acct({
+    accessToken: 'at-old', refreshToken: 'rt-old', expiresAt: Date.now() + 600_000,
+  }));
+  check('older pool token → creds-newer', older === 'creds-newer');
+  const afterOlder = await readCredentials();
+  check('credentials.json untouched (older case)', afterOlder.accessToken === 'at-cred-fresh');
+
+  // Equal expiry is also a no-op — files already agree / same-second race.
+  const equal = await mirrorLoginToCredentials(acct({
+    accessToken: 'at-equal', refreshToken: 'rt-equal', expiresAt: credExpiry,
+  }));
+  check('equal-expiry pool token → creds-newer', equal === 'creds-newer');
+  const afterEqual = await readCredentials();
+  check('credentials.json untouched (equal case)', afterEqual.accessToken === 'at-cred-fresh');
+}
+
+// ----------------------------------------------------------------------
+header('mirrors when no credentials.json exists yet (missing = expiry 0)');
+// ----------------------------------------------------------------------
+{
+  await deleteCredentials();
+  const result = await mirrorLoginToCredentials(acct({
+    accessToken: 'at-boot', refreshToken: 'rt-boot', expiresAt: Date.now() + 3600_000,
+  }));
+  check('no credentials.json → mirrored (creates it)', result === 'mirrored');
+  const after = await readCredentials();
+  check('credentials.json created with pool token', after && after.accessToken === 'at-boot');
+}
+
+// ----------------------------------------------------------------------
+//  Cleanup
+// ----------------------------------------------------------------------
+await rm(tmpHome, { recursive: true, force: true });
+
+console.log(`\n======================================================================`);
+console.log(`  Results: ${pass} passed, ${fail} failed`);
+console.log(`======================================================================\n`);
+if (fail > 0) process.exit(1);


### PR DESCRIPTION
Closes #808. Follow-up to #805.

## Problem
#805 stopped the pool→credentials clobber but left the two files diverged. After a pool refresh, `accounts/login.json` is fresh but `credentials.json` stays frozen at the last `dario login` (nothing ever writes it back). Consequences:

1. `dario doctor` reads `credentials.json` for its OAuth row → prints `expired`/`expiring` in pool-of-1 mode even when the active pool token is fresh and the fleet is 200-healthy (alarm-inducing false positive; likely auto-filed the doctor-drift issue during the 2026-07-18 outage).
2. Any other reader of `credentials.json` (co-resident Claude Code, ops script) sees a stale token indefinitely.

## Fix
New `mirrorLoginToCredentials(refreshed)` in `src/accounts.ts` writes a refreshed `login` account's token back into `credentials.json` via a durable atomic write (`saveCredentialsTokens` in oauth.ts — shares `saveCredentials`' fsync temp+dir #790, cache invalidation, and refresh-dead-flag clear).

Wired into **both** proxy refresh sites (startup self-heal + 15-min background loop), best-effort (`.catch` logs) so a mirror failure never fails the refresh that produced the live token.

Only the `login` alias is mirrored — it's the one back-filled FROM `credentials.json` (`ensureLoginCredentialsInPool`), so the only account whose canonical home is that legacy file. `work`/`personal` accounts have no legacy counterpart.

**Freshness-guarded, symmetric with #805:** mirror only when the refreshed login token is strictly newer than `credentials.json` (by `expiresAt`). A newer-or-equal `credentials.json` means another process (e.g. a concurrent `dario login --force-reauth`) just wrote a fresher family — never clobber it; `resyncLoginFromCredentialsIfStale` pulls that direction on next startup.

## Test plan
New `test/mirror-login-to-credentials.mjs` (no network) covers all four branches:
- non-login alias → `skip-not-login`, no file created
- strictly-newer pool token → `mirrored` (access/refresh/expiresAt/scopes written)
- older AND equal-expiry pool token → `creds-newer`, legacy file untouched (#805 direction)
- missing `credentials.json` → `mirrored` (creates it)

CI compiles (build 18/20/22) + auto-discovers the new test via `all.test.mjs`. No version bump (not shipping — per ticket DEV-8cf98def).