### PR TITLE
feat(oauth): DARIO_IGNORE_CC_CREDENTIALS — run dario next to a live Claude Code session without rotating its OAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ checklist.
 
 ## [Unreleased]
 
+## [5.4.25] - 2026-08-03
+
+- **`DARIO_IGNORE_CC_CREDENTIALS` — run dario next to a live `claude` session without rotating its OAuth.** When dario runs on the same machine/account as an interactive Claude Code session, `loadCredentials()` reads dario's own `~/.dario/credentials.json`, CC's `~/.claude/.credentials.json`, AND the OS keychain, then uses the *freshest*. The moment CC's token is fresher (e.g. right after you log into CC), dario grabs that same token, refreshes it, Anthropic rotates it, and the interactive session still holding the old copy starts 401ing — the "dario broke my Claude Code login" failure.
+
+  Set `DARIO_IGNORE_CC_CREDENTIALS=1` (accepts `1`/`true`/`yes`/`on`) and dario uses ONLY its own `~/.dario/credentials.json` — from a prior `dario login` — never the CC file or keychain. This keeps dario on the Max subscription ($0) while guaranteeing it can never touch the interactive session's token. It is env-only, default off (unchanged behaviour), and surfaced in `dario config` and the proxy startup banner. The existing `ANTHROPIC_UPSTREAM_API_KEY` also isolates, but bypasses OAuth/Max onto retail per-token billing — which defeats the purpose of running dario at all; this flag is the isolation path that preserves the subscription.
+
 ## [5.4.24] - 2026-08-02
 
 - **`dario doctor` told you to run a command that cannot work.** The Identity check fires when a pool account's stored `deviceId`/`accountUuid` no longer matches `~/.claude.json` — the state where non-Haiku requests come back 401 — and its remedy read "re-run `dario accounts add <alias>` to refresh the stored snapshot". `accounts add` exits 1 on an alias that already exists, telling you to remove it first, and its default path runs a full OAuth browser flow rather than re-snapshotting anything. The single instruction the warning gave was a dead end for every user who reached it, in the one situation where they were already stuck.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "5.4.24",
+  "version": "5.4.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "5.4.24",
+      "version": "5.4.25",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.4.24",
+  "version": "5.4.25",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/config-report.ts
+++ b/src/config-report.ts
@@ -19,6 +19,7 @@ import { readFileSync, existsSync, statSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { homedir } from 'node:os';
+import { ignoreCcCredentials } from './oauth.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -93,6 +94,12 @@ export async function collectEffectiveConfig(): Promise<ConfigReport> {
     rows: [
       { label: 'credentials', value: credsInfo },
       { label: 'path', value: credsPath },
+      {
+        label: 'DARIO_IGNORE_CC_CREDENTIALS',
+        value: ignoreCcCredentials()
+          ? "on — using ONLY dario's own credentials.json; Claude Code session token + keychain ignored (won't rotate a live `claude` session)"
+          : 'off — also reads ~/.claude/.credentials.json + OS keychain, picks freshest (can rotate a live `claude` session on the same machine)',
+      },
     ],
   });
 

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -98,6 +98,45 @@ function getDarioCredentialsPath(): string {
   return join(homedir(), '.dario', 'credentials.json');
 }
 
+/**
+ * Whether to ignore the interactive Claude Code session's credentials entirely
+ * — set via `DARIO_IGNORE_CC_CREDENTIALS` (1/true/yes/on). Exported for tests.
+ *
+ * Default (unset) keeps the historical behaviour: loadCredentials reads dario's
+ * own file, CC's `~/.claude/.credentials.json`, AND the OS keychain (where
+ * modern CC stores its token), then uses the FRESHEST. That auto-detection is
+ * convenient for a machine dedicated to dario, but it is exactly what breaks a
+ * live `claude` session running on the SAME machine/account: the moment CC's
+ * token is fresher (e.g. right after you log into CC), dario grabs that same
+ * token and refreshes it, Anthropic rotates it, and the interactive session
+ * still holding the old copy starts 401ing.
+ *
+ * With the flag set, dario uses ONLY its own `~/.dario/credentials.json` (from a
+ * prior `dario login`) and never touches the CC file or keychain — so it stays
+ * on the Max subscription ($0) while never rotating the interactive session's
+ * token. The API-key path (`ANTHROPIC_UPSTREAM_API_KEY`) also isolates, but
+ * bypasses OAuth/Max onto retail billing, defeating the point of dario.
+ */
+export function ignoreCcCredentials(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = (env['DARIO_IGNORE_CC_CREDENTIALS'] ?? '').trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes' || v === 'on';
+}
+
+/**
+ * Which credential sources loadCredentials() consults, given whether the
+ * interactive Claude Code session's credentials should be ignored. Exported so
+ * the isolation guarantee is testable without real credentials on disk.
+ *
+ * `readKeychain` gates the OS keychain the same way as the CC file: the modern
+ * CC binary stores its OAuth token in the keychain, not on disk, so isolating
+ * from the interactive session means skipping BOTH.
+ */
+export function credentialSourcePlan(ignoreCc: boolean): { filePaths: string[]; readKeychain: boolean } {
+  return ignoreCc
+    ? { filePaths: [getDarioCredentialsPath()], readKeychain: false }
+    : { filePaths: [getDarioCredentialsPath(), getClaudeCodeCredentialsPath()], readKeychain: true };
+}
+
 function getClaudeCodeCredentialsPath(): string {
   return join(homedir(), '.claude', '.credentials.json');
 }
@@ -417,9 +456,16 @@ export async function loadCredentials(): Promise<CredentialsFile | null> {
   // work the way it did before any `dario login` had ever run, while
   // still preferring dario's own file when both sources are equivalent
   // (dario file wins ties on expiresAt by being checked first).
+  //
+  // DARIO_IGNORE_CC_CREDENTIALS narrows the source set to dario's OWN file
+  // only — never the interactive CC session's token (its file OR the keychain).
+  // See ignoreCcCredentials() / credentialSourcePlan() for why: on a machine
+  // shared with a live `claude` session, grabbing + refreshing CC's token here
+  // rotates it out from under that session.
+  const plan = credentialSourcePlan(ignoreCcCredentials());
   const candidates: CredentialsFile[] = [];
 
-  for (const path of [getDarioCredentialsPath(), getClaudeCodeCredentialsPath()]) {
+  for (const path of plan.filePaths) {
     try {
       const raw = await readFile(path, 'utf-8');
       const parsed = JSON.parse(raw);
@@ -430,9 +476,11 @@ export async function loadCredentials(): Promise<CredentialsFile | null> {
   }
 
   // OS keychain (modern CC stores credentials here, not on disk).
-  const keychainCreds = await loadKeychainCredentials();
-  if (keychainCreds?.claudeAiOauth?.accessToken && keychainCreds?.claudeAiOauth?.refreshToken) {
-    candidates.push(keychainCreds);
+  if (plan.readKeychain) {
+    const keychainCreds = await loadKeychainCredentials();
+    if (keychainCreds?.claudeAiOauth?.accessToken && keychainCreds?.claudeAiOauth?.refreshToken) {
+      candidates.push(keychainCreds);
+    }
   }
 
   const best = pickFreshestCredentials(candidates);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { setDefaultResultOrder } from 'node:dns';
 import { arch, platform } from 'node:process';
-import { getAccessToken, getStatus } from './oauth.js';
+import { getAccessToken, getStatus, ignoreCcCredentials } from './oauth.js';
 import { buildHealthResponse, derivePoolStatus, shouldDiscloseHealthInternals } from './health-response.js';
 import { darioVersion } from './version.js';
 import { buildCCRequest, applyCcPromptCaching, parseEffortSuffix, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, overlayTemplateHeaderValues, forwardClientCCIdentityHeaders, isMcpToolName, CC_TEMPLATE, CC_CACHE_CONTROL, effectiveCacheControl, withForced1hBeta, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
@@ -1270,6 +1270,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
   const upstreamFetch: typeof fetch = opts.fetchImpl ?? fetch;
   const upstreamApiKey = (opts.upstreamApiKey ?? process.env.ANTHROPIC_UPSTREAM_API_KEY ?? '').trim();
   if (upstreamApiKey) console.error('[dario] upstream auth: per-token API key (x-api-key) — OAuth/Max + account pool bypassed');
+  else if (ignoreCcCredentials()) console.error("[dario] DARIO_IGNORE_CC_CREDENTIALS: using ONLY dario's own credentials.json — Claude Code session token + keychain ignored (won't rotate a live `claude` session; run `dario login` if not authed)");
 
   // DNS result order — prefer IPv4 for the Anthropic upstream by default.
   // api.anthropic.com publishes both A and AAAA records. In a container with

--- a/test/ignore-cc-credentials.mjs
+++ b/test/ignore-cc-credentials.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * DARIO_IGNORE_CC_CREDENTIALS — isolate dario from a live Claude Code session.
+ *
+ * The problem this solves (the "dario rotates my CC OAuth" complaint): when
+ * dario runs on the same machine/account as an interactive `claude` session,
+ * loadCredentials() reads dario's own ~/.dario/credentials.json AND CC's
+ * ~/.claude/.credentials.json AND the OS keychain, then uses the FRESHEST. The
+ * moment CC's token is fresher (e.g. right after you log into CC), dario grabs
+ * that same token, refreshes it, Anthropic rotates it, and the interactive
+ * session still holding the old copy starts 401ing.
+ *
+ * The flag narrows the source set to dario's OWN file only — keeping the Max
+ * subscription ($0) while never touching the interactive session's token. The
+ * API-key path (ANTHROPIC_UPSTREAM_API_KEY) also isolates but drops onto retail
+ * billing, which defeats the point of running dario at all.
+ *
+ * credentialSourcePlan / ignoreCcCredentials are pure + exported so the
+ * isolation guarantee is testable without real credentials on disk — same
+ * pattern as pickFreshestCredentials in credential-freshness.mjs.
+ */
+
+import { ignoreCcCredentials, credentialSourcePlan } from '../dist/oauth.js';
+
+let pass = 0, fail = 0;
+function check(label, cond) {
+  if (cond) { pass++; console.log(`  ✅ ${label}`); }
+  else { fail++; console.log(`  ❌ ${label}`); }
+}
+function header(name) {
+  console.log(`\n${'='.repeat(70)}\n  ${name}\n${'='.repeat(70)}`);
+}
+
+// ────────────────────────────────────────────────────────────────────
+header('1. ignoreCcCredentials — env parsing (1/true/yes/on, case/space tolerant)');
+
+for (const v of ['1', 'true', 'TRUE', 'yes', 'YES', 'on', 'ON', '  true  ']) {
+  check(`"${v}" → true`, ignoreCcCredentials({ DARIO_IGNORE_CC_CREDENTIALS: v }) === true);
+}
+for (const v of [undefined, '', '0', 'false', 'no', 'off', 'nope', '2']) {
+  check(`${JSON.stringify(v)} → false (default keeps auto-detect)`, ignoreCcCredentials({ DARIO_IGNORE_CC_CREDENTIALS: v }) === false);
+}
+check('missing env key → false', ignoreCcCredentials({}) === false);
+
+// ────────────────────────────────────────────────────────────────────
+header('2. credentialSourcePlan(false) — default, reads ALL sources');
+
+const off = credentialSourcePlan(false);
+check('reads two files (dario + CC)', off.filePaths.length === 2);
+check('first file is dario\'s own credentials.json', /[\\/]\.dario[\\/]credentials\.json$/.test(off.filePaths[0]));
+check('second file is the Claude Code session file', /[\\/]\.claude[\\/]\.credentials\.json$/.test(off.filePaths[1]));
+check('reads the OS keychain too', off.readKeychain === true);
+
+// ────────────────────────────────────────────────────────────────────
+header('3. credentialSourcePlan(true) — isolated, dario file ONLY');
+
+const on = credentialSourcePlan(true);
+check('reads exactly ONE file', on.filePaths.length === 1);
+check('the one file is dario\'s own credentials.json', /[\\/]\.dario[\\/]credentials\.json$/.test(on.filePaths[0]));
+check('does NOT read the Claude Code session file', !on.filePaths.some((p) => /[\\/]\.claude[\\/]/.test(p)));
+check('does NOT read the OS keychain (modern CC stores its token there)', on.readKeychain === false);
+
+// ────────────────────────────────────────────────────────────────────
+header('4. the whole point: nothing in the isolated plan can reach a CC-session token');
+
+// The interactive session's token lives in EITHER ~/.claude/.credentials.json
+// OR the keychain. The isolated plan must exclude both — that is the property
+// that stops dario rotating a live `claude` session.
+check('no CC file path AND no keychain read when isolated',
+  !on.filePaths.some((p) => /[\\/]\.claude[\\/]/.test(p)) && on.readKeychain === false);
+// And the default must still include at least one CC source, or auto-detect
+// would silently be broken for the dedicated-machine case.
+check('default plan still includes a CC source (file or keychain)',
+  off.filePaths.some((p) => /[\\/]\.claude[\\/]/.test(p)) || off.readKeychain === true);
+
+console.log(`\n${'='.repeat(70)}`);
+console.log(`  ${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## The problem

When dario runs on the **same machine/account** as an interactive `claude` session, `loadCredentials()` reads dario's own `~/.dario/credentials.json`, CC's `~/.claude/.credentials.json`, **and** the OS keychain, then uses the *freshest*. The moment CC's token is fresher — e.g. right after you log into CC — dario grabs that same token, refreshes it, Anthropic rotates it, and the interactive session still holding the old copy starts 401ing.

That's the "dario broke my Claude Code login" failure, and until now there was **no config that keeps the subscription AND stops it**:

- `ANTHROPIC_UPSTREAM_API_KEY` isolates, but forwards via `x-api-key`, bypassing OAuth/Max + the pool entirely → **retail per-token billing**, which defeats the entire purpose of running dario.
- The credential source list `[darioPath, ccPath]` + keychain was **hardcoded with no opt-out**.

## The fix

`DARIO_IGNORE_CC_CREDENTIALS=1` (accepts `1`/`true`/`yes`/`on`) narrows the source set to dario's **own** `~/.dario/credentials.json` only — never the CC file **or** the keychain (modern CC stores its token there, so isolating from the interactive session means skipping both).

Result: dario stays on the Max subscription (**$0**) and can never rotate a live `claude` session's token.

- `ignoreCcCredentials(env)` and `credentialSourcePlan(ignoreCc)` are pure + exported so the isolation guarantee is testable without real credentials on disk (same pattern as `pickFreshestCredentials`).
- **Default off** — unset behaves exactly as before (reads all sources, picks freshest). Purely additive, no behaviour change for anyone not setting it.
- Surfaced in `dario config` (OAuth section) and the proxy startup banner so it's visible which mode is active.
- Requires a prior `dario login` when set; the banner says so.

## Test plan

- [x] 27 new assertions (`test/ignore-cc-credentials.mjs`): env parsing across `1/true/yes/on` + falsey/whitespace/missing cases; both source plans; and the core property — the isolated plan reaches **neither** the CC file **nor** the keychain, while the default still includes a CC source.
- [x] Full suite **127/127**
- [x] `tsc --noEmit` clean
