### PR TITLE
feat(pkg): ship docs/ in the package, minus the maintainer runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ checklist.
 
 ## [Unreleased]
 
+## [5.4.17] - 2026-07-26
+
+- **`docs/` now ships in the npm package.** `docs/configuration.md` landed in 5.4.14 and was reachable only on GitHub, which is the wrong place for a config reference whose whole audience is someone running the installed package in a container. The `files` allowlist gains `docs`, costing about 270 kB against a 1.5 MB unpacked package.
+
+  **`docs/recovery.md` is deliberately excluded.** It is a maintainer runbook — "things automation can't fix", including recovering OAuth credentials on the release host — and it hardcodes that host's root SSH target and key filename. It is already public in this repo, so this is not novel exposure, but an npm tarball is a different distribution: mirrored, scraped, pulled onto machines that never asked for it, and immutable once published. Publishing a production SSH target to every install buys a user nothing. Verified with `npm pack --dry-run`: 0 occurrences of `docs/recovery.md`, every other doc present.
+
+  Audited the rest before shipping rather than after. No real credentials: the `sk-ant-api03-...` and `$GHCR_PAT` hits are placeholders in command examples. No host paths, no usernames.
+
 ## [5.4.16] - 2026-07-26
 
 - **`afk-mode-2026-01-31` no longer drives a release every time Anthropic flips it.** It is remote-config gated, not version gated, and on 2026-07-26 it moved four times in twelve hours: off when #869 re-baked at 04:51Z, on for 8/8 captures and baked into 5.4.13, off again in #878 at 16:45Z. Each flip opened a rebake PR, bumped a version, and cut a full release — multi-arch GHCR build, Sigstore attestation, npm publish, box autodeploy. New `REMOTE_CONFIG_CONDITIONAL_BETAS` strips it from the baked base and excludes it from the drift comparison on both sides, so neither state reads as drift. A genuine base-beta add or removal still surfaces — asserted, not assumed.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.4.16",
+  "version": "5.4.17",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {
@@ -16,6 +16,8 @@
   },
   "files": [
     "dist",
+    "docs",
+    "!docs/recovery.md",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
`docs/configuration.md` shipped in 5.4.14 and was reachable **only on GitHub** — the wrong place for a config reference whose entire audience is someone running the installed package in a container, where a flag isn't available.

## What ships, what doesn't

`files` gains `docs`, with one exclusion.

| | |
|---|---|
| cost | 1.5 MB → **1.8 MB** unpacked, 108 → 131 files (~270 kB) |
| excluded | `docs/recovery.md` |

**Why that one is excluded.** It's a maintainer runbook — *"things automation can't fix"*, including recovering OAuth credentials on the release host — and it hardcodes that host's **root SSH target and key filename**. It's already public in this repo, so this isn't novel exposure. But an npm tarball is a different *distribution*: mirrored, scraped, pulled onto machines that never asked for it, and **immutable** once published. Publishing a production SSH target to every install buys a user nothing.

## Verified rather than assumed

`npm pack --dry-run` confirms npm honours the `!` negation in `files`:

- `docs/recovery.md` — **0 occurrences**
- every other doc present, including `configuration.md` (6.9 kB)

I audited the contents **before** shipping rather than trusting that public-on-GitHub meant safe-to-publish. No real credentials: the `sk-ant-api03-...` and `$GHCR_PAT` matches are placeholders inside command examples. No host paths, no usernames.

## One risk I can't fully retire

npm's content scanner has blocked `@askalf` publishes before, and 22 docs discussing OAuth interception, fingerprint replay and stealth pacing widen that surface. If the publish leg 403s at PUT, that's the scanner and not this change — the existing chase-an-allowlist thread applies.

## Separate question, not actioned here

Whether `docs/recovery.md` belongs in a **public repo** at all is worth deciding on its own. This PR only stops it being republished to npm; it doesn't move it.

Suite 125/125.