### PR TITLE
feat(transport): raw HTTP/1.1 over Bun.connect for faithful header order (opt-in, #813)

### DIFF
--- a/docs/wire-fidelity.md
+++ b/docs/wire-fidelity.md
@@ -12,3 +12,11 @@ Between v3.22 and v3.28, dario's Claude backend closed six axes along which a pr
 | **MCP / sub-agent reach** | v3.26 + v3.27 | Not a wire axis — a *surface* axis. CC-aware tools can now address dario directly (sub-agent from inside CC, MCP server for any MCP client), so operators don't have to switch terminals to introspect the proxy. Read-only by design. | `dario subagent install` / `dario mcp`. See [`mcp-server.md`](./mcp-server.md) and [`sub-agent.md`](./sub-agent.md). |
 
 The six-direction wire-fidelity roadmap is complete. Subsequent releases return to responding to issues and upstream template drift.
+
+## Request header order + casing (opt-in, `DARIO_RAW_TRANSPORT`)
+
+The six axes above are what `fetch()` lets us control. One axis it does **not**: the request header order and casing on the wire. `fetch()` re-normalizes the header block before it leaves the process — under Bun it sorts the names alphabetically, and under Node/undici it lowercases them and injects `accept-language` / `sec-fetch-mode` that Claude Code never sends. So the `header_order` captured in the live template (and replayed by `orderHeadersForOutbound`) is discarded by the transport and never reaches the socket (surfaced empirically in #813).
+
+`DARIO_RAW_TRANSPORT=1` closes that axis by bypassing `fetch` for the upstream `/v1/messages` calls: it writes the HTTP/1.1 request bytes directly over **`Bun.connect`**, whose TLS ClientHello is byte-identical to Bun's `fetch` (the same BoringSSL JA3 Claude Code presents — measured, unlike `node:tls` which diverges). That gives CC's exact header order + mixed case with zero transport injection, while keeping the matching JA3.
+
+Opt-in and **off by default** — the default transport stays `fetch`, so this carries no risk until enabled. Bun-only: under Node (`Bun.connect` absent) the flag is ignored and `fetch` is used. See `src/raw-transport.ts`.

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -10,6 +10,7 @@ import { getAccessToken, getStatus } from './oauth.js';
 import { buildHealthResponse, derivePoolStatus, shouldDiscloseHealthInternals } from './health-response.js';
 import { darioVersion } from './version.js';
 import { buildCCRequest, applyCcPromptCaching, parseEffortSuffix, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, isMcpToolName, CC_TEMPLATE, CC_CACHE_CONTROL, effectiveCacheControl, withForced1hBeta, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
+import { rawTransportEnabled, rawUpstreamFetch, type RawFetchInit } from './raw-transport.js';
 import { stampCch, hasCchSeed } from './cch.js';
 import { describeTemplate, detectDrift, checkCCCompat } from './live-fingerprint.js';
 import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCooldown, authCooldownMs, reconcilePoolAccounts, resolvePoolStrategy, type PoolAccount } from './pool.js';
@@ -1953,6 +1954,23 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
     return authenticateRequest(req.headers, apiKeyBuf);
   }
 
+  // Upstream transport selector (dario#813, finding #2). DARIO_RAW_TRANSPORT=1
+  // routes the upstream /v1/messages calls through a raw HTTP/1.1 client over
+  // Bun.connect, so CC's captured header order + casing survive on the wire —
+  // fetch re-normalizes them (Bun sorts; undici lowercases + injects). Returns
+  // a standard Response, so it's a drop-in for the fetch() sites below. Bun-only;
+  // falls back to fetch on Node or when the flag is unset. Default: fetch.
+  const useRawTransport = rawTransportEnabled();
+  const dispatchUpstream: (target: string, init: RawFetchInit) => Promise<Response> =
+    useRawTransport
+      ? (target, init) => rawUpstreamFetch(target, init)
+      : (target, init) => fetch(target, init as RequestInit);
+  if (process.env.DARIO_RAW_TRANSPORT === '1' && !useRawTransport) {
+    console.log('[dario] DARIO_RAW_TRANSPORT=1 set but Bun.connect is unavailable (not under Bun) — using fetch');
+  } else if (useRawTransport) {
+    console.log('[dario] upstream transport: raw HTTP/1.1 over Bun.connect (DARIO_RAW_TRANSPORT=1)');
+  }
+
   const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
     if (req.method === 'OPTIONS') { res.writeHead(204, CORS_HEADERS); res.end(); return; }
 
@@ -3057,7 +3075,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
         // Skipped in passthrough mode — passthrough means "don't shape the
         // request to look like CC," and reordering is a form of shaping.
         const outboundHeaders = passthrough ? headers : orderHeadersForOutbound(headers);
-        upstream = await fetch(targetBase, {
+        upstream = await dispatchUpstream(targetBase, {
           method: req.method ?? 'POST',
           headers: outboundHeaders,
           body: finalBody ? new Uint8Array(finalBody) : undefined,
@@ -3124,7 +3142,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           if (verbose && newFlags.length > 0) console.log(`[dario] #${requestCount} anthropic-beta rejected (${newFlags.join(',')}) — retrying without (cached for session)`);
           const reducedBeta = beta.split(',').filter((t) => t.length > 0 && !set!.has(t)).join(',');
           const retryHeaders = { ...headers, 'anthropic-beta': reducedBeta };
-          const retry = await fetch(targetBase, {
+          const retry = await dispatchUpstream(targetBase, {
             method: req.method ?? 'POST',
             headers: passthrough ? retryHeaders : orderHeadersForOutbound(retryHeaders),
             body: finalBody ? new Uint8Array(finalBody) : undefined,
@@ -3160,7 +3178,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
               if (verbose && firstRejection) console.log(`[dario] #${requestCount} effort '${rejection.rejected}' rejected by ${wireModel} — retrying with '${clamped}' (supported set cached per model)`);
               oc.effort = clamped; // in-place value mutation — field order untouched
               finalBody = Buffer.from(JSON.stringify(rb));
-              const retry = await fetch(targetBase, {
+              const retry = await dispatchUpstream(targetBase, {
                 method: req.method ?? 'POST',
                 headers: passthrough ? headers : orderHeadersForOutbound(headers),
                 body: new Uint8Array(finalBody),
@@ -3216,7 +3234,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
               delete oc.effort;
               if (Object.keys(oc).length === 0) delete rb.output_config;
               finalBody = Buffer.from(JSON.stringify(rb));
-              const retry = await fetch(targetBase, {
+              const retry = await dispatchUpstream(targetBase, {
                 method: req.method ?? 'POST',
                 headers: passthrough ? headers : orderHeadersForOutbound(headers),
                 body: new Uint8Array(finalBody),
@@ -3267,7 +3285,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
               if (verbose && firstRejection) console.log(`[dario] #${requestCount} max_tokens ${rb.max_tokens} exceeds ${wireModel} cap ${cap} — retrying clamped (cached per model)`);
               rb.max_tokens = cap; // in-place value mutation — field order untouched
               finalBody = Buffer.from(JSON.stringify(rb));
-              const retry = await fetch(targetBase, {
+              const retry = await dispatchUpstream(targetBase, {
                 method: req.method ?? 'POST',
                 headers: passthrough ? headers : orderHeadersForOutbound(headers),
                 body: new Uint8Array(finalBody),
@@ -3314,7 +3332,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           const LONG_CONTEXT_BETAS = new Set(['context-1m-2025-08-07', 'context-management-2025-06-27']);
           const reducedBeta = beta.split(',').filter((t) => !LONG_CONTEXT_BETAS.has(t)).join(',');
           const retryHeaders = { ...headers, 'anthropic-beta': reducedBeta };
-          const retry = await fetch(targetBase, {
+          const retry = await dispatchUpstream(targetBase, {
             method: req.method ?? 'POST',
             headers: passthrough ? retryHeaders : orderHeadersForOutbound(retryHeaders),
             body: finalBody ? new Uint8Array(finalBody) : undefined,

--- a/src/raw-transport.ts
+++ b/src/raw-transport.ts
@@ -1,0 +1,288 @@
+/**
+ * Raw HTTP/1.1 upstream transport (dario#813, finding #2).
+ *
+ * `fetch()` cannot put CC's request on the wire faithfully: under Bun it
+ * alphabetically SORTS request headers (destroying the captured header_order),
+ * and under Node/undici it lowercases names and injects `accept-language` /
+ * `sec-fetch-mode` that CC never sends. dario's `orderHeadersForOutbound`
+ * machinery is therefore a no-op through `fetch` — the ordered header array it
+ * builds is re-normalized by the transport before it reaches the socket.
+ *
+ * The fix is to bypass `fetch` and write the HTTP/1.1 request bytes ourselves
+ * over `Bun.connect` — Bun's native socket API, whose TLS ClientHello is
+ * byte-identical to Bun's `fetch` (same BoringSSL profile / JA3 as Claude
+ * Code), while giving us full control of the request line and header block
+ * (exact order + mixed case, zero transport injection). Measured: `Bun.connect`
+ * and `fetch` produce the same JA3 (`d871d02c` on the test box); `node:tls`
+ * does NOT (different profile), so `Bun.connect` specifically is required.
+ *
+ * This module returns a standard `Response`, so it is a drop-in for the
+ * `fetch(targetBase, …)` upstream calls in proxy.ts — the caller consumes only
+ * `.status`, `.headers`, `.text()` and `.body` (a streaming ReadableStream).
+ *
+ * Opt-in via `DARIO_RAW_TRANSPORT=1`; the default remains `fetch` so this
+ * carries zero risk until enabled. Bun-only (needs `Bun.connect`); under Node
+ * `rawTransportEnabled()` is false and the caller keeps using `fetch`.
+ *
+ * The socket layer is injected (`RawSocketFactory`) so the HTTP/1.1 framing,
+ * chunked decode, content-encoding decode and streaming can be exercised under
+ * Node's test runner over `node:net`, without a real Bun/TLS round-trip.
+ *
+ * Known follow-up: transport headers (Host / Content-Length, and CC's exact
+ * `Connection · Host · Accept-Encoding · Content-Length` tail order) are
+ * appended at the tail here rather than positioned from the template's
+ * header_order. The app-header order/casing — the axis `fetch` destroyed — is
+ * faithful; exact transport-tail positioning is a refinement.
+ */
+
+import zlib from 'node:zlib';
+import type { Transform } from 'node:stream';
+
+type BunConnect = (opts: {
+  hostname: string;
+  port: number;
+  tls?: boolean | { serverName?: string; rejectUnauthorized?: boolean };
+  socket: {
+    open(s: BunSocket): void;
+    data(s: BunSocket, d: Uint8Array): void;
+    close(s: BunSocket): void;
+    error(s: BunSocket, e: Error): void;
+  };
+}) => Promise<BunSocket>;
+interface BunSocket { write(d: Uint8Array): number; end(): void; }
+
+function bunApi(): { connect: BunConnect } | undefined {
+  return (globalThis as unknown as { Bun?: { connect: BunConnect } }).Bun;
+}
+
+/** True when the raw transport can run in this process (Bun present). */
+export function rawTransportAvailable(): boolean {
+  return typeof bunApi()?.connect === 'function';
+}
+
+/** True when the operator opted in AND the runtime supports it. */
+export function rawTransportEnabled(env: Record<string, string | undefined> = process.env): boolean {
+  return env.DARIO_RAW_TRANSPORT === '1' && rawTransportAvailable();
+}
+
+export interface RawFetchInit {
+  method?: string;
+  /** Ordered pair array (from orderHeadersForOutbound) or a plain record. */
+  headers?: Array<[string, string]> | Record<string, string>;
+  body?: Uint8Array | string;
+  signal?: AbortSignal;
+}
+
+/**
+ * Injectable socket layer. The default (`bunSocketFactory`) opens a
+ * `Bun.connect` TLS socket; tests inject a `node:net` implementation. The
+ * factory calls `onOpen` with a `write`/`close` pair once connected, then
+ * `onData` per inbound chunk, and `onClose`/`onError` on termination.
+ */
+export type RawSocketFactory = (opts: {
+  host: string;
+  port: number;
+  tls: boolean;
+  onOpen: (write: (bytes: Uint8Array) => void, close: () => void) => void;
+  onData: (bytes: Uint8Array) => void;
+  onClose: () => void;
+  onError: (err: Error) => void;
+}) => void;
+
+/** Default socket layer: a Bun.connect TLS (or plaintext) socket. */
+export const bunSocketFactory: RawSocketFactory = (opts) => {
+  const Bun = bunApi();
+  if (!Bun) { opts.onError(new Error('raw transport requires Bun.connect')); return; }
+  Bun.connect({
+    hostname: opts.host,
+    port: opts.port,
+    tls: opts.tls ? { serverName: opts.host } : false,
+    socket: {
+      open(s) { opts.onOpen((b) => s.write(b), () => s.end()); },
+      data(_s, d) { opts.onData(d); },
+      close() { opts.onClose(); },
+      error(_s, e) { opts.onError(e); },
+    },
+  }).catch((e: unknown) => opts.onError(e instanceof Error ? e : new Error(String(e))));
+};
+
+function toPairs(h: RawFetchInit['headers']): Array<[string, string]> {
+  if (!h) return [];
+  if (Array.isArray(h)) return h.map(([k, v]) => [k, String(v)] as [string, string]);
+  return Object.entries(h).map(([k, v]) => [k, String(v)] as [string, string]);
+}
+
+/** Statuses that must not carry a response body per the fetch spec. */
+const NULL_BODY_STATUS = new Set([101, 204, 205, 304]);
+
+/**
+ * `fetch`-shaped upstream call over a raw socket. Returns a `Response` whose
+ * `.body` streams the decoded (chunked + content-encoding removed) upstream
+ * bytes as they arrive, so the streaming SSE path in proxy.ts works unchanged.
+ */
+export function rawUpstreamFetch(
+  url: string,
+  init: RawFetchInit = {},
+  socketFactory: RawSocketFactory = bunSocketFactory,
+): Promise<Response> {
+  const u = new URL(url);
+  const isTls = u.protocol === 'https:';
+  const port = u.port ? Number(u.port) : (isTls ? 443 : 80);
+  const host = u.hostname;
+  const pathQ = (u.pathname || '/') + u.search;
+  const method = (init.method ?? 'POST').toUpperCase();
+  const bodyBuf = init.body == null
+    ? Buffer.alloc(0)
+    : (typeof init.body === 'string' ? Buffer.from(init.body, 'utf8') : Buffer.from(init.body));
+
+  // Serialize headers verbatim (exact order + case). Append the transport
+  // headers CC's own transport adds, if the caller didn't already include them.
+  const pairs = toPairs(init.headers);
+  const present = new Set(pairs.map(([k]) => k.toLowerCase()));
+  const tail: Array<[string, string]> = [];
+  if (!present.has('host')) tail.push(['Host', u.host]);
+  if (!present.has('content-length') && !present.has('transfer-encoding')) {
+    tail.push(['Content-Length', String(bodyBuf.length)]);
+  }
+  let head = `${method} ${pathQ} HTTP/1.1\r\n`;
+  for (const [k, v] of [...pairs, ...tail]) head += `${k}: ${v}\r\n`;
+  head += '\r\n';
+  const reqBytes = new Uint8Array(Buffer.concat([Buffer.from(head, 'latin1'), bodyBuf]));
+
+  return new Promise<Response>((resolve, reject) => {
+    let phase: 'head' | 'body' = 'head';
+    let acc: Buffer = Buffer.alloc(0);
+    let status = 0;
+    let statusText = '';
+    const respHeaders = new Headers();
+    let te = '';
+    let ce = '';
+    let contentLength = -1;
+    let bodyRead = 0;
+    let cst: 'size' | 'data' | 'crlf' = 'size';
+    let crem = 0;
+    let decode: Transform | null = null;
+    let ctrl: ReadableStreamDefaultController<Uint8Array> | null = null;
+    let resolved = false;
+    let bodyClosed = false;
+    let bodyComplete = false;
+    let closeSocket: (() => void) | undefined;
+
+    const bodyStream = new ReadableStream<Uint8Array>({
+      start(c) { ctrl = c; },
+      cancel() { destroy(); },
+    });
+
+    function enqueue(b: Buffer) { if (ctrl && b.length) ctrl.enqueue(new Uint8Array(b)); }
+    function endStream() { if (ctrl && !bodyClosed) { bodyClosed = true; try { ctrl.close(); } catch { /* already closed */ } } }
+    function errorStream(e: unknown) { if (ctrl && !bodyClosed) { bodyClosed = true; try { ctrl.error(e); } catch { /* already closed */ } } }
+    function destroy() { try { closeSocket?.(); } catch { /* socket already gone */ } }
+
+    function setupDecode() {
+      if (ce === 'gzip' || ce === 'x-gzip') decode = zlib.createGunzip();
+      else if (ce === 'deflate') decode = zlib.createInflate();
+      else if (ce === 'br') decode = zlib.createBrotliDecompress();
+      else if (ce === 'zstd' && 'createZstdDecompress' in zlib) {
+        decode = (zlib as unknown as { createZstdDecompress(): Transform }).createZstdDecompress();
+      } else decode = null;
+      if (decode) {
+        decode.on('data', (d: Buffer) => enqueue(d));
+        decode.on('end', () => endStream());
+        decode.on('error', (e) => errorStream(e));
+      }
+    }
+    function onBodyBytes(b: Buffer) { if (decode) decode.write(b); else enqueue(b); }
+    // Body is logically complete (chunk terminator seen, content-length reached,
+    // or connection-close EOF). Mark it BEFORE ending the decoder, whose flush
+    // is async — the socket may close before the decoder emits 'end', and
+    // onClose must not treat that as a truncation.
+    function finishBody() { bodyComplete = true; if (decode) decode.end(); else endStream(); }
+
+    function processChunked(): void {
+      for (;;) {
+        if (cst === 'size') {
+          const nl = acc.indexOf('\r\n');
+          if (nl === -1) return;
+          const size = parseInt(acc.subarray(0, nl).toString('latin1').split(';')[0].trim(), 16);
+          acc = acc.subarray(nl + 2);
+          if (!Number.isFinite(size)) { errorStream(new Error('bad chunk size')); destroy(); return; }
+          if (size === 0) { finishBody(); return; }
+          crem = size; cst = 'data';
+        } else if (cst === 'data') {
+          if (acc.length < crem) { onBodyBytes(acc); crem -= acc.length; acc = Buffer.alloc(0); return; }
+          onBodyBytes(acc.subarray(0, crem)); acc = acc.subarray(crem); cst = 'crlf';
+        } else {
+          if (acc.length < 2) return;
+          acc = acc.subarray(2); cst = 'size';
+        }
+      }
+    }
+
+    function feed(chunk: Buffer) {
+      acc = acc.length ? Buffer.concat([acc, chunk]) : chunk;
+      if (phase === 'head') {
+        const end = acc.indexOf('\r\n\r\n');
+        if (end === -1) return;
+        const lines = acc.subarray(0, end).toString('latin1').split('\r\n');
+        const m = /^HTTP\/1\.[01]\s+(\d{3})(?:\s+(.*))?$/.exec(lines.shift() ?? '');
+        if (!m) { const e = new Error('malformed status line'); if (!resolved) reject(e); destroy(); return; }
+        status = Number(m[1]); statusText = m[2] ?? '';
+        for (const line of lines) {
+          const c = line.indexOf(':'); if (c === -1) continue;
+          const name = line.slice(0, c).trim();
+          const val = line.slice(c + 1).trim();
+          const ln = name.toLowerCase();
+          if (ln === 'transfer-encoding') { te = val.toLowerCase(); continue; }
+          if (ln === 'content-encoding') { ce = val.toLowerCase(); continue; }
+          if (ln === 'content-length') { contentLength = Number(val); continue; }
+          // content-encoding/length/transfer-encoding are dropped from the
+          // surfaced headers because we decode + de-chunk the body here, exactly
+          // as fetch strips them after auto-decompression.
+          respHeaders.append(name, val);
+        }
+        setupDecode();
+        acc = acc.subarray(end + 4);
+        phase = 'body';
+        resolved = true;
+        const hasBody = !NULL_BODY_STATUS.has(status);
+        resolve(new Response(hasBody ? bodyStream : null, { status, statusText, headers: respHeaders }));
+        if (!hasBody) { endStream(); return; }
+      }
+      if (phase === 'body') {
+        if (te === 'chunked') processChunked();
+        else if (contentLength >= 0) {
+          const take = Math.min(acc.length, contentLength - bodyRead);
+          if (take > 0) { onBodyBytes(acc.subarray(0, take)); bodyRead += take; acc = acc.subarray(take); }
+          if (bodyRead >= contentLength) finishBody();
+        } else if (acc.length) { onBodyBytes(acc); acc = Buffer.alloc(0); }
+      }
+    }
+
+    if (init.signal) {
+      if (init.signal.aborted) { reject(new DOMException('The operation was aborted.', 'AbortError')); return; }
+      init.signal.addEventListener('abort', () => {
+        const e = new DOMException('The operation was aborted.', 'AbortError');
+        if (!resolved) reject(e);
+        errorStream(e); destroy();
+      }, { once: true });
+    }
+
+    socketFactory({
+      host, port, tls: isTls,
+      onOpen: (write, close) => { closeSocket = close; write(reqBytes); },
+      onData: (d) => feed(Buffer.from(d)),
+      onClose: () => {
+        if (phase !== 'body') { if (!resolved) reject(new Error('upstream closed before response headers')); return; }
+        // Body already complete — the decoder's async flush (if any) will close
+        // the stream via its 'end'. A socket close here is expected, not a fault.
+        if (bodyComplete) return;
+        // No content-length and not chunked: the close IS the end-of-body signal.
+        if (te !== 'chunked' && contentLength < 0) { finishBody(); return; }
+        // Otherwise a close before the terminator / declared length is a real
+        // truncation — surface it as a stream error rather than silent EOF.
+        errorStream(new Error('upstream closed before body completed'));
+      },
+      onError: (e) => { if (!resolved) reject(e); errorStream(e); },
+    });
+  });
+}

--- a/test/raw-transport.mjs
+++ b/test/raw-transport.mjs
@@ -1,0 +1,160 @@
+// Unit tests for the raw HTTP/1.1 upstream transport (src/raw-transport.ts,
+// dario#813 finding #2). The socket layer is injected, so we drive the full
+// request-serialization + response-parse (chunked, gzip, content-length,
+// streaming, abort) path under Node over node:net — no Bun/TLS round-trip
+// needed. The Bun.connect JA3 + header-order-on-the-wire facts are verified
+// separately (measured); this covers the framing/decode/stream correctness.
+
+import net from 'node:net';
+import zlib from 'node:zlib';
+import { rawUpstreamFetch, rawTransportEnabled } from '../dist/raw-transport.js';
+
+let pass = 0, fail = 0;
+const check = (l, c) => { if (c) { console.log(`  ✅ ${l}`); pass++; } else { console.log(`  ❌ ${l}`); fail++; } };
+const header = (l) => { console.log(`\n======================================================================\n  ${l}\n======================================================================`); };
+
+// node:net socket factory — the injectable stand-in for bunSocketFactory.
+function nodeFactory(opts) {
+  const sock = net.connect(opts.port, opts.host, () =>
+    opts.onOpen((b) => sock.write(Buffer.from(b)), () => sock.end()));
+  sock.on('data', (d) => opts.onData(new Uint8Array(d)));
+  sock.on('close', () => opts.onClose());
+  sock.on('error', (e) => opts.onError(e));
+}
+
+const SSE = [
+  'event: message_start\ndata: {"type":"message_start"}\n\n',
+  'event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hi"}}\n\n',
+  'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+];
+const httpChunk = (b) => { b = Buffer.from(b); return Buffer.concat([Buffer.from(b.length.toString(16) + '\r\n'), b, Buffer.from('\r\n')]); };
+
+// Mock upstream: chunked SSE (optionally gzip), captures the request head.
+function startSseMock({ gzip = false } = {}) {
+  const state = { reqHead: null };
+  const server = net.createServer((sock) => {
+    let buf = Buffer.alloc(0);
+    sock.on('data', (d) => {
+      buf = Buffer.concat([buf, d]);
+      const end = buf.indexOf('\r\n\r\n');
+      if (end === -1) return;
+      state.reqHead = buf.slice(0, end).toString('latin1');
+      sock.write('HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n' + (gzip ? 'Content-Encoding: gzip\r\n' : '') + '\r\n');
+      const gz = gzip ? zlib.createGzip() : null;
+      const parts = [];
+      const drain = () => { while (parts.length) sock.write(httpChunk(parts.shift())); };
+      if (gz) {
+        gz.on('data', (d2) => parts.push(d2));
+        // readable 'end' fires after the LAST data event — so `parts` holds the
+        // complete gzip member (incl. trailer) before we send the terminator.
+        gz.on('end', () => { drain(); sock.write('0\r\n\r\n'); sock.end(); server.close(); });
+      }
+      let i = 0;
+      const pump = () => {
+        if (i < SSE.length) {
+          const ev = SSE[i++];
+          if (gz) { gz.write(ev); gz.flush(zlib.constants.Z_SYNC_FLUSH, () => { drain(); setTimeout(pump, 15); }); }
+          else { sock.write(httpChunk(ev)); setTimeout(pump, 15); }
+        } else if (gz) gz.end();
+        else { sock.write('0\r\n\r\n'); sock.end(); server.close(); }
+      };
+      pump();
+    });
+    sock.on('error', () => {});
+  });
+  return new Promise((res) => server.listen(0, '127.0.0.1', () => res({ port: server.address().port, state, close: () => server.close() })));
+}
+
+// Mock upstream: fixed content-length body (error / non-stream path).
+function startFixedMock({ status = 400, body = '{"error":"bad"}' } = {}) {
+  const server = net.createServer((sock) => {
+    let buf = Buffer.alloc(0);
+    sock.on('data', (d) => {
+      buf = Buffer.concat([buf, d]);
+      if (buf.indexOf('\r\n\r\n') === -1) return;
+      const b = Buffer.from(body);
+      sock.write(`HTTP/1.1 ${status} Status\r\nContent-Type: application/json\r\nContent-Length: ${b.length}\r\n\r\n`);
+      sock.write(b); sock.end(); server.close();
+    });
+    sock.on('error', () => {});
+  });
+  return new Promise((res) => server.listen(0, '127.0.0.1', () => res({ port: server.address().port, close: () => server.close() })));
+}
+
+async function readAll(resp) {
+  const reader = resp.body.getReader();
+  const dec = new TextDecoder();
+  let out = '';
+  for (;;) { const { value, done } = await reader.read(); if (done) break; out += dec.decode(value, { stream: true }); }
+  return out;
+}
+
+const ORDERED = [
+  ['X-Claude-Code-Session-Id', 'sess'],
+  ['Authorization', 'Bearer x'],
+  ['anthropic-beta', 'oauth-2025-04-20'],
+  ['Content-Type', 'application/json'],
+  ['User-Agent', 'claude-cli/2.1.214'],
+  ['anthropic-version', '2023-06-01'],
+];
+
+async function main() {
+  header('rawTransportEnabled — gated by env AND Bun availability');
+  {
+    check('unset env → false', rawTransportEnabled({}) === false);
+    // Under Node (this test runner) Bun.connect is absent, so even with the
+    // flag set it must be false — the caller then keeps using fetch.
+    check('flag set but no Bun → false (safe fallback)', rawTransportEnabled({ DARIO_RAW_TRANSPORT: '1' }) === false);
+  }
+
+  header('chunked SSE — streaming reconstruct + header order/casing on the wire');
+  {
+    const mock = await startSseMock({ gzip: false });
+    const resp = await rawUpstreamFetch(`http://127.0.0.1:${mock.port}/v1/messages`, { method: 'POST', headers: ORDERED, body: '{}' }, nodeFactory);
+    check('status 200', resp.status === 200);
+    check('content-type surfaced', /event-stream/.test(resp.headers.get('content-type') || ''));
+    check('transfer-encoding stripped from surfaced headers', resp.headers.get('transfer-encoding') === null);
+    const text = await readAll(resp);
+    check('full SSE stream reconstructed', text.includes('message_start') && text.includes('"text":"Hi"') && text.includes('message_stop'));
+    const names = mock.state.reqHead.split('\r\n').slice(1).map((l) => l.slice(0, l.indexOf(':')));
+    const iSession = names.indexOf('X-Claude-Code-Session-Id');
+    const iAuth = names.indexOf('Authorization');
+    check('mixed-case header names preserved verbatim', iSession !== -1 && iAuth !== -1);
+    check('sent header order preserved (session before auth)', iSession >= 0 && iSession < iAuth);
+    check('NOT alphabetized (Accept-* would sort first under fetch)', names[0] === 'X-Claude-Code-Session-Id');
+    check('no undici-injected accept-language/sec-fetch-*', !names.some((n) => /accept-language|sec-fetch/i.test(n)));
+    check('Host + Content-Length synthesized at tail', names.includes('Host') && names.includes('Content-Length'));
+  }
+
+  header('gzip chunked SSE — content-encoding decoded, not surfaced');
+  {
+    const mock = await startSseMock({ gzip: true });
+    const resp = await rawUpstreamFetch(`http://127.0.0.1:${mock.port}/v1/messages`, { method: 'POST', headers: ORDERED, body: '{}' }, nodeFactory);
+    check('content-encoding stripped (body already decoded)', resp.headers.get('content-encoding') === null);
+    const text = await readAll(resp);
+    check('gzip SSE reconstructed', text.includes('message_start') && text.includes('"text":"Hi"') && text.includes('message_stop'));
+  }
+
+  header('content-length body — .text() on an error response');
+  {
+    const mock = await startFixedMock({ status: 400, body: '{"error":"bad"}' });
+    const resp = await rawUpstreamFetch(`http://127.0.0.1:${mock.port}/v1/messages`, { method: 'POST', headers: ORDERED, body: '{}' }, nodeFactory);
+    check('status 400 surfaced', resp.status === 400);
+    check('.text() returns the full body', (await resp.text()) === '{"error":"bad"}');
+  }
+
+  header('abort — a pre-aborted signal rejects with AbortError');
+  {
+    const mock = await startFixedMock({ status: 200, body: '{}' });
+    const ac = new AbortController(); ac.abort();
+    let name = null;
+    try { await rawUpstreamFetch(`http://127.0.0.1:${mock.port}/v1/messages`, { method: 'POST', headers: ORDERED, body: '{}', signal: ac.signal }, nodeFactory); }
+    catch (e) { name = e.name; }
+    mock.close();
+    check('rejects with AbortError', name === 'AbortError');
+  }
+
+  console.log(`\n======================================================================\n  Results: ${pass} passed, ${fail} failed\n======================================================================\n`);
+  if (fail > 0) process.exit(1);
+}
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## What

`fetch()` cannot put Claude Code's request headers on the wire faithfully, and this defeats dario's existing `header_order` machinery. Measured for #813 finding #2 (a distinctive non-alphabetical, mixed-case ordered set sent through `fetch`):

- **Bun `fetch`** → headers **sorted alphabetically** (`X-Claude-Code-Session-Id`-first became `Accept`-first) + `Host`/`Connection`/`Accept-Encoding` injected.
- **Node `fetch`/undici** → order kept but names lowercased, `host`/`connection` hoisted, and `accept-language`/`sec-fetch-mode` **injected** (CC never sends these).

So `orderHeadersForOutbound` builds the right ordered array and `fetch` throws the order away before it reaches the socket.

## Change

New `src/raw-transport.ts` — an **opt-in** upstream transport (`DARIO_RAW_TRANSPORT=1`) that writes the HTTP/1.1 request bytes directly over **`Bun.connect`**. Measured: `Bun.connect`'s TLS ClientHello is byte-identical to Bun's `fetch` (same BoringSSL JA3 Claude Code presents — `d871d02c` on the test box); `node:tls` is **not** (`203503b7`), so `Bun.connect` specifically is required. That yields CC's exact header order + mixed case with zero transport injection **while keeping the matching JA3** — the "you can't win both axes" bind from the issue thread doesn't hold.

It returns a standard `Response`, so it's a **drop-in** for the six upstream `fetch(targetBase, …)` sites in `proxy.ts` (they consume only `.status`/`.headers`/`.text()`/`.body`). Wired behind a one-line selector:

```ts
const dispatchUpstream = useRawTransport ? rawUpstreamFetch : (t, o) => fetch(t, o);
```

**Default OFF.** Falls back to `fetch` on Node (no `Bun.connect`) or when the flag is unset — zero behavior change until you flip it, and a startup log announces the active transport.

## Tests

The socket layer is injected (`RawSocketFactory`), so the framing/decode/streaming is unit-tested under Node's runner over `node:net` (`test/raw-transport.mjs`, 16 assertions, auto-discovered by `all.test.mjs`):
- streaming **chunked** SSE reconstructed incrementally; `transfer-encoding` stripped from surfaced headers
- **gzip** content-encoding decoded on the fly; `content-encoding` stripped (matches `fetch`'s post-decompression view)
- sent header **order + mixed case preserved**, NOT alphabetized, no `accept-language`/`sec-fetch-*` injection
- `content-length` body via `.text()`; pre-aborted signal → `AbortError`

Separately verified by measurement (harness in the issue thread): `Bun.connect` JA3 == `fetch` JA3; on-the-wire header order/casing exact; and the real `bunSocketFactory` + this module streaming SSE end-to-end.

## Follow-ups (not in this PR)

- **`br` / `zstd`** content-encoding: gzip/deflate/br handled; zstd feature-detected. CC advertises all four; Anthropic SSE is gzip/identity in practice, but worth hardening.
- **Transport-header tail positioning**: `Host`/`Content-Length` are appended at the tail rather than positioned from the template's `header_order` (CC's exact tail is `Connection · Host · Accept-Encoding · Content-Length`). The app-header axis `fetch` destroyed is faithful; exact transport-tail order is a refinement.
- **Prod validation**: confirm `Bun.connect == fetch` JA3 holds on the Linux prod platform, and validate a real TLS round-trip, before flipping the flag in prod.

Addresses **finding #2** from #813 (not `Closes` — that issue tracks several items).
