### PR TITLE
fix(tui): bound every Hits row to the terminal width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ checklist.
 
 ## [Unreleased]
 
+## [5.4.5] - 2026-07-25
+
+- **The Hits tab pushed its chrome rows with no width bound.** Data rows were already truncated to `w - 2` and the detail pane is bounded by `renderKvRow`, but the title, column header, empty-state copy, scroll hint and halt banner were not — so they wrapped onto a second physical line. `renderTui` measures body height with `body.split('\n').length` (`tui-app.ts:282`), a logical count blind to wrapping, and `App.redraw` writes after a bare `clearScreen` with the cursor at home, so each surplus physical row pushed the head of the panel off the top of the alt-screen. Same mechanism as the Config overflow fixed in 5.4.3.
+
+- **Measured across columns 30–160:** the halt banner was 105 and 106 wide, the SSE-error hint 106 (its upstream error text is unbounded entirely), the empty-state copy 67, the column header a fixed 56, and the no-selection hint 41.
+
+- **The halt banner was the one that mattered.** It is pinned visible while scrolling (#288) and its width scales with the account and model strings, so it wrapped on a standard 80-column terminal every time it appeared — precisely when the user needs to read it. Rather than clip it, both lines are reflowed most-actionable-first and now measure **78 and 52** at 80 columns: claim, time, short model and account on the first; the resume path (`R` / `dario resume`) and auto-resume countdown on the second. The account sits last so a narrow terminal clips the least-critical field, and the resume instructions fit outright.
+
+- **The column header now truncates to `w - 2`**, the same budget the data rows use, so the columns stay aligned instead of the header running two characters wider than the rows beneath it.
+
+- **Tests:** `test/tui-tabs.mjs` sweeps all six Hits states — connecting, waiting, SSE error, populated, halted, no-selection — across columns 30–160 and asserts no row exceeds `cols`, plus that the halt banner fits 80 *without* being clipped to get there. Confirmed to fail 8 assertions against the pre-fix build and pass after.
+
+- Closes #862.
+
 ## [5.4.4] - 2026-07-25
 
 - **`truncate()` dropped the closing code of any style span it cut through.** The walk stopped the moment it had emitted `maxWidth` visible characters and returned immediately, so every escape sequence past the cut point was discarded — including the `\x1b[22m` / `\x1b[39m` that `dim()` and `fg()` append. A clipped span left its attribute switched on.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.4.4",
+  "version": "5.4.5",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/tui/tabs/hits.ts
+++ b/src/tui/tabs/hits.ts
@@ -140,15 +140,16 @@ export const HitsTab: Tab<HitsState> = {
     const listRows = Math.max(3, totalRows - detailRows - 2);
 
     if (state.buffer.length === 0) {
-      lines.push(' ' + brand('Hits') + dim('  — live request stream'));
+      lines.push(truncate(' ' + brand('Hits') + dim('  — live request stream'), w));
       lines.push('');
       if (state.connectionError) {
-        lines.push('  ' + fg('red', `SSE error: ${state.connectionError}`));
-        lines.push('  ' + dim('Is `dario proxy` running? The stream reconnects automatically on the next mount.'));
+        // The error text is upstream-supplied and unbounded.
+        lines.push(truncate('  ' + fg('red', `SSE error: ${state.connectionError}`), w));
+        lines.push(truncate('  ' + dim('Is `dario proxy` running? The stream reconnects automatically on the next mount.'), w));
       } else if (!state.subscribed) {
-        lines.push('  ' + dim('Connecting to /analytics/stream …'));
+        lines.push(truncate('  ' + dim('Connecting to /analytics/stream …'), w));
       } else {
-        lines.push('  ' + dim('Waiting for requests. Send one through dario to see it land here.'));
+        lines.push(truncate('  ' + dim('Waiting for requests. Send one through dario to see it land here.'), w));
       }
       return lines.join('\n');
     }
@@ -165,29 +166,37 @@ export const HitsTab: Tab<HitsState> = {
     const colModel = 18;
     const colIn = 8, colOut = 7, colLat = 7, colStatus = 5;
 
-    lines.push(' ' + brand('Hits') +
-      dim(`  ${state.buffer.length} buffered · ${state.subscribed ? fg('green', 'live') : fg('yellow', 'disconnected')}`));
+    lines.push(truncate(' ' + brand('Hits') +
+      dim(`  ${state.buffer.length} buffered · ${state.subscribed ? fg('green', 'live') : fg('yellow', 'disconnected')}`), w));
 
     // ── Overage-halt banner (v4.1, dario#288) ──────────────────
     // Pinned at the top so it's always visible while scrolling the buffer.
+    //
+    // Both lines are ordered most-actionable-first and kept short enough
+    // to fit 80 columns, because a banner that wraps costs a second
+    // physical row and pushes the panel head off the top of the screen —
+    // and it wraps exactly when the user needs to read it. The account is
+    // last on line 1 so a narrow terminal clips the least-critical field;
+    // the resume instructions on line 2 fit outright.
     if (state.halt) {
       const since = formatTimestamp(state.halt.since);
       const cooldown = formatRemaining(state.halt.cooldownUntil - Date.now());
-      const line1 = `  ${fg('red', '⚠ HALTED')}  ${state.halt.request.claim} detected at ${since} on ${state.halt.request.model}  (account=${state.halt.request.account})`;
-      const line2 = `  ${dim('→ New /v1/messages requests return 503 until')} ${fg('cyan', 'R')} ${dim('here, or')} ${fg('cyan', 'dario resume')}${dim(' from any shell. Auto-resume in')} ${cooldown}${dim('.')}`;
-      lines.push(line1);
-      lines.push(line2);
+      const line1 = `  ${fg('red', '⚠ HALTED')}  ${state.halt.request.claim} · ${since} · ${shortenModel(state.halt.request.model)} · ${dim(state.halt.request.account)}`;
+      const line2 = `  ${dim('→ 503 until')} ${fg('cyan', 'R')} ${dim('or')} ${fg('cyan', 'dario resume')} ${dim(`· auto-resume in ${cooldown}`)}`;
+      lines.push(truncate(line1, w));
+      lines.push(truncate(line2, w));
     }
     lines.push('');
-    // Header row (aligned with data rows)
-    lines.push('  ' + dim(
+    // Header row — truncated to the same budget as the data rows below
+    // (`w - 2`) so the columns stay aligned when the terminal is narrow.
+    lines.push(truncate('  ' + dim(
       pad('time', colTime) +
       pad('model', colModel) +
       pad('in', colIn) +
       pad('out', colOut) +
       pad('lat', colLat) +
       pad('st', colStatus)
-    ));
+    ), w - 2));
 
     for (let i = startIdx; i < endIdx; i++) {
       const r = newestFirst[i];
@@ -216,11 +225,11 @@ export const HitsTab: Tab<HitsState> = {
 
     // Scroll hint
     if (newestFirst.length > listRows) {
-      lines.push(' ' + dim(
+      lines.push(truncate(' ' + dim(
         `${state.selectedIdx + 1} / ${newestFirst.length}  ` +
         (startIdx > 0 ? '↑ more ' : '') +
         (endIdx < newestFirst.length ? '↓ more' : '')
-      ));
+      ), w));
     }
 
     // Separator
@@ -229,7 +238,7 @@ export const HitsTab: Tab<HitsState> = {
     // Detail pane
     if (state.selectedIdx >= 0 && state.selectedIdx < newestFirst.length) {
       const r = newestFirst[state.selectedIdx];
-      lines.push('  ' + brand('Selected') + dim(`  ${formatTime(r.timestamp)}`));
+      lines.push(truncate('  ' + brand('Selected') + dim(`  ${formatTime(r.timestamp)}`), w));
       lines.push('  ' + renderKvRow('Account', r.account, w - 4));
       lines.push('  ' + renderKvRow('Model', r.model, w - 4));
       lines.push('  ' + renderKvRow('Billing bucket', billingBucketFromClaim(r.claim), w - 4));
@@ -240,7 +249,7 @@ export const HitsTab: Tab<HitsState> = {
       lines.push('  ' + renderKvRow('Status', formatStatus(r.status), w - 4));
     } else {
       lines.push('');
-      lines.push('  ' + dim('Use ↑↓ to select a request for details.'));
+      lines.push(truncate('  ' + dim('Use ↑↓ to select a request for details.'), w));
     }
 
     return lines.join('\n');

--- a/test/tui-tabs.mjs
+++ b/test/tui-tabs.mjs
@@ -476,5 +476,69 @@ header('truncate() closes every SGR attribute it opens');
 }
 
 // ─────────────────────────────────────────────────────────────
+header('Hits tab — no row exceeds the terminal width');
+{
+  // The data rows were already truncated and the detail pane is bounded
+  // by renderKvRow, but the tab's chrome — title, halt banner, column
+  // header, empty-state copy, scroll hint — was pushed unbounded. A row
+  // wider than `cols` wraps onto a second physical line, and renderTui
+  // measures body height with a logical line count (tui-app.ts:282), so
+  // the surplus pushes the panel head off the top of the screen. See #862.
+  const rec = (i, status, claim) => ({
+    timestamp: 1753480000000 + i * 1000,
+    account: 'thomas@sprayberrylabs.com',
+    model: 'claude-opus-4-5-20260101',
+    inputTokens: 12345, outputTokens: 6789,
+    cacheReadTokens: 1024, cacheCreateTokens: 512, thinkingTokens: 256,
+    claim, util5h: 0.42, util7d: 0.17, overageUtil: 0,
+    latencyMs: 1234, status, isStream: true, isOpenAI: false,
+  });
+  const buffer = [rec(0, 200, 'subscription'), rec(1, 429, 'overage'), rec(2, 500, 'api'), rec(3, 404, 'subscription')];
+  const halt = {
+    since: 1753480000000,
+    cooldownUntil: 1753481800000,
+    request: { claim: 'overage', model: 'claude-opus-4-5-20260101', account: 'thomas@sprayberrylabs.com' },
+  };
+
+  const STATES = {
+    'connecting':   (s) => { s.buffer = []; s.subscribed = false; },
+    'waiting':      (s) => { s.buffer = []; s.subscribed = true; },
+    'sse error':    (s) => { s.buffer = []; s.connectionError = 'connect ECONNREFUSED 127.0.0.1:3456 — upstream closed the stream unexpectedly after 3 retries'; },
+    'populated':    (s) => { s.buffer = buffer; s.subscribed = true; },
+    'halted':       (s) => { s.buffer = buffer; s.subscribed = true; s.halt = halt; },
+    'no selection': (s) => { s.buffer = buffer; s.subscribed = true; s.selectedIdx = -1; },
+  };
+
+  for (const [label, mutate] of Object.entries(STATES)) {
+    let worst = 0, worstAt = null;
+    for (let cols = 30; cols <= 160; cols++) {
+      const s = HitsTab.initialState();
+      mutate(s);
+      for (const line of HitsTab.render(s, { cols, rows: 24 }).split('\n')) {
+        const over = visibleWidth(line) - cols;
+        if (over > worst) { worst = over; worstAt = `cols=${cols} width=${visibleWidth(line)}`; }
+      }
+    }
+    check(`Hits [${label}]: every row fits, cols 30-160`, worst === 0, worstAt);
+  }
+
+  // The halt banner is pinned visible while scrolling, so it has to fit a
+  // standard terminal outright — clipping it would hide the resume path.
+  {
+    const s = HitsTab.initialState();
+    s.buffer = buffer; s.subscribed = true; s.halt = halt;
+    const [l1, l2] = HitsTab.render(s, { cols: 80, rows: 24 }).split('\n').slice(1, 3);
+    // Both halves matter: within 80 (the pre-fix banner was 105/106) AND
+    // not clipped to get there, so the reflow is doing the work.
+    check('halt banner line 1 fits 80 unclipped',
+      visibleWidth(l1) <= 80 && !l1.includes('…'), `width=${visibleWidth(l1)}`);
+    check('halt banner line 2 fits 80 unclipped',
+      visibleWidth(l2) <= 80 && !l2.includes('…'), `width=${visibleWidth(l2)}`);
+    check('halt banner still names the claim', l1.includes('overage'));
+    check('halt banner still shows the resume path', l2.includes('dario resume'));
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
 console.log(`\n${pass} pass, ${fail} fail`);
 process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Closes #862.

## What does this PR do?

The Hits tab's data rows were already truncated to `w - 2` and the detail pane is bounded by `renderKvRow` — but the tab's **chrome** was pushed unbounded: title, column header, empty-state copy, scroll hint, and the halt banner. Those rows wrapped onto a second physical line.

That matters because `renderTui` measures body height with `body.split('\n').length` (`src/tui/tui-app.ts:282`), a logical count blind to wrapping, and `App.redraw` writes the frame after a bare `clearScreen` with the cursor at home (`src/tui/app.ts:215`). Every surplus physical row pushes the head of the panel off the top of the alt-screen — the same mechanism as the Config overflow fixed in 5.4.3.

## Measured, columns 30–160

| Row | Width | Wrapped when |
|---|---|---|
| Halt banner, line 2 | 106 | `cols < 106` |
| Halt banner, line 1 | 105 | `cols < 105` |
| SSE-error hint | 106 | `cols < 106` |
| Empty-state copy | 67 | `cols < 67` |
| Column header | 56 (fixed) | `cols < 56` |
| No-selection hint | 41 | `cols < 41` |

The SSE-error line is worse than its measured width suggests — it interpolates `state.connectionError`, which is upstream-supplied and unbounded.

## The halt banner

This is the row that actually hurt. It's pinned visible while scrolling (#288) and its width scales with the account and model strings, so it wrapped on a standard 80-column terminal **every time it appeared** — exactly when the user needs to read it.

Clipping it would hide the account and the resume instructions, so both lines are reflowed most-actionable-first instead:

```
  ⚠ HALTED  overage · 17:46:40 · opus-4-5-20260101 · thomas@sprayberrylabs.com   (78)
  → 503 until R or dario resume · auto-resume in 30m                             (52)
```

Down from 105/106. The account sits last so a narrow terminal clips the least-critical field, and the resume path fits outright. Everything is still truncated to `w` as a hard floor.

The column header now truncates to `w - 2` — the same budget the data rows use — so the columns stay aligned rather than the header running two characters wider than the rows beneath it.

## Tests

`test/tui-tabs.mjs` sweeps all six Hits states (connecting, waiting, SSE error, populated, halted, no-selection) across columns 30–160, asserting no row exceeds `cols`. Plus two assertions that the halt banner fits 80 **and** isn't clipped to get there — checking only "not clipped" would have passed against the pre-fix build, since nothing was truncating.

Verified it pins the bug: reverting `hits.ts` fails **8 assertions**. Full suite 121/121 with the fix.

## How to test

```
npm run build
node dist/cli.js tui     # press `h`, then resize narrow
```

## Checklist
- [x] `npm run build` passes
- [x] `npm test` passes — 121/121
- [x] For changes that touch `proxy.ts`, `cc-template.ts`, or streaming behavior: n/a, TUI render path only
- [x] No new runtime dependencies added
- [x] No tokens/secrets in code or logs
- [x] Version bumped (5.4.4 → 5.4.5) + CHANGELOG section, validated with `extract-release-notes.mjs 5.4.5` and `check-package-json.mjs`
