### PR TITLE
docs: surface the Own Your Stack family above the fold, add plumbline

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 
 <sub><code>npm i -g @askalf/dario</code> · <strong>0</strong> runtime deps · <a href="https://www.npmjs.com/package/@askalf/dario">SLSA-attested</a> every release · nothing phones home · ~24k lines you can read in a weekend · independent, unofficial, third-party (<a href="DISCLAIMER.md">DISCLAIMER.md</a>)</sub>
 
+<sub>Part of <a href="#own-your-stack"><strong>Own Your Stack</strong></a> — 12 open tools for owning your AI infra: <a href="https://github.com/askalf/truecopy">truecopy</a> · <a href="https://github.com/askalf/strongroom">strongroom</a> · <a href="https://github.com/askalf/fieldpass">fieldpass</a> · <a href="https://github.com/askalf/plumbline">plumbline</a> · <a href="#own-your-stack">full family ↓</a></sub>
+
 </div>
 
 ---
@@ -353,6 +355,7 @@ dario is the routing layer of **[Own Your Stack](https://github.com/askalf)** �
 - **[strongroom](https://github.com/askalf/strongroom)** — own your agent secrets
 - **[cordon](https://github.com/askalf/cordon)** — own your prompts
 - **[fieldpass](https://github.com/askalf/fieldpass)** — own your agent browser
+- **[plumbline](https://github.com/askalf/plumbline)** — own your agent oversight
 - **[amnesia](https://github.com/askalf/amnesia)** — own your search
 - **[askalf](https://askalf.org)** — own your operation: the AI operation that runs Sprayberry Labs
 


### PR DESCRIPTION
## What

Two README-only changes to make the Own Your Stack family findable from dario:

1. **Header strip.** The `## Own Your Stack` section sits at the very bottom of a ~370-line README — below License — where the ~21k monthly npm installs' worth of readers never scroll. This adds one centered `<sub>` line to the header naming four siblings (truecopy · strongroom · fieldpass · plumbline) with an anchor to the full family section.
2. **Adds plumbline to the family list** — public since July, it was missing from the section (slotted after fieldpass: "own your agent oversight").

## Why

dario's README is the highest-traffic surface the family has; the family section exists but is effectively invisible at its current position. One quiet line above the fold, no layout changes, no nagware.

## Notes

- Docs-only: no version bump, so nothing ships per the release gate; the npm README updates at the next publish.
- Diff is 3 added lines, nothing removed.
