### PR TITLE
harden(transport): CC-exact header tail + br/zstd + fail-loud on unknown encoding (#813)

### DIFF
--- a/src/raw-transport.ts
+++ b/src/raw-transport.ts
@@ -135,12 +135,18 @@ export function rawUpstreamFetch(
     ? Buffer.alloc(0)
     : (typeof init.body === 'string' ? Buffer.from(init.body, 'utf8') : Buffer.from(init.body));
 
-  // Serialize headers verbatim (exact order + case). Append the transport
-  // headers CC's own transport adds, if the caller didn't already include them.
+  // Serialize headers verbatim (exact order + case), then append the transport
+  // headers CC's own transport adds — in CC's captured tail order
+  // (Connection · Host · Accept-Encoding · Content-Length, from the template's
+  // header_order) with CC-faithful values — skipping any the caller already
+  // supplied. Casing matches CC's wire request (mixed-case, not the lowercased
+  // header_order slugs).
   const pairs = toPairs(init.headers);
   const present = new Set(pairs.map(([k]) => k.toLowerCase()));
   const tail: Array<[string, string]> = [];
+  if (!present.has('connection')) tail.push(['Connection', 'keep-alive']);
   if (!present.has('host')) tail.push(['Host', u.host]);
+  if (!present.has('accept-encoding')) tail.push(['Accept-Encoding', 'gzip, deflate, br, zstd']);
   if (!present.has('content-length') && !present.has('transfer-encoding')) {
     tail.push(['Content-Length', String(bodyBuf.length)]);
   }
@@ -178,18 +184,22 @@ export function rawUpstreamFetch(
     function errorStream(e: unknown) { if (ctrl && !bodyClosed) { bodyClosed = true; try { ctrl.error(e); } catch { /* already closed */ } } }
     function destroy() { try { closeSocket?.(); } catch { /* socket already gone */ } }
 
-    function setupDecode() {
+    // Returns false when content-encoding is set but not one we can decode, so
+    // the caller fails the request loudly rather than passing compressed bytes
+    // through as if they were the plaintext body (silent corruption). gzip,
+    // deflate, br and zstd are all decodable under both Bun and Node.
+    function setupDecode(): boolean {
+      if (ce === '' || ce === 'identity') { decode = null; return true; }
       if (ce === 'gzip' || ce === 'x-gzip') decode = zlib.createGunzip();
       else if (ce === 'deflate') decode = zlib.createInflate();
       else if (ce === 'br') decode = zlib.createBrotliDecompress();
       else if (ce === 'zstd' && 'createZstdDecompress' in zlib) {
         decode = (zlib as unknown as { createZstdDecompress(): Transform }).createZstdDecompress();
-      } else decode = null;
-      if (decode) {
-        decode.on('data', (d: Buffer) => enqueue(d));
-        decode.on('end', () => endStream());
-        decode.on('error', (e) => errorStream(e));
-      }
+      } else return false;
+      decode.on('data', (d: Buffer) => enqueue(d));
+      decode.on('end', () => endStream());
+      decode.on('error', (e) => errorStream(e));
+      return true;
     }
     function onBodyBytes(b: Buffer) { if (decode) decode.write(b); else enqueue(b); }
     // Body is logically complete (chunk terminator seen, content-length reached,
@@ -240,7 +250,12 @@ export function rawUpstreamFetch(
           // as fetch strips them after auto-decompression.
           respHeaders.append(name, val);
         }
-        setupDecode();
+        if (!setupDecode()) {
+          const e = new Error(`unsupported content-encoding: ${ce}`);
+          if (!resolved) reject(e);
+          destroy();
+          return;
+        }
         acc = acc.subarray(end + 4);
         phase = 'body';
         resolved = true;

--- a/test/raw-transport.mjs
+++ b/test/raw-transport.mjs
@@ -81,6 +81,30 @@ function startFixedMock({ status = 400, body = '{"error":"bad"}' } = {}) {
   return new Promise((res) => server.listen(0, '127.0.0.1', () => res({ port: server.address().port, close: () => server.close() })));
 }
 
+// Mock upstream: whole-body compressed with `encoding`, sent chunked. Used to
+// cover br decode and the unsupported-encoding path. For an encoding we don't
+// recognize (e.g. 'snappy') the raw body is sent under that header.
+function startEncodedMock({ encoding = 'identity', body = 'DATA' } = {}) {
+  const server = net.createServer((sock) => {
+    let buf = Buffer.alloc(0);
+    sock.on('data', (d) => {
+      buf = Buffer.concat([buf, d]);
+      if (buf.indexOf('\r\n\r\n') === -1) return;
+      let payload = Buffer.from(body), ce = '';
+      if (encoding === 'gzip') { payload = zlib.gzipSync(payload); ce = 'Content-Encoding: gzip\r\n'; }
+      else if (encoding === 'br') { payload = zlib.brotliCompressSync(payload); ce = 'Content-Encoding: br\r\n'; }
+      else if (encoding && encoding !== 'identity') ce = `Content-Encoding: ${encoding}\r\n`;
+      sock.write('HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n' + ce + 'Transfer-Encoding: chunked\r\n\r\n');
+      const mid = Math.ceil(payload.length / 2);
+      sock.write(httpChunk(payload.subarray(0, mid)));
+      sock.write(httpChunk(payload.subarray(mid)));
+      sock.write('0\r\n\r\n'); sock.end(); server.close();
+    });
+    sock.on('error', () => {});
+  });
+  return new Promise((res) => server.listen(0, '127.0.0.1', () => res({ port: server.address().port, close: () => server.close() })));
+}
+
 async function readAll(resp) {
   const reader = resp.body.getReader();
   const dec = new TextDecoder();
@@ -123,7 +147,10 @@ async function main() {
     check('sent header order preserved (session before auth)', iSession >= 0 && iSession < iAuth);
     check('NOT alphabetized (Accept-* would sort first under fetch)', names[0] === 'X-Claude-Code-Session-Id');
     check('no undici-injected accept-language/sec-fetch-*', !names.some((n) => /accept-language|sec-fetch/i.test(n)));
-    check('Host + Content-Length synthesized at tail', names.includes('Host') && names.includes('Content-Length'));
+    check('transport headers in CC tail order (Connection·Host·Accept-Encoding·Content-Length)',
+      JSON.stringify(names.slice(-4)) === JSON.stringify(['Connection', 'Host', 'Accept-Encoding', 'Content-Length']));
+    const aeLine = mock.state.reqHead.split('\r\n').find((l) => /^Accept-Encoding:/.test(l)) || '';
+    check('Accept-Encoding value = CC set (gzip, deflate, br, zstd)', aeLine.includes('gzip, deflate, br, zstd'));
   }
 
   header('gzip chunked SSE — content-encoding decoded, not surfaced');
@@ -133,6 +160,24 @@ async function main() {
     check('content-encoding stripped (body already decoded)', resp.headers.get('content-encoding') === null);
     const text = await readAll(resp);
     check('gzip SSE reconstructed', text.includes('message_start') && text.includes('"text":"Hi"') && text.includes('message_stop'));
+  }
+
+  header('br content-encoding — decoded, not surfaced');
+  {
+    const mock = await startEncodedMock({ encoding: 'br', body: 'brotli-decoded-ok' });
+    const resp = await rawUpstreamFetch(`http://127.0.0.1:${mock.port}/v1/messages`, { method: 'POST', headers: ORDERED, body: '{}' }, nodeFactory);
+    check('content-encoding stripped', resp.headers.get('content-encoding') === null);
+    check('br body decoded', (await readAll(resp)) === 'brotli-decoded-ok');
+  }
+
+  header('unsupported content-encoding — fails loud (no silent corruption)');
+  {
+    const mock = await startEncodedMock({ encoding: 'snappy', body: 'raw' });
+    let msg = null;
+    try { await rawUpstreamFetch(`http://127.0.0.1:${mock.port}/v1/messages`, { method: 'POST', headers: ORDERED, body: '{}' }, nodeFactory); }
+    catch (e) { msg = e.message; }
+    mock.close();
+    check('rejects rather than passing bytes through', /unsupported content-encoding/.test(msg || ''));
   }
 
   header('content-length body — .text() on an error response');


### PR DESCRIPTION
Hardening follow-ups to #815, closing two of the three items I flagged in that PR. All in `src/raw-transport.ts`.

## 1. Exact transport-header tail order

#815 appended `Host` + `Content-Length` at the tail. CC's captured `header_order` ends with **`connection · host · accept-encoding · content-length`**, and dario doesn't set any of those itself (it relied on `fetch` to add them). The transport now synthesizes all four in that exact order with CC-faithful values:

- `Connection: keep-alive`
- `Host: <url host>`
- `Accept-Encoding: gzip, deflate, br, zstd` (CC's advertised set — vs undici's `br, gzip, deflate`)
- `Content-Length: <n>`

Casing matches CC's wire request (mixed-case), not the lowercased `header_order` slugs. Each is skipped if the caller already supplied it.

## 2. br/zstd decode + fail-loud on the rest

Confirmed `createBrotliDecompress` **and** `createZstdDecompress` exist under both Bun and Node, so all four encodings dario advertises (gzip/deflate/br/zstd) actually decode. And the silent-corruption hole is closed: an encoding we *can't* decode now **fails the request** (`unsupported content-encoding: …`) instead of passing the compressed bytes through as if they were the body.

## Tests

`test/raw-transport.mjs` extended — **20/20 green**:
- transport headers appear in CC's exact tail order; `Accept-Encoding` value asserted
- br body decoded + `content-encoding` stripped
- unsupported encoding (`snappy`) → rejects rather than corrupts

## Remaining #815 follow-up (not this PR)

Confirming `Bun.connect == fetch` JA3 on the **Linux prod** platform + a real TLS round-trip before the flag is ever flipped in prod — that's the validation step, tracked separately.

Follow-up to #815; addresses more of finding #2 from #813.
