### PR TITLE
feat(drift): trip a loud tripwire when a base capture matches the #881 anomaly

### DIFF
--- a/.github/workflows/cc-drift-template-watch.yml
+++ b/.github/workflows/cc-drift-template-watch.yml
@@ -121,6 +121,21 @@ jobs:
           node scripts/capture-and-bake.mjs --check 2> drift-output.txt
           code=$?
           echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+
+          # dario#881 tripwire. capture-and-bake writes issue-881-tripwire.txt
+          # only when the scrubbed base capture carries the known +279-char
+          # residue. The loud ::warning:: annotation itself rides in
+          # drift-output.txt and reaches the run summary via the `cat` below —
+          # this just records the hit as a step output so the rebake step can
+          # label the PR it opens. 26h of CI data says this has never fired on
+          # the runner; if it does, the rebake is #881 residue, not CC drift.
+          if [ -f issue-881-tripwire.txt ]; then
+            echo "issue_881=true" >> "$GITHUB_OUTPUT"
+            echo "::notice title=dario#881::tripwire hit on the --check capture — see the warning annotation and https://github.com/askalf/dario/issues/881"
+          else
+            echo "issue_881=false" >> "$GITHUB_OUTPUT"
+          fi
+
           if [ $code -eq 0 ]; then
             echo "No drift detected."
             cat drift-output.txt
@@ -159,6 +174,8 @@ jobs:
           # v4.6.4). Setup: docs/drift-monitor.md "Optional: PAT for
           # downstream workflow triggers".
           GH_TOKEN: ${{ secrets.DARIO_DRIFT_BOT_PAT || secrets.GITHUB_TOKEN }}
+          # dario#881 tripwire verdict from the --check capture (see below).
+          CHECK_ISSUE_881: ${{ steps.check.outputs.issue_881 }}
         run: |
           set -eo pipefail
 
@@ -179,6 +196,22 @@ jobs:
 
           # Run the real bake. Writes src/cc-template-data.json.
           node scripts/capture-and-bake.mjs
+
+          # dario#881 tripwire, second read. The bake above is a SEPARATE live
+          # capture from the --check one, and the anomaly is intermittent — so
+          # the two can disagree, and the bake's verdict is the one that
+          # describes the bundle this PR actually ships. Rewritten (or removed)
+          # by every capture-and-bake run, so this is fresh. OR them: either
+          # capture carrying the residue is enough to mark the PR, because
+          # either way a human is about to look at a base-prompt diff whose
+          # provenance is in doubt.
+          issue_881_bake=false
+          [ -f issue-881-tripwire.txt ] && issue_881_bake=true
+          issue_881=false
+          if [ "$issue_881_bake" = "true" ] || [ "$CHECK_ISSUE_881" = "true" ]; then
+            issue_881=true
+          fi
+          echo "issue_881=$issue_881" >> "$GITHUB_OUTPUT"
 
           # Sanity: did the bake actually change the bundle?
           if git diff --quiet -- src/cc-template-data.json; then
@@ -217,6 +250,17 @@ jobs:
             echo ""
             echo "The watcher's \`--check\` exited 2 against a live capture from the self-hosted runner. This PR contains the freshly-baked \`src/cc-template-data.json\` from that capture (with the v4.2.2 platform-superset preservation applied), plus a patch version bump to \`v$new_version\` and a CHANGELOG entry — so merging ships the rebake to npm via \`cc-drift-auto-release.yml\`."
             echo ""
+            if [ "$issue_881" = "true" ]; then
+              echo "> [!CAUTION]"
+              echo "> ## ⚠ This rebake is dario#881 residue — do NOT treat it as a genuine CC prompt change"
+              echo ">"
+              echo "> The base system-prompt capture behind this PR matched the known [#881](https://github.com/askalf/dario/issues/881) signature: the extra \`# Context management\` paragraph beginning \"When you have enough information to act, act.\", which appears in roughly **1 local capture in 10** and had **never** reached CI before this run. See the \`::warning::\` annotation on the run for the exact clause that matched and the captured-vs-bundled lengths."
+              echo ">"
+              echo "> **What to do:** re-dispatch \`cc-drift-template-watch.yml\`. If the next capture comes back clean, this PR is the anomaly — close it. Merging it bakes the residue into the shipped wire-shape contract and cuts a release for a prompt change that did not happen upstream."
+              echo ">"
+              echo "> **Either way, comment the outcome on #881.** Whether the tripwire caught a real CI occurrence or a false positive, that is exactly the data the issue is open for. #881 defers the bake-time normalisation deliberately, so nothing here strips the paragraph — this is detection only."
+              echo ""
+            fi
             if [ -f drift-summary.md ]; then
               echo "### Summary"
               echo ""
@@ -240,12 +284,32 @@ jobs:
             echo "Background: [v4.2.1 CHANGELOG entry](https://github.com/askalf/dario/blob/master/CHANGELOG.md#421---2026-05-17) documents this drift class — same CC binary, different runtime wire shape via remote configuration."
           } > "$pr_body_file"
 
+          # Title carries the tripwire verdict too — the PR list, the merge-queue
+          # view and the email notification all show the title and nothing else.
+          pr_title="auto-rebake: template drift detected $(date +%Y-%m-%d)"
+          if [ "$issue_881" = "true" ]; then
+            pr_title="[#881 residue?] $pr_title"
+          fi
+
+          # A dedicated label so the #881 residue is recognisable from the PR
+          # list alone, without opening it. Created on demand (--force is a
+          # no-op update when it exists) because it is rare enough that
+          # pre-creating it in repo settings would just rot. Same
+          # create-then-use shape the other watchers use for their labels.
+          extra_label=()
+          if [ "$issue_881" = "true" ]; then
+            gh label create issue-881-residue --color D93F0B \
+              --description "Rebake whose base capture matched the dario#881 +279-char anomaly — not genuine CC drift" \
+              --force >/dev/null 2>&1 || true
+            extra_label=(--label issue-881-residue)
+          fi
+
           pr_url=$(gh pr create \
             --head "$branch" \
             --base master \
-            --title "auto-rebake: template drift detected $(date +%Y-%m-%d)" \
+            --title "$pr_title" \
             --body-file "$pr_body_file" \
-            --label cc-drift-template)
+            --label cc-drift-template "${extra_label[@]}")
 
           pr_number=$(echo "$pr_url" | grep -oE '[0-9]+$')
           echo "opened $pr_url"

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ credentials.json
 drift-summary.md
 drift-output.txt
 label-target.txt
+issue-881-tripwire.txt
 .tui-audit/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ checklist.
 
 ## [Unreleased]
 
+## [5.4.23] - 2026-07-27
+
+- **The drift watcher now trips a tripwire when a base-prompt capture matches the #881 anomaly.** #881 records that roughly **1 local capture in 10** returns the scrubbed base system prompt at **5038 chars instead of 4759** — an extra `# Context management` paragraph beginning "When you have enough information to act, act." that is not in the baked bundle. 26h of CI data says it has never reached the Linux runner. The harm it would do if it did is specific: `cc-drift-template-watch.yml` would exit 2, auto-open a rebake PR, and that PR would look exactly like a genuine CC prompt change while actually baking a bad capture into the shipped wire-shape contract and cutting a release for an upstream change that never happened.
+
+  `detectIssue881Residue` fires on either of two clauses, both **relative to the bundle**: the marker sentence present in the capture and absent from the bundle, or the exact 5038/4759 length pair. Relative is what keeps it from becoming permanent noise — if the paragraph is ever legitimately baked in, the bundle gains the marker, both clauses go false, and the detector disarms with no code change. Specificity was the harder half of the requirement: the genuine 4754 → 4759 step #881 cites must still flow through as ordinary drift, so length-changed-at-all is not a signal and `# Context management` alone is not either (the current 4759-char bundle already contains that heading — matching on it would flag every clean run).
+
+  On a hit the bake writes a `::warning::` annotation naming #881 to stderr, which the workflow already `cat`s into the run summary and embeds verbatim in the drift issue and PR body. The workflow reads the verdict from a sibling marker file rather than grepping prose, then puts `[#881 residue?]` in the PR title, adds an `issue-881-residue` label, and prepends a CAUTION block telling the reviewer to re-run the watcher and report the outcome on #881. The detector runs in **both** `--check` and the real bake and the two verdicts are OR'd, because they are separate live captures of an intermittent fault and a clean `--check` followed by a 5038 bake is the dangerous ordering.
+
+  **Detection only, deliberately.** Nothing here strips the paragraph or suppresses the drift it causes. #881 defers the bake-time normalisation on the grounds that the call "should not be taken on a hunch", and this does not take it — it just makes sure the hunch gets data instead of a merged rebake. Suite 132/132.
+
 ## [5.4.22] - 2026-07-27
 
 - **dario's own state files are written with explicit restrictive modes.** A security pass over the state directory found that credentials were correct — `durableWriteFile` opens with `0o600` and the Linux deployment confirms `-rw-------` on every `credentials.json` — but three writes passed no mode at all and therefore landed `0644`:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.4.22",
+  "version": "5.4.23",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/scripts/capture-and-bake.mjs
+++ b/scripts/capture-and-bake.mjs
@@ -46,7 +46,7 @@ import { fileURLToPath } from 'node:url';
 import { captureLiveTemplateAsync, findInstalledCC, promptVariantsOf, TEMPLATE_BASE_MODEL } from '../dist/live-fingerprint.js';
 import { scrubTemplate, findUserPathHits } from '../dist/scrub-template.js';
 import { PLATFORM_ONLY_TOOLS, INTERACTIVE_ONLY_TOOLS } from '../dist/cc-template.js';
-import { computeDrift, formatDriftReport, interpretDrift, formatDriftSummary, stripModelConditionalBetas, isOlderCCVersion } from './drift-report.mjs';
+import { computeDrift, formatDriftReport, interpretDrift, formatDriftSummary, stripModelConditionalBetas, isOlderCCVersion, detectIssue881Residue, formatIssue881Warning } from './drift-report.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, '..');
@@ -244,6 +244,31 @@ if (preservedInteractiveTools.length > 0) {
 scrubbed.tool_names = scrubbed.tools.map((t) => t.name);
 
 log(`previous baked template: CC v${prev._version} captured ${prev._captured}, ${prev.tools.length} tools, ${prev.system_prompt.length} char system prompt`);
+
+// ── #881 tripwire ────────────────────────────────────────────────────
+// Detect-and-shout only: never strips the paragraph, never suppresses the
+// drift it causes. #881 defers the bake-time normalisation call deliberately,
+// so all this does is make sure a 5038 capture cannot be mistaken for a
+// genuine CC prompt change by whoever reviews the resulting rebake PR.
+//
+// Runs in BOTH modes on purpose. In --check it explains the exit-2 that opens
+// the PR; in the real bake it describes the capture the PR actually ships,
+// and those can differ — the anomaly is intermittent, so a clean --check
+// followed by a 5038 bake is the genuinely dangerous ordering.
+const TRIPWIRE_881 = join(repoRoot, 'issue-881-tripwire.txt');
+rmSync(TRIPWIRE_881, { force: true });
+const residue881 = detectIssue881Residue(scrubbed.system_prompt, prev.system_prompt);
+if (residue881.detected) {
+  const lines = formatIssue881Warning(residue881);
+  // Straight to stderr, NOT through log() — a `[bake] ` prefix would stop
+  // GitHub Actions parsing line 1 as a workflow command, and the annotation
+  // is the whole point. The workflow's `cat drift-output.txt` is what lands
+  // it on the run summary.
+  for (const line of lines) console.error(line);
+  // Sibling of drift-summary.md / label-target.txt: a file the workflow can
+  // test for without grepping prose, used to label the rebake PR.
+  writeFileSync(TRIPWIRE_881, `${residue881.reason} ${residue881.capturedLen} ${residue881.bundledLen}\n`);
+}
 
 // ── Fable system-prompt variant (dario#lock-step) ────────────────────
 // CC 2.1.198 sends Fable a larger, model-specific system prompt than the base.

--- a/scripts/drift-report.mjs
+++ b/scripts/drift-report.mjs
@@ -473,3 +473,105 @@ export function formatDriftSummary(interpretation) {
 
   return lines;
 }
+
+// ── #881 tripwire: the intermittent +279-char base-prompt residue ─────
+//
+// About one local capture in ten, the scrubbed BASE system prompt comes back
+// 5038 chars instead of the usual 4759 — an extra `# Context management`
+// paragraph that is not in the baked bundle. Root cause unknown (dario#881);
+// 26h of CI data says it has never reached the Linux runner, and #881
+// deliberately defers any bake-time normalisation ("should not be taken on a
+// hunch"). So this is a DETECTOR ONLY: it never strips, rewrites or suppresses
+// anything. Its whole job is to make a 5038 capture impossible to mistake for
+// a genuine CC prompt change if it ever does reach CI and auto-opens a rebake
+// PR.
+
+/**
+ * The paragraph's opening sentence. `# Context management` alone is useless as
+ * a discriminator — the CURRENT 4759-char bundle already has that heading, so
+ * matching on it would flag every clean capture. This sentence is the part
+ * that only appears in the 5038 readings.
+ */
+export const ISSUE_881_MARKER =
+  'When you have enough information to act, act.';
+
+/** Scrubbed base lengths from #881: the normal reading and the anomalous one. */
+export const ISSUE_881_BASELINE_LEN = 4759;
+export const ISSUE_881_ANOMALY_LEN = 5038;
+
+/**
+ * Decide whether a scrubbed base capture carries the #881 residue relative to
+ * the bundled template.
+ *
+ * Two independent clauses, either sufficient:
+ *
+ *  1. **Marker clause** — the capture contains the marker sentence and the
+ *     bundle does not. This is the primary signal and survives the paragraph's
+ *     wording drifting in length.
+ *  2. **Length clause** — the capture is exactly 5038 and the bundle exactly
+ *     4759, the pair documented in #881. A backstop for the case where the
+ *     sentence gets reworded but the byte count still lands on the known pair.
+ *
+ * Both clauses are relative to the bundle, which is what keeps the tripwire
+ * from becoming permanent noise: if the paragraph is ever legitimately baked
+ * in, the bundle gains the marker (and stops being 4759), both clauses go
+ * false, and the detector silently disarms with no code change.
+ *
+ * A genuine CC prompt change — #881 cites the real 4754 -> 4759 step — trips
+ * neither clause, so it flows through as ordinary drift. That specificity is
+ * the point: flagging every base-length change would defeat the tripwire.
+ *
+ * @param {string} capturedPrompt scrubbed base system_prompt from the live capture
+ * @param {string} bundledPrompt  system_prompt from src/cc-template-data.json
+ * @returns {{detected: boolean, reason: string|null, capturedLen: number, bundledLen: number}}
+ */
+export function detectIssue881Residue(capturedPrompt, bundledPrompt) {
+  const captured = typeof capturedPrompt === 'string' ? capturedPrompt : '';
+  const bundled = typeof bundledPrompt === 'string' ? bundledPrompt : '';
+  const result = { detected: false, reason: null, capturedLen: captured.length, bundledLen: bundled.length };
+
+  if (captured.includes(ISSUE_881_MARKER) && !bundled.includes(ISSUE_881_MARKER)) {
+    result.detected = true;
+    result.reason = 'marker';
+    return result;
+  }
+  if (captured.length === ISSUE_881_ANOMALY_LEN && bundled.length === ISSUE_881_BASELINE_LEN) {
+    result.detected = true;
+    result.reason = 'length';
+    return result;
+  }
+  return result;
+}
+
+/**
+ * Render the tripwire hit for the `--check` log. Line 1 is a GitHub Actions
+ * `::warning::` annotation, so a hit surfaces on the run summary rather than
+ * being buried in step output; the rest is prose for the human reading the
+ * drift issue / PR body, both of which embed this stream verbatim.
+ *
+ * The annotation is emitted unconditionally rather than gated on `$GITHUB_ACTIONS`
+ * — outside Actions it is just a prefixed line, and gating on the env var would
+ * make the one path that matters the one path that is never exercised locally.
+ */
+export function formatIssue881Warning(detection) {
+  const via = detection.reason === 'marker'
+    ? `the "${ISSUE_881_MARKER}" marker sentence is in the capture but not the bundle`
+    : `the capture is exactly ${ISSUE_881_ANOMALY_LEN} chars against a ${ISSUE_881_BASELINE_LEN}-char bundle`;
+  return [
+    `::warning title=dario#881 base-prompt residue::Base system prompt captured at ${detection.capturedLen} chars vs ${detection.bundledLen} bundled — matches the KNOWN dario#881 anomaly (${via}). Any rebake PR from this run is #881 residue, NOT a genuine CC prompt change. Do not merge without reading https://github.com/askalf/dario/issues/881`,
+    '',
+    'TRIPWIRE: dario#881 — intermittent +279-char base-prompt residue',
+    `  captured base: ${detection.capturedLen} chars`,
+    `  bundled base:  ${detection.bundledLen} chars`,
+    `  matched via:   ${detection.reason} clause (${via})`,
+    '',
+    '  This capture carries the extra "# Context management" paragraph that #881',
+    '  documents as appearing in roughly 1 local capture in 10 and never (until now)',
+    '  in CI. Treat any resulting rebake PR as #881 residue until proven otherwise:',
+    '  the base prompt did not change upstream, this run captured it wrong.',
+    '',
+    '  Do NOT merge the rebake on the assumption that CC edited its prompt. Re-run the',
+    '  workflow; if the next capture comes back clean, this was the anomaly. Comment the',
+    '  outcome on #881 either way — the correlating conditions are what that issue needs.',
+  ];
+}

--- a/test/bake-drift-report.mjs
+++ b/test/bake-drift-report.mjs
@@ -3,7 +3,7 @@
 // test runner spawns each file via node:test which is fine for imports
 // too, but the existing pattern groups script-imports in serial).
 
-import { unifiedDiff, computeDrift, describeTool, formatDriftReport, interpretDrift, formatDriftSummary, MODEL_CONDITIONAL_BETAS, REMOTE_CONFIG_CONDITIONAL_BETAS, normalizeMemoryPath, stripModelConditionalBetas, isOlderCCVersion } from '../scripts/drift-report.mjs';
+import { unifiedDiff, computeDrift, describeTool, formatDriftReport, interpretDrift, formatDriftSummary, MODEL_CONDITIONAL_BETAS, REMOTE_CONFIG_CONDITIONAL_BETAS, normalizeMemoryPath, stripModelConditionalBetas, isOlderCCVersion, detectIssue881Residue, formatIssue881Warning, ISSUE_881_MARKER, ISSUE_881_BASELINE_LEN, ISSUE_881_ANOMALY_LEN } from '../scripts/drift-report.mjs';
 
 let pass = 0;
 let fail = 0;
@@ -476,6 +476,93 @@ header('22. remote-config betas do not drift in either direction');
     'and it drops the flag rather than keeping it',
     !stripModelConditionalBetas('claude-code-20250219,afk-mode-2026-01-31').includes('afk-mode'),
   );
+}
+
+// ──────────────────────────────────────────────────────────────────────
+header('40. detectIssue881Residue — the #881 base-prompt tripwire');
+{
+  // Padding so the constructed prompts hit the exact #881 lengths without
+  // needing the real 4759-char prompt inline.
+  const pad = (n) => 'x'.repeat(n);
+  const para = `\n\n# Context management\n${ISSUE_881_MARKER} Do not re-derive facts already established in the conversation.`;
+
+  // --- marker clause -------------------------------------------------
+  const bundleClean = `You are Claude Code.\n\n# Context management\nSome other paragraph.`;
+  const captureWithPara = bundleClean + para;
+  {
+    const d = detectIssue881Residue(captureWithPara, bundleClean);
+    check('marker in capture but not bundle → detected', d.detected === true);
+    check('reported via the marker clause', d.reason === 'marker');
+    check('carries both lengths for the annotation', d.capturedLen === captureWithPara.length && d.bundledLen === bundleClean.length);
+  }
+
+  // The heading alone must NOT trip it — the shipped 4759-char bundle already
+  // contains `# Context management`, so a heading match would flag every run.
+  check(
+    'the bundle already having the heading is not enough to fire',
+    detectIssue881Residue(bundleClean, bundleClean).detected === false,
+  );
+
+  // --- length clause -------------------------------------------------
+  {
+    const d = detectIssue881Residue(pad(ISSUE_881_ANOMALY_LEN), pad(ISSUE_881_BASELINE_LEN));
+    check('5038 capture vs 4759 bundle → detected without the marker', d.detected === true);
+    check('reported via the length clause', d.reason === 'length');
+  }
+  check(
+    '5038 against some other bundle length does not fire',
+    detectIssue881Residue(pad(ISSUE_881_ANOMALY_LEN), pad(4800)).detected === false,
+  );
+  check(
+    '4759 against 4759 does not fire',
+    detectIssue881Residue(pad(ISSUE_881_BASELINE_LEN), pad(ISSUE_881_BASELINE_LEN)).detected === false,
+  );
+
+  // --- specificity: genuine drift must flow through as normal drift ---
+  // #881 cites the real 4754 -> 4759 CC prompt change as the case that must
+  // NOT be flagged. Flagging every base-length change defeats the tripwire.
+  check(
+    'the genuine 4754 -> 4759 step is NOT flagged',
+    detectIssue881Residue(pad(4759), pad(4754)).detected === false,
+  );
+  check(
+    'an unrelated large prompt change is NOT flagged',
+    detectIssue881Residue(pad(9000), pad(ISSUE_881_BASELINE_LEN)).detected === false,
+  );
+
+  // --- self-disarm ---------------------------------------------------
+  // If the paragraph is ever legitimately baked in, the bundle gains the
+  // marker and both clauses go false with no code change.
+  check(
+    'once the paragraph is baked into the bundle the tripwire disarms',
+    detectIssue881Residue(captureWithPara, captureWithPara).detected === false,
+  );
+
+  // --- defensive -----------------------------------------------------
+  check('undefined inputs do not throw', detectIssue881Residue(undefined, undefined).detected === false);
+  check('non-string inputs do not throw', detectIssue881Residue(null, 42).detected === false);
+}
+
+// ──────────────────────────────────────────────────────────────────────
+header('41. formatIssue881Warning — the Actions annotation');
+{
+  const d = detectIssue881Residue(
+    'prompt\n' + ISSUE_881_MARKER,
+    'prompt',
+  );
+  const lines = formatIssue881Warning(d);
+  check('first line is a GitHub Actions warning command', lines[0].startsWith('::warning '));
+  // A `[bake] ` prefix (or anything else before `::`) stops Actions parsing
+  // the line as a workflow command — the annotation is the whole point.
+  check('nothing precedes the :: on line 1', lines[0].indexOf('::') === 0);
+  check('the annotation names the issue', lines[0].includes('881'));
+  check('and points at the issue URL', lines[0].includes('github.com/askalf/dario/issues/881'));
+  check('reports the captured length', lines[0].includes(String(d.capturedLen)));
+  check('body explains it is residue, not a genuine change', lines.join('\n').includes('NOT a genuine CC prompt change'));
+  check('body tells the reader to re-run', lines.join('\n').includes('Re-run the'));
+
+  const byLength = formatIssue881Warning(detectIssue881Residue('y'.repeat(ISSUE_881_ANOMALY_LEN), 'y'.repeat(ISSUE_881_BASELINE_LEN)));
+  check('the length clause renders its own explanation', byLength[0].includes(`exactly ${ISSUE_881_ANOMALY_LEN} chars`));
 }
 
 // ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up to #881. **Tripwire only — this does not fix #881 and deliberately does not close it.**

## The gap

#881 records that roughly **1 local capture in 10** returns the scrubbed base system prompt at **5038 chars instead of 4759** — an extra `# Context management` paragraph beginning "When you have enough information to act, act." that is not in the baked bundle. 26h of CI data says it has never reached the Linux runner.

The harm if it ever does is specific and silent: `cc-drift-template-watch.yml` exits 2, auto-opens a rebake PR, and that PR looks exactly like a genuine CC prompt change. Merging it bakes a bad capture into the shipped wire-shape contract and cuts a release for an upstream change that never happened. Nothing in the current path distinguishes that from real drift.

## What this adds

`detectIssue881Residue(captured, bundled)` in `scripts/drift-report.mjs`, fires on either of two clauses, **both relative to the bundle**:

1. **marker** — the marker sentence is in the capture and absent from the bundle. Primary signal; survives the paragraph's wording drifting in length.
2. **length** — the capture is exactly 5038 against a bundle of exactly 4759, the pair documented in #881. Backstop for the sentence being reworded while the byte count still lands on the known pair.

Relative-to-the-bundle is what keeps this from becoming permanent noise: if the paragraph is ever legitimately baked in, the bundle gains the marker (and stops being 4759), both clauses go false, and the detector **self-disarms with no code change**.

## Specificity — the harder half

The ticket's constraint was to alert on the #881 signature, *not* on any base-length change, since false-flagging every change defeats the tripwire.

- The genuine **4754 → 4759** step #881 itself cites trips neither clause and flows through as ordinary drift. Covered by a test.
- `# Context management` **alone is not usable** as the discriminator. I checked `src/cc-template-data.json` before choosing: the current 4759-char bundle *already contains that heading* (it does not contain the marker sentence). Matching on the heading would have flagged every clean run. The marker sentence is the part that only appears in 5038 readings.

## How the signal surfaces

On a hit the bake writes the `::warning title=dario#881::` annotation **straight to stderr, not through `log()`** — a `[bake] ` prefix would stop Actions parsing line 1 as a workflow command, and the annotation is the whole point. The workflow's existing `cat drift-output.txt` puts it on the run summary, and that same stream is already embedded verbatim in the drift issue and PR bodies.

It also drops `issue-881-tripwire.txt` (sibling of `drift-summary.md` / `label-target.txt`, gitignored) so the workflow tests for a file instead of grepping prose. On a hit the workflow:

- titles the PR **`[#881 residue?] auto-rebake: ...`** — the PR list, merge-queue view and email notification show the title and nothing else;
- adds an **`issue-881-residue`** label, created on demand via `gh label create --force` (rare enough that pre-creating it in repo settings would just rot; same create-then-use shape the other watchers use);
- prepends a `[!CAUTION]` block to the body telling the reviewer to re-dispatch the watcher, and to **comment the outcome on #881 either way** — hit or false positive, that correlation is what the issue is open for.

The detector runs in **both** `--check` and the real bake, and the two verdicts are **OR'd**. They are separate live captures of an intermittent fault, so they can disagree, and a clean `--check` followed by a 5038 bake is the genuinely dangerous ordering — the bake's capture is the one the PR actually ships.

## Detection only, deliberately

Nothing here strips the paragraph, rewrites it, or suppresses the drift it causes. #881 defers the bake-time normalisation on the grounds that the call "should not be taken on a hunch", and this does not take it — it makes sure the hunch gets data instead of a merged rebake.

## Test plan

`test/bake-drift-report.mjs` gains sections 40 and 41 (21 new assertions), picked up automatically by `test/all.test.mjs`:

- both clauses fire; each reports its own `reason`
- heading-only does **not** fire; 4759-vs-4759 does not fire; 5038 against a non-4759 bundle does not fire
- the genuine 4754 → 4759 step is **not** flagged; an unrelated 9000-char change is **not** flagged
- self-disarm: once the paragraph is in the bundle, it stops firing
- `undefined` / non-string inputs do not throw
- line 1 of the warning starts at index 0 with `::warning ` (the no-prefix invariant), names 881, carries the issue URL and the captured length

Run locally: **132 pass, 0 fail** (was 110). `node scripts/check-package-json.mjs` → OK.

Version bumped `5.4.22 → 5.4.23` with a CHANGELOG entry, since dario needs an in-PR bump or nothing ships.

Refs #881.
