### PR TITLE
fix(doctor): name a remedy that actually works for identity drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ checklist.
 
 ## [Unreleased]
 
+## [5.4.24] - 2026-08-02
+
+- **`dario doctor` told you to run a command that cannot work.** The Identity check fires when a pool account's stored `deviceId`/`accountUuid` no longer matches `~/.claude.json` — the state where non-Haiku requests come back 401 — and its remedy read "re-run `dario accounts add <alias>` to refresh the stored snapshot". `accounts add` exits 1 on an alias that already exists, telling you to remove it first, and its default path runs a full OAuth browser flow rather than re-snapshotting anything. The single instruction the warning gave was a dead end for every user who reached it, in the one situation where they were already stuck.
+
+  The remedy now splits by alias kind, because the two cases genuinely differ. The reserved `login` alias needs only `dario accounts remove login`: it is back-filled from whatever credentials are current, so it re-materializes on the next `dario login` / `dario proxy`. A user-added alias needs `dario accounts remove <alias>` then `dario accounts add <alias>`, in that order, and that add re-runs OAuth for the account by design rather than by accident.
+
+  The unit test covering this line asserted the broken advice. It checked that the detail string contained `dario accounts add` — which the *correct* instruction also contains — so it would have passed either way and never had a chance of catching this. It now asserts the ordering (remove before add) and that a drifted `login` is never routed through a bare re-add.
+
 - **The README's "~22k lines you can read in a weekend" was understating by 9%, and CI now measures it.** `src/` is **23,986 lines across 52 files**; the hero line said `~22k`. It now says `~24k`.
 
   The reason this needs a guard rather than another correction is that it is the second one. The 5.4.15 entry below records "Source is 23,833 lines across 52 files, not ~22k across 49" — an accurate measurement, logged in this file, that never reached the line it was about. `git log -L 21,21:README.md` shows the hero line untouched since #717, so the correction landed everywhere except the claim a reader actually sees. Before that, #582 had already refreshed the same number once.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.4.23",
+  "version": "5.4.24",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -33,6 +33,7 @@ import {
 } from './live-fingerprint.js';
 import { detectCCOAuthConfig } from './cc-oauth-detect.js';
 import { runAuthorizeProbe } from './cc-authorize-probe.js';
+import { MIGRATED_LOGIN_ALIAS } from './accounts.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -175,6 +176,7 @@ export function checkIdentityDrift(input: IdentityDriftInput): Check[] {
 
   const aligned: string[] = [];
   const drifted: string[] = [];
+  const driftedAliases: string[] = [];
   for (const acc of poolAccounts) {
     const deviceMatch = acc.deviceId === live.deviceId;
     const acctMatch = acc.accountUuid === live.accountUuid;
@@ -183,6 +185,7 @@ export function checkIdentityDrift(input: IdentityDriftInput): Check[] {
     } else {
       const which = !deviceMatch && !acctMatch ? 'both' : !deviceMatch ? 'deviceId' : 'accountUuid';
       drifted.push(`${acc.alias} (${which})`);
+      driftedAliases.push(acc.alias);
     }
   }
 
@@ -193,10 +196,34 @@ export function checkIdentityDrift(input: IdentityDriftInput): Check[] {
       detail: `${aligned.length}/${poolAccounts.length} pool account${poolAccounts.length === 1 ? '' : 's'} match ~/.claude.json (userID=${shortId(live.deviceId)})`,
     }];
   }
+  // The remedy is deliberately NOT `accounts add <alias>`. That command
+  // exits 1 on an alias that already exists ("Remove it first"), and its
+  // default path runs a full OAuth browser flow rather than re-snapshotting
+  // — so naming it here walked every drifted user into a dead end. The two
+  // alias kinds genuinely need different commands: the reserved login alias
+  // is back-filled from whatever credentials are current, so removing it is
+  // enough (it re-materializes on the next `dario login` / `dario proxy`),
+  // while a user-added alias has to be removed and re-added, which re-runs
+  // OAuth for that account by design.
+  const loginDrifted = driftedAliases.includes(MIGRATED_LOGIN_ALIAS);
+  const otherDrifted = driftedAliases.filter((a) => a !== MIGRATED_LOGIN_ALIAS);
+  const fixes: string[] = [];
+  if (loginDrifted) {
+    fixes.push(
+      `\`dario accounts remove ${MIGRATED_LOGIN_ALIAS}\` — it re-materializes from your ` +
+      `current credentials on the next \`dario login\` / \`dario proxy\``,
+    );
+  }
+  if (otherDrifted.length > 0) {
+    fixes.push(
+      `\`dario accounts remove <alias>\` then \`dario accounts add <alias>\` to re-snapshot` +
+      `${otherDrifted.length === 1 ? '' : ' (for each of them)'} — the add re-runs OAuth for that account`,
+    );
+  }
   return [{
     status: 'warn',
     label: 'Identity',
-    detail: `${drifted.length}/${poolAccounts.length} pool account${poolAccounts.length === 1 ? '' : 's'} drifted from ~/.claude.json (live userID=${shortId(live.deviceId)}): ${drifted.join('; ')} — re-run \`dario accounts add <alias>\` to refresh the stored snapshot, or non-Haiku requests on the drifted account(s) will 401`,
+    detail: `${drifted.length}/${poolAccounts.length} pool account${poolAccounts.length === 1 ? '' : 's'} drifted from ~/.claude.json (live userID=${shortId(live.deviceId)}): ${drifted.join('; ')} — non-Haiku requests on the drifted account(s) will 401. Fix: ${fixes.join('; ')}`,
   }];
 }
 

--- a/test/doctor-identity-drift.mjs
+++ b/test/doctor-identity-drift.mjs
@@ -97,8 +97,50 @@ header('one account drifted (accountUuid mismatch) — warn row');
   check('detail says 1/2 drifted', out[0].detail.includes('1/2'));
   check('detail names the drifted alias', out[0].detail.includes('work'));
   check('detail says accountUuid differs', out[0].detail.includes('accountUuid'));
-  check('detail recommends re-add', out[0].detail.includes('dario accounts add'));
+  check('detail recommends removing first', out[0].detail.includes('dario accounts remove'));
   check('detail warns about 401', out[0].detail.includes('401'));
+}
+
+// ======================================================================
+//  The remedy has to be a command that actually works. `accounts add`
+//  exits 1 on an alias that already exists and its default path runs a
+//  full OAuth flow, so the warning must route through `accounts remove`
+//  first. Asserting only `includes('dario accounts add')` — which the
+//  old test did — passes for BOTH the broken advice and the correct
+//  advice, so it never had a chance of catching this.
+// ======================================================================
+header('drifted user alias — remove THEN add, in that order');
+{
+  const live = { deviceId: 'd'.repeat(64), accountUuid: '11111111-2222-3333-4444-555555555555' };
+  const out = checkIdentityDrift({
+    live,
+    poolAccounts: [
+      { alias: 'work', deviceId: 'e'.repeat(64), accountUuid: live.accountUuid },
+    ],
+  });
+  const detail = out[0].detail;
+  check('names accounts remove', detail.includes('dario accounts remove'));
+  check('names accounts add', detail.includes('dario accounts add'));
+  check('remove is ordered BEFORE add',
+    detail.indexOf('accounts remove') < detail.indexOf('accounts add'));
+  check('says the add re-runs OAuth', detail.includes('OAuth'));
+}
+
+header('drifted `login` alias — remove only, never a bare re-add');
+{
+  const live = { deviceId: 'd'.repeat(64), accountUuid: '11111111-2222-3333-4444-555555555555' };
+  const out = checkIdentityDrift({
+    live,
+    poolAccounts: [
+      { alias: 'login', deviceId: 'e'.repeat(64), accountUuid: live.accountUuid },
+    ],
+  });
+  const detail = out[0].detail;
+  check('status is warn', out[0].status === 'warn');
+  check('tells you to remove the login alias', detail.includes('dario accounts remove login'));
+  check('never says `accounts add login` (that command refuses an existing alias)',
+    !detail.includes('accounts add login'));
+  check('explains it re-materializes on next login/proxy', detail.includes('re-materializes'));
 }
 
 header('both fields differ on a single account — surfaces as "both"');


### PR DESCRIPTION
`dario doctor`'s Identity warning named a command that cannot work, in the exact situation where the user is already stuck.

## The bug

The Identity check fires when a pool account's stored `deviceId`/`accountUuid` no longer matches `~/.claude.json` — the state where non-Haiku requests come back 401 from Anthropic. Its remedy read:

> re-run `dario accounts add <alias>` to refresh the stored snapshot

Two things are wrong with that, and either alone is fatal:

1. `accounts add` **exits 1 on an alias that already exists** (`cli.ts`, "Account "<alias>" already exists. Remove it first"). A drifted alias exists by definition, so the suggested command can never succeed.
2. Its default path **runs a full OAuth browser flow**, not a re-snapshot of the current credentials.

Hit live on a box whose `login` alias had drifted: the doctor said to re-add, the CLI refused, and there was no route forward from the warning itself.

## The fix

The remedy now splits by alias kind, because the two cases genuinely differ:

- **The reserved `login` alias** needs only `dario accounts remove login`. It is back-filled from whatever credentials are current, so it re-materializes on the next `dario login` / `dario proxy`.
- **A user-added alias** needs `dario accounts remove <alias>` then `dario accounts add <alias>`, in that order — and there the add re-running OAuth is correct by design rather than by accident.

The warning also now leads with the consequence (401 on non-Haiku) and closes with the fix, instead of burying the 401 after a dead-end instruction.

## Why the test didn't catch it

`test/doctor-identity-drift.mjs` asserted `detail.includes('dario accounts add')` — which the **correct** instruction also contains. It passed on the broken message and would have passed on the fixed one, so it never had discriminating power.

It now asserts the ordering (`remove` before `add`) and adds a case for a drifted `login` alias, checking it is never routed through a bare re-add. Verified the new assertions actually discriminate: reverting only `src/doctor.ts` and rebuilding fails **5 assertions**; with the fix, 38/38 pass.

## Verification

- `npm run build` — clean
- `npm test` — **126/126 pass**
- `node scripts/check-package-json.mjs` — OK
- `node scripts/extract-release-notes.mjs 5.4.24 --file CHANGELOG.md` — returns the section (release body will not be empty)

Version bumped to **5.4.24** in-PR per the release gate, with the CHANGELOG's `[Unreleased]` section promoted to `[5.4.24]` per the file's own convention — which also ships the README line-count guard from #893 that has been sitting unreleased.
