### PR TITLE
security: clear Scorecard alert #42 — bump tar in .clusterfuzzlite lockfile + widen dependabot npm coverage

### DIFF
--- a/.clusterfuzzlite/package-lock.json
+++ b/.clusterfuzzlite/package-lock.json
@@ -1082,9 +1082,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,45 @@ updates:
       prefix: chore
       include: scope
 
+  # Build-side fuzz deps (ClusterFuzzLite; see .clusterfuzzlite/build.sh).
+  # Committed lockfile — watched here so vulns like GHSA-r292-9mhp-454m
+  # (node-tar) get a version-update PR instead of only surfacing via
+  # Scorecard's osv-scanner.
+  - package-ecosystem: npm
+    directory: /.clusterfuzzlite
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 10
+    groups:
+      non-major:
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: chore
+      include: scope
+
+  # Drift-probe deps — committed lockfile, same rationale as above.
+  - package-ecosystem: npm
+    directory: /.github/drift-probe-deps
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 10
+    groups:
+      non-major:
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: chore
+      include: scope
+
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
Clears Scorecard code-scanning alert #42 (GHSA-r292-9mhp-454m: node-tar <=7.5.20 uncontrolled recursion in mapHas/filesFilter → uncatchable stack-overflow DoS).

## Context (not an incident, a free fix)
`tar` is a **build-only** dep of the ClusterFuzzLite fuzz container (`@jazzer.js/core@4.0.0` → `cmake-js@8.0.0` → `tar ^7.5.6`, used in `.clusterfuzzlite/build.sh` to unpack Node headers from nodejs.org). dario declares zero runtime deps and ships `files: ["dist","README.md","LICENSE"]`, so tar never enters the published tarball or the proxy runtime. No user-facing impact.

## Two changes, one PR
1. **`.clusterfuzzlite/package-lock.json`** — lockfile-only bump `tar 7.5.20 → 7.5.22` (patched). The declared range `^7.5.6` already permitted it, so no manifest edit. Integrity hashes regenerated intact.
2. **`.github/dependabot.yml`** — register npm for `/.clusterfuzzlite` and `/.github/drift-probe-deps` (their committed lockfiles were watched by nothing → Dependabot had 0 alerts, which is why Scorecard's osv-scanner caught this instead of Dependabot). Matches the existing weekly Mon 09:00 UTC schedule, non-major grouping, and `chore` scope prefix so this class self-heals in future.

## No release
No `dist/` change, no version bump, no CHANGELOG entry, `SUPPORTED_CC_RANGE.maxTested` untouched.

## Verification
- `npm ci` in `.clusterfuzzlite/` resolves clean: `added 105 packages, audited 106, found 0 vulnerabilities`.
- Lockfile diff touches only the `tar` entry (version/resolved/integrity), nothing else.
- Expect Scorecard's next run to clear alert #42 to fixed after merge.

Source ticket: DEV-0a431669