### PR TITLE
chore(drift-watch): hourly instead of every 30 min to halve the OAuth-split window

### DIFF
--- a/.github/workflows/cc-drift-template-watch.yml
+++ b/.github/workflows/cc-drift-template-watch.yml
@@ -15,7 +15,15 @@ name: CC template drift watch (self-hosted)
 # AND authenticated (~/.claude/.credentials.json or DARIO_CLAUDE_BIN env var).
 # Hetzner / DO / EC2 / etc — anything dedicated. Setup: docs/drift-monitor.md.
 #
-# Runs every 30 min when the runner is online. Idempotent: if drift persists
+# Runs HOURLY (:41, staggered off the :00 grid) when the runner is online.
+# Was */30 until 2026-08-02. Every run is a chance for CC's atomic tmp+rename
+# to replace the pinned credential symlink AFTER the pin step below, splitting
+# the shared OAuth family and revoking the fleet's token (4th occurrence that
+# day; see docs/recovery.md "OAuth credential dead"). Halving the cadence halves
+# the collision surface. This is a MITIGATION, not the fix — the real fix is a
+# dedicated Max seat for dario so the runner and the container stop sharing one
+# refresh-token family. Drift moves at the pace of Anthropic releases, so hourly
+# costs very little detection latency. Idempotent: if drift persists
 # across cycles AND a bot rebake PR is already open, no new PR is opened
 # (the existing one stays current). When the template is re-baked + merged,
 # the issue auto-closes on the next clean cycle.
@@ -39,7 +47,7 @@ name: CC template drift watch (self-hosted)
 
 on:
   schedule:
-    - cron: '*/30 * * * *'
+    - cron: '41 * * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Drops this watcher from every 30 minutes to hourly (`41 * * * *`, staggered off the `:00` grid like the other schedules here). Comment-only change otherwise — no logic touched.

## Why

This job is the source of the recurring fleet-wide OAuth outage. Today was the fourth recorded occurrence.

The pin step added in #563 re-links `/root/.claude/.credentials.json` to the container's canonical file *before* the Max-OAuth step, so the runner reads dario's always-fresh token and never refreshes. It does not hold: Claude Code refreshes via atomic tmp+rename, which **replaces the symlink with a regular file after the pin has run**. From that moment the runner and the container hold two copies of one refresh-token family, refresh independently, and Anthropic's reuse-detection revokes the family.

Today's instance, measured rather than inferred:

- `11:59:52Z` — this workflow ran.
- `12:00:05Z` — `/root/.claude/.credentials.json` written as a **regular file, inode 284518**, while canonical stayed at **284083**. Split confirmed.
- `08:03:55Z` (next cycle) — dario's proactive refresh returned `invalid_grant`; it then failed every 15 minutes, 18 times.
- Fleet LLM calls were down until a `--force-reauth` recovery. The container stayed `Up (healthy)` throughout, so `docker ps` showed nothing — only `/health` reporting `degraded` and `cc-oauth-health` issue #897 caught it.

## What this does and does not fix

Halving the cadence halves the collision surface: 48 opportunities a day become 24. **It is a mitigation, not a fix** — a single unlucky run still revokes the family, and the comment in the file says so explicitly rather than leaving a future reader to think the problem is solved.

The real fix remains a dedicated Max seat for dario, so the runner and the container stop sharing one refresh-token family. That is not currently affordable, which is why this stopgap is worth having.

## Cost

Detection latency for same-binary wire drift goes from ≤30 min to ≤60 min. Drift arrives at the pace of Anthropic's remote-config pushes, not minutes, so the practical loss is small — and a missed hour of drift detection is far cheaper than an hour of the whole fleet 401ing.

`workflow_dispatch` is unchanged, so an on-demand check is still one command away.
