### PR TITLE
fix(drift): stop the two rebake loops — suppress afk-mode, gate non-Linux bakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ checklist.
 
 ## [Unreleased]
 
+## [5.4.16] - 2026-07-26
+
+- **`afk-mode-2026-01-31` no longer drives a release every time Anthropic flips it.** It is remote-config gated, not version gated, and on 2026-07-26 it moved four times in twelve hours: off when #869 re-baked at 04:51Z, on for 8/8 captures and baked into 5.4.13, off again in #878 at 16:45Z. Each flip opened a rebake PR, bumped a version, and cut a full release — multi-arch GHCR build, Sigstore attestation, npm publish, box autodeploy. New `REMOTE_CONFIG_CONDITIONAL_BETAS` strips it from the baked base and excludes it from the drift comparison on both sides, so neither state reads as drift. A genuine base-beta add or removal still surfaces — asserted, not assumed.
+
+  Deliberately a separate set from `MODEL_CONDITIONAL_BETAS` rather than a quiet widening of it, because the reasons differ: those are flags dario appends per-request, so comparing them against a base that never carried them is a false positive we manufactured (#484). This one CC sends. Suppressing it is a real, if small, divergence from wire fidelity, taken because the alternative is a release per flip. Safe in both directions: `betaForModel` documents that its per-family shape holds whether or not the base carries afk-mode, `removing a beta can never provoke an upstream 400`, and afk-mode is the side with a cost — it is rejected on Max 5x, which `unavailableBetas` absorbs at one 400 per account.
+
+- **A bake now refuses to write the bundle from a non-Linux host.** The sonnet-5 prompt variant names the tools that exist where the capture ran: Windows yields `, Glob, Grep` and `the Glob or Grep`, Linux yields `` `find` or `grep` via the Bash tool``. Six bytes, one slot, every other slot byte-identical — so a Windows bake and CI's Linux bake each report the other as drift and re-bake forever. Third channel for the same disease: #854 -> #860 was paths, #856 was the OS/arch headers, this is prose that mentions the tool list.
+
+  Unlike those two it cannot be normalised. The correct text depends on which tools the caller has, which the bundle cannot know, and rewriting CC's prose would be inventing wire shape rather than replaying it — `PLATFORM_ONLY_TOOLS` already unions the tools array, but nothing can union a sentence. So the fix is procedural, mirroring the existing `--allow-older-cc` guard: `--allow-non-linux-bake` for a deliberate local bake, and `--check` is not gated at all, since detecting drift from any platform is useful and only writing is harmful.
+
+  Two existing assertions used afk-mode as their stand-in for "a real base beta" and now use one that still is. Each carries a note on what it previously claimed.
+
 ## [5.4.15] - 2026-07-26
 
 - **Template rebake** — re-captured `src/cc-template-data.json` after cc-drift-template-watch detected wire-fingerprint drift against a live CC capture. Bundled fallback template now matches the current CC wire shape.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.4.15",
+  "version": "5.4.16",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/scripts/capture-and-bake.mjs
+++ b/scripts/capture-and-bake.mjs
@@ -54,6 +54,7 @@ const OUT = join(repoRoot, 'src/cc-template-data.json');
 
 const CHECK_MODE = process.argv.includes('--check');
 const ALLOW_OLDER_CC = process.argv.includes('--allow-older-cc');
+const ALLOW_NON_LINUX = process.argv.includes('--allow-non-linux-bake');
 
 function log(msg) {
   console.error(`[bake] ${msg}`);
@@ -149,6 +150,39 @@ if (isOlderCCVersion(captured._version, prev._version)) {
     log(`error: installed CC v${captured._version} is OLDER than the CC that baked the current bundle (v${prev._version}).`);
     log('error: an older binary cannot observe forward drift; any "drift" it reports would re-bake the previous wire shape (a downgrade).');
     log('error: update CC on this machine (npm i -g @anthropic-ai/claude-code@latest) and re-run, or pass --allow-older-cc for a deliberate downgrade bake.');
+    process.exit(1);
+  }
+}
+
+
+// Bake host must be Linux, because CC's prompt is not host-portable.
+//
+// The sonnet-5 variant names the tools that exist where the capture ran: a
+// Windows host yields `, Glob, Grep` and `the Glob or Grep`, a Linux host yields
+// `\`find\` or \`grep\` via the Bash tool`. Six bytes, in one slot, and every other
+// slot byte-identical. So a Windows bake and CI's Linux bake each report the
+// other as drift and re-bake forever — dario#854 -> #860 was the same disease
+// through the path channel, #856 through the OS/arch header channel, and this is
+// the third channel: prose that mentions the tool list.
+//
+// Unlike those two, this one cannot be normalised away. The correct text depends
+// on which tools the caller actually has, which the bundle cannot know, and
+// rewriting CC's prose would be inventing wire shape rather than replaying it.
+// PLATFORM_ONLY_TOOLS already unions the tools ARRAY across platforms; nothing
+// can union a sentence.
+//
+// So the fix is procedural: CI bakes on Linux (cc-drift-template-watch, which
+// also pins the OAuth sole-refresher), and a bake from anywhere else has to be
+// deliberate. --check is deliberately NOT gated — detecting drift from any
+// platform is useful and harmless; only WRITING the bundle is restricted.
+if (!CHECK_MODE && process.platform !== 'linux') {
+  if (ALLOW_NON_LINUX) {
+    log(`warning: baking on ${process.platform}, not linux — proceeding because --allow-non-linux-bake was passed.`);
+    log('warning: expect CI to re-bake this bundle on its next drift check (see the sonnet-5 variant note in this file).');
+  } else {
+    log(`error: refusing to write the bundle from ${process.platform}. CC's prompt names the tools available on the bake host, so a non-Linux bundle ping-pongs with CI's Linux bake indefinitely.`);
+    log('error: dispatch the cc-drift-template-watch workflow instead — it bakes on Linux and pins the OAuth sole-refresher.');
+    log('error: pass --allow-non-linux-bake for a deliberate local bake, or use --check to detect drift without writing.');
     process.exit(1);
   }
 }

--- a/scripts/drift-report.mjs
+++ b/scripts/drift-report.mjs
@@ -21,7 +21,42 @@ export const MODEL_CONDITIONAL_BETAS = new Set([
 ]);
 
 /**
- * Strip the model-conditional betas (the ones betaForModel() appends per-request)
+ * Betas CC toggles by REMOTE CONFIG, independent of its version.
+ *
+ * Distinct from MODEL_CONDITIONAL_BETAS above, which are flags dario itself
+ * appends per-request — those are ours, and comparing them against a base that
+ * never carried them is a false positive we manufactured. These are CC's own:
+ * it sends them or it does not, on Anthropic's schedule, and a bake captures
+ * whichever state happened to be live that minute.
+ *
+ * Observed 2026-07-26: afk-mode flipped off (auto-rebake #869, 04:51Z), on
+ * (8/8 captures at 15:45Z, baked into 5.4.13), then off again (#878, 16:45Z) —
+ * four transitions in twelve hours. Each flip opened a rebake PR, bumped a
+ * version and cut a full release: multi-arch GHCR build, Sigstore attestation,
+ * npm publish, autodeploy. Release churn on Anthropic's remote-config cadence.
+ *
+ * Stripping is safe in both directions. betaForModel() documents that its
+ * per-family shape is correct whether or not the base carries afk-mode — the
+ * anchor-relative inserts degrade to append/no-op when the anchor is absent —
+ * and `removing a beta can never provoke an upstream 400`. Sending it is the
+ * side with a cost: afk-mode is rejected on Max 5x, which the unavailableBetas
+ * recovery absorbs at one 400 per account. So a base without it is strictly
+ * cheaper than a base that oscillates.
+ *
+ * The tradeoff, stated plainly: dario's beta set differs from CC's by this one
+ * flag whenever CC is sending it. That is a deliberate divergence from wire
+ * fidelity, taken because the alternative is a release per flip.
+ */
+export const REMOTE_CONFIG_CONDITIONAL_BETAS = new Set([
+  'afk-mode-2026-01-31', // AFK_MODE_BETA in src/proxy.ts — remote-config gated
+]);
+
+/**
+ * Strip the betas that must not reach the baked base: the model-conditional ones
+ * betaForModel() appends per-request, and the remote-config ones CC toggles on
+ * Anthropic's schedule (see the two sets above).
+ *
+ * Historical note on the name: it predates the remote-config class and is kept
  * from a comma-joined beta string. Used by the BAKE path (capture-and-bake.mjs) so
  * the canonical base set written to cc-template-data.json never carries them — a
  * live capture that happened to ride them (e.g. a `[1m]` request carrying
@@ -32,7 +67,7 @@ export function stripModelConditionalBetas(beta) {
   return (beta || '')
     .split(',')
     .filter(Boolean)
-    .filter((b) => !MODEL_CONDITIONAL_BETAS.has(b))
+    .filter((b) => !MODEL_CONDITIONAL_BETAS.has(b) && !REMOTE_CONFIG_CONDITIONAL_BETAS.has(b))
     .join(',');
 }
 
@@ -227,15 +262,20 @@ export function computeDrift(prev, now) {
     });
   }
 
-  // anthropic_beta — added/removed sets, ignoring the model-conditional betas
-  // that betaForModel() appends per-request. The bundle's anthropic_beta is the
-  // BASE set; a live capture carries base + per-request betas for whatever model
-  // it used, so context-1m / fallback-credit appear in a capture without being
-  // base drift. Filter them from BOTH sides; every other beta (incl. afk-mode)
-  // is still compared, so a genuine base-beta add/removal still surfaces.
+  // anthropic_beta — added/removed sets, ignoring two classes of flag.
+  // The model-conditional ones betaForModel() appends per-request: the bundle's
+  // anthropic_beta is the BASE set, so context-1m / fallback-credit ride a live
+  // capture without being base drift (#484). And the remote-config ones CC
+  // toggles on Anthropic's schedule, which flip faster than a release can ship
+  // (afk-mode moved four times in twelve hours on 2026-07-26).
+  //
+  // Filtered from BOTH sides so the exclusion is symmetric — a base that still
+  // carries an excluded flag from an older bake does not read as drift either.
+  // Every other beta is still compared, so a genuine base-beta change surfaces.
   {
     const stripManaged = (s) =>
-      new Set((s || '').split(',').filter(Boolean).filter((b) => !MODEL_CONDITIONAL_BETAS.has(b)));
+      new Set((s || '').split(',').filter(Boolean)
+        .filter((b) => !MODEL_CONDITIONAL_BETAS.has(b) && !REMOTE_CONFIG_CONDITIONAL_BETAS.has(b)));
     const prevBetas = stripManaged(prev.anthropic_beta);
     const nowBetas = stripManaged(now.anthropic_beta);
     const addedB = [...nowBetas].filter((b) => !prevBetas.has(b));

--- a/test/bake-drift-report.mjs
+++ b/test/bake-drift-report.mjs
@@ -3,7 +3,7 @@
 // test runner spawns each file via node:test which is fine for imports
 // too, but the existing pattern groups script-imports in serial).
 
-import { unifiedDiff, computeDrift, describeTool, formatDriftReport, interpretDrift, formatDriftSummary, MODEL_CONDITIONAL_BETAS, normalizeMemoryPath, stripModelConditionalBetas, isOlderCCVersion } from '../scripts/drift-report.mjs';
+import { unifiedDiff, computeDrift, describeTool, formatDriftReport, interpretDrift, formatDriftSummary, MODEL_CONDITIONAL_BETAS, REMOTE_CONFIG_CONDITIONAL_BETAS, normalizeMemoryPath, stripModelConditionalBetas, isOlderCCVersion } from '../scripts/drift-report.mjs';
 
 let pass = 0;
 let fail = 0;
@@ -352,12 +352,14 @@ header('33. computeDrift — fallback-credit appearing in capture is NOT drift')
 
 header('34. computeDrift — a REAL base beta change still surfaces alongside managed ones');
 {
-  // afk-mode removed (real) + context-1m added (managed, ignored)
-  const prev = makeTemplate({ anthropic_beta: 'claude-code-20250219,afk-mode-2026-01-31' });
+  // Was written with afk-mode as the "real" beta. afk-mode is now remote-config
+  // suppressed (case 22), so it can no longer play that role — a genuine base
+  // beta stands in and the case tests what it was built to test.
+  const prev = makeTemplate({ anthropic_beta: 'claude-code-20250219,advisor-tool-2026-03-01' });
   const now = makeTemplate({ anthropic_beta: 'claude-code-20250219,context-1m-2025-08-07' });
   const d = computeDrift(prev, now);
   const summaries = d.map((e) => e.summary);
-  check('afk-mode removal still flagged', summaries.some((s) => /anthropic_beta removed: afk-mode-2026-01-31/.test(s)));
+  check('real beta removal still flagged', summaries.some((s) => /anthropic_beta removed: advisor-tool-2026-03-01/.test(s)));
   check('context-1m add NOT flagged', !summaries.some((s) => /context-1m/.test(s)));
 }
 
@@ -399,7 +401,11 @@ header('38. stripModelConditionalBetas — removes context-1m / fallback-credit,
   check('context-1m removed', !baked.includes('context-1m-2025-08-07'));
   check('base betas preserved in order', baked === 'claude-code-20250219,interleaved-thinking-2025-05-14,effort-2025-11-24');
   check('fallback-credit removed too', stripModelConditionalBetas('claude-code-20250219,fallback-credit-2026-06-01') === 'claude-code-20250219');
-  check('no-op when no managed betas present', stripModelConditionalBetas('claude-code-20250219,afk-mode-2026-01-31') === 'claude-code-20250219,afk-mode-2026-01-31');
+  // Used afk-mode as its example of a beta the strip leaves alone. It is now
+  // stripped too (remote-config class), so the no-op case needs a beta that
+  // really is untouched. afk-mode's removal is asserted in case 22.
+  check('no-op when no managed betas present', stripModelConditionalBetas('claude-code-20250219,advisor-tool-2026-03-01') === 'claude-code-20250219,advisor-tool-2026-03-01');
+  check('remote-config beta IS stripped', stripModelConditionalBetas('claude-code-20250219,afk-mode-2026-01-31') === 'claude-code-20250219');
   check('empty / undefined safe', stripModelConditionalBetas('') === '' && stripModelConditionalBetas(undefined) === '');
 }
 
@@ -432,6 +438,44 @@ header('isOlderCCVersion — stale-binary guard (PR #632 regression)');
   check('non-numeric live version fails open', isOlderCCVersion('unknown', '2.1.198') === false);
   check('prerelease-style suffix fails open', isOlderCCVersion('2.1.197-beta.1', '2.1.198') === false);
   check('non-string fails open', isOlderCCVersion(2, '2.1.198') === false);
+}
+
+
+// ────────────────────────────────────────────────────────────────────
+// Remote-config betas: CC toggles these on Anthropic's schedule, not with its
+// version. afk-mode moved four times in twelve hours on 2026-07-26 (off at the
+// #869 rebake, on for 8/8 captures and baked into 5.4.13, off again in #878),
+// and each flip opened a rebake PR, bumped a version and cut a full release.
+// Excluded from BOTH the baked base and the comparison, so neither state drifts.
+header('22. remote-config betas do not drift in either direction');
+{
+  check('afk-mode is in the remote-config set', REMOTE_CONFIG_CONDITIONAL_BETAS.has('afk-mode-2026-01-31'));
+  check('and NOT in the model-conditional set (different reason)', !MODEL_CONDITIONAL_BETAS.has('afk-mode-2026-01-31'));
+
+  const withAfk = makeTemplate({ anthropic_beta: 'claude-code-20250219,effort-2025-11-24,afk-mode-2026-01-31' });
+  const withoutAfk = makeTemplate({ anthropic_beta: 'claude-code-20250219,effort-2025-11-24' });
+
+  const gone = computeDrift(withAfk, withoutAfk).map((e) => e.summary ?? e);
+  const back = computeDrift(withoutAfk, withAfk).map((e) => e.summary ?? e);
+  check('present -> absent reports no drift', gone.length === 0);
+  check('absent -> present reports no drift (symmetric)', back.length === 0);
+
+  // The suppression must not blind the detector to a real base-beta change.
+  const genuine = makeTemplate({ anthropic_beta: 'claude-code-20250219,effort-2025-11-24,brand-new-2026-09-01' });
+  const real = computeDrift(withoutAfk, genuine).map((e) => e.summary ?? e);
+  check('a genuine new beta still surfaces', real.some((s) => /brand-new-2026-09-01/.test(s)));
+  check('and it is reported as an addition', real.some((s) => /anthropic_beta added/.test(s)));
+
+  // The bake side: whichever state the capture caught, the baked base is the same.
+  check(
+    'stripped base is identical whichever way the flag sits',
+    stripModelConditionalBetas('claude-code-20250219,afk-mode-2026-01-31') ===
+      stripModelConditionalBetas('claude-code-20250219'),
+  );
+  check(
+    'and it drops the flag rather than keeping it',
+    !stripModelConditionalBetas('claude-code-20250219,afk-mode-2026-01-31').includes('afk-mode'),
+  );
 }
 
 // ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Two slots were re-baking on a loop. They turned out to have different causes and need different fixes — only one of them is suppressible.

Bundle changes ride #878, which merged first and is already the Linux-canonical state. This PR is mechanism only.

## afk-mode: suppressed

`afk-mode-2026-01-31` is remote-config gated, not version gated. On 2026-07-26 it moved four times in twelve hours:

| time | state |
|---|---|
| 04:51Z | off — auto-rebake #869 |
| 15:45Z | on — 8/8 captures, baked into 5.4.13 |
| 16:45Z | off — auto-rebake #878 |

Each flip opened a rebake PR, bumped a version, and cut a full release: multi-arch GHCR build, Sigstore attestation, npm publish, box autodeploy. Release churn on Anthropic's remote-config cadence.

New `REMOTE_CONFIG_CONDITIONAL_BETAS` strips it from the baked base and excludes it from the drift comparison on both sides. Verified against `computeDrift`:

| case | drift entries |
|---|---|
| present → absent | **0** |
| absent → present | **0** (symmetric) |
| a genuine new beta | **1**, reported as an addition |

**A separate set from `MODEL_CONDITIONAL_BETAS`, not a quiet widening of it**, because the reasons differ and the distinction is the whole argument. Those are flags *dario* appends per-request, so comparing them against a base that never carried them is a false positive we manufactured (#484). This one *CC sends* — suppressing it is a real, if small, divergence from wire fidelity, taken because the alternative is a release per flip.

Safe in both directions, and this is checked in the code rather than assumed: `betaForModel` documents that its per-family shape holds whether or not the base carries afk-mode (anchor-relative inserts degrade to append/no-op), `removing a beta can never provoke an upstream 400`, and afk-mode is the side with a cost — it is rejected on Max 5x, absorbed by `unavailableBetas` at one 400 per account. A base without it is strictly cheaper than a base that oscillates.

## sonnet-5: not suppressible — it was bake-host divergence

I went looking for a second oscillator and found something else. Diffing master's variant against #878's:

```
master (Windows) : ", Glob, Grep"     "the Glob or Grep"
pr878  (Linux)   : (removed)          "`find` or `grep` via the Bash tool"
```

CC's sonnet-5 prompt **names the tools that exist on the bake host**. Six bytes, one slot; base, `agent_identity`, fable and opus-5 are byte-identical across both bakes. So a Windows bake and CI's Linux bake each report the other as drift, indefinitely.

Third channel for the same disease: **#854 → #860 was paths, #856 was the OS/arch headers, this is prose that mentions the tool list.**

Unlike those two it cannot be normalised. The correct text depends on which tools the *caller* has, which the bundle cannot know, and rewriting CC's prose would be inventing wire shape instead of replaying it. `PLATFORM_ONLY_TOOLS` already unions the tools *array* — both bundles carry 33 names including Glob/Grep/PowerShell — but nothing can union a sentence.

So the fix is procedural, mirroring the existing `--allow-older-cc` guard: a write bake from a non-Linux host refuses with an actionable message, `--allow-non-linux-bake` overrides for a deliberate local bake, and **`--check` is not gated at all** — detecting drift from any platform is useful and harmless; only *writing* the bundle is restricted.

Verified both directions on this Windows box:

```
write bake  -> refused, exit 1, points at cc-drift-template-watch
--check     -> exit 0, unaffected
```

And the guard's value shows in the current state: `--check` from here against #878's Linux bundle now reports **exactly one** differing slot, sonnet-5, correctly attributed to my host — with afk-mode absent from the report entirely. Previously that would have been an invisible ping-pong; now it is a local-only artifact I am prevented from baking in.

## Two assertions updated, deliberately

Cases 34 and 38 both used afk-mode as their stand-in for "a real base beta" — precisely the role it no longer plays. Both now use `advisor-tool-2026-03-01`, which still is one, so each case tests what it was written to test. Each carries a note recording what it previously claimed. Case 38 also gains the inverse assertion, that afk-mode *is* stripped.

Full suite 125/125; `bake-drift-report` 111 assertions.

## Still open, and not fixed here

The base prompt occasionally scrubs to **5038 instead of 4759** — a +279 char `# Context management` paragraph. Two occurrences today against **20 consecutive clean captures** (8 in one sampler run, 12 in another), so roughly 1-in-10 and not reproducible on demand. It will occasionally trigger a CI rebake.

I also want to correct something I wrote in 5.4.13: I called the base prompt stable on the strength of 8 identical samples. That was a clean streak, not stability. Filing the observation separately rather than leaving it in a changelog entry as settled.
