### PR TITLE
fix(tui): give each tab a real row budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ checklist.
 
 ## [Unreleased]
 
+## [5.4.9] - 2026-07-26
+
+- **Every tab now spends its own row budget instead of being clipped from the bottom.** 5.4.7 stopped the app writing frames taller than the terminal, but that fix is a floor: `renderTui` clips whatever sorts *last*. On Status that was the Overage-guard panel — so the one tab that tells you the proxy has HALTED hid the halt, the cause, the auto-resume countdown and the resume instructions, on a default 80×24 terminal. Closes #868.
+
+- **New `src/tui/panels.ts`.** A panel declares its full `lines`, an optional shorter `collapsed` form, a `priority`, and whether it is `required`. `fitPanels` degrades least-important-first — collapse everything that offers a shorter form, then drop what isn't required — and preserves *display* order, since users navigate by position and reordering panels under pressure would be its own surprise.
+
+- **Status** keeps Proxy and, when halted, Overage-guard; Models collapses to a count (`5 advertised`) then drops, and Config collapses to one row. HALTED and the resume path survive at every budget from 40 rows down to 14.
+
+- **Analytics** keeps the rate-limit gauges and the overage row — the "investigate immediately" signal — and collapses the per-model breakdown and billing buckets to summaries. It was a fixed 28 rows against a 19-row body budget.
+
+- **Hits** reserved 11 rows of chrome while rendering up to 15: the pinned halt banner was missing from the arithmetic entirely, and the detail pane is 8 rows, not the 9 reserved. The reservation is now derived from what the render actually emits, and on a terminal too short for both, the detail pane yields to the request list rather than the other way round.
+
+- **Backends** had no budget at all and pushed unbounded rows — a 70-wide column header and data rows interpolating `baseUrl`. Rows are bounded at the push site, the list windows to the available height, and a truncated list says how many backends are hidden.
+
+- **The overage gauge was mislabelled `Overa…`.** Its label column was 6 characters — narrower than the word "Overage" — so `pad` truncated it and left it flush against its bar. The gauge rows (5h / 7d / Overage) now share an 8-wide label column, so the row that means "investigate immediately" reads unambiguously.
+
+- **Two footers were unbounded** (`Updated <ago>…` on Analytics, `Last refresh: <ago>…` on Status). They had been invisible because an over-long body was clipped before reaching them; now that the tabs fit and reserve their footers, they render — and are bounded.
+
+- **Tests:** new `test/tui-budget.mjs` (79 assertions) covers `fitPanels` directly — collapse-before-drop, required panels surviving at the lowest priority, display order preserved — then asserts per tab that the body fits AND that the rows worth looking at survive: HALTED and the resume path on Status, the overage row on Analytics, the halt banner on Hits, width and height on Backends. Each of the four tabs was reverted individually and confirmed to fail (status 5, analytics 9, hits 12, backends 14 assertions). `test/tui-frame.mjs` gains an assertion that 80×24 no longer needs the frame clamp at all.
+
 ## [5.4.8] - 2026-07-26
 
 - **Template rebake** — re-captured `src/cc-template-data.json` after cc-drift-template-watch detected wire-fingerprint drift against a live CC capture. Bundled fallback template now matches the current CC wire shape.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.4.8",
+  "version": "5.4.9",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/tui/panels.ts
+++ b/src/tui/panels.ts
@@ -1,0 +1,78 @@
+/**
+ * Panel fitting — let a tab spend its row budget deliberately instead of
+ * rendering everything and being clipped from the bottom.
+ *
+ * Background (#862, #866, #868): tabs used to push every panel
+ * unconditionally. `renderTui` clips an over-long body so the header and
+ * tab strip survive, but clipping is dumb — it drops whatever happens to
+ * sort last. On the Status tab that was the Overage-guard panel, so the
+ * one tab that tells you the proxy has HALTED hid that fact first, on a
+ * default 80x24 terminal.
+ *
+ * The fix is for each tab to decide what to give up. A panel declares:
+ *
+ *   - `lines`      full rendering
+ *   - `collapsed`  a shorter stand-in (typically one summary row)
+ *   - `priority`   lower = more important; drives what degrades first
+ *   - `required`   never drop entirely, even if it doesn't fit
+ *
+ * `fitPanels` keeps DISPLAY order (the order given) and uses priority
+ * only to choose what degrades. Users navigate by position, so reordering
+ * panels under pressure would be its own kind of surprise.
+ */
+
+export interface Panel {
+  /** Full rendering, including the panel's own trailing blank line if it wants one. */
+  lines: string[];
+  /** Shorter stand-in used when the full form doesn't fit. */
+  collapsed?: string[];
+  /** Lower = more important. Least important degrades first. */
+  priority: number;
+  /** Never dropped entirely (it may still be collapsed). */
+  required?: boolean;
+}
+
+const size = (p: Panel, isCollapsed: boolean): number =>
+  (isCollapsed && p.collapsed ? p.collapsed : p.lines).length;
+
+/**
+ * Fit `panels` into `budget` rows.
+ *
+ * Degrades in two passes, least-important first: collapse everything that
+ * offers a `collapsed` form, then drop whole panels that aren't
+ * `required`. Returns the flattened lines in the original display order.
+ *
+ * If even the required panels overflow, the result is still returned
+ * over-budget — `renderTui`'s clamp is the final floor, and returning a
+ * truncated required panel here would hide the very thing marked
+ * essential.
+ */
+export function fitPanels(panels: Panel[], budget: number): string[] {
+  const collapsed = new Set<number>();
+  const dropped = new Set<number>();
+
+  const total = () => panels.reduce(
+    (n, p, i) => n + (dropped.has(i) ? 0 : size(p, collapsed.has(i))), 0);
+
+  // Least important first — ties broken by later position, so a trailing
+  // panel degrades before an equally-ranked one above it.
+  const byLeastImportant = panels
+    .map((p, i) => ({ p, i }))
+    .sort((a, b) => (b.p.priority - a.p.priority) || (b.i - a.i));
+
+  for (const { p, i } of byLeastImportant) {
+    if (total() <= budget) break;
+    if (p.collapsed && p.collapsed.length < p.lines.length) collapsed.add(i);
+  }
+  for (const { p, i } of byLeastImportant) {
+    if (total() <= budget) break;
+    if (!p.required) dropped.add(i);
+  }
+
+  const out: string[] = [];
+  panels.forEach((p, i) => {
+    if (dropped.has(i)) return;
+    out.push(...(collapsed.has(i) && p.collapsed ? p.collapsed : p.lines));
+  });
+  return out;
+}

--- a/src/tui/tabs/analytics.ts
+++ b/src/tui/tabs/analytics.ts
@@ -13,8 +13,9 @@
  */
 
 import type { Tab, TabContext } from '../tab.js';
-import { fg, dim, brand, progressBar, pad } from '../render.js';
+import { fg, dim, brand, progressBar, pad, truncate } from '../render.js';
 import { renderKvRow } from '../layout.js';
+import { fitPanels, type Panel } from '../panels.js';
 
 /** Subset of AnalyticsSummary the Analytics tab actually renders. */
 interface SummaryShape {
@@ -48,6 +49,15 @@ export interface AnalyticsState {
 }
 
 const POLL_INTERVAL_MS = 2000;
+
+/**
+ * Label column for the gauge rows (5h / 7d / Overage). Was 6, which is
+ * narrower than "Overage" — `pad` truncates rather than overflowing, so
+ * the row rendered as `Overa…` hard against its bar. That row is the
+ * "investigate immediately" signal, so it should be the one row that
+ * reads unambiguously.
+ */
+const GAUGE_LABEL_W = 8;
 
 export const AnalyticsTab: Tab<AnalyticsState> = {
   id: 'analytics',
@@ -114,61 +124,84 @@ export const AnalyticsTab: Tab<AnalyticsState> = {
 
     const s = state.summary;
 
+    // Panels are built full-size then fitted to the row budget. Rendering
+    // all of them unconditionally overflowed a default 80x24 terminal by
+    // four rows (#868); the clip took whatever sorted last rather than
+    // whatever mattered least.
+    const panels: Panel[] = [{ lines: [...lines], priority: 0, required: true }];
+    lines.length = 0;
+
     // ── Counters ───────────────────────────────────────────────
     const rpm = s.window.requests / Math.max(1, s.window.minutes);
-    lines.push('');
-    lines.push('  ' + renderKvRow('Requests',
+    const counters: string[] = [''];
+    counters.push('  ' + renderKvRow('Requests',
       `${s.window.requests}  ${dim(`(${rpm.toFixed(1)}/min)`)}`, w - 4));
-    lines.push('  ' + renderKvRow('Tokens in',
+    counters.push('  ' + renderKvRow('Tokens in',
       formatNumber(s.window.totalInputTokens), w - 4));
-    lines.push('  ' + renderKvRow('Tokens out',
+    counters.push('  ' + renderKvRow('Tokens out',
       formatNumber(s.window.totalOutputTokens), w - 4));
-    lines.push('  ' + renderKvRow('Thinking tokens',
+    counters.push('  ' + renderKvRow('Thinking tokens',
       formatNumber(s.window.totalThinkingTokens), w - 4));
-    lines.push('  ' + renderKvRow('Avg latency',
+    counters.push('  ' + renderKvRow('Avg latency',
       `${Math.round(s.window.avgLatencyMs)}ms`, w - 4));
-    lines.push('  ' + renderKvRow('Subscription %',
+    counters.push('  ' + renderKvRow('Subscription %',
       `${s.window.subscriptionPercent.toFixed(0)}%`, w - 4));
+    // Headline numbers — the two that answer "is this costing me money?"
+    // survive as the collapsed form.
+    panels.push({
+      lines: counters,
+      collapsed: ['',
+        '  ' + renderKvRow('Requests', `${s.window.requests}  ${dim(`(${rpm.toFixed(1)}/min)`)}`, w - 4),
+        '  ' + renderKvRow('Subscription %', `${s.window.subscriptionPercent.toFixed(0)}%`, w - 4)],
+      priority: 1,
+    });
 
     // ── Per-model bars ─────────────────────────────────────────
     const models = Object.entries(s.perModel).sort((a, b) => b[1].requests - a[1].requests);
     if (models.length > 0) {
-      lines.push('');
-      lines.push(' ' + brand('Per-model'));
+      const perModel: string[] = ['', ' ' + brand('Per-model')];
       const totalReq = Math.max(1, models.reduce((sum, [, m]) => sum + m.requests, 0));
       for (const [name, m] of models) {
         const share = m.requests / totalReq;
         const sharePct = `${(share * 100).toFixed(0)}%`.padStart(4);
-        lines.push('  ' + pad(shortenModelName(name), 18) +
+        perModel.push('  ' + pad(shortenModelName(name), 18) +
           fg('green', progressBar(share, barWidth)) +
           '  ' + dim(`${sharePct} (${m.requests})`));
       }
+      // Breakdown, not a signal — degrades first.
+      panels.push({
+        lines: perModel,
+        collapsed: ['', '  ' + renderKvRow('Per-model', dim(`${models.length} model${models.length === 1 ? '' : 's'}`), w - 4)],
+        priority: 5,
+      });
     }
 
     // ── Rate-limit ────────────────────────────────────────────
     // Each account hits its OWN 5h/7d windows, so with >1 account an
     // aggregate gauge is misleading (#600) — show one row per account, the
     // bar tracking the binding constraint (max of 5h/7d = closest to a limit).
-    lines.push('');
+    const rate: string[] = [''];
     const accts = s.perAccount ? Object.entries(s.perAccount) : [];
+    let peakUtil = Math.max(s.utilization.lastUtil5h, s.utilization.lastUtil7d);
     if (accts.length > 1) {
-      lines.push(' ' + brand('Rate-limit') + dim('  (per account)'));
+      rate.push(' ' + brand('Rate-limit') + dim('  (per account)'));
       const acctBarWidth = Math.max(8, Math.min(20, w - 48));
       for (const [alias, a] of accts.sort((x, y) => y[1].requests - x[1].requests)) {
         const u5 = a.currentUtil5h ?? 0;
         const u7 = a.currentUtil7d ?? 0;
         const peak = Math.max(u5, u7);
-        lines.push('  ' + pad(alias, 14) +
+        peakUtil = Math.max(peakUtil, peak);
+        rate.push('  ' + pad(alias, 14) +
           fg(peak >= 0.9 ? 'red' : 'cyan', progressBar(peak, acctBarWidth)) +
           '  ' + dim(`5h ${(u5 * 100).toFixed(0)}%`.padEnd(8)) +
           dim(`7d ${(u7 * 100).toFixed(0)}%`));
       }
     } else {
-      lines.push(' ' + brand('Rate-limit'));
-      lines.push('  ' + pad('5h', 6) +
+      rate.push(' ' + brand('Rate-limit'));
+      rate.push('  ' + pad('5h', GAUGE_LABEL_W) +
         fg('cyan', progressBar(s.utilization.lastUtil5h, barWidth)) +
         '  ' + dim(`${(s.utilization.lastUtil5h * 100).toFixed(0)}%`));
-      lines.push('  ' + pad('7d', 6) +
+      rate.push('  ' + pad('7d', GAUGE_LABEL_W) +
         fg('cyan', progressBar(s.utilization.lastUtil7d, barWidth)) +
         '  ' + dim(`${(s.utilization.lastUtil7d * 100).toFixed(0)}%`));
     }
@@ -180,28 +213,49 @@ export const AnalyticsTab: Tab<AnalyticsState> = {
     const totalCount = Object.values(s.window.billingBucketBreakdown ?? {}).reduce((a, b) => a + b, 0);
     const overageFrac = totalCount > 0 ? overageCount / totalCount : 0;
     const overageColor = overageCount > 0 ? 'red' : 'cyan';
-    lines.push('  ' + pad('Overage', 6) +
+    const overageRow = '  ' + pad('Overage', GAUGE_LABEL_W) +
       fg(overageColor, progressBar(overageFrac, barWidth)) +
       '  ' + (overageCount > 0
         ? fg('red', `${overageCount} req`) + dim(` of ${totalCount}`)
-        : dim('0  ← clean')));
+        : dim('0  ← clean'));
+    rate.push(overageRow);
+    // Overage is the "investigate immediately" signal and utilisation is
+    // what predicts a halt, so this panel is never dropped — collapsed it
+    // keeps the overage row plus the binding utilisation number.
+    panels.push({
+      lines: rate,
+      collapsed: ['',
+        '  ' + renderKvRow('Peak utilisation', `${(peakUtil * 100).toFixed(0)}%`, w - 4),
+        overageRow],
+      priority: 2,
+      required: true,
+    });
 
     // ── Billing buckets ───────────────────────────────────────
     const buckets = s.window.billingBucketBreakdown;
     const totalBucketCount = Object.values(buckets).reduce((a, b) => a + b, 0);
     if (totalBucketCount > 0) {
-      lines.push('');
-      lines.push(' ' + brand('Billing'));
+      const billing: string[] = ['', ' ' + brand('Billing')];
+      let shown = 0;
       for (const [bucket, count] of Object.entries(buckets)) {
         if (count === 0) continue;
-        lines.push('  ' + pad(bucket, 22) + dim(`${count} req`));
+        billing.push('  ' + pad(bucket, 22) + dim(`${count} req`));
+        shown++;
       }
+      panels.push({
+        lines: billing,
+        collapsed: ['', '  ' + renderKvRow('Billing', dim(`${shown} bucket${shown === 1 ? '' : 's'}, ${totalBucketCount} req`), w - 4)],
+        priority: 4,
+      });
     }
 
-    // Footer
-    lines.push('');
-    lines.push(' ' + dim(`Updated ${ago(state.lastFetchAt)}. Press ${fg('cyan', 'r')} to refresh.`));
-    return lines.join('\n');
+    // Footer — reserved outside the fit so the refresh key stays reachable.
+    // Bounded: `ago()` grows without limit on a long-lived session, and
+    // this row is now always rendered (it used to be clipped away with the
+    // rest of an over-long body).
+    const footer = ['', truncate(' ' + dim(`Updated ${ago(state.lastFetchAt)}. Press ${fg('cyan', 'r')} to refresh.`), w)];
+    const body = fitPanels(panels, Math.max(0, dimv.rows - footer.length));
+    return [...body, ...footer].join('\n');
   },
 };
 

--- a/src/tui/tabs/backends.ts
+++ b/src/tui/tabs/backends.ts
@@ -7,7 +7,7 @@
  */
 
 import type { Tab } from '../tab.js';
-import { fg, dim, brand, pad } from '../render.js';
+import { fg, dim, brand, pad, truncate } from '../render.js';
 
 export interface BackendsState {
   loading: boolean;
@@ -38,45 +38,62 @@ export const BackendsTab: Tab<BackendsState> = {
   render(state, dimv): string {
     const lines: string[] = [];
     const w = dimv.cols;
+    // Bound rows at the push site: the column header is 70 wide and the
+    // data rows interpolate `baseUrl`, which is unbounded (#868).
+    const push = (s: string) => lines.push(truncate(s, w));
 
-    lines.push(' ' + brand('OpenAI-compat Backends'));
+    push(' ' + brand('OpenAI-compat Backends'));
 
     if (state.loading && state.backends.length === 0) {
-      lines.push('');
-      lines.push('  ' + dim('Loading backends…'));
+      push('');
+      push('  ' + dim('Loading backends…'));
       return lines.join('\n');
     }
 
     if (state.backends.length === 0) {
-      lines.push('');
-      lines.push('  ' + dim('No OpenAI-compat backends configured.'));
-      lines.push('  ' + 'Add one: ' + fg('cyan', 'dario backend add openai --key=sk-...'));
+      push('');
+      push('  ' + dim('No OpenAI-compat backends configured.'));
+      push('  ' + 'Add one: ' + fg('cyan', 'dario backend add openai --key=sk-...'));
       return lines.join('\n');
     }
 
+    // This tab fits today, but it had no row budget at all — one more
+    // backend or one more hint line and it would overflow like the others.
+    const errorRows = state.error ? 2 : 0;
+    const chromeRows = 1 /*title*/ + 1 /*header*/ + 1 /*rule*/ + errorRows +
+      1 /*blank*/ + 1 /*"Mutations via CLI:"*/ + 2 /*commands*/;
+    const listRows = Math.max(1, dimv.rows - chromeRows);
+    const shown = state.backends.slice(0, listRows);
+    const hidden = state.backends.length - shown.length;
+
     // Header
-    lines.push('  ' + dim(
+    push('  ' + dim(
       pad('name', 16) + pad('provider', 12) + pad('base url', 40)
     ));
-    lines.push('  ' + dim('─'.repeat(Math.min(w - 4, 68))));
+    push('  ' + dim('─'.repeat(Math.min(w - 4, 68))));
 
-    for (const b of state.backends) {
-      lines.push('  ' +
+    for (const b of shown) {
+      push('  ' +
         pad(b.name, 16) +
         pad(b.provider, 12) +
         b.baseUrl
       );
     }
-
-    if (state.error) {
-      lines.push('');
-      lines.push(' ' + fg('red', `Load error: ${state.error}`));
+    if (hidden > 0) {
+      // Spend the last list row saying what it cost, rather than dropping
+      // backends silently.
+      lines[lines.length - 1] = truncate('  ' + dim(`… ${hidden + 1} more backends — resize for the rest`), w);
     }
 
-    lines.push('');
-    lines.push(' ' + dim('Mutations via CLI:'));
-    lines.push('   ' + fg('cyan', 'dario backend add <name> --key=sk-... [--base-url=...]'));
-    lines.push('   ' + fg('cyan', 'dario backend remove <name>'));
+    if (state.error) {
+      push('');
+      push(' ' + fg('red', `Load error: ${state.error}`));
+    }
+
+    push('');
+    push(' ' + dim('Mutations via CLI:'));
+    push('   ' + fg('cyan', 'dario backend add <name> --key=sk-... [--base-url=...]'));
+    push('   ' + fg('cyan', 'dario backend remove <name>'));
 
     return lines.join('\n');
   },

--- a/src/tui/tabs/hits.ts
+++ b/src/tui/tabs/hits.ts
@@ -135,9 +135,28 @@ export const HitsTab: Tab<HitsState> = {
     const lines: string[] = [];
     const w = dimv.cols;
     const totalRows = dimv.rows;
-    // Split the body roughly 60/40 between list and detail.
-    const detailRows = 9;
-    const listRows = Math.max(3, totalRows - detailRows - 2);
+    // Reserve the chrome this render will actually emit, rather than a
+    // flat guess. The old `detailRows = 9; totalRows - detailRows - 2`
+    // reserved 11 but the tab renders up to 15 non-list rows — the halt
+    // banner was missing from the arithmetic entirely and the detail pane
+    // is 8 rows, not 9 — so the body overran its budget by 4 (#868).
+    const hasSelection = state.selectedIdx >= 0 && state.selectedIdx < state.buffer.length;
+    const haltRows = state.halt ? 2 : 0;         // pinned banner
+    const fixedRows =
+      1 +            // title
+      haltRows +
+      1 +            // blank before the table
+      1 +            // column header
+      1;             // scroll hint (reserved; only drawn when the list overflows)
+    const detailPaneRows = (hasSelection ? 8 : 2) + 1;   // pane + its separator
+    // The list is the tab's reason to exist, so the detail pane yields to
+    // it rather than the other way round: on a terminal too short to show
+    // both, drop the pane and spend the rows on requests. Without this the
+    // halt banner + an 8-row pane made a 15-row floor no budget could meet.
+    const MIN_LIST = 3;
+    const showDetail = totalRows - fixedRows - detailPaneRows >= MIN_LIST;
+    const chromeRows = fixedRows + (showDetail ? detailPaneRows : 0);
+    const listRows = Math.max(1, totalRows - chromeRows);
 
     if (state.buffer.length === 0) {
       lines.push(truncate(' ' + brand('Hits') + dim('  — live request stream'), w));
@@ -232,10 +251,12 @@ export const HitsTab: Tab<HitsState> = {
       ), w));
     }
 
-    // Separator
+    // Separator + detail pane — omitted entirely on a terminal too short
+    // to show both the list and the pane (see the budget above).
+    if (!showDetail) return lines.join('\n');
+
     lines.push(' ' + dim(BOX.horizontal.repeat(w - 2)));
 
-    // Detail pane
     if (state.selectedIdx >= 0 && state.selectedIdx < newestFirst.length) {
       const r = newestFirst[state.selectedIdx];
       lines.push(truncate('  ' + brand('Selected') + dim(`  ${formatTime(r.timestamp)}`), w));

--- a/src/tui/tabs/status.ts
+++ b/src/tui/tabs/status.ts
@@ -27,8 +27,9 @@
  */
 
 import type { Tab, TabContext } from '../tab.js';
-import { fg, dim, brand } from '../render.js';
+import { fg, dim, brand, truncate } from '../render.js';
 import { renderKvRow } from '../layout.js';
+import { fitPanels, type Panel } from '../panels.js';
 import type { OverageGuardStatus } from '../proxy-client.js';
 
 export interface StatusState {
@@ -118,14 +119,18 @@ export const StatusTab: Tab<StatusState> = {
   },
 
   render(state, dim_): string {
-    const lines: string[] = [];
     const w = dim_.cols;
 
     if (state.loading && !state.health) {
-      lines.push('');
-      lines.push('  ' + dim('Loading status…'));
-      return lines.join('\n');
+      return ['', '  ' + dim('Loading status…')].join('\n');
     }
+
+    // Panels are assembled full-size, then fitted to the row budget by
+    // priority (see panels.ts). Rendering everything unconditionally used
+    // to overflow a default 80x24 terminal by four rows, and the clip took
+    // the LAST panel — Overage-guard. A halted proxy hid the halt.
+    const panels: Panel[] = [];
+    let lines: string[] = [];
 
     // ── Proxy section ──────────────────────────────────────────
     lines.push(' ' + brand('Proxy'));
@@ -146,8 +151,11 @@ export const StatusTab: Tab<StatusState> = {
       }
     }
     lines.push('');
+    // Reachability is the tab's reason to exist — never dropped.
+    panels.push({ lines, priority: 1, required: true });
 
     // ── Config section ─────────────────────────────────────────
+    lines = [];
     lines.push(' ' + brand('Config'));
     const sourceLabel = state.configSource === 'file' ? '~/.dario/config.json'
                      : state.configSource === 'missing' ? dim('(no file — using defaults)')
@@ -155,6 +163,11 @@ export const StatusTab: Tab<StatusState> = {
                      : dim('not loaded');
     lines.push('  ' + renderKvRow('Source', sourceLabel, w - 4));
     lines.push('');
+    panels.push({
+      lines,
+      collapsed: ['  ' + renderKvRow('Config', sourceLabel, w - 4), ''],
+      priority: 4,
+    });
 
     // ── Models section ─────────────────────────────────────────
     // Live from the proxy's /v1/models (upstream-autodetected catalog,
@@ -162,15 +175,25 @@ export const StatusTab: Tab<StatusState> = {
     // show up here without a TUI change. `[1m]` variants are folded
     // onto their base id as a +[1m] marker instead of doubling the list.
     if (state.models && state.models.length > 0) {
+      lines = [];
       lines.push(' ' + brand('Models'));
-      for (const row of foldLongContextVariants(state.models)) {
+      const folded = foldLongContextVariants(state.models);
+      for (const row of folded) {
         lines.push('  ' + renderKvRow(row.base, row.has1m ? dim('+[1m]') : '', w - 4));
       }
       lines.push('');
+      // Longest panel and the least time-critical — the catalog is static
+      // between releases, so it collapses to a count first.
+      panels.push({
+        lines,
+        collapsed: ['  ' + renderKvRow('Models', dim(`${folded.length} advertised`), w - 4), ''],
+        priority: 5,
+      });
     }
 
     // ── Overage-guard section (v4.1, dario#288) ────────────────
     if (state.overageGuard) {
+      lines = [];
       lines.push(' ' + brand('Overage-guard'));
       if (state.overageGuard.halted && state.overageGuard.state) {
         const s = state.overageGuard.state;
@@ -194,14 +217,33 @@ export const StatusTab: Tab<StatusState> = {
         lines.push('  ' + fg(c, state.resumeMessage));
       }
       lines.push('');
+      // A halt is the loudest thing this tab can say and it carries the
+      // resume instructions, so when halted it outranks everything except
+      // reachability and is never dropped. Idle, it is just configuration
+      // and collapses to a single line.
+      const halted = state.overageGuard.halted;
+      panels.push(halted
+        ? { lines, priority: 0, required: true }
+        : {
+            lines,
+            collapsed: ['  ' + renderKvRow('Overage-guard', fg('green', 'normal'), w - 4), ''],
+            priority: 3,
+          });
     }
 
     // ── Footer hint ────────────────────────────────────────────
-    lines.push('');
     const resumeHint = state.overageGuard?.halted ? ` · ${fg('cyan', 'R')} resume` : '';
-    lines.push(' ' + dim(`Last refresh: ${formatAgo(state.lastRefreshAt)}. ${fg('cyan', 'r')} refresh${resumeHint}.`));
+    const footer = [
+      '',
+      // Bounded: formatAgo() grows without limit, and this row is now
+      // always rendered rather than clipped away with an over-long body.
+      truncate(' ' + dim(`Last refresh: ${formatAgo(state.lastRefreshAt)}. ${fg('cyan', 'r')} refresh${resumeHint}.`), w),
+    ];
 
-    return lines.join('\n');
+    // Footer is reserved outside the fit so the refresh/resume keys stay
+    // reachable no matter how short the terminal is.
+    const body = fitPanels(panels, Math.max(0, dim_.rows - footer.length));
+    return [...body, ...footer].join('\n');
   },
 };
 

--- a/test/tui-budget.mjs
+++ b/test/tui-budget.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+// Per-tab row budgets (#868).
+//
+// #866 stopped the app writing frames taller than the terminal, but that
+// fix is a floor: renderTui clips whatever sorts last. On Status that was
+// the Overage-guard panel, so the tab that tells you the proxy has HALTED
+// hid the halt on a default 80x24 terminal.
+//
+// These assertions are about WHAT a tab gives up, not just how much:
+// a tab must fit its budget AND keep the rows that are the reason to look
+// at it.
+
+import { fitPanels } from '../dist/tui/panels.js';
+import { visibleWidth } from '../dist/tui/render.js';
+import { StatusTab } from '../dist/tui/tabs/status.js';
+import { AnalyticsTab } from '../dist/tui/tabs/analytics.js';
+import { HitsTab } from '../dist/tui/tabs/hits.js';
+import { BackendsTab } from '../dist/tui/tabs/backends.js';
+
+let pass = 0, fail = 0;
+function check(name, cond, detail) {
+  if (cond) { pass++; console.log(`  OK ${name}`); }
+  else { fail++; console.log(`  FAIL ${name}${detail ? ' :: ' + detail : ''}`); }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+const NOW = 1753480000000;
+const MODEL = 'claude-opus-4-5-20260101';
+const ACCOUNT = 'thomas@sprayberrylabs.com';
+const strip = (s) => s.replace(/\x1b\[[0-9;]*m/g, '');
+
+// ─────────────────────────────────────────────────────────────
+header('fitPanels — degrades least-important first');
+{
+  const P = (n, priority, opts = {}) => ({
+    lines: Array.from({ length: n }, (_, i) => `${opts.tag ?? 'p'}${i}`),
+    ...opts,
+  });
+  const a = { lines: ['a0', 'a1', 'a2'], collapsed: ['a!'], priority: 1 };
+  const b = { lines: ['b0', 'b1', 'b2'], collapsed: ['b!'], priority: 5 };
+
+  check('fits untouched when there is room', fitPanels([a, b], 10).join(',') === 'a0,a1,a2,b0,b1,b2');
+  check('collapses the LEAST important first',
+    fitPanels([a, b], 4).join(',') === 'a0,a1,a2,b!', JSON.stringify(fitPanels([a, b], 4)));
+  check('collapses both before dropping anything',
+    fitPanels([a, b], 2).join(',') === 'a!,b!', JSON.stringify(fitPanels([a, b], 2)));
+  check('drops only after collapsing',
+    fitPanels([a, b], 1).join(',') === 'a!', JSON.stringify(fitPanels([a, b], 1)));
+
+  const req = { lines: ['R0', 'R1'], priority: 9, required: true };
+  const opt = { lines: ['o0', 'o1'], priority: 0 };
+  check('required survives even at the lowest priority',
+    fitPanels([req, opt], 2).join(',') === 'R0,R1', JSON.stringify(fitPanels([req, opt], 2)));
+  check('display order is preserved, not priority order',
+    fitPanels([b, a], 10).join(',') === 'b0,b1,b2,a0,a1,a2');
+  check('over-budget required panels are returned rather than truncated',
+    fitPanels([req], 1).length === 2, 'renderTui clamp is the final floor');
+  void P;
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Status — a halt is never what gets dropped');
+{
+  const guard = {
+    halted: true,
+    state: {
+      since: NOW - 240000, cooldownUntil: NOW + 1560000, reason: 'representative-claim=overage',
+      request: { timestamp: NOW - 240000, model: MODEL, account: ACCOUNT, claim: 'overage' },
+    },
+    config: { enabled: true, behavior: 'halt', cooldownMs: 1800000, notifyOs: true },
+  };
+  const halted = {
+    ...StatusTab.initialState(), loading: false, configSource: 'missing',
+    health: { status: 'ok', oauth: 'healthy', expiresIn: '6h 12m', requests: 1234 },
+    models: [MODEL, MODEL + '[1m]', 'claude-sonnet-5-20260115', 'claude-fable-5', 'claude-haiku-4-5-20251001'],
+    overageGuard: guard, lastRefreshAt: NOW,
+  };
+
+  for (const rows of [40, 25, 19, 16, 14]) {
+    const out = StatusTab.render(halted, { cols: 80, rows });
+    const n = out.split('\n').length;
+    check(`80x${rows}: body within budget`, n <= rows, `${n} > ${rows}`);
+    check(`80x${rows}: HALTED still shown`, /HALTED/.test(strip(out)));
+    check(`80x${rows}: resume path still shown`, /dario resume/.test(strip(out)));
+  }
+  // 19 rows is the body budget of a default 80x24 terminal — the exact
+  // case where the halt used to be clipped.
+  const at19 = strip(StatusTab.render(halted, { cols: 80, rows: 19 }));
+  check('80x24 body: Models collapsed rather than the halt dropped', /advertised/.test(at19), JSON.stringify(at19.slice(0, 80)));
+  check('80x24 body: cause still shown', /overage/.test(at19));
+
+  // Idle, Overage-guard is just configuration and may collapse.
+  const idle = { ...halted, overageGuard: { halted: false, state: null, config: guard.config } };
+  const idleOut = StatusTab.render(idle, { cols: 80, rows: 14 });
+  check('idle: fits a short terminal', idleOut.split('\n').length <= 14);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Analytics — the overage signal survives');
+{
+  const s = {
+    ...AnalyticsTab.initialState(), loading: false, lastFetchAt: NOW,
+    summary: {
+      window: {
+        minutes: 60, requests: 128, totalInputTokens: 1284321, totalOutputTokens: 486210,
+        totalThinkingTokens: 41200, estimatedCost: 12.4, avgLatencyMs: 1842,
+        subscriptionPercent: 94, billingBucketBreakdown: { subscription: 120, extra_usage: 6, api: 2 },
+      },
+      allTime: { requests: 98213 },
+      perModel: {
+        [MODEL]: { requests: 84, totalInputTokens: 9, totalOutputTokens: 3 },
+        'claude-sonnet-5-20260115': { requests: 44, totalInputTokens: 3, totalOutputTokens: 1 },
+      },
+      utilization: { lastUtil5h: 0.62, lastUtil7d: 0.31 },
+      perAccount: {
+        [ACCOUNT]: { requests: 96, currentUtil5h: 0.62, currentUtil7d: 0.31, lastClaim: 'subscription' },
+        'ops+secondary@sprayberrylabs.com': { requests: 32, currentUtil5h: 0.18, currentUtil7d: 0.09, lastClaim: 'extra_usage' },
+      },
+    },
+  };
+  for (const rows of [40, 25, 19, 14, 10]) {
+    const out = AnalyticsTab.render(s, { cols: 80, rows });
+    const n = out.split('\n').length;
+    check(`80x${rows}: body within budget`, n <= rows, `${n} > ${rows}`);
+    check(`80x${rows}: overage row survives`, /Overage/.test(strip(out)), JSON.stringify(strip(out).slice(0, 70)));
+    check(`80x${rows}: refresh hint survives`, /refresh/.test(strip(out)));
+  }
+  // The gauge label column was 6 — narrower than "Overage", so `pad`
+  // truncated the most important row's label to "Overa…".
+  const full = strip(AnalyticsTab.render(s, { cols: 100, rows: 40 }));
+  check('overage row is labelled in full, not "Overa…"', /Overage/.test(full) && !/Overa…/.test(full));
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Hits — chrome reservation matches what it renders');
+{
+  const rec = (i) => ({
+    timestamp: NOW + i * 1000, account: ACCOUNT, model: MODEL,
+    inputTokens: 1000 + i, outputTokens: 500 + i, cacheReadTokens: 0,
+    cacheCreateTokens: 0, thinkingTokens: 0, claim: 'subscription',
+    util5h: 0.4, util7d: 0.2, overageUtil: 0, latencyMs: 300,
+    status: 200, isStream: true, isOpenAI: false,
+  });
+  const base = {
+    ...HitsTab.initialState(), subscribed: true, selectedIdx: 0,
+    buffer: Array.from({ length: 40 }, (_, i) => rec(i)),
+  };
+  const halted = {
+    ...base,
+    halt: { since: NOW - 240000, cooldownUntil: NOW + 1560000, request: { claim: 'overage', model: MODEL, account: ACCOUNT } },
+  };
+  for (const rows of [45, 35, 25, 19, 14, 10]) {
+    for (const [label, st] of [['plain', base], ['halted', halted]]) {
+      const n = HitsTab.render(st, { cols: 100, rows }).split('\n').length;
+      check(`${label} 100x${rows}: body within budget`, n <= rows, `${n} > ${rows}`);
+    }
+  }
+  check('halted still shows the banner', /HALTED/.test(strip(HitsTab.render(halted, { cols: 100, rows: 19 }))));
+}
+
+// ─────────────────────────────────────────────────────────────
+header('Backends — bounded in both directions');
+{
+  const b = (i) => ({ name: `backend-${i}`, provider: 'openai', baseUrl: `https://api.example-${i}.com/v1/very/long/base/url/path` });
+  const s = { ...BackendsTab.initialState(), loading: false, backends: Array.from({ length: 12 }, (_, i) => b(i)) };
+  for (const cols of [40, 60, 80, 120]) {
+    for (const rows of [30, 19, 12]) {
+      const lines = BackendsTab.render(s, { cols, rows }).split('\n');
+      check(`${cols}x${rows}: within budget`, lines.length <= rows, `${lines.length} > ${rows}`);
+      const widest = Math.max(...lines.map(visibleWidth));
+      check(`${cols}x${rows}: no row exceeds cols`, widest <= cols, `widest=${widest}`);
+    }
+  }
+  check('truncated list says how many are hidden',
+    /more backends/.test(strip(BackendsTab.render(s, { cols: 100, rows: 12 }))));
+}
+
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);

--- a/test/tui-frame.mjs
+++ b/test/tui-frame.mjs
@@ -141,12 +141,20 @@ header('The chrome the user navigates by is never what gets dropped');
 // ─────────────────────────────────────────────────────────────
 header('Clipping is announced, not silent');
 {
-  // Status is a fixed ~27 rows loaded, so 24 rows must clip it.
-  const frame = renderTui(loadedState(0), { cols: 80, rows: 24 }, '5.4.6', 'http://127.0.0.1:3456');
+  // Since #868 the tabs budget themselves, so 80x24 no longer overflows —
+  // that IS the change. The frame clamp remains the floor for a terminal
+  // too short for even a tab's REQUIRED panels: Status keeps Proxy + a
+  // halted Overage-guard + its footer (14 rows), so a 12-row terminal
+  // (7-row body) still has to clip.
+  const frame = renderTui(loadedState(0), { cols: 80, rows: 12 }, '5.4.6', 'http://127.0.0.1:3456');
   check('clipped frame carries a "more rows" note', /more rows? — resize/.test(frame), JSON.stringify(frame.split('\n').slice(-4, -1)));
   // A tall terminal fits Status outright and must NOT show the note.
   const roomy = renderTui(loadedState(0), { cols: 120, rows: 45 }, '5.4.6', 'http://127.0.0.1:3456');
   check('unclipped frame has no note', !/more rows? — resize/.test(roomy));
+  // The point of #868: at the DEFAULT size the tab now fits itself, so the
+  // backstop never has to fire.
+  const standard = renderTui(loadedState(0), { cols: 80, rows: 24 }, '5.4.6', 'http://127.0.0.1:3456');
+  check('80x24 no longer needs the frame clamp', !/more rows? — resize/.test(standard));
 }
 
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #868.

## Why this, when #866 already stopped the overflow

5.4.7 made `renderTui` clip an over-long body so the header and tab strip survive. That's a **floor, not a layout** — it drops whatever sorts last. On Status that was the Overage-guard panel, so at a default 80×24 the tab that tells you the proxy has **HALTED** hid the halt, the cause, the auto-resume countdown and the resume instructions. The `… N more rows` note made the loss visible, not acceptable.

## The mechanism

New `src/tui/panels.ts`. A panel declares:

| field | meaning |
|---|---|
| `lines` | full rendering |
| `collapsed` | shorter stand-in, usually one summary row |
| `priority` | lower = more important; drives what degrades first |
| `required` | never dropped (may still collapse) |

`fitPanels` degrades **least-important-first** in two passes — collapse everything offering a shorter form, then drop what isn't required — and preserves **display order**. Priority decides what degrades, never where a panel appears: users navigate by position, so resorting panels under pressure would be its own kind of surprise.

## Per tab

**Status** — Proxy is `required`; Overage-guard is `required` at top priority *when halted* and collapses to one line when idle. Models is the longest and least time-critical (a static catalog between releases), so it collapses to `5 advertised` first and drops last. Confirmed: HALTED and `dario resume` survive every budget from 40 rows down to 14.

**Analytics** — the rate-limit gauges and the overage row are `required`; the per-model breakdown and billing buckets collapse to counts. Was a fixed 28 rows against a 19-row budget.

**Hits** — reserved 11 rows of chrome while rendering up to 15. The pinned halt banner was **absent from the arithmetic entirely** and the detail pane is 8 rows, not the 9 reserved. Now derived from what the render actually emits; on a terminal too short for both, the detail pane yields to the request list rather than the reverse — the list is the tab's reason to exist.

**Backends** — had no budget at all, plus a 70-wide column header and data rows interpolating `baseUrl` (unbounded). Bounded at the push site, list windows to the height, and a truncated list says how many are hidden.

## Two incidental bugs, both found by the tests

- **The overage gauge rendered as `Overa…`.** Its label column was 6 — one narrower than the word — so `pad` truncated it and left it flush against its bar: `  Overa…██░░░…`. The row that means "investigate immediately" was the one row that didn't read. Gauge rows now share an 8-wide label column.
- **Two footers were unbounded** (`Updated <ago>` on Analytics, `Last refresh: <ago>` on Status). They'd been invisible because an over-long body was clipped before reaching them — fixing the height exposed the width.

## Tests

New `test/tui-budget.mjs`, 79 assertions:

- `fitPanels` directly — collapse-before-drop, `required` surviving at the lowest priority, display order preserved, over-budget required panels returned rather than truncated
- per tab: the body fits **and** the rows worth looking at survive — HALTED + resume path on Status, the overage row on Analytics, the halt banner on Hits, width *and* height on Backends

Each of the four tabs was reverted individually and confirmed to fail: **status 5, analytics 9, hits 12, backends 14**. Notably, reverting `analytics.ts` fails "overage row survives" at *every* size — that's the `Overa…` clip, not a budget issue.

`test/tui-frame.mjs` gains an assertion that **80×24 no longer needs the frame clamp at all**, and its clip test moves to 80×12, where Status's required panels genuinely can't fit. The 5.4.7 backstop is unchanged and still correct — it just isn't reached at ordinary sizes any more.

Full suite: 123/123.

## Checklist
- [x] `npm run build` passes
- [x] `npm test` passes — 123/123
- [x] For changes that touch `proxy.ts`, `cc-template.ts`, or streaming behavior: n/a, TUI render path only
- [x] No new runtime dependencies added
- [x] No tokens/secrets in code or logs
- [x] Version bumped (5.4.8 → 5.4.9) + CHANGELOG section, validated with `extract-release-notes.mjs 5.4.9` and `check-package-json.mjs`
