### PR TITLE
fix(auto-merge): arm auto-merge on bot/template-label- PRs too

### DIFF
--- a/.github/workflows/auto-merge-bot-prs.yml
+++ b/.github/workflows/auto-merge-bot-prs.yml
@@ -38,12 +38,13 @@ jobs:
       contents: write
       pull-requests: write
     runs-on: ubuntu-latest
-    # Broader job-level filter: any dependabot PR OR any cc-drift bot PR
-    # gets the runner. Major-version gating is enforced at step level
+    # Broader job-level filter: any dependabot PR OR any cc-drift / template-label
+    # bot PR gets the runner. Major-version gating is enforced at step level
     # using structured Dependabot metadata.
     if: |
       github.event.pull_request.user.login == 'dependabot[bot]' ||
-      startsWith(github.event.pull_request.head.ref, 'bot/cc-drift-')
+      startsWith(github.event.pull_request.head.ref, 'bot/cc-drift-') ||
+      startsWith(github.event.pull_request.head.ref, 'bot/template-label-')
     steps:
       - name: Fetch Dependabot metadata
         id: dep_meta
@@ -54,7 +55,8 @@ jobs:
 
       - name: Enable auto-merge
         # Dependabot path: only when update-type is NOT major.
-        # Drift-bot path: always (no metadata to read; branch name is the gate).
+        # Drift-bot path (cc-drift + template-label): always (no metadata to read;
+        # branch name is the gate). Same-repo guard blocks fork spoofing.
         if: |
           (
             github.event.pull_request.user.login == 'dependabot[bot]' &&
@@ -62,7 +64,10 @@ jobs:
           ) ||
           (
             github.event.pull_request.head.repo.full_name == github.repository &&
-            startsWith(github.event.pull_request.head.ref, 'bot/cc-drift-')
+            (
+              startsWith(github.event.pull_request.head.ref, 'bot/cc-drift-') ||
+              startsWith(github.event.pull_request.head.ref, 'bot/template-label-')
+            )
           )
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## The gap

`auto-merge-bot-prs.yml` reliably arms native auto-merge on bot PRs when they open — but its branch filter only matched `bot/cc-drift-`. Label-refresh PRs land on `bot/template-label-` branches, so they fell through and depended solely on `cc-drift-template-watch.yml`'s inline `gh pr merge --auto`, which is best-effort (`|| echo warning`) and can silently fail.

It did fail on #840: the PR opened, CI ran, `sprayberry-reviewer` approved — but auto-merge was never armed, so it sat until it was armed by hand. Every `bot/template-label-` PR was one flaky arm away from the same stall.

## The change

Add `bot/template-label-` to both the job-level filter and the enable-step condition, alongside `bot/cc-drift-`. Same low-risk class: an empty-`computeDrift` label refresh is byte-identical wire shape — the workflow already auto-merges the equivalent `maxTested` bump. The same-repo guard (`head.repo.full_name == github.repository`) is preserved so a fork can't spoof it, and `bot/template-rebake-` is deliberately left out — shape rebakes still get human review.

Required checks still gate the merge; this only closes the arming gap.
