### PR TITLE
fix(tui): close every SGR attribute truncate() opens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ checklist.
 
 ## [Unreleased]
 
+## [5.4.4] - 2026-07-25
+
+- **`truncate()` dropped the closing code of any style span it cut through.** The walk stopped the moment it had emitted `maxWidth` visible characters and returned immediately, so every escape sequence past the cut point was discarded — including the `\x1b[22m` / `\x1b[39m` that `dim()` and `fg()` append. A clipped span left its attribute switched on.
+
+- **The leak escaped the line, and the frame.** `App.redraw` writes `clearScreen + frame`, and `\x1b[2J\x1b[H` does not reset SGR; `renderFooter` ends on plain text, so nothing closed the attribute before the frame did. The dim carried into the *next* frame's header and tab strip, clearing only at the `dim('─')` separator on row 3 — and every frame re-leaked it.
+
+- **Surfaced by the Config viewport fix (#861).** That change made Config rows `truncate(… + dim(hint), w)`; at 80 columns the value column clamps to 16, leaving hints 32 characters, so 7 of the 14 clip on a default-width terminal. The underlying bug predates it — `renderFooter` already leaked cyan at 11 widths between 4 and 60. `hits.ts` was checked across columns 20–160 and is unaffected: its cut always lands clear of the colored status column.
+
+- **Fixed by replaying the clipped remainder's own SGR codes**, not by appending a blanket reset. `config.ts` wraps the truncated row in `inverse()`, and an inner `\x1b[0m` would end the highlight before the row's trailing padding, dropping it off the right edge of the selected row. Openers whose content was clipped arrive paired with their closers, so they render as a no-op.
+
+- **Tests:** `test/tui-tabs.mjs` gains an SGR-balance pass — a control assertion so the checker cannot pass vacuously, direct `truncate()` cuts at six widths, the `inverse()`-preservation case that rules out the reset, a Config sweep over six geometries with a full selection walk, and a `renderFooter` width sweep. Confirmed to fail 8 assertions against the pre-fix build (134 leaking Config lines at 80×24, 11 leaking footer widths) and pass after.
+
 ## [5.4.3] - 2026-07-25
 
 - **Template rebake** — re-captured `src/cc-template-data.json` after cc-drift-template-watch detected wire-fingerprint drift against a live CC capture. Bundled fallback template now matches the current CC wire shape.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.4.3",
+  "version": "5.4.4",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -162,7 +162,15 @@ export function truncate(text: string, maxWidth: number, ellipsis: string = '…
     visible++;
     i++;
   }
-  return out + ellipsis;
+  // Flush SGR sequences from the clipped remainder. Without this, a cut
+  // that lands inside a dim()/fg() block drops the closing code, leaving
+  // the attribute open — it then bleeds into the following line, and past
+  // the frame entirely (clearScreen does not reset SGR). Replaying the
+  // remainder's own codes rather than appending a blanket reset keeps an
+  // enclosing inverse() wrapper intact; clipped openers arrive paired
+  // with their closers, so they render as a no-op.
+  const tail = text.slice(i).match(/\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]/g);
+  return out + ellipsis + (tail ? tail.join('') : '');
 }
 
 /** Pad `text` (right-aligned by default 'left' fills right side) to `width`. */

--- a/test/tui-tabs.mjs
+++ b/test/tui-tabs.mjs
@@ -12,7 +12,8 @@ import { AnalyticsTab } from '../dist/tui/tabs/analytics.js';
 import { HitsTab } from '../dist/tui/tabs/hits.js';
 import { AccountsTab } from '../dist/tui/tabs/accounts.js';
 import { BackendsTab } from '../dist/tui/tabs/backends.js';
-import { visibleWidth } from '../dist/tui/render.js';
+import { visibleWidth, truncate, dim, inverse, pad } from '../dist/tui/render.js';
+import { renderFooter } from '../dist/tui/layout.js';
 
 let pass = 0, fail = 0;
 function check(name, cond, detail) {
@@ -383,6 +384,95 @@ header('Config tab — body fits its row budget at every size');
   }
   check('scrolled to bottom: last field visible',
     ConfigTab.render(s, dimv).includes('Overage OS-notify'));
+}
+
+// ─────────────────────────────────────────────────────────────
+header('truncate() closes every SGR attribute it opens');
+{
+  // A cut that lands inside a dim()/fg() span used to drop that span's
+  // closing code, because the walk stops at `visible === target` and
+  // returned immediately. The attribute then stayed on: it bled into
+  // the next line and past the frame entirely, since App.redraw writes
+  // `clearScreen + frame` and \x1b[2J\x1b[H does not reset SGR.
+  const DEFAULT = { intensity: 0, underline: 0, inverse: 0, fg: 39, bg: 49 };
+
+  // Replay a line's SGR codes and report the attributes left active.
+  function sgrStateAtEnd(line) {
+    const st = { ...DEFAULT };
+    for (const m of line.matchAll(/\x1b\[([0-9;]*)m/g)) {
+      const ps = m[1] === '' ? [0] : m[1].split(';').map(Number);
+      for (let i = 0; i < ps.length; i++) {
+        const p = ps[i];
+        if (p === 0) Object.assign(st, DEFAULT);
+        else if (p === 1 || p === 2) st.intensity = p;
+        else if (p === 22) st.intensity = 0;
+        else if (p === 4) st.underline = 4;
+        else if (p === 24) st.underline = 0;
+        else if (p === 7) st.inverse = 7;
+        else if (p === 27) st.inverse = 0;
+        else if (p === 38 || p === 48) {
+          const k = p === 38 ? 'fg' : 'bg';
+          if (ps[i + 1] === 5) { st[k] = p; i += 2; }
+          else if (ps[i + 1] === 2) { st[k] = p; i += 4; }
+        }
+        else if ((p >= 30 && p <= 37) || (p >= 90 && p <= 97)) st.fg = p;
+        else if (p === 39) st.fg = 39;
+        else if ((p >= 40 && p <= 47) || (p >= 100 && p <= 107)) st.bg = p;
+        else if (p === 49) st.bg = 49;
+      }
+    }
+    return st;
+  }
+  const balanced = (line) => JSON.stringify(sgrStateAtEnd(line)) === JSON.stringify(DEFAULT);
+
+  // The checker must be able to fail, or everything below is vacuous.
+  check('control: an unbalanced line IS detected', !balanced('x \x1b[2mclipped'));
+  check('control: a balanced line is NOT flagged', balanced(dim('fine') + ' plain'));
+
+  // Cut inside a trailing dim() span at a spread of widths.
+  const styled = '  label:  value  ' + dim('— halt proxy on any representative-claim=overage');
+  for (const w of [20, 30, 40, 60, 80, 100]) {
+    const t = truncate(styled, w);
+    check(`truncate w=${w}: within width`, visibleWidth(t) <= w, `got ${visibleWidth(t)}`);
+    check(`truncate w=${w}: no attribute left open`, balanced(t), JSON.stringify(sgrStateAtEnd(t)));
+  }
+
+  // The fix replays the clipped remainder's own codes rather than
+  // appending a blanket reset — a reset would end an enclosing
+  // inverse() before the row's trailing padding, dropping the
+  // highlight off the right edge of the selected row.
+  {
+    const w = 80;
+    const raw = '  ' + pad('Overage-guard:', 26) + pad('true', 16) + '  ' +
+      dim('— halt proxy on any representative-claim=overage');
+    const row = inverse(pad(truncate(raw, w), w));
+    check('selected row: no blanket reset inside', !/\x1b\[0m/.test(row));
+    check('selected row: inverse survives to the end of the padding',
+      sgrStateAtEnd(row.slice(0, row.lastIndexOf('\x1b[27m'))).inverse === 7);
+    check('selected row: balanced overall', balanced(row));
+  }
+
+  // Config rows end in a dim() hint, so this is the tab that clips one
+  // on a default-width terminal. Walk the selection at each geometry.
+  for (const [cols, rows] of [[40, 8], [60, 20], [80, 24], [100, 30], [120, 40], [200, 50]]) {
+    let s = ConfigTab.initialState();
+    let leaks = 0;
+    for (let i = 0; i < 20; i++) {
+      for (const line of ConfigTab.render(s, { cols, rows: rows - 5 }).split('\n')) {
+        if (!balanced(line)) leaks++;
+      }
+      s = ConfigTab.onKey(s, { name: 'down', ch: '', ctrl: false, shift: false, meta: false }) ?? s;
+    }
+    check(`Config ${cols}x${rows}: no line leaves an attribute open`, leaks === 0, `${leaks} leaking lines`);
+  }
+
+  // renderFooter truncates cyan key hints and hit the same bug.
+  {
+    const hints = [{ key: 'Tab', label: 'next tab' }, { key: 'q', label: 'quit' }, { key: 'r', label: 'refresh' }];
+    let leaks = 0;
+    for (let cols = 4; cols <= 60; cols++) if (!balanced(renderFooter(cols, hints))) leaks++;
+    check('renderFooter: no width leaves an attribute open', leaks === 0, `${leaks} leaking widths`);
+  }
 }
 
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

`truncate()` (`src/tui/render.ts`) counted visible width correctly but exited its walk the moment `visible === target` and returned `out + ellipsis` — **every escape sequence past the cut point was discarded**, including the `\x1b[22m` / `\x1b[39m` that `dim()` and `fg()` append. A cut landing inside a styled span left that attribute switched on.

The leak escaped the frame, not just the line. `App.redraw` writes `clearScreen + frame` (`src/tui/app.ts:215`) and `\x1b[2J\x1b[H` does not reset SGR; `renderFooter` ends on plain text, so nothing closed the attribute before the frame did. The dim carried into the *next* frame's header and tab strip, clearing only at the `dim('─')` separator on row 3 — and every frame re-leaked it.

**Surfaced by #861.** That fix made Config rows `truncate(… + dim(hint), w)`. At 80 columns the value column clamps to 16, so the row prefix is 44 and hints get 32 visible characters — **7 of the 14 hints clip on a default-width terminal.** The underlying bug predates #861: `renderFooter` already leaked cyan at 11 widths between 4 and 60.

`hits.ts:213` was checked and is **unaffected** — swept columns 20–160 with a populated buffer, zero leaks, because its cut always lands clear of the colored status column.

## The fix

Replay the clipped remainder's own SGR codes:

```ts
const tail = text.slice(i).match(/\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]/g);
return out + ellipsis + (tail ? tail.join('') : '');
```

Not a blanket `reset`, which would look simpler but breaks the selected row: `config.ts` wraps the already-truncated row in `inverse(...)`, and an inner `\x1b[0m` would end the highlight before the row's trailing padding, dropping it off the right edge. Openers whose content was clipped arrive paired with their closers, so they render as a no-op.

## How to test

```
npm run build
node dist/cli.js tui     # press `c`
```

Before: the Config hints clip and everything after the first clipped row renders dim, including the header and tab strip. After: attributes close at the cut.

## Tests

`test/tui-tabs.mjs` gains an SGR-balance pass that replays each line's codes and asserts nothing is left active at its end:

- a **control assertion** that the checker flags a known-unbalanced string, so the suite cannot pass vacuously
- direct `truncate()` cuts at six widths through a trailing `dim()` span
- the `inverse()`-preservation case that rules out the blanket-reset fix
- a Config sweep over six geometries with a full selection walk
- a `renderFooter` sweep across widths 4–60

Verified it pins the bug: reverting `render.ts` fails **8 assertions** (134 leaking Config lines at 80×24, 151 at 60×20, 11 leaking footer widths). Full suite is 121/121 with the fix.

## Checklist
- [x] `npm run build` passes
- [x] `npm test` passes — 121/121
- [x] For changes that touch `proxy.ts`, `cc-template.ts`, or streaming behavior: n/a, TUI render path only
- [x] No new runtime dependencies added
- [x] No tokens/secrets in code or logs
- [x] Version bumped (5.4.3 → 5.4.4) + CHANGELOG section, validated with `extract-release-notes.mjs 5.4.4` and `check-package-json.mjs`
