### PR TITLE
fix(scrub): catch instruction-file prose by its wrapper, not by the heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ checklist.
 
 ## [Unreleased]
 
+## [5.4.11] - 2026-07-26
+
+- **A bake can no longer ship instruction-file prose that the section strip missed.** `scrubText` already removes CC's host-context sections and `findUserPathHits` already flags any that survive, but both read the same heading list — so a heading CC renames or reshapes strips nothing and flags nothing, and once paths are scrubbed the leftover prose carries no user path for the other detectors to catch. That is two silent failures stacked, and it is the shape of what dario#872 saw: one capture in six came back carrying another session's instruction text. `findUserPathHits` now also matches the wrapper prose itself — the `Codebase and user instructions are shown below` and `IMPORTANT: These instructions OVERRIDE` sentences, the `Contents of <path>.md` line, the private-instruction and auto-memory annotations — so the heading no longer has to be intact for the leak to be caught. Both existing gates pick it up for free: the bake fails hard on the serialized template and `check-cc-drift` fails the release.
+
+  Marker selection was empirical, not guesswork. Bare `CLAUDE.md` and `system-reminder` are deliberately NOT markers — CC's own system prompt mentions both (2 hits) and its tool descriptions mention them again (3 and 5), so either would have failed every bake from the first run. `test/context-bleed.mjs` pins that, asserts every baked slot is clean, and asserts the renamed-heading case that the heading detector provably misses.
+
+  Not wired into `extractTemplate`, on purpose: that function also serves the live-capture path, and the live fingerprint keeps host context deliberately — it exists to replay the operator's own CC install faithfully. Only the bake publishes, so only the bake gates. Verified against a real `--check` run on a machine that has both a user-level and a project-level CLAUDE.md: the guard stays silent, because CC delivers instruction files in `messages` and the bake only keeps `system`.
+
 ## [5.4.10] - 2026-07-26
 
 - **The TUI audit harness now lives in the repo** as `tools/tui-audit`, run with `npm run audit:tui`. It drives the real `startTuiApp()` through a fake TTY against a local stub proxy — real sockets, real SSE, real raw-mode key parsing, real tab mount/unmount — and audits every frame the app actually writes for row width, frame height and SGR balance, across twelve geometries from 200×50 down to 24×8. The stub serves every endpoint `ProxyClient` calls, on port 39456 so it can never collide with a real `dario proxy`. Navigation keys only, so a run can't write config or POST `/admin/resume`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.4.10",
+  "version": "5.4.11",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {
@@ -22,7 +22,7 @@
   "scripts": {
     "build": "tsc && cp src/cc-template-data.json dist/",
     "test": "node --test --test-concurrency=8 test/all.test.mjs",
-    "test:serial": "node test/issue-29-tool-translation.mjs && node test/hybrid-tools.mjs && node test/tool-schema-contract.mjs && node test/scrub-paths.mjs && node test/provider-prefix.mjs && node test/analytics-recording.mjs && node test/analytics-billing-bucket.mjs && node test/failover-429.mjs && node test/pool-sticky.mjs && node test/live-fingerprint.mjs && node test/proxy-header-order.mjs && node test/proxy-body-order.mjs && node test/runtime-fingerprint.mjs && node test/pacing.mjs && node test/stream-drain.mjs && node test/subagent.mjs && node test/mcp-protocol.mjs && node test/mcp-tools.mjs && node test/mcp-e2e.mjs && node test/session-rotation.mjs && node test/drift-detection.mjs && node test/cc-authorize-probe-classifier.mjs && node test/compat-range.mjs && node test/doctor-formatter.mjs && node test/doctor-identity-drift.mjs && node test/atomic-write.mjs && node test/account-refresh-singleflight.mjs && node test/durable-token-persist.mjs && node test/streaming-edge-cases.mjs && node test/client-detection.mjs && node test/manual-oauth-flow.mjs && node test/scrub-template.mjs && node test/sanitize-messages.mjs && node test/platform-tools.mjs && node test/strict-template-flags.mjs && node test/request-queue.mjs && node test/effort-flag.mjs && node test/template-invariants.mjs",
+    "test:serial": "node test/issue-29-tool-translation.mjs && node test/hybrid-tools.mjs && node test/tool-schema-contract.mjs && node test/scrub-paths.mjs && node test/provider-prefix.mjs && node test/analytics-recording.mjs && node test/analytics-billing-bucket.mjs && node test/failover-429.mjs && node test/pool-sticky.mjs && node test/live-fingerprint.mjs && node test/proxy-header-order.mjs && node test/proxy-body-order.mjs && node test/runtime-fingerprint.mjs && node test/pacing.mjs && node test/stream-drain.mjs && node test/subagent.mjs && node test/mcp-protocol.mjs && node test/mcp-tools.mjs && node test/mcp-e2e.mjs && node test/session-rotation.mjs && node test/drift-detection.mjs && node test/cc-authorize-probe-classifier.mjs && node test/compat-range.mjs && node test/doctor-formatter.mjs && node test/doctor-identity-drift.mjs && node test/atomic-write.mjs && node test/account-refresh-singleflight.mjs && node test/durable-token-persist.mjs && node test/streaming-edge-cases.mjs && node test/client-detection.mjs && node test/manual-oauth-flow.mjs && node test/scrub-template.mjs && node test/context-bleed.mjs && node test/sanitize-messages.mjs && node test/platform-tools.mjs && node test/strict-template-flags.mjs && node test/request-queue.mjs && node test/effort-flag.mjs && node test/template-invariants.mjs",
     "audit": "npm audit --production --audit-level=high",
     "prepublishOnly": "npm run build",
     "start": "node dist/cli.js",

--- a/scripts/capture-and-bake.mjs
+++ b/scripts/capture-and-bake.mjs
@@ -118,7 +118,7 @@ scrubbed._supportedMaxTested = captured._version;
 
 const residualHits = findUserPathHits(JSON.stringify(scrubbed));
 if (residualHits.length > 0) {
-  log(`error: scrub left residual user paths in the serialized template:`);
+  log(`error: scrub left host content in the serialized template (paths, an unstripped section, or instruction-file prose — dario#872):`);
   for (const h of residualHits.slice(0, 10)) log(`  - ${h}`);
   process.exit(1);
 }
@@ -234,7 +234,7 @@ for (const { key, model } of VARIANT_MODELS) {
     }
     const vResidual = findUserPathHits(vScrubbed.system_prompt);
     if (vResidual.length > 0) {
-      log(`warning: ${key}-variant scrub left residual user paths — NOT storing variant: ${vResidual.slice(0, 3).join(', ')}`);
+      log(`warning: ${key}-variant scrub left host content — NOT storing variant: ${vResidual.slice(0, 3).join(', ')}`);
       keepPrevious();
       continue;
     }

--- a/scripts/check-cc-drift.mjs
+++ b/scripts/check-cc-drift.mjs
@@ -364,7 +364,7 @@ try {
       category: 'template.user_paths',
       severity: 'high',
       message:
-        `Baked cc-template-data.json contains user-identifying paths (${scrubHits.length} hit${scrubHits.length === 1 ? '' : 's'}; first: ${JSON.stringify(scrubHits[0])}). Re-run scripts/capture-and-bake.mjs — the scrub pipeline should strip these automatically.`,
+        `Baked cc-template-data.json contains host content (${scrubHits.length} hit${scrubHits.length === 1 ? '' : 's'}; first: ${JSON.stringify(scrubHits[0])}) — a user path, a section the strip missed, or instruction-file prose (dario#872). Re-run scripts/capture-and-bake.mjs; the scrub pipeline should strip these automatically.`,
     });
   }
   const mcpTools = (templateData.tools ?? []).filter((t) => typeof t?.name === 'string' && t.name.startsWith('mcp__'));

--- a/src/scrub-template.ts
+++ b/src/scrub-template.ts
@@ -234,9 +234,45 @@ function scrubObjectStrings(value: unknown): unknown {
 }
 
 /**
- * Run over a string and report any user-identifying patterns that remain.
- * Used by `scripts/check-cc-drift.mjs` to verify the baked template
- * passes scrubbing before a release goes out.
+ * Prose CC emits when it injects user- or project-level instruction files
+ * (CLAUDE.md, memory, environment) into a prompt. The section strip above is
+ * keyed on the `# claudeMd` heading shape; these are keyed on the wrapper text
+ * itself, so a reshaped or renamed heading still gets caught.
+ *
+ * Both halves are load-bearing. `removeSection` and the heading detector in
+ * findUserPathHits read the SAME heading list, so a heading CC renames strips
+ * nothing and flags nothing — two silent failures — and once paths are scrubbed
+ * the leftover prose carries no user path for the other detectors to catch.
+ * dario#872 saw one capture in six come back carrying another session's
+ * instruction text; this is the half that does not depend on the heading.
+ *
+ * Every marker is verified absent from the real baked template — base, fable,
+ * opus-5 and sonnet-5 prompts plus every tool description. Do NOT add bare
+ * `CLAUDE.md` or `system-reminder`: CC's own system prompt and tool
+ * descriptions both mention them, so either would fail every bake. Verified,
+ * not assumed, and test/context-bleed.mjs pins it.
+ */
+const INSTRUCTION_INJECTION_MARKERS: ReadonlyArray<{ label: string; re: RegExp }> = [
+  { label: 'instruction-file wrapper', re: /Codebase and user instructions are shown below/ },
+  { label: 'instruction-file wrapper', re: /IMPORTANT: These instructions OVERRIDE any default behavior/ },
+  // Straight and typographic apostrophe both — CC emits the straight one today,
+  // and a marker that a quote-style change silently disarms is not a guard.
+  { label: 'instruction-file annotation', re: /user['’]s private global instructions/ },
+  { label: 'memory-file annotation', re: /auto-memory, persists across conversations/ },
+  { label: 'instruction-file heading', re: /\bContents of [^\n]{1,300}\.md\b/ },
+  { label: 'project-instruction wrapper', re: /Here are useful instructions from/ },
+];
+
+/**
+ * Run over a string and report anything that must not survive into a bake:
+ * user-identifying paths, host-context sections the strip missed, and
+ * instruction-file prose (dario#872). Despite the name the contract has never
+ * been paths-only. Used by `scripts/check-cc-drift.mjs` to gate a release and
+ * by `scripts/capture-and-bake.mjs` to fail a bake.
+ *
+ * Deliberately NOT called from `extractTemplate`: that serves the live-capture
+ * path too, and the live fingerprint keeps host context on purpose — it exists
+ * to replay the operator's own CC install faithfully. Only the bake publishes.
  */
 export function findUserPathHits(text: string): string[] {
   const hits: string[] = [];
@@ -259,6 +295,13 @@ export function findUserPathHits(text: string): string[] {
     if (new RegExp(`\\r?\\n# ${esc}[ \\t]*\\r?\\n`).test(text)) {
       hits.push(`# ${name} (host-context section not stripped)`);
     }
+  }
+  // Instruction-file prose, matched on the wrapper rather than the heading.
+  // Excerpt is bounded: a hit is printed by the bake, and the whole point is
+  // that the matched text may be somebody's private instructions.
+  for (const { label, re } of INSTRUCTION_INJECTION_MARKERS) {
+    const m = text.match(re);
+    if (m) hits.push(`${m[0].slice(0, 60)} (${label} not stripped)`);
   }
   return hits;
 }

--- a/test/context-bleed.mjs
+++ b/test/context-bleed.mjs
@@ -1,0 +1,135 @@
+/**
+ * dario#872 — instruction-file prose must not survive into a bake.
+ *
+ * The scrub already strips CC's host-context sections and flags any that
+ * survive, but both halves of that are keyed on the `# claudeMd` heading shape.
+ * Rename or reshape the heading and `removeSection` strips nothing while the
+ * heading detector flags nothing — and once paths are scrubbed the leftover
+ * prose carries no user path for the other detectors to see. These cases pin
+ * the content-keyed half, which does not depend on the heading.
+ *
+ * The negative cases matter as much as the positives. A marker that appears in
+ * CC's genuine prompt would fail every bake, so `CLAUDE.md` and
+ * `system-reminder` are deliberately NOT markers: CC's own system prompt and
+ * tool descriptions mention both.
+ */
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { findUserPathHits } from '../dist/scrub-template.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const bundle = JSON.parse(
+  readFileSync(join(__dirname, '..', 'src', 'cc-template-data.json'), 'utf-8'),
+);
+
+let pass = 0;
+let fail = 0;
+
+function header(name) {
+  console.log(`\n${name}`);
+}
+
+function check(label, cond) {
+  if (cond) {
+    pass++;
+    console.log(`  ok   ${label}`);
+  } else {
+    fail++;
+    console.log(`  FAIL ${label}`);
+  }
+}
+
+// A bleed sample in CC's real wrapper shape with paths ALREADY scrubbed — the
+// case the path detectors are blind to by construction.
+const WRAPPED = [
+  'static prose that belongs in a prompt',
+  '',
+  '# claudeMd',
+  'Codebase and user instructions are shown below. Be sure to adhere to these instructions.',
+  '',
+  "Contents of /home/user/.claude/CLAUDE.md (user's private global instructions for all projects):",
+  '',
+  'some private operator instruction',
+  '',
+].join('\n');
+
+header('1. instruction-file prose is caught');
+check('wrapper sentence flagged', findUserPathHits(WRAPPED).some((h) => h.includes('instruction-file wrapper')));
+check(
+  'Contents-of heading flagged',
+  findUserPathHits(WRAPPED).some((h) => h.includes('instruction-file heading')),
+);
+check(
+  'file annotation flagged',
+  findUserPathHits("Contents of x (user's private global instructions for all projects):").some((h) =>
+    h.includes('instruction-file annotation'),
+  ),
+);
+check(
+  'typographic apostrophe also flagged',
+  findUserPathHits('(user’s private global instructions)').length > 0,
+);
+check(
+  'OVERRIDE sentence flagged',
+  findUserPathHits(
+    'IMPORTANT: These instructions OVERRIDE any default behavior and you MUST follow them.',
+  ).length > 0,
+);
+check(
+  'memory annotation flagged',
+  findUserPathHits("(user's auto-memory, persists across conversations)").length > 0,
+);
+check(
+  'project-instruction wrapper flagged',
+  findUserPathHits('Here are useful instructions from the repository:').length > 0,
+);
+
+header('2. the gap this closes — a heading CC renames');
+// With the heading intact the old detector already fires. Renaming it disarms
+// BOTH the strip and the heading detector; only the content markers survive.
+const renamed = WRAPPED.replace('# claudeMd', '# projectInstructions');
+check(
+  'intact heading is caught by the heading detector',
+  findUserPathHits(WRAPPED).some((h) => h.includes('host-context section not stripped')),
+);
+check(
+  'renamed heading is NOT caught by the heading detector',
+  !findUserPathHits(renamed).some((h) => h.includes('host-context section not stripped')),
+);
+check('renamed heading is still caught by the content markers', findUserPathHits(renamed).length > 0);
+
+header('3. no false positives on the real baked template');
+// If any of these fire, every bake fails. This is the case that disqualified
+// `CLAUDE.md` and `system-reminder` as markers during design.
+const slots = {
+  agent_identity: bundle.agent_identity ?? '',
+  system_prompt: bundle.system_prompt ?? '',
+  tool_descriptions: (bundle.tools ?? []).map((t) => t.description ?? '').join('\n'),
+  serialized: JSON.stringify(bundle),
+};
+for (const [key, value] of Object.entries(bundle.system_prompt_variants ?? {})) {
+  slots[`variant:${key}`] = value;
+}
+for (const [name, text] of Object.entries(slots)) {
+  const hits = findUserPathHits(text);
+  check(`${name} is clean`, hits.length === 0);
+  if (hits.length > 0) console.log(`       hits: ${JSON.stringify(hits.slice(0, 3))}`);
+}
+
+header('4. markers deliberately excluded');
+check('bare CLAUDE.md mention is not bleed', findUserPathHits('see CLAUDE.md for details').length === 0);
+check(
+  'bare system-reminder mention is not bleed',
+  findUserPathHits('wrapped in a <system-reminder> block').length === 0,
+);
+check(
+  'the words "contents of" without a .md are not bleed',
+  findUserPathHits('the contents of the response are streamed').length === 0,
+);
+check('ordinary prose is clean', findUserPathHits('be concise and direct\n# Tone\nbe nice').length === 0);
+
+console.log(`\n# pass ${pass}`);
+console.log(`# fail ${fail}`);
+if (fail > 0) process.exit(1);


### PR DESCRIPTION
Closes #872 — guard 1, the deterministic one. Guards 2 and 3 are not in this PR; see the bottom.

## What was actually missing

Less than #872 assumed. The scrub already handles this class: `removeHostContextSections` strips CC's `# claudeMd`, `# auto memory`, `# userEmail`, `# currentDate` and `# Environment` sections, and `findUserPathHits` flags any that survive so the release gate fails rather than shipping a leak (#642-audit).

The gap is that **both halves read the same heading list**. Rename or reshape the heading and `removeSection` strips nothing while the heading detector flags nothing — two silent failures stacked — and once paths are scrubbed the leftover prose carries no user path for the other detectors to see. The existing code comment already worried about "a renamed heading"; nothing acted on it.

That is the shape of what #872 observed: prose with no path in it, arriving somewhere the section detector wasn't looking.

## The change

`findUserPathHits` now also matches the wrapper prose itself, so the heading no longer has to be intact:

- `Codebase and user instructions are shown below`
- `IMPORTANT: These instructions OVERRIDE any default behavior`
- `Contents of <path>.md` (on one line)
- `user's private global instructions` — straight and typographic apostrophe
- `auto-memory, persists across conversations`
- `Here are useful instructions from`

Extending that function rather than adding a parallel one means both existing gates arm themselves with no new call sites: the bake fails hard on `JSON.stringify(scrubbed)` (capture-and-bake.mjs:119) and `check-cc-drift` fails the release (check-cc-drift.mjs:361). The variant path keeps its existing warn-and-keep-previous behaviour, which is right — a variant is optional, the base is not.

Both failure messages said "residual user paths". A hit is no longer necessarily a path, and mis-naming one is what sent the original investigation looking at model pricing, so they now say "host content" and name the three possibilities.

## Marker selection was measured, not guessed

I probed every candidate against the real baked template before committing to any. Two obvious ones are disqualified:

| candidate | agent_identity | system_prompt | fable | opus-5 | sonnet-5 | tool descriptions |
|---|---|---|---|---|---|---|
| `CLAUDE.md` | 0 | **1** | **1** | **1** | **1** | **3** |
| `<system-reminder>` | 0 | **2** | **1** | **1** | **1** | **1** |

CC's own system prompt and tool descriptions mention both. Either as a marker would have failed **every** bake from the first run — a guard that fires on legitimate content is worse than no guard. `test/context-bleed.mjs` pins them as explicit non-markers so nobody "tightens" the list and breaks the pipeline.

## Deliberately not in `extractTemplate`

`extractTemplate` serves the live-capture path too, and `refreshLiveFingerprintAsync` writes the capture to `~/.dario/cc-template.live.json` **unscrubbed on purpose** — the live fingerprint exists to replay the operator's own CC install faithfully, host context included. Gating there would break that by design. Only the bake publishes, so only the bake gates.

## Verification

`test/context-bleed.mjs`, 21 assertions in four groups: the prose is caught; the renamed-heading case is caught by the content markers and provably *not* by the heading detector; every baked slot plus the whole serialized bundle is clean; and the excluded markers stay excluded.

Full suite **124/124**.

Ran a real `capture-and-bake --check` with the guard armed, on a machine that has both a user-level and a project-level `CLAUDE.md`. **The guard stays silent** — because CC delivers instruction files in `messages` and the bake only keeps `system[1]` and `system[2]`. That is the same boundary #872 identified as the reason the original bleed never reached a bundle, now confirmed from the other direction: no false positive on a live capture that has plenty of instruction content available to bleed.

## Two things this does not do

**Guard 3 (the provenance nonce) is not here.** #872 already noted the caveat: when a real `ANTHROPIC_API_KEY` is present the capture passes it through deliberately, so a nonce needs a fallback rather than unconditionally overriding the child's auth, and changing what the child authenticates with can change what CC sends. That deserves its own PR with its own live check, not a rider on this one. Guard 2 (anchor assertion) only catches wholesale substitution, which the tool-count and block-shape checks in `extractTemplate` already largely cover.

**The bundled template is stale and I did not re-bake it.** That `--check` run reports genuine drift — `afk-mode-2026-01-31` back on (it is remote-config controlled and flips), sonnet-5 variant 13448 → 13442, and +279 chars in the base prompt. Re-baking here would collide with the cc-drift bot, which CLAUDE.md says not to compete with. `src/cc-template-data.json` is untouched.
