### PR TITLE
auto-rebake: template drift detected 2026-07-18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ checklist.
 
 ## [Unreleased]
 
+## [5.2.11] - 2026-07-18
+
+- **Template rebake** — re-captured `src/cc-template-data.json` after cc-drift-template-watch detected wire-fingerprint drift against a live CC capture. Bundled fallback template now matches the current CC wire shape.
 ## [5.2.10] - 2026-07-18
 
 - **Fix: a container recreate could clobber a freshly-refreshed pool token, causing a fleet-wide auth outage (#805).** `resyncLoginFromCredentialsIfStale` overwrote the pool's `login` account from `credentials.json` on *any* token divergence, assuming the legacy file was always the newer source (#235's single-account case). In pool mode the reverse happens — the pool's own refresh loop advances `accounts/login.json` while `credentials.json` stays frozen — so a recreate replaced the live pool token with the stale legacy one, whose refresh token Anthropic had already rotated → `invalid_grant` on every startup → every request 503s until a manual re-auth. The resync now reconciles by freshness: it only overwrites when `credentials.json` is newer-or-equal, and leaves a strictly-newer pool token untouched (`creds-stale`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.2.10",
+  "version": "5.2.11",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template-data.json
+++ b/src/cc-template-data.json
@@ -1,6 +1,6 @@
 {
   "_version": "2.1.214",
-  "_captured": "2026-07-14T06:32:01.705Z",
+  "_captured": "2026-07-18T14:14:16.825Z",
   "_source": "bundled",
   "_schemaVersion": 3,
   "agent_identity": "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
@@ -8,7 +8,7 @@
   "tools": [
     {
       "name": "Agent",
-      "description": "Launch a new agent to handle complex, multi-step tasks. Each agent type has specific capabilities and tools available to it.\n\nAvailable agent types are listed in <system-reminder> messages in the conversation.\n\nWhen using the Agent tool, specify a subagent_type parameter to select which agent type to use. If omitted, the general-purpose agent is used.\n\n## When to use\n\nReach for this when the task matches an available agent type, when you have independent work to run in parallel, or when answering would mean reading across several files — delegate it and you keep the conclusion, not the file dumps. For a single-fact lookup where you already know the file, symbol, or value, search directly. Once you've delegated a search, don't also run it yourself — wait for the result.\n\n- The agent's final message is returned to you as the tool result; it is not shown to the user — relay what matters.\n- Use SendMessage with the agent's ID or name to continue a previously spawned agent with its context intact; a new Agent call starts fresh.\n- Each agent type's model, reasoning effort, and tools come from its definition (`.claude/agents/*.md` frontmatter or SDK `agents`).\n- `isolation: \"worktree\"` gives the agent its own git worktree (auto-cleaned if unchanged).\n- Subagents run in the background by default; you'll be notified when one completes. Pass `run_in_background: false` for a synchronous run when you need the result before continuing.",
+      "description": "Launch a new agent to handle complex, multi-step tasks. Each agent type has specific capabilities and tools available to it.\n\nAvailable agent types are listed in <system-reminder> messages in the conversation.\n\nWhen using the Agent tool, specify a subagent_type parameter to select which agent type to use. If omitted, the general-purpose agent is used.\n\n## When to use\n\nReach for this when the task matches an available agent type, when you have independent work to run in parallel, or when answering would mean reading across several files — delegate it and you keep the conclusion, not the file dumps. For a single-fact lookup where you already know the file, symbol, or value, search directly. Once you've delegated a search, don't also run it yourself — wait for the result.\n\n- The agent's final report is not shown to the user — relay what matters.\n- Use SendMessage with the agent's ID or name to continue a previously spawned agent with its context intact; a new Agent call starts fresh.\n- Each agent type's model, reasoning effort, and tools come from its definition (`.claude/agents/*.md` frontmatter or SDK `agents`).\n- `isolation: \"worktree\"` gives the agent its own git worktree (auto-cleaned if unchanged).\n- Subagents run in the background by default; you'll be notified when one completes. Pass `run_in_background: false` for a synchronous run when you need the result before continuing. Never fabricate or predict a pending agent's results — the notification is never something you write yourself; if the user asks before it arrives, say it's still running.",
       "input_schema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
@@ -939,6 +939,11 @@
                   "description": "One-sentence statement of the defect",
                   "type": "string"
                 },
+                "short_summary": {
+                  "description": "Compressed label for compact UI (≤60 chars): the claim alone, no rationale or consequence clause",
+                  "type": "string",
+                  "maxLength": 60
+                },
                 "failure_scenario": {
                   "description": "Concrete inputs/state → wrong output/crash",
                   "type": "string"
@@ -1038,7 +1043,7 @@
     },
     {
       "name": "Skill",
-      "description": "Execute a skill within the main conversation\n\nWhen users ask you to perform tasks, check if any of the available skills match. Skills provide specialized capabilities and domain knowledge.\n\nWhen users reference a \"slash command\" or \"/<something>\", they are referring to a skill. Use this tool to invoke it.\n\nHow to invoke:\n- Set `skill` to the exact name of an available skill (no leading slash). For plugin-namespaced skills use the fully qualified `plugin:skill` form.\n- Set `args` to pass optional arguments.\n- Some skills are scoped to a directory: their name is prefixed with the directory (e.g. `apps/web:deploy`) and their description says which directory they apply to. When a skill name has both a scoped and an unscoped variant, pick by the files you are working on: if the files are under a variant's directory, invoke that variant (most specific directory wins); otherwise invoke the unscoped one.\n\nImportant:\n- Available skills are listed in system-reminder messages in the conversation\n- Only invoke a skill that appears in that list, or one the user explicitly typed as `/<name>` in their message. Never guess or invent a skill name from training data; otherwise do not call this tool\n- When a skill matches the user's request, this is a BLOCKING REQUIREMENT: invoke the relevant Skill tool BEFORE generating any other response about the task\n- NEVER mention a skill without actually calling this tool\n- Do not invoke a skill that is already running\n- Do not use this tool for built-in CLI commands (like /help, /clear, etc.)\n- If you see a <command-name> tag in the current conversation turn, the skill has ALREADY been loaded - follow the instructions directly instead of calling this tool again\n",
+      "description": "Invoke a skill.\n\nA skill is a packaged set of instructions the user or project has set up for a particular kind of task (deploy steps, a review checklist, a repo-specific workflow). Available skills appear in a system-reminder listing with one-line descriptions. When the task at hand is one a listed skill covers, call this tool first — the skill's instructions load into the turn for you to follow in place of your default approach; some skills instead run in a subagent and return the finished result. Users may also ask for one by name (`/<name>`, or \"slash command\"); that's a request to invoke it.\n\n- `skill`: exact name from the listing, no leading slash. Plugin skills use `plugin:skill`. Directory-scoped skills are listed with a path prefix (`apps/web:deploy`); when both scoped and unscoped variants of a name exist, pick the one whose directory contains the files you're working on (most specific wins; unscoped otherwise).\n- `args`: optional arguments to pass through.\n\nOnly names from the listing (or that the user typed explicitly) are valid. Built-in CLI commands (`/help`, `/clear`, …) aren't skills. If a `<command-name>` block is already present this turn, the skill is loaded — follow it directly rather than calling again.\n",
       "input_schema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",


### PR DESCRIPTION
## Auto-rebake from class-B drift detection

Generated by [`cc-drift-template-watch.yml`](.github/workflows/cc-drift-template-watch.yml) on 2026-07-18T14:14:38+00:00.

The watcher's `--check` exited 2 against a live capture from the self-hosted runner. This PR contains the freshly-baked `src/cc-template-data.json` from that capture (with the v4.2.2 platform-superset preservation applied), plus a patch version bump to `v5.2.11` and a CHANGELOG entry — so merging ships the rebake to npm via `cc-drift-auto-release.yml`.

### Summary

**Verdict:** ✅ Benign

- **system_prompt:** +279 chars net (text-content drift — see unified diff below)

### Drift report

```
[bake] using CC at /usr/bin/claude (version 2.1.214) [--check mode: dry-run]
[bake] spawning CC (base: claude-opus-4-8) against loopback MITM to capture /v1/messages...
[bake] captured: CC v2.1.214, 27 tools, 6466 char system prompt
[bake] scrubbed:
[bake]   tools: 27 → 27 (dropped 0 mcp__* tools)
[bake]   system_prompt: 6466 → 5033 chars
[bake] preserved 3 other-platform tools from previous bundle: Glob, Grep, PowerShell
[bake] preserved 3 interactive-only tools from previous bundle (headless capture omits them): AskUserQuestion, EnterPlanMode, ExitPlanMode
[bake] previous baked template: CC v2.1.214 captured 2026-07-14T06:32:01.705Z, 33 tools, 4754 char system prompt
[bake] spawning CC (fable-variant: claude-fable-5) against loopback MITM to capture /v1/messages...
[bake] fable system-prompt variant: base 5033 → fable 9200 chars
[bake] check: drift detected — 1 differing slot (verdict: benign):
[bake] **Verdict:** ✅ Benign
[bake] 
[bake] - **system_prompt:** +279 chars net (text-content drift — see unified diff below)
[bake] 
[bake] check: per-slot detail:
[bake]   • system_prompt content changed (4728 → 5007 chars, delta +279)
[bake]         …
[bake]        # Context management
[bake]        When the conversation grows long, some or all of the current context is summarized; the summary, along with any remaining unsummarized context, is provided in the next context window so work can continue — you don't need to wrap up early or hand off mid-task.
[bake]       +
[bake]       +When you have enough information to act, act. Do not re-derive facts already established in the conversation, re-litigate a decision the user has already made, or narrate options you will not pursue. If you are weighing a choice, give a recommendation, not an exhaustive survey
[bake]        
[bake] wrote drift-summary.md for workflow embedding
[bake] check: bundled template is stale relative to live CC. Run `node scripts/capture-and-bake.mjs` to re-bake.
```

### Validation

Compat-test (`compat-test-self-hosted.yml`) will auto-fire on this PR because it touches `src/cc-template-data.json`. If it goes green, this is mergeable as-is. If it fails, the rebake captured something Anthropic isn't ready to ship — close the PR, investigate manually.

### Why not auto-merged

The bundled template is the wire-shape contract for non-CC clients. compat-test exercises passthrough mode; it cannot validate the rebuild-from-canonical path, so a human approves the bake. Approving + merging bumps the patch version and triggers `cc-drift-auto-release.yml` — approval is the ship gate.

Background: [v4.2.1 CHANGELOG entry](https://github.com/askalf/dario/blob/master/CHANGELOG.md#421---2026-05-17) documents this drift class — same CC binary, different runtime wire shape via remote configuration.
