### PR TITLE
docs(README): correct the line-count claim to ~24k and guard it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,12 @@ jobs:
       - name: package.json is valid JSON and canonically formatted
         run: node scripts/check-package-json.mjs
 
+      # Kept in this job rather than a new one so it does not add a required
+      # status check to branch protection -- it is the same class of cheap
+      # metadata assertion, and it needs no npm install.
+      - name: README line-count claim still matches src/
+        run: node scripts/check-readme-line-count.mjs
+
   build:
     needs: validate-package-json
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ checklist.
 
 ## [Unreleased]
 
+- **The README's "~22k lines you can read in a weekend" was understating by 9%, and CI now measures it.** `src/` is **23,986 lines across 52 files**; the hero line said `~22k`. It now says `~24k`.
+
+  The reason this needs a guard rather than another correction is that it is the second one. The 5.4.15 entry below records "Source is 23,833 lines across 52 files, not ~22k across 49" — an accurate measurement, logged in this file, that never reached the line it was about. `git log -L 21,21:README.md` shows the hero line untouched since #717, so the correction landed everywhere except the claim a reader actually sees. Before that, #582 had already refreshed the same number once.
+
+  `scripts/check-readme-line-count.mjs` runs in `validate-package-json` (no npm install, no new required status check) and fails the build if the claim is more than 1000 lines off, printing the value to write. It also fails if the sentence disappears, so the guard cannot end up pointing at nothing. Tolerance is deliberately a full thousand — tight enough that the claim never misleads by a round number, loose enough that ordinary PRs do not trip it. A number nobody re-measures only ever drifts in the flattering direction.
+
 ## [5.4.23] - 2026-07-27
 
 - **The drift watcher now trips a tripwire when a base-prompt capture matches the #881 anomaly.** #881 records that roughly **1 local capture in 10** returns the scrubbed base system prompt at **5038 chars instead of 4759** — an extra `# Context management` paragraph beginning "When you have enough information to act, act." that is not in the baked bundle. 26h of CI data says it has never reached the Linux runner. The harm it would do if it did is specific: `cc-drift-template-watch.yml` would exit 2, auto-open a rebake PR, and that PR would look exactly like a genuine CC prompt change while actually baking a bad capture into the shipped wire-shape contract and cutting a release for an upstream change that never happened.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 <p><strong>One local endpoint. Every AI tool you own. The subscription you already pay for.</strong></p>
 
-<sub><code>npm i -g @askalf/dario</code> · <strong>0</strong> runtime deps · <a href="https://www.npmjs.com/package/@askalf/dario">SLSA-attested</a> every release · nothing phones home · ~22k lines you can read in a weekend · independent, unofficial, third-party (<a href="DISCLAIMER.md">DISCLAIMER.md</a>)</sub>
+<sub><code>npm i -g @askalf/dario</code> · <strong>0</strong> runtime deps · <a href="https://www.npmjs.com/package/@askalf/dario">SLSA-attested</a> every release · nothing phones home · ~24k lines you can read in a weekend · independent, unofficial, third-party (<a href="DISCLAIMER.md">DISCLAIMER.md</a>)</sub>
 
 </div>
 

--- a/scripts/check-readme-line-count.mjs
+++ b/scripts/check-readme-line-count.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// The README's "~Nk lines you can read in a weekend" claim is a load-bearing
+// selling point -- it is the thing that makes "audit it yourself" credible --
+// and it rots on its own, silently, every release.
+//
+// It has already rotted twice. #582 refreshed it, #717 rewrote the hero line
+// back to ~22k, and #877's changelog records "Source is 23,833 lines across 52
+// files, not ~22k across 49" -- a correction that never reached the hero line,
+// which still read ~22k on 2026-08-01 at an actual 23,986. A number nobody
+// re-measures is a number that only ever drifts in the flattering direction,
+// so this measures it on every PR instead.
+//
+// Tolerance is +/- 1000 lines, i.e. "~24k" is honest anywhere in 23k-25k. That
+// is loose enough that ordinary PRs do not trip it and tight enough that the
+// claim never misleads by a full thousand lines.
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const TOLERANCE = 1000;
+const CLAIM = /~(\d+)k lines you can read in a weekend/;
+
+function tsFiles(dir) {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) return tsFiles(p);
+    return e.name.endsWith('.ts') ? [p] : [];
+  });
+}
+
+const files = tsFiles('src');
+const actual = files.reduce(
+  (n, f) => n + readFileSync(f, 'utf8').split('\n').length - 1,
+  0,
+);
+
+const readme = readFileSync('README.md', 'utf8');
+const m = readme.match(CLAIM);
+
+if (!m) {
+  console.error(
+    'FAIL: README.md no longer contains a "~Nk lines you can read in a weekend"\n' +
+      'claim. If it was removed on purpose, delete this check and its CI step --\n' +
+      'do not leave a guard pointing at nothing.',
+  );
+  process.exit(1);
+}
+
+const claimed = Number(m[1]) * 1000;
+const drift = actual - claimed;
+
+if (Math.abs(drift) > TOLERANCE) {
+  console.error(
+    `FAIL: README claims ~${m[1]}k lines; src/ actually has ${actual.toLocaleString()} ` +
+      `across ${files.length} files (off by ${drift > 0 ? '+' : ''}${drift}).\n` +
+      `Update the hero line in README.md to ~${Math.round(actual / 1000)}k.`,
+  );
+  process.exit(1);
+}
+
+console.log(
+  `ok  README ~${m[1]}k vs actual ${actual.toLocaleString()} lines ` +
+    `across ${files.length} files (${drift > 0 ? '+' : ''}${drift}, tolerance ${TOLERANCE})`,
+);


### PR DESCRIPTION
`src/` is **23,986 lines across 52 files**. The README hero line claimed `~22k` — a 9% understatement of the one number that makes "audit it yourself" a credible invitation rather than a slogan.

### Why a guard and not just another correction

This is the second time the number has gone stale, and the first correction is instructive. The 5.4.15 changelog entry already contains the right measurement:

> Source is 23,833 lines across 52 files, not ~22k across 49.

That was accurate when written. But `git log -L 21,21:README.md` shows the hero line untouched since #717, so the correction reached the changelog and never reached the claim a reader actually sees. #582 had refreshed the same number once before that. A hardcoded figure nobody re-measures only ever drifts in the flattering direction — the repo grows, the claim doesn't, and the understatement quietly becomes the marketing.

### The check

`scripts/check-readme-line-count.mjs` measures `src/**/*.ts` on every PR and fails if the claim is more than **1000 lines** off, printing the exact value to write:

```
FAIL: README claims ~22k lines; src/ actually has 23,986 across 52 files (off by +1986).
Update the hero line in README.md to ~24k.
```

It also fails if the sentence is deleted, so the guard cannot outlive the thing it guards. Tolerance is deliberately a full thousand: tight enough that the claim never misleads by a round number, loose enough that ordinary PRs do not trip it.

It runs inside the existing `validate-package-json` job rather than a new one — same class of cheap metadata assertion, no `npm install`, and no new required status check to add to branch protection.

### Verification

All three paths exercised locally:

| case | result |
|---|---|
| corrected README (`~24k`) | `ok  README ~24k vs actual 23,986 lines across 52 files (-14, tolerance 1000)` — exit 0 |
| stale claim (`~22k`) | exit 1, message above |
| claim deleted | exit 1, tells you to remove the check too |

No source changes, so no version bump — this rides the next release.
