### PR TITLE
fix(config): make the documented env off-switches actually switch off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ checklist.
 
 ## [Unreleased]
 
+## [5.4.14] - 2026-07-26
+
+- **`DARIO_OVERAGE_GUARD=off` and `DARIO_OVERAGE_NOTIFY=off` now actually turn those features off.** `cli.ts` has documented both as the env equivalents of `--no-overage-guard` / `--no-overage-notify` since v4.1, but `parseBooleanEnv` returns `true` or `undefined` and never `false` — so `off` fell straight through `flag ?? env ?? fileCfg ?? true` and the guard stayed enabled, silently. Container deployments were the only ones affected, and the worst ones to affect: a flag was the sole working way to disable it. New `parseTriStateEnv` handles `off|0|false|no` as well as `on|1|true|yes`, and is used only at those two sites. `parseBooleanEnv` keeps its truthy-only contract — the three call sites that read it (`DARIO_STEALTH`, `DARIO_NO_LIVE_CAPTURE`, `DARIO_STRICT_TEMPLATE`) use `||`, where `false` and `undefined` are indistinguishable, and `test/strict-template-flags.mjs` pins that behaviour. An unrecognised value still yields `undefined` at both, so a typo defers to the config file and the default instead of guessing.
+
+- **New [`docs/configuration.md`](docs/configuration.md).** 29 environment variables that appeared in neither the README nor `docs/`: the whole overage-guard set, the request-queue knobs, template fidelity, the pacing axes, and the env forms of flags the README already documents. Grouped by task rather than by flag, because the audience is Docker / Compose / k8s / systemd, where a flag is not available. Also states the precedence order and which variables are not part of the supported surface. `commands.md` remains the per-flag reference and the two cross-link; nothing is documented in both, since two copies of a default is one that goes stale.
+
+- **Corrected four stale self-referential claims in the README.** Per-model `anthropic-beta` counts were opus 9 / sonnet 8 / haiku 6 and are now 10 / 9 / 6 — they moved with 5.4.13's re-bake, which added `afk-mode` to the base, so the line now says the counts track the baked base instead of freezing a number. Source is 23,833 lines across 52 files, not ~22k across 49. `test/` holds 132 files of which 125 run under the parallel runner, not 113. Zero runtime dependencies re-verified and unchanged. Also documented the six drift and audit runners (`drift:wire`, `drift:sdk`, `audit:tui`, `check:overage`, `stress`, `cch:calibrate`) that existed in `package.json` and nowhere else.
+
 ## [5.4.13] - 2026-07-26
 
 - **Re-baked the CC template against v2.1.220.** `--check` now reports no drift and exits 0. Three slots moved and the rest are byte-identical: `anthropic_beta` gains `afk-mode-2026-01-31`, the sonnet-5 prompt variant goes 13448 -> 13442, and the base prompt stays at 4759. Baked with the #874 and #875 guards both in the tree, so the capture behind this bundle was provenance-checked by the nonce and the instruction-file detector was armed and silent throughout.

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Guarded by a PR-time compat gate that runs the full suite against a live proxy b
 |---|---|---|
 | `context-1m` dropped from the default beta set on the OAuth path | Subscription requests default to the 200K window on Sonnet/Opus | v3.38.3–4 |
 | `thinking: {type:"adaptive"}` gated per-model server-side | Sonnet/Opus 4-5 400 every request through any proxy | [v3.38.5](https://github.com/askalf/dario/pull/273) |
-| Per-model `anthropic-beta` sets (opus 9, sonnet 8, haiku 6) | Proxies sending one set diverge for non-opus models | [v4.8.53](https://github.com/askalf/dario/pull/478) |
+| Per-model `anthropic-beta` sets (opus 10, sonnet 9, haiku 6 — they track the baked base, so counts shift when CC's set does) | Proxies sending one set diverge for non-opus models | [v4.8.53](https://github.com/askalf/dario/pull/478) |
 
 The full ledger lives in the [CHANGELOG](CHANGELOG.md). Setup + walkthrough: [`docs/drift-monitor.md`](./docs/drift-monitor.md). Residual manual cases — OAuth rotation, runner re-registration — are in the [recovery runbook](./docs/recovery.md).
 
@@ -218,11 +218,11 @@ The split isn't live, but it was announced once on short notice and could return
 
 | Signal | Status |
 |---|---|
-| Source | **~22k** lines of TypeScript across **49** files — auditable in a weekend (v5 removed shim; the pool is the one code path) |
+| Source | **~24k** lines of TypeScript across **52** files — auditable in a weekend (v5 removed shim; the pool is the one code path) |
 | Dependencies | **0 runtime.** Verify: `npm ls --production` |
 | Provenance | Every release [SLSA-attested](https://www.npmjs.com/package/@askalf/dario) via GitHub Actions + Sigstore |
 | Scanning | [CodeQL](https://github.com/askalf/dario/actions/workflows/codeql.yml) on every push and weekly |
-| Tests | **113 test files** run in parallel by `test/all.test.mjs` — green on every release |
+| Tests | **132 test files**, 125 run in parallel by `test/all.test.mjs` (e2e / compat / stealth opt out and have their own entry points) — green on every release |
 | Credentials | Your own subscription tokens, never logged, redacted from errors, `0600` on disk in `0700` dirs |
 | Network | Binds `127.0.0.1` by default; upstream only to configured backends over HTTPS; hardcoded SSRF allow-list |
 | Telemetry | **None.** No analytics, no tracking, nothing phones home |
@@ -253,7 +253,7 @@ dario uses your own subscription credentials, authenticates you as you, and impe
 
 `dario` (TUI) · `login` · `proxy` · `doctor` · `accounts {list,add,remove}` · `backend {list,add,remove}` · `mcp` · `subagent {install,status,remove}` · `usage` · `config` · `upgrade` · `status` · `refresh` · `resume` · `logout` · `help`
 
-Full flag/env reference: [`docs/commands.md`](./docs/commands.md) · SDK examples + per-tool setup: [`docs/usage.md`](./docs/usage.md)
+Per-flag reference: [`docs/commands.md`](./docs/commands.md) · env vars grouped by task, for Docker / k8s / systemd: [`docs/configuration.md`](./docs/configuration.md) · SDK examples + per-tool setup: [`docs/usage.md`](./docs/usage.md)
 
 ---
 
@@ -299,8 +299,19 @@ PRs welcome. Small TypeScript codebase, zero runtime deps. Architecture + file-b
 git clone https://github.com/askalf/dario && cd dario
 npm install
 npm run dev    # tsx, no build step
-npm test       # 113 test files via test/all.test.mjs
+npm test       # 125 suites in parallel via test/all.test.mjs
 npm run e2e    # live proxy + OAuth (needs a working Claude backend)
+```
+
+Drift and audit runners, none of them part of `npm test`:
+
+```bash
+npm run drift:wire    # compare a live CC capture against the baked template
+npm run drift:sdk     # Agent-SDK / Stainless pin drift
+npm run audit:tui     # drives the real TUI through a fake TTY at 12 geometries
+npm run check:overage # overage-classifier check against live headers
+npm run stress        # concurrency / queue behaviour under load
+npm run cch:calibrate # re-derive the billing-tag cch seed for a new CC build
 ```
 
 Two easy ways to help beyond code: **star the repo** (the clearest signal this is useful), and **file drift** — open an issue when a rate-limit header flips or a tool that worked yesterday breaks today, and it gets documented in public alongside the fix. Follow [@ask_alf](https://x.com/ask_alf) for drift bulletins as they land.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,5 +1,7 @@
 # Commands and proxy options
 
+This page is the per-flag reference. For environment variables grouped by task — overage guard, request queue, template fidelity, pacing — see [`configuration.md`](./configuration.md), which also covers the precedence order and the boolean-parsing rules.
+
 ## Commands
 
 | Command | Description |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,109 @@
+# Configuration
+
+Every knob below is settable three ways. Precedence, highest first:
+
+1. a CLI flag
+2. an environment variable
+3. `~/.dario/config.json`
+4. the built-in default
+
+`dario --help` is the complete list and always matches the binary you have installed. [`commands.md`](./commands.md) documents the proxy options flag-by-flag, including the OAuth overrides, session-rotation and TLS vars not repeated here.
+
+This page is the other view: grouped by what you are trying to do, covering the vars that matter when you cannot pass a flag — Docker, Compose, k8s, systemd — plus the ones whose behaviour has a sharp edge worth stating in prose. Anything documented in `commands.md` is deliberately not restated here; two copies of a default is one that goes stale.
+
+## Booleans
+
+Two shapes, and the difference is not cosmetic.
+
+**Off-switches** (`DARIO_OVERAGE_GUARD`, `DARIO_OVERAGE_NOTIFY`) accept `on|1|true|yes` and `off|0|false|no`. They guard features that default **on**, so they have to be able to say no.
+
+**On-switches** (everything else) accept only `1|true|yes|on`. They guard features that default **off**, so an unset var and a falsy var mean the same thing and there is nothing to express.
+
+An unrecognised value is ignored in both cases and the next source down wins. A typo leaves you on the default rather than silently flipping the knob.
+
+> `DARIO_OVERAGE_GUARD=off` and `DARIO_OVERAGE_NOTIFY=off` were documented in `cli.ts` from v4.1 but did nothing until v5.4.14 — the shared parser could only return `true` or `undefined`, so `off` fell through the `?? … ?? true` chain and the guard stayed on. Container deployments were the only ones affected, because a flag was the sole working way to turn it off.
+
+## Overage guard
+
+Halts the proxy when an upstream response reports `representative-claim: overage`, so a subscription never silently starts billing per token. Defaults on. See [`#288`](https://github.com/askalf/dario/issues/288).
+
+| Variable | Flag | Default | Values |
+|---|---|---|---|
+| `DARIO_OVERAGE_GUARD` | `--no-overage-guard` | on | off-switch |
+| `DARIO_OVERAGE_BEHAVIOR` | `--overage-behavior=` | `halt` | `halt` returns 503 until cooldown or `dario resume`; `warn` logs and keeps serving |
+| `DARIO_OVERAGE_COOLDOWN` | `--overage-cooldown=MS` | `1800000` (30 min) | ms |
+| `DARIO_OVERAGE_NOTIFY` | `--no-overage-notify` | on | off-switch; suppresses the desktop notification only |
+
+## Request queue
+
+| Variable | Flag | Default | Notes |
+|---|---|---|---|
+| `DARIO_MAX_CONCURRENT` | `--max-concurrent=N` | `10` | in-flight ceiling |
+| `DARIO_MAX_QUEUED` | `--max-queued=N` | `128` | buffered waiting for a slot; over this, dario returns 429 `queue-full` |
+| `DARIO_QUEUE_TIMEOUT_MS` | `--queue-timeout=MS` | `60000` | a queued request waiting longer gets 504 `queue-timeout` |
+
+## Template fidelity
+
+dario replays Claude Code's wire shape from a template it captures from your installed `claude` binary, falling back to a baked snapshot. These two make the unsafe states require intent ([`#77`](https://github.com/askalf/dario/issues/77)).
+
+| Variable | Flag | Default | Notes |
+|---|---|---|---|
+| `DARIO_NO_LIVE_CAPTURE` | `--no-live-capture` | off | Never spawn the installed CC; use the baked snapshot only. For air-gapped and reproducible-build runs. |
+| `DARIO_STRICT_TEMPLATE` | `--strict-template` | off | Refuse to start if the live capture never succeeded or drifts from the installed CC version. |
+
+## Client shape
+
+Off by default, each one a deliberate divergence from what real CC sends.
+
+| Variable | Flag | Notes |
+|---|---|---|
+| `DARIO_STEALTH` | `--stealth` | Behavioural-stealth preset. Per-knob pacing vars below still win, so you can flip this on and tune one axis. |
+| `DARIO_HONOR_CLIENT_THINKING` | `--honor-client-thinking` | Pass a client's own `thinking` block through unchanged. |
+| `DARIO_PRESERVE_OUTPUT_FORMAT` | `--preserve-output-format` | Carry a client's `output_config.format` schema through, for structured-output SDKs. |
+| `DARIO_PRESERVE_ORCHESTRATION_TAGS` | `--preserve-orchestration-tags` | Keep orchestration tags instead of stripping them ([`#78`](https://github.com/askalf/dario/issues/78)). |
+| `DARIO_EFFORT` | `--effort=` | Forces a reasoning-effort level. Can flip requests to overage billing — watch `-v` logs for representative-claim changes ([`#87`](https://github.com/askalf/dario/issues/87)). |
+| `DARIO_MAX_TOKENS` | `--max-tokens=` | Anthropic enforces the per-model ceiling server-side, so too-high values return a clean 400 ([`#88`](https://github.com/askalf/dario/issues/88)). |
+
+## Pacing
+
+Only meaningful with stealth, and all default to 0 (off) except the cap. See [`wire-fidelity.md`](./wire-fidelity.md).
+
+| Variable | Flag | Default |
+|---|---|---|
+| `DARIO_THINK_TIME_BASE_MS` | `--think-time-base=MS` | `0` |
+| `DARIO_THINK_TIME_PER_TOKEN_MS` | `--think-time-per-token=MS` | `0` |
+| `DARIO_THINK_TIME_JITTER_MS` | `--think-time-jitter=MS` | `0` |
+| `DARIO_THINK_TIME_MAX_MS` | `--think-time-max=MS` | `30000` |
+| `DARIO_SESSION_START_MIN_MS` | `--session-start-min=MS` | `0` |
+| `DARIO_SESSION_START_JITTER_MS` | `--session-start-jitter=MS` | `0` |
+
+## Pool and routing
+
+The pool-strategy, fallback-model, alias and upstream-proxy vars live in [`commands.md`](./commands.md).
+
+| Variable | Flag | Notes |
+|---|---|---|
+| `DARIO_SUSPENDED_MODELS` | — | Filters families from `/v1/models` so it never advertises a model that 404s. |
+| `DARIO_SKIP_FIELDS` | `--skip-fields=CSV` | Drop named fields from the outbound body. |
+
+## Networking and caches
+
+| Variable | Flag | Default | Notes |
+|---|---|---|---|
+| `DARIO_DNS_RESULT_ORDER` | — | `ipv4first` | `verbatim` uses the resolver's own order. IPv4-first because an IPv6 answer is not universally routable. |
+| `DARIO_MODEL_CATALOG_TTL_MS` | — | `3600000` (1h) | How long `/v1/models` caches Anthropic's live catalog. Model launches are rare; shorten it if you are chasing one. |
+| `DARIO_USAGE_PORT` | `--port=N` | `3456` | Which proxy the `dario usage` subcommand queries. |
+
+## Escape hatches
+
+Reversible switches for behaviour that is normally correct. You should not need them; they exist so a bad guess on our side is not fatal.
+
+| Variable | Values | Notes |
+|---|---|---|
+| `DARIO_CCH` | `random` | Stops replaying a calibrated `cch` token in the billing tag and randomises it per request instead. Only affects CC versions we hold a seed for — current CC sends no `cch` at all, so dario omits it and this does nothing. |
+
+## Not part of the supported surface
+
+`DARIO_LIVE_TEMPLATE_CACHE` and `DARIO_TEST_URL` exist for the test suite. They are not configuration, are not covered by semver, and can change or vanish in a patch release.
+
+If an unsupported var is the only way to do something you need, that is a missing flag. Open an issue.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.4.13",
+  "version": "5.4.14",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -595,13 +595,15 @@ async function proxy() {
   //   --overage-behavior=halt|warn       → halt (default) or warn-only (no 503)
   //   --overage-cooldown=<MS>            → auto-resume after this delay (default 30 min)
   //   --no-overage-notify                → suppress OS-level desktop notification
-  //   DARIO_OVERAGE_GUARD=off            → env equivalent of --no-overage-guard
+  //   DARIO_OVERAGE_GUARD=off|0|false|no → env equivalent of --no-overage-guard
   //   DARIO_OVERAGE_BEHAVIOR=halt|warn   → env equivalent of --overage-behavior
   //   DARIO_OVERAGE_COOLDOWN=<MS>        → env equivalent of --overage-cooldown
-  //   DARIO_OVERAGE_NOTIFY=off           → env equivalent of --no-overage-notify
+  //   DARIO_OVERAGE_NOTIFY=off|0|false|no → env equivalent of --no-overage-notify
   const overageGuardEnabledFromFlag = args.includes('--no-overage-guard') ? false
     : args.includes('--overage-guard') ? true : undefined;
-  const overageGuardEnabledFromEnv = parseBooleanEnv(process.env['DARIO_OVERAGE_GUARD']);
+  // Tri-state: this chain defaults to true, so `=off` must yield false rather
+  // than undefined or it is silently ignored.
+  const overageGuardEnabledFromEnv = parseTriStateEnv(process.env['DARIO_OVERAGE_GUARD']);
   const overageGuardEnabled = overageGuardEnabledFromFlag
     ?? overageGuardEnabledFromEnv
     ?? fileCfg.overageGuard?.enabled
@@ -621,7 +623,7 @@ async function proxy() {
     ?? 30 * 60 * 1000;
 
   const overageNotifyFromFlag = args.includes('--no-overage-notify') ? false : undefined;
-  const overageNotifyFromEnv = parseBooleanEnv(process.env['DARIO_OVERAGE_NOTIFY']);
+  const overageNotifyFromEnv = parseTriStateEnv(process.env['DARIO_OVERAGE_NOTIFY']);
   const overageGuardNotifyOs = overageNotifyFromFlag
     ?? overageNotifyFromEnv
     ?? fileCfg.overageGuard?.notifyOs
@@ -824,6 +826,32 @@ export function parsePositiveIntEnv(value: string | undefined): number | undefin
   const n = Number.parseInt(value.trim(), 10);
   if (!Number.isFinite(n) || n <= 0) return undefined;
   return n;
+}
+
+/**
+ * Parse a boolean env var that has to be able to say NO.
+ *
+ * `parseBooleanEnv` returns true|undefined and never false. That is correct
+ * for a knob whose default is off and whose env mirror is read with `||` --
+ * false and undefined behave identically there, and its truthy-only contract
+ * is pinned by test/strict-template-flags.mjs.
+ *
+ * It is wrong for a knob that defaults ON and is read with
+ * `flag ?? env ?? fileCfg ?? true`: undefined falls straight through to the
+ * default, so `DARIO_OVERAGE_GUARD=off` left the guard enabled while the
+ * comment above claimed it was the equivalent of --no-overage-guard. Silent,
+ * and worst for the container users who have no flag to pass instead.
+ *
+ * Returns false for off/0/false/no, true for on/1/true/yes, undefined for
+ * unset or unrecognised — so an unreadable value still defers to the config
+ * file and the default rather than guessing.
+ */
+export function parseTriStateEnv(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on') return true;
+  if (normalized === '0' || normalized === 'false' || normalized === 'no' || normalized === 'off') return false;
+  return undefined;
 }
 
 /**

--- a/test/strict-template-flags.mjs
+++ b/test/strict-template-flags.mjs
@@ -4,7 +4,7 @@
 // exercised end-to-end through the proxy startup path; this file covers
 // the small parsing / resolution primitives that feed the runtime checks.
 
-import { parseBooleanEnv } from '../dist/cli.js';
+import { parseBooleanEnv, parseTriStateEnv } from '../dist/cli.js';
 
 let pass = 0, fail = 0;
 function check(name, cond) {
@@ -37,6 +37,43 @@ header('parseBooleanEnv — falsy / unset values');
   check('"off"    → undefined',  parseBooleanEnv('off') === undefined);
   check('"xyz"    → undefined',  parseBooleanEnv('xyz') === undefined);
   check('" "      → undefined',  parseBooleanEnv(' ') === undefined);
+}
+
+
+// ─────────────────────────────────────────────────────────────
+// Found while writing docs/configuration.md, not by a failing test: cli.ts
+// documents `DARIO_OVERAGE_GUARD=off` as the env equivalent of
+// --no-overage-guard, but parseBooleanEnv never returns false, so the value
+// fell through `flag ?? env ?? fileCfg ?? true` and the guard stayed ON.
+// parseTriStateEnv is the version that can say no. parseBooleanEnv keeps its
+// truthy-only contract (asserted above) because its three call sites read it
+// with `||`, where false and undefined are indistinguishable.
+header('parseTriStateEnv — can express false, unlike parseBooleanEnv');
+{
+  check('"off"   → false', parseTriStateEnv('off') === false);
+  check('"0"     → false', parseTriStateEnv('0') === false);
+  check('"false" → false', parseTriStateEnv('false') === false);
+  check('"no"    → false', parseTriStateEnv('no') === false);
+  check('"OFF" (case) → false', parseTriStateEnv('OFF') === false);
+  check('"  off  " (whitespace) → false', parseTriStateEnv('  off  ') === false);
+
+  check('"1"    → true', parseTriStateEnv('1') === true);
+  check('"true" → true', parseTriStateEnv('true') === true);
+  check('"yes"  → true', parseTriStateEnv('yes') === true);
+  check('"on"   → true', parseTriStateEnv('on') === true);
+
+  // Unrecognised stays undefined so a typo defers to the config file and the
+  // default instead of being guessed either way.
+  check('undefined → undefined', parseTriStateEnv(undefined) === undefined);
+  check('""        → undefined', parseTriStateEnv('') === undefined);
+  check('"xyz"     → undefined', parseTriStateEnv('xyz') === undefined);
+
+  // The bug, stated as the chain that produced it.
+  const guardEnabled = (env) => undefined ?? parseTriStateEnv(env) ?? undefined ?? true;
+  check('DARIO_OVERAGE_GUARD=off disables the guard', guardEnabled('off') === false);
+  check('unset leaves the guard on', guardEnabled(undefined) === true);
+  check('=on leaves the guard on', guardEnabled('on') === true);
+  check('a typo leaves the guard on (fails safe)', guardEnabled('offf') === true);
 }
 
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Started as a README accuracy pass. Turned up a bug on the way, so it fixes that too.

## The bug: two documented env off-switches did nothing

`cli.ts` has advertised these since v4.1:

```
//   DARIO_OVERAGE_GUARD=off            → env equivalent of --no-overage-guard
//   DARIO_OVERAGE_NOTIFY=off           → env equivalent of --no-overage-notify
```

Neither worked. `parseBooleanEnv` returns `true` or `undefined` and **never `false`**:

```
parseBooleanEnv("off")   = undefined
parseBooleanEnv("0")     = undefined
parseBooleanEnv("false") = undefined
```

Both feed `flag ?? env ?? fileCfg ?? true`, so `off` fell through to the default and **the overage guard stayed enabled**. No warning, no log line. The people it hit are the ones with no alternative: a CLI flag was the only working way to disable it, which rules out Docker, Compose, k8s and systemd — exactly the deployments that reach for an env var.

The truthy-only behaviour is deliberate, not an accident — `test/strict-template-flags.mjs` asserts `parseBooleanEnv('off') === undefined`. So this adds `parseTriStateEnv` and uses it **only** at those two sites, rather than widening the shared parser and flipping four existing assertions. The other three call sites (`DARIO_STEALTH`, `DARIO_NO_LIVE_CAPTURE`, `DARIO_STRICT_TEMPLATE`) read their env with `||`, where `false` and `undefined` are indistinguishable, so they neither need the change nor notice it.

Unrecognised values still return `undefined` at both parsers, so a typo defers to the config file and the default instead of being guessed either way. `test/strict-template-flags.mjs` now covers that too: 16 assertions → 33.

## New: docs/configuration.md

**29 environment variables were documented nowhere** — not the README, not `docs/`. The whole overage-guard set, the request-queue knobs, template fidelity, the pacing axes, and the env forms of flags the README already documents. The README's own "Overage guard" section named none of its four variables.

Grouped by task rather than by flag, because the audience is the deployment that can't pass a flag. It also states the precedence order and which vars are not part of the supported surface.

**Deliberately not a second copy of `commands.md`.** That page is already billed as the "full flag/env reference" and covers 29 vars of its own, so I measured the overlap before writing:

| | count |
|---|---|
| in both | 10 |
| only in `commands.md` (OAuth overrides, session rotation, TLS, CORS, `PACE_*`) | 19 |
| only in the new page | 29 |

Neither was a superset. I cut all 10 duplicates out of the new page and cross-linked both ways, so **overlap is now zero** and no default is stated twice. Two copies of a default is one that goes stale.

## Four stale README numbers

| claim | actual |
|---|---|
| per-model beta sets "opus 9, sonnet 8, haiku 6" | **opus 10, sonnet 9**, haiku 6 |
| "~22k lines across **49** files" | **23,833 lines across 52** |
| "**113 test files**" | **132** in `test/`, **125** under the parallel runner |
| "0 runtime dependencies" | correct, re-verified |

The beta counts moved **today** — 5.4.13's re-bake added `afk-mode` to the base set, lifting every per-model set by one. That line now says the counts track the baked base rather than freezing a number, so the next base change doesn't re-stale it. The test-file line now distinguishes 132 files from 125 runner subtests, the delta being the e2e/compat/stealth suites that opt out and have their own entry points.

Also documented the six drift and audit runners that existed in `package.json` and nowhere else: `drift:wire`, `drift:sdk`, `audit:tui`, `check:overage`, `stress`, `cch:calibrate`.

## What I checked and did not change

The model lineup is current — Fable 5 / Opus 5 / Sonnet 5 / Haiku 4.5, `[1m]` variants, the `opus48`/`47`/`46`/`sonnet46` pins. The TUI section is accurate: its six tabs match `src/tui/tabs/` exactly and the mock already shows opus-5 / sonnet-5 / haiku-4-5. Capabilities and the billing-split section hold up.

One correction I made mid-write, worth recording because it nearly shipped: my first draft listed `DARIO_DIR`, `DARIO_DNS_RESULT_ORDER`, `DARIO_MODEL_CATALOG_TTL_MS`, `DARIO_CCH` and `DARIO_USAGE_PORT` as "not part of the supported surface". Checking each individually, `DARIO_DIR` **is not an environment variable at all** — it's a `const` in `accounts.ts` that my `DARIO_[A-Z_]+` inventory matched by name — and the other four are real knobs with real defaults that now have proper sections. Only `DARIO_LIVE_TEMPLATE_CACHE` and `DARIO_TEST_URL` are genuinely test-only.

Full suite 125/125.
