### PR TITLE
feat(capture): prove the captured request came from the CC we spawned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ checklist.
 
 ## [Unreleased]
 
+## [5.4.12] - 2026-07-26
+
+- **The capture now proves the request came from the CC child it spawned.** `runCapture` accepted the first request whose URL merely contained `/v1/messages`, with nothing tying it to the child — the ephemeral port was the whole of the defence, and once a foreign request was captured nothing downstream could tell it from the child's (dario#872). `ANTHROPIC_BASE_URL` now carries a per-capture nonce and the MITM only accepts a path with that nonce as its prefix; anything else 404s, and a `/v1/messages` without it logs rather than passing unnoticed. Fails closed — no nonce, no capture, and the bake exits non-zero.
+
+  The nonce rides in the URL rather than in `ANTHROPIC_API_KEY`, which #872 had proposed. Measured first: CC honours a path segment in `ANTHROPIC_BASE_URL` (it requests `/<nonce>/v1/messages?beta=true`, probing `/<nonce>/api/hello` first), and on a subscription install it authenticates with `authorization: Bearer` and sends no `x-api-key` at all — so a key-borne nonce would do nothing there while changing the auth path for API-key installs. Changing what the child authenticates with is the one thing a fingerprint capture must not do. Verified with a real `--check`: all four prompts captured through the nonce path (base 5038, fable 9205, opus-5 8093, sonnet-5 13442).
+
+  The third guard #872 listed, a structural anchor assertion, is redundant rather than deferred: `extractTemplate` already requires two system blocks, a non-empty identity and prompt, and at least one non-`mcp__` tool, and the nonce makes wholesale substitution unreachable — a request that is not ours is never captured at all.
+
 ## [5.4.11] - 2026-07-26
 
 - **A bake can no longer ship instruction-file prose that the section strip missed.** `scrubText` already removes CC's host-context sections and `findUserPathHits` already flags any that survive, but both read the same heading list — so a heading CC renames or reshapes strips nothing and flags nothing, and once paths are scrubbed the leftover prose carries no user path for the other detectors to catch. That is two silent failures stacked, and it is the shape of what dario#872 saw: one capture in six came back carrying another session's instruction text. `findUserPathHits` now also matches the wrapper prose itself — the `Codebase and user instructions are shown below` and `IMPORTANT: These instructions OVERRIDE` sentences, the `Contents of <path>.md` line, the private-instruction and auto-memory annotations — so the heading no longer has to be intact for the leak to be caught. Both existing gates pick it up for free: the bake fails hard on the serialized template and `check-cc-drift` fails the release.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.4.11",
+  "version": "5.4.12",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {
@@ -22,7 +22,7 @@
   "scripts": {
     "build": "tsc && cp src/cc-template-data.json dist/",
     "test": "node --test --test-concurrency=8 test/all.test.mjs",
-    "test:serial": "node test/issue-29-tool-translation.mjs && node test/hybrid-tools.mjs && node test/tool-schema-contract.mjs && node test/scrub-paths.mjs && node test/provider-prefix.mjs && node test/analytics-recording.mjs && node test/analytics-billing-bucket.mjs && node test/failover-429.mjs && node test/pool-sticky.mjs && node test/live-fingerprint.mjs && node test/proxy-header-order.mjs && node test/proxy-body-order.mjs && node test/runtime-fingerprint.mjs && node test/pacing.mjs && node test/stream-drain.mjs && node test/subagent.mjs && node test/mcp-protocol.mjs && node test/mcp-tools.mjs && node test/mcp-e2e.mjs && node test/session-rotation.mjs && node test/drift-detection.mjs && node test/cc-authorize-probe-classifier.mjs && node test/compat-range.mjs && node test/doctor-formatter.mjs && node test/doctor-identity-drift.mjs && node test/atomic-write.mjs && node test/account-refresh-singleflight.mjs && node test/durable-token-persist.mjs && node test/streaming-edge-cases.mjs && node test/client-detection.mjs && node test/manual-oauth-flow.mjs && node test/scrub-template.mjs && node test/context-bleed.mjs && node test/sanitize-messages.mjs && node test/platform-tools.mjs && node test/strict-template-flags.mjs && node test/request-queue.mjs && node test/effort-flag.mjs && node test/template-invariants.mjs",
+    "test:serial": "node test/issue-29-tool-translation.mjs && node test/hybrid-tools.mjs && node test/tool-schema-contract.mjs && node test/scrub-paths.mjs && node test/provider-prefix.mjs && node test/analytics-recording.mjs && node test/analytics-billing-bucket.mjs && node test/failover-429.mjs && node test/pool-sticky.mjs && node test/live-fingerprint.mjs && node test/proxy-header-order.mjs && node test/proxy-body-order.mjs && node test/runtime-fingerprint.mjs && node test/pacing.mjs && node test/stream-drain.mjs && node test/subagent.mjs && node test/mcp-protocol.mjs && node test/mcp-tools.mjs && node test/mcp-e2e.mjs && node test/session-rotation.mjs && node test/drift-detection.mjs && node test/cc-authorize-probe-classifier.mjs && node test/compat-range.mjs && node test/doctor-formatter.mjs && node test/doctor-identity-drift.mjs && node test/atomic-write.mjs && node test/account-refresh-singleflight.mjs && node test/durable-token-persist.mjs && node test/streaming-edge-cases.mjs && node test/client-detection.mjs && node test/manual-oauth-flow.mjs && node test/scrub-template.mjs && node test/context-bleed.mjs && node test/capture-provenance.mjs && node test/sanitize-messages.mjs && node test/platform-tools.mjs && node test/strict-template-flags.mjs && node test/request-queue.mjs && node test/effort-flag.mjs && node test/template-invariants.mjs",
     "audit": "npm audit --production --audit-level=high",
     "prepublishOnly": "npm run build",
     "start": "node dist/cli.js",

--- a/src/live-fingerprint.ts
+++ b/src/live-fingerprint.ts
@@ -86,6 +86,7 @@
  */
 
 import { spawn, execFileSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
 import { createServer, IncomingMessage, ServerResponse } from 'node:http';
 import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync, unlinkSync } from 'node:fs';
 import { homedir } from 'node:os';
@@ -472,6 +473,40 @@ interface CapturedRequest {
 }
 
 /**
+ * Does this request belong to the capture we started?
+ *
+ * The MITM used to accept the FIRST request whose URL contained
+ * `/v1/messages` with nothing tying it to the child we spawned (dario#872).
+ * The port is ephemeral, so a collision is improbable rather than
+ * impossible, and nothing downstream could tell a foreign request from the
+ * child's once it was captured.
+ *
+ * The nonce rides in the URL path because that is the one channel we fully
+ * control without touching what CC sends. Two measurements decided it over a
+ * key-borne nonce:
+ *
+ *   1. CC honours a path segment in ANTHROPIC_BASE_URL — given
+ *      `http://127.0.0.1:PORT/<nonce>` it requests
+ *      `/<nonce>/v1/messages?beta=true` (and probes `/<nonce>/api/hello`
+ *      first, which still 404s here).
+ *   2. On a subscription install CC authenticates with
+ *      `authorization: Bearer sk-ant-…`, so ANTHROPIC_API_KEY is not the auth
+ *      header at all. A key-borne nonce would do nothing on OAuth installs
+ *      while changing the auth path for API-key ones — and changing what the
+ *      child authenticates with can change what it sends, which is the whole
+ *      thing a fingerprint capture must not do.
+ *
+ * Fails closed: no nonce, no capture. A miss makes the capture return null
+ * and the bake exit non-zero, which is the correct outcome for a request we
+ * cannot attribute.
+ */
+export function isOwnCaptureRequest(url: string | undefined, nonce: string): boolean {
+  if (!url || nonce.length === 0) return false;
+  if (!url.startsWith(`/${nonce}/`)) return false;
+  return url.includes('/v1/messages');
+}
+
+/**
  * Run a loopback MITM server on a random port, spawn CC with
  * ANTHROPIC_BASE_URL pointed at it, wait for one request, respond with a
  * minimal valid SSE stream, and return the captured request.
@@ -485,9 +520,11 @@ export async function captureLiveTemplateAsync(timeoutMs: number = 10_000): Prom
 }
 
 async function runCapture(timeoutMs: number): Promise<CapturedRequest | null> {
+  const nonce = `dario-capture-${randomBytes(12).toString('hex')}`;
   return new Promise((resolve) => {
     let captured: CapturedRequest | null = null;
     let settled = false;
+    let foreign = 0;
     const settle = (result: CapturedRequest | null) => {
       if (settled) return;
       settled = true;
@@ -497,9 +534,19 @@ async function runCapture(timeoutMs: number): Promise<CapturedRequest | null> {
     };
 
     const server = createServer((req: IncomingMessage, res: ServerResponse) => {
-      // Only handle /v1/messages — everything else gets a 404 so CC doesn't
-      // accidentally think /v1/models is live.
-      if (!req.url?.includes('/v1/messages')) {
+      // Only handle OUR /v1/messages — everything else gets a 404 so CC
+      // doesn't accidentally think /v1/models is live, and so a request we
+      // cannot attribute to the spawned child is never captured (dario#872).
+      if (!isOwnCaptureRequest(req.url, nonce)) {
+        // A /v1/messages without our nonce is exactly the case #872 is about:
+        // something else reached this port. Say so — a silent 404 here is how
+        // a foreign capture would have gone unnoticed.
+        if (req.url?.includes('/v1/messages')) {
+          foreign++;
+          console.error(
+            `[dario] capture: rejected a /v1/messages request that did not carry this capture's nonce (${foreign} so far) — see dario#872`,
+          );
+        }
         res.writeHead(404, { 'content-type': 'application/json' });
         res.end('{"type":"error","error":{"type":"not_found_error","message":"not found"}}');
         return;
@@ -518,7 +565,7 @@ async function runCapture(timeoutMs: number): Promise<CapturedRequest | null> {
           }
           captured = {
             method: req.method ?? 'POST',
-            path: req.url ?? '/v1/messages',
+            path: (req.url ?? '/v1/messages').replace(`/${nonce}`, ''),
             headers,
             rawHeaders: Array.isArray(req.rawHeaders) ? [...req.rawHeaders] : [],
             body,
@@ -585,7 +632,7 @@ async function runCapture(timeoutMs: number): Promise<CapturedRequest | null> {
         settle(null);
         return;
       }
-      const url = `http://127.0.0.1:${address.port}`;
+      const url = `http://127.0.0.1:${address.port}/${nonce}`;
 
       // Spawn CC with ANTHROPIC_BASE_URL pointed at our MITM.
       const claudeBin = findClaudeBinary();

--- a/test/capture-provenance.mjs
+++ b/test/capture-provenance.mjs
@@ -1,0 +1,74 @@
+/**
+ * dario#872 guard 3 — the capture must not accept a request it cannot attribute
+ * to the CC child it spawned.
+ *
+ * Before this, the MITM took the FIRST request whose URL merely contained
+ * `/v1/messages`. The port is ephemeral so a collision is improbable rather than
+ * impossible, and nothing downstream could tell a foreign request from the
+ * child's once captured.
+ *
+ * The nonce rides in the URL rather than in ANTHROPIC_API_KEY, which was
+ * measured rather than assumed: CC honours a path segment in
+ * ANTHROPIC_BASE_URL (`http://127.0.0.1:PORT/<nonce>` produces
+ * `/<nonce>/v1/messages?beta=true`), and on a subscription install it
+ * authenticates with `authorization: Bearer sk-ant-…` — so a key-borne nonce
+ * would do nothing there while changing the auth path for API-key installs.
+ */
+import { isOwnCaptureRequest } from '../dist/live-fingerprint.js';
+
+const N = 'dario-capture-deadbeefdeadbeefdeadbeef';
+
+let pass = 0;
+let fail = 0;
+
+function header(name) {
+  console.log(`\n${name}`);
+}
+
+function check(label, cond) {
+  if (cond) {
+    pass++;
+    console.log(`  ok   ${label}`);
+  } else {
+    fail++;
+    console.log(`  FAIL ${label}`);
+  }
+}
+
+header('1. our own child is accepted');
+check('plain path', isOwnCaptureRequest(`/${N}/v1/messages`, N) === true);
+// CC actually sends this shape — the query string is not optional in practice.
+check('with ?beta=true', isOwnCaptureRequest(`/${N}/v1/messages?beta=true`, N) === true);
+check('count_tokens under the same nonce', isOwnCaptureRequest(`/${N}/v1/messages/count_tokens`, N) === true);
+
+header('2. the dario#872 case — a /v1/messages we cannot attribute');
+check('no nonce at all is rejected', isOwnCaptureRequest('/v1/messages', N) === false);
+check('with query string, still rejected', isOwnCaptureRequest('/v1/messages?beta=true', N) === false);
+check(
+  "another capture's nonce is rejected",
+  isOwnCaptureRequest('/dario-capture-0000000000000000000000/v1/messages', N) === false,
+);
+// The nonce must be the PREFIX. Appearing anywhere in the path is not enough,
+// or anything that can echo it back into a URL defeats the check.
+check(
+  'nonce present but not as prefix is rejected',
+  isOwnCaptureRequest(`/someone-else/${N}/v1/messages`, N) === false,
+);
+
+header('3. other paths on our own port');
+// CC probes this first; it must 404 like before, not be mistaken for a capture.
+check('api/hello under our nonce is not a capture', isOwnCaptureRequest(`/${N}/api/hello`, N) === false);
+check('v1/models under our nonce is not a capture', isOwnCaptureRequest(`/${N}/v1/models`, N) === false);
+check('bare nonce root is not a capture', isOwnCaptureRequest(`/${N}/`, N) === false);
+
+header('4. fails closed');
+check('undefined url', isOwnCaptureRequest(undefined, N) === false);
+check('empty url', isOwnCaptureRequest('', N) === false);
+// An empty nonce would otherwise make `/${''}/v1/messages` = `//v1/messages`
+// matchable, and worse, would accept a bare `/v1/...` under some prefixes.
+check('empty nonce accepts nothing', isOwnCaptureRequest('/v1/messages', '') === false);
+check('empty nonce with slash prefix accepts nothing', isOwnCaptureRequest('//v1/messages', '') === false);
+
+console.log(`\n# pass ${pass}`);
+console.log(`# fail ${fail}`);
+if (fail > 0) process.exit(1);


### PR DESCRIPTION
Completes the last guard from #872. Guard 1 landed in #874; #872 closed with it, so this is the remainder rather than a new issue.

## The hole

`runCapture` accepted the first request whose URL merely contained `/v1/messages`, with nothing tying it to the CC child it had just spawned. The port is ephemeral so a collision is improbable rather than impossible — but "improbable" is the whole of the defence, and once a foreign request was captured nothing downstream could tell it from the child's.

## The nonce goes in the URL, not the API key

#872 proposed a nonce in `ANTHROPIC_API_KEY` and flagged the caveat: the capture passes a real key through deliberately, so overriding it could change what CC sends. I probed the installed CC before writing anything, and the measurement redirected the design:

```
base url given to CC:  http://127.0.0.1:60370/dario-capture-probe-abc123
  request 1: /dario-capture-probe-abc123/api/hello
  request 2: /dario-capture-probe-abc123/v1/messages?beta=true
  authorization: Bearer sk-an…      x-api-key: (absent)
```

Two results:

1. **CC honours a path segment in `ANTHROPIC_BASE_URL`.** It appends its own paths beneath it, and probes `/api/hello` first — which still 404s here, as before.
2. **On a subscription install CC authenticates with `authorization: Bearer`, and sends no `x-api-key` at all.** A key-borne nonce would therefore do nothing on OAuth installs while changing the auth path for API-key ones. Changing what the child authenticates with is exactly what a fingerprint capture must not do.

So the nonce rides in the path: `ANTHROPIC_BASE_URL=http://127.0.0.1:<port>/<nonce>`, and `isOwnCaptureRequest` requires that nonce as a **prefix** plus `/v1/messages`. Nothing about the child's auth changes.

Fails closed. No nonce, no capture — `runCapture` returns null and the bake exits non-zero, which is the right outcome for a request we cannot attribute. A `/v1/messages` that arrives without the nonce now logs, because a silent 404 there is precisely how a foreign capture went unnoticed the first time.

The nonce is also stripped from the recorded `CapturedRequest.path`. Nothing bakes that field today, but a per-capture random value has no business travelling further than it must.

## Guard 2 is not here, on purpose

The anchor assertion #872 listed third is now redundant rather than deferred. `extractTemplate` already requires two system blocks, a non-empty `agent_identity` and `system_prompt`, and at least one non-`mcp__` tool. Guard 2 existed to catch wholesale substitution by some other client — and guard 3 makes that unreachable by construction, because a request that isn't ours is never captured at all. What remains is "our own child sent something structurally odd", which the existing non-empty checks cover and the drift detector reports on. Adding it would be ceremony.

## Verification

`test/capture-provenance.mjs`, 14 assertions. The ones that matter beyond the happy path:

- a bare `/v1/messages` with no nonce is rejected — the #872 case
- `/someone-else/<nonce>/v1/messages` is rejected, so the nonce appearing *anywhere* in the path is not enough; anything that could echo it back cannot defeat the check
- another capture's nonce is rejected
- an empty nonce accepts nothing, rather than degrading into matching `//v1/messages`
- `/<nonce>/api/hello` and `/<nonce>/v1/models` are not captures

**A real `capture-and-bake --check` captured all four prompts through the nonce path** — base 5038, fable 9205, opus-5 8093, sonnet-5 13442, CC v2.1.220. No null capture, no foreign-request warnings. That was the make-or-break test: if CC had not honoured the subpath, every capture would have timed out and the bake would have broken.

Full suite green.

## The bundle is still stale, deliberately

That `--check` reports genuine drift — `afk-mode-2026-01-31` back on (it is remote-config controlled and flips), sonnet-5 variant 13448 → 13442, +279 chars in the base prompt. The re-bake is a separate PR on top of this one, so the bundle is produced by the final guard code rather than an intermediate state. `src/cc-template-data.json` is untouched here.
