### PR TITLE
feat(tools): land the TUI audit harness, fix the Analytics title overflow it found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ credentials.json
 drift-summary.md
 drift-output.txt
 label-target.txt
+.tui-audit/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ checklist.
 
 ## [Unreleased]
 
+## [5.4.10] - 2026-07-26
+
+- **The TUI audit harness now lives in the repo** as `tools/tui-audit`, run with `npm run audit:tui`. It drives the real `startTuiApp()` through a fake TTY against a local stub proxy — real sockets, real SSE, real raw-mode key parsing, real tab mount/unmount — and audits every frame the app actually writes for row width, frame height and SGR balance, across twelve geometries from 200×50 down to 24×8. The stub serves every endpoint `ProxyClient` calls, on port 39456 so it can never collide with a real `dario proxy`. Navigation keys only, so a run can't write config or POST `/admin/resume`.
+
+  This is deliberately not part of `npm test` — it takes ~25s and needs a build. `test/` keeps the fast pure-render assertions; this catches what only appears when the whole loop runs against moving data.
+
+- **The Analytics title row overflowed a very narrow terminal** — ` Analytics  — last 60 min` is 25 characters against 24 columns. It's a `required` panel, so the row budget never clips it, and it had no `truncate` of its own. Found by the harness on its first in-repo run.
+
+  Worth recording why `test/tui-frame.mjs` missed it despite sweeping to 24×6: at six rows the body budget is one row, so the frame clamp swaps the title for the `… more rows` note before its width can be measured. At 24×8 there's room for the title to render — and overflow. `test/tui-budget.mjs` now checks Analytics at 24/28/32/40 columns by 8 rows, so CI covers it without needing the harness.
+
 ## [5.4.9] - 2026-07-26
 
 - **Every tab now spends its own row budget instead of being clipped from the bottom.** 5.4.7 stopped the app writing frames taller than the terminal, but that fix is a floor: `renderTui` clips whatever sorts *last*. On Status that was the Overage-guard panel — so the one tab that tells you the proxy has HALTED hid the halt, the cause, the auto-resume countdown and the resume instructions, on a default 80×24 terminal. Closes #868.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.4.9",
+  "version": "5.4.10",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {
@@ -35,7 +35,8 @@
     "drift:wire": "node scripts/check-wire-drift.mjs",
     "check:overage": "node scripts/check-overage-live.mjs",
     "cch:calibrate": "node scripts/cch-calibrate.mjs",
-    "fix:pkg": "node -e \"const fs=require('fs');fs.writeFileSync('package.json',JSON.stringify(JSON.parse(fs.readFileSync('package.json','utf-8')),null,2)+'\\n')\""
+    "fix:pkg": "node -e \"const fs=require('fs');fs.writeFileSync('package.json',JSON.stringify(JSON.parse(fs.readFileSync('package.json','utf-8')),null,2)+'\\n')\"",
+    "audit:tui": "node tools/tui-audit/audit.mjs"
   },
   "keywords": [
     "llm",

--- a/src/tui/tabs/analytics.ts
+++ b/src/tui/tabs/analytics.ts
@@ -103,7 +103,10 @@ export const AnalyticsTab: Tab<AnalyticsState> = {
     const w = dimv.cols;
     const barWidth = Math.min(36, w - 32);
 
-    lines.push(' ' + brand('Analytics') + dim(`  — last ${state.summary?.window.minutes ?? 60} min`));
+    // Bounded like every other row. This is a `required` panel, so the row
+    // budget never clips it — without a truncate it overflows a very narrow
+    // terminal (25 wide at 24 cols). Found by tools/tui-audit.
+    lines.push(truncate(' ' + brand('Analytics') + dim(`  — last ${state.summary?.window.minutes ?? 60} min`), w));
 
     if (!state.summary && state.loading) {
       lines.push('');

--- a/test/tui-budget.mjs
+++ b/test/tui-budget.mjs
@@ -129,6 +129,17 @@ header('Analytics — the overage signal survives');
   // truncated the most important row's label to "Overa…".
   const full = strip(AnalyticsTab.render(s, { cols: 100, rows: 40 }));
   check('overage row is labelled in full, not "Overa…"', /Overage/.test(full) && !/Overa…/.test(full));
+
+  // Narrow widths at a height that still renders the title. tui-frame.mjs
+  // sweeps to 24x6, but at 6 rows the body budget is 1 and the frame clamp
+  // swaps the title for the "… more rows" note before it can be measured,
+  // so the title's own width went unchecked. tools/tui-audit caught it live
+  // at 24x8: " Analytics  — last 60 min" is 25 wide.
+  for (const cols of [24, 28, 32, 40]) {
+    const lines = AnalyticsTab.render(s, { cols, rows: 8 }).split('\n');
+    const widest = Math.max(...lines.map(visibleWidth));
+    check(`Analytics ${cols}x8: no row exceeds cols`, widest <= cols, `widest=${widest}`);
+  }
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/tools/tui-audit/README.md
+++ b/tools/tui-audit/README.md
@@ -1,0 +1,60 @@
+# TUI audit harness
+
+Drives the **real** `startTuiApp()` through a fake TTY against a local stub
+proxy — real sockets, real SSE, real raw-mode key parsing, real tab
+mount/unmount — and audits every frame the app actually writes to stdout.
+
+```bash
+npm run build
+npm run audit:tui            # or: npm run audit:tui -- --strict
+```
+
+Output lands in `.tui-audit/` (gitignored): one `frames-<cols>x<rows>.txt`
+per geometry with the ANSI stripped, plus `findings.json`.
+
+## What it checks
+
+Per frame, across twelve geometries from 200×50 down to 24×8:
+
+- **row width** — no line wider than `cols` (a wrapped row costs a second
+  physical line and pushes the panel head off the top of the alt-screen)
+- **frame height** — no more physical rows than the terminal has
+- **SGR balance** — per line and cumulatively across the frame, so an
+  unclosed `dim()`/`fg()` can't bleed into the next line or the next frame
+
+`--strict` exits non-zero on any finding. Without it the exit code is 0 and
+you read the report — the default, because a finding usually wants human
+judgement about which tab should give up what.
+
+## Why it isn't in `npm test`
+
+It takes ~25 seconds, needs `dist/` built, and binds a port. `test/` holds
+the fast pure-render assertions (`tui-tabs`, `tui-frame`, `tui-budget`);
+this is the slow integration pass you run when changing render or layout
+code.
+
+## Safety
+
+Sends navigation keys only — Tab and arrows. Never `s`/`d`/`r`/`R`/Enter,
+which would write config or POST `/admin/resume`. The stub binds 39456, not
+3456, so it cannot collide with a real `dario proxy`. Override with
+`STUB_PORT`.
+
+## The lesson worth keeping
+
+This harness and the fixture sweeps in `test/` catch **different** classes
+of bug, and neither is sufficient alone:
+
+- It found three tabs rendering taller than the terminal at a default 80×24,
+  scrolling the header and tab strip off the top — only visible with real
+  data flowing through the real loop.
+- It **missed** `progressBar()` throwing `RangeError` on a negative width,
+  which crashed Analytics at any width ≤ 31, because its narrowest geometry
+  was then 40 columns. A fixture sweep down to 24×6 caught that.
+- Going the other way, `test/tui-frame.mjs` **missed** the Analytics title
+  overflowing at 24 columns: at the 6-row height it sweeps, the frame clamp
+  replaces the title with the `… more rows` note before its width can be
+  measured. This harness caught it at 24×8.
+
+Live runs are better evidence for what real data does; fixture sweeps are
+better for edge geometry. If you extend either, push the ranges outward.

--- a/tools/tui-audit/audit.mjs
+++ b/tools/tui-audit/audit.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+/**
+ * Live TUI audit — drives the REAL startTuiApp() through a fake TTY against
+ * a local stub proxy, and audits every frame the app actually writes.
+ *
+ *   npm run build && npm run audit:tui
+ *
+ * This is not a unit test. It exercises App.start(), raw-mode key parsing,
+ * tab mount/unmount, ProxyClient over real sockets and the SSE stream, and
+ * captures frames exactly as the terminal would receive them. `test/` has
+ * the fast pure-render assertions; this catches what only shows up when the
+ * whole loop runs against moving data.
+ *
+ * Complementary, not redundant — and neither alone is sufficient:
+ * this harness found three tabs rendering taller than the terminal, but
+ * MISSED progressBar() throwing RangeError on a negative width (Analytics
+ * crashed at any width <= 31) because its narrowest geometry was 40 cols.
+ * A fixture sweep down to 24x6 in test/tui-frame.mjs caught that instead.
+ * Live runs are better evidence for what real data does; fixture sweeps are
+ * better for edge geometry. If you extend this, go narrower.
+ *
+ * Safety: sends navigation keys only (Tab, arrows). Never s/d/r/R/Enter,
+ * which would write config or POST /admin/resume.
+ *
+ * Exit code is 0 unless --strict is passed, in which case any finding fails.
+ */
+import { EventEmitter } from 'node:events';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { startStub, DEFAULT_PORT } from './stub-proxy.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = join(HERE, '..', '..');
+const OUT = process.env.TUI_AUDIT_OUT || join(REPO, '.tui-audit');
+const STRICT = process.argv.includes('--strict');
+const CLEAR = '\x1b[2J\x1b[H';
+
+const GEOMETRIES = [
+  [200, 50], [160, 45], [120, 40], [100, 30], [80, 24],
+  [70, 20], [60, 18], [55, 16], [45, 14], [40, 12], [32, 10], [24, 8],
+];
+
+// ── fake TTY ────────────────────────────────────────────────────────
+class FakeStdout extends EventEmitter {
+  constructor(cols, rows) { super(); this.columns = cols; this.rows = rows; this.isTTY = true; this.chunks = []; }
+  write(s) { this.chunks.push(String(s)); return true; }
+  get raw() { return this.chunks.join(''); }
+}
+class FakeStdin extends EventEmitter {
+  constructor() { super(); this.isTTY = true; this.isRaw = false; }
+  setRawMode(v) { this.isRaw = v; return this; }
+  resume() { return this; }
+  pause() { return this; }
+  send(seq) { this.emit('data', Buffer.from(seq, 'utf8')); }
+}
+
+// ── SGR state machine ───────────────────────────────────────────────
+const DEFAULT_SGR = { intensity: 0, underline: 0, inverse: 0, fg: 39, bg: 49 };
+function sgrFold(line, start) {
+  const st = { ...start };
+  for (const m of line.matchAll(/\x1b\[([0-9;]*)m/g)) {
+    const ps = m[1] === '' ? [0] : m[1].split(';').map(Number);
+    for (let i = 0; i < ps.length; i++) {
+      const p = ps[i];
+      if (p === 0) Object.assign(st, DEFAULT_SGR);
+      else if (p === 1 || p === 2) st.intensity = p;
+      else if (p === 22) st.intensity = 0;
+      else if (p === 4) st.underline = 4;
+      else if (p === 24) st.underline = 0;
+      else if (p === 7) st.inverse = 7;
+      else if (p === 27) st.inverse = 0;
+      else if (p === 38 || p === 48) { const k = p === 38 ? 'fg' : 'bg'; if (ps[i + 1] === 5) { st[k] = p; i += 2; } else if (ps[i + 1] === 2) { st[k] = p; i += 4; } }
+      else if ((p >= 30 && p <= 37) || (p >= 90 && p <= 97)) st.fg = p;
+      else if (p === 39) st.fg = 39;
+      else if ((p >= 40 && p <= 47) || (p >= 100 && p <= 107)) st.bg = p;
+      else if (p === 49) st.bg = 49;
+    }
+  }
+  return st;
+}
+const isDefaultSgr = (st) => JSON.stringify(st) === JSON.stringify(DEFAULT_SGR);
+const stripAnsi = (s) => s.replace(/\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]/g, '');
+const vw = (s) => stripAnsi(s).length;
+
+const TAB_NAMES = ['Status', 'Config', 'Analytics', 'Hits', 'Accounts', 'Backends'];
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function runGeometry(cols, rows, startTuiApp, port) {
+  const out = new FakeStdout(cols, rows);
+  const inp = new FakeStdin();
+  const realOut = Object.getOwnPropertyDescriptor(process, 'stdout');
+  const realIn = Object.getOwnPropertyDescriptor(process, 'stdin');
+  Object.defineProperty(process, 'stdout', { value: out, configurable: true });
+  Object.defineProperty(process, 'stdin', { value: inp, configurable: true });
+
+  let err = null;
+  try {
+    const done = startTuiApp({ version: 'audit', proxyUrl: `http://127.0.0.1:${port}` });
+    await wait(900);                       // health + models + guard + SSE backlog
+    for (let t = 1; t < TAB_NAMES.length; t++) {
+      inp.send('\t');
+      await wait(400);
+      for (let k = 0; k < 4; k++) { inp.send('\x1b[B'); await wait(60); }
+      inp.send('\x1b[A'); await wait(60);
+    }
+    inp.send('\t');
+    await wait(350);
+    inp.send('\x03');                      // Ctrl-C -> stop
+    await Promise.race([done, wait(1500)]);
+  } catch (e) {
+    err = e;
+  } finally {
+    Object.defineProperty(process, 'stdout', realOut);
+    Object.defineProperty(process, 'stdin', realIn);
+  }
+
+  const frames = out.raw.split(CLEAR).slice(1)
+    .map((p) => p.replace(/\x1b\[\?1049l\x1b\[\?25h$/, ''));
+  return { frames, err };
+}
+
+function auditFrame(frame, cols, rows) {
+  const lines = frame.split('\n');
+  const found = [];
+  if (lines.length > rows) found.push({ kind: 'frame-too-tall', detail: `${lines.length} lines > ${rows} rows` });
+  let carry = { ...DEFAULT_SGR };
+  lines.forEach((line, n) => {
+    const w = vw(line);
+    if (w > cols) found.push({ kind: 'row-too-wide', detail: `line ${n}: ${w} > ${cols}`, sample: stripAnsi(line).slice(0, 60) });
+    carry = sgrFold(line, carry);
+    if (!isDefaultSgr(carry)) {
+      found.push({ kind: 'sgr-open-at-eol', detail: `line ${n}: ${JSON.stringify(carry)}`, sample: stripAnsi(line).slice(0, 60) });
+      carry = { ...DEFAULT_SGR };
+    }
+  });
+  return found;
+}
+
+// ── main ────────────────────────────────────────────────────────────
+let startTuiApp;
+const distEntry = join(REPO, 'dist', 'tui', 'tui-app.js');
+try {
+  // pathToFileURL, not the bare path: a Windows absolute path (`C:\…`) is
+  // not a valid import specifier.
+  ({ startTuiApp } = await import(pathToFileURL(distEntry).href));
+} catch (e) {
+  console.error(`Cannot load ${distEntry}\n  ${e.message}\n  Run \`npm run build\` first.`);
+  process.exit(2);
+}
+
+const stub = await startStub({ port: Number(process.env.STUB_PORT) || DEFAULT_PORT });
+mkdirSync(OUT, { recursive: true });
+console.log(`stub proxy on 127.0.0.1:${stub.port}   output -> ${OUT}\n`);
+
+const all = [];
+for (const [cols, rows] of GEOMETRIES) {
+  const { frames, err } = await runGeometry(cols, rows, startTuiApp, stub.port);
+  const byKind = new Map();
+  for (const f of frames) {
+    for (const finding of auditFrame(f, cols, rows)) {
+      const key = finding.kind;
+      if (!byKind.has(key)) byKind.set(key, { ...finding, cols, rows, count: 0 });
+      byKind.get(key).count++;
+    }
+  }
+  const findings = [...byKind.values()];
+  all.push({ cols, rows, frames: frames.length, findings, err: err?.message ?? null });
+  if (frames.length) {
+    writeFileSync(join(OUT, `frames-${cols}x${rows}.txt`),
+      frames.map((f, i) => `\n===== frame ${i} =====\n` + stripAnsi(f)).join(''));
+  }
+  const n = findings.reduce((a, b) => a + b.count, 0);
+  console.log(`${String(cols).padStart(3)}x${String(rows).padEnd(3)}  frames=${String(frames.length).padStart(3)}  findings=${n}${err ? '  ERR ' + err.message : ''}`);
+}
+
+await stub.close();
+
+const flat = all.flatMap((g) => g.findings);
+console.log('\n================ FINDINGS ================');
+if (!flat.length) console.log('none');
+const order = { 'row-too-wide': 0, 'frame-too-tall': 1, 'sgr-open-at-eol': 2 };
+for (const f of flat.sort((a, b) => (order[a.kind] - order[b.kind]) || (b.cols - a.cols))) {
+  console.log(`[${f.kind}] ${f.cols}x${f.rows} (x${f.count})  ${f.detail}`);
+  if (f.sample) console.log(`    ${JSON.stringify(f.sample)}`);
+}
+writeFileSync(join(OUT, 'findings.json'), JSON.stringify(all, null, 2));
+
+process.exit(STRICT && flat.length ? 1 : 0);

--- a/tools/tui-audit/stub-proxy.mjs
+++ b/tools/tui-audit/stub-proxy.mjs
@@ -1,0 +1,147 @@
+/**
+ * Stub of the dario proxy's TUI-facing endpoints.
+ *
+ * Lets the TUI audit exercise the real network + SSE paths without a live
+ * proxy and without touching production. Serves everything ProxyClient
+ * calls: /health, /v1/models, /admin/resume (GET), /analytics, /accounts,
+ * and the /analytics/stream SSE feed.
+ *
+ * Listens on 39456 by default — deliberately NOT 3456, so it can never
+ * collide with a real `dario proxy` on the same box.
+ *
+ * Used by audit.mjs; also runnable standalone:
+ *   node tools/tui-audit/stub-proxy.mjs
+ */
+import { createServer } from 'node:http';
+
+export const DEFAULT_PORT = 39456;
+
+const MODEL = 'claude-opus-4-5-20260101';
+const ACCOUNT = 'operator@example.com';
+
+const json = (res, code, body) => {
+  const s = JSON.stringify(body);
+  res.writeHead(code, { 'content-type': 'application/json', 'content-length': Buffer.byteLength(s) });
+  res.end(s);
+};
+
+const record = (i, now) => ({
+  timestamp: now - (20 - i) * 1000,
+  account: ACCOUNT,
+  model: i % 3 === 0 ? MODEL : 'claude-sonnet-5-20260115',
+  inputTokens: 1000 + i * 137,
+  outputTokens: 500 + i * 61,
+  cacheReadTokens: i % 2 ? 2048 : 0,
+  cacheCreateTokens: i % 4 ? 512 : 0,
+  thinkingTokens: i % 5 ? 256 : 0,
+  claim: i % 7 === 6 ? 'extra_usage' : 'subscription',
+  util5h: 0.1 + (i % 9) / 10,
+  util7d: 0.05 + (i % 7) / 20,
+  overageUtil: 0,
+  latencyMs: 300 + i * 47,
+  status: i % 11 === 10 ? 500 : i % 13 === 12 ? 429 : 200,
+  isStream: i % 2 === 0,
+  isOpenAI: false,
+});
+
+/** Start the stub. Returns { server, port, close() }. */
+export function startStub({ port = DEFAULT_PORT, halt = true } = {}) {
+  const timers = new Set();
+
+  const server = createServer((req, res) => {
+    const now = Date.now();
+    const path = req.url.split('?')[0];
+
+    if (path === '/health') {
+      return json(res, 200, { status: 'ok', oauth: 'healthy', expiresIn: '6h 12m', requests: 1234 });
+    }
+    if (path === '/v1/models') {
+      return json(res, 200, { data: [
+        { id: MODEL }, { id: MODEL + '[1m]' },
+        { id: 'claude-sonnet-5-20260115' }, { id: 'claude-fable-5' },
+        { id: 'claude-haiku-4-5-20251001' },
+      ] });
+    }
+    if (path === '/admin/resume' && req.method === 'GET') {
+      return json(res, 200, {
+        halted: halt,
+        state: halt ? {
+          since: now - 240000, cooldownUntil: now + 1560000,
+          reason: 'representative-claim=extra_usage',
+          request: { timestamp: now - 240000, model: MODEL, account: ACCOUNT, claim: 'extra_usage' },
+        } : null,
+        config: { enabled: true, behavior: 'halt', cooldownMs: 1800000, notifyOs: true },
+      });
+    }
+    if (path === '/analytics') {
+      return json(res, 200, {
+        window: {
+          minutes: 60, requests: 128, totalInputTokens: 1284321, totalOutputTokens: 486210,
+          totalThinkingTokens: 41200, estimatedCost: 12.4471, avgLatencyMs: 1842,
+          subscriptionPercent: 94,
+          billingBucketBreakdown: { subscription: 120, extra_usage: 6, api: 2 },
+        },
+        allTime: { requests: 98213 },
+        perModel: {
+          [MODEL]: { requests: 84, totalInputTokens: 901221, totalOutputTokens: 322110 },
+          'claude-sonnet-5-20260115': { requests: 44, totalInputTokens: 383100, totalOutputTokens: 164100 },
+        },
+        utilization: { lastUtil5h: 0.62, lastUtil7d: 0.31 },
+        perAccount: {
+          [ACCOUNT]: { requests: 96, currentUtil5h: 0.62, currentUtil7d: 0.31, lastClaim: 'subscription' },
+          'secondary@example.com': { requests: 32, currentUtil5h: 0.18, currentUtil7d: 0.09, lastClaim: 'extra_usage' },
+        },
+      });
+    }
+    if (path === '/accounts') {
+      return json(res, 200, { mode: 'pool', accounts: [
+        { alias: ACCOUNT, expiresInMs: 22320000, util5h: 0.62, util7d: 0.31, status: 'active' },
+        { alias: 'secondary@example.com', expiresInMs: 5400000, util5h: 0.18, util7d: 0.09, status: 'active' },
+        { alias: 'archive+coldstorage@example.com', expiresInMs: -1, util5h: 0, util7d: 0, status: 'expired' },
+      ] });
+    }
+    if (path === '/analytics/stream') {
+      res.writeHead(200, {
+        'content-type': 'text/event-stream',
+        'cache-control': 'no-cache',
+        connection: 'keep-alive',
+      });
+      for (let i = 0; i < 20; i++) res.write(`data: ${JSON.stringify(record(i, now))}\n\n`);
+      if (halt) {
+        res.write(`event: overage_halt\ndata: ${JSON.stringify({
+          since: now - 240000,
+          cooldownUntil: now + 1560000,
+          request: { claim: 'extra_usage', model: MODEL, account: ACCOUNT },
+        })}\n\n`);
+      }
+      let n = 20;
+      const t = setInterval(() => {
+        if (res.writableEnded) { clearInterval(t); timers.delete(t); return; }
+        res.write(`data: ${JSON.stringify(record(n++, Date.now()))}\n\n`);
+      }, 400);
+      timers.add(t);
+      req.on('close', () => { clearInterval(t); timers.delete(t); });
+      return;
+    }
+    json(res, 404, { error: 'not found', path });
+  });
+
+  return new Promise((resolve) => {
+    server.listen(port, '127.0.0.1', () => resolve({
+      server,
+      port,
+      close: () => new Promise((r) => {
+        for (const t of timers) clearInterval(t);
+        timers.clear();
+        server.closeAllConnections?.();
+        server.close(() => r());
+      }),
+    }));
+  });
+}
+
+// Standalone: `node tools/tui-audit/stub-proxy.mjs`
+if (import.meta.url === `file://${process.argv[1]?.replace(/\\/g, '/')}`) {
+  const { port } = await startStub();
+  console.log(`stub proxy on http://127.0.0.1:${port}`);
+}


### PR DESCRIPTION
Lands the harness that found the v5.4.7 and v5.4.9 bugs, so it stops living on one box — and fixes the bug it found on its first in-repo run.

## `tools/tui-audit`

```bash
npm run build
npm run audit:tui              # or: npm run audit:tui -- --strict
```

Drives the **real** `startTuiApp()` through a fake TTY against a local stub proxy — real sockets, real SSE, real raw-mode key parsing, real tab mount/unmount — and audits every frame the app actually writes:

- **row width** — no line wider than `cols`
- **frame height** — no more physical rows than the terminal has
- **SGR balance** — per line *and* cumulatively across the frame

Twelve geometries, 200×50 down to **24×8**. Output to `.tui-audit/` (gitignored): stripped frame dumps per geometry plus `findings.json`.

The stub serves everything `ProxyClient` calls — `/health`, `/v1/models`, `/admin/resume`, `/analytics`, `/accounts`, and the `/analytics/stream` SSE feed with an `overage_halt` event.

**Not part of `npm test`** — ~25s and needs `dist/` built. `test/` keeps the fast pure-render assertions; this is the slow integration pass for render/layout changes. `--strict` exits non-zero on findings; the default is 0, because a finding usually needs a judgement call about which tab gives up what.

**Safety:** navigation keys only (Tab, arrows) — never `s`/`d`/`r`/`R`/Enter, so a run can't write config or POST `/admin/resume`. Stub binds **39456**, not 3456, so it can't collide with a real `dario proxy`.

## The bug it found

` Analytics  — last 60 min` is **25 characters against 24 columns**. The title is a `required` panel, so the row budget never clips it, and it had no `truncate` of its own — the one row in that tab still unbounded after #871.

## Why CI didn't already catch it

Worth recording, because it's the second time these two approaches have covered for each other:

`test/tui-frame.mjs` sweeps to 24×6 and asserts no row exceeds `cols` — it *should* have caught this. It didn't, because at six rows the body budget is one row, so the frame clamp swaps the title for the `… more rows` note **before its width can be measured**. At 24×8 there's room for the title to render, and overflow.

The reverse happened during the v5.4.7 audit: this harness missed `progressBar()` throwing `RangeError` on a negative width (Analytics crashed at any width ≤ 31) because its narrowest geometry was 40 columns — the fixture sweep caught that one.

Live runs are better evidence for what real data does; fixture sweeps are better for edge geometry. Neither alone has been sufficient. Both README and CHANGELOG record this so the next person doesn't assume one covers the other.

`test/tui-budget.mjs` now checks Analytics at 24/28/32/40 columns × 8 rows, so CI covers this class without needing the harness. Confirmed to fail on revert: `widest=25`.

## Verification

- `npm test` — **123/123**
- `npm run audit:tui` — **0 findings** across all twelve geometries (2 findings before the fix, both the title row at 24×8)

## Checklist
- [x] `npm run build` passes
- [x] `npm test` passes — 123/123
- [x] For changes that touch `proxy.ts`, `cc-template.ts`, or streaming behavior: n/a
- [x] No new runtime dependencies added (harness is zero-dep, stdlib only)
- [x] No tokens/secrets in code or logs
- [x] Version bumped (5.4.9 → 5.4.10) + CHANGELOG — required because this carries a runtime change to `analytics.ts`, not just tooling
