### PR TITLE
fix(proxy): request-queue slot leak on a connected-but-not-reading client (#905)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ checklist.
 
 ## [Unreleased]
 
+## [5.4.28] - 2026-08-04
+
+- **Fixed: request-queue slot leak on a connected-but-not-reading streaming client (#905).** A client that stayed connected but stopped reading mid-stream (dead peer behind an open TCP window, a wedged consumer) could permanently hold one of the `--max-concurrent` slots. `res.write()` returning `false` parked the SSE forwarding loop in a drain wait that resolved only on `res` `'drain'`/`'close'` — events a silent-but-alive client never fires. The 5-minute upstream timeout still fired and aborted the upstream fetch, but nothing was awaiting `reader.read()` at that moment, so the request handler's `finally` (where `queue.release()` lives) never ran. Each such client permanently ate one slot; enough of them over hours/days pinned `active` at `maxConcurrent`, and every subsequent request queued until it 504'd with `queue-timeout` — while `/health` stayed green throughout, because it's a separate fast path uninvolved in the wedge. Only a full process restart cleared it.
+
+  Fix: the drain wait (`waitForClientDrain` in `src/stream-drain.ts`) now also resolves when the upstream `AbortSignal` fires — the same signal the existing 5-minute timeout, client-disconnect, and SSE-overflow paths already abort through. Once the wait resolves, the next `reader.read()` rejects on the aborted body (already relied on by those other abort reasons), normal error teardown runs, and the slot releases — bounding worst-case slot hold time to `UPSTREAM_TIMEOUT_MS` instead of forever.
+
+- **`/health` and `/analytics` now surface the request-queue snapshot (#905).** `src/request-queue.ts`'s `snapshot()` had documented itself as "exposed for /analytics + tests" since the queue was introduced (dario#80), but was never actually wired into either endpoint — there was no way to see `active`/`queued` from outside the process, so slot exhaustion was invisible short of sending a real inference request and watching it hang. Both endpoints now include `queue: { active, queued, maxConcurrent, maxQueued }` for authenticated/internal callers; `active === maxConcurrent` with `queued > 0` sustained is the slot-exhaustion signature.
+
 ## [5.4.27] - 2026-08-04
 
 - **Template label refresh** — `_version`, `_supportedMaxTested`, and the `user-agent` header bumped to `2.1.221` to track `@anthropic-ai/claude-code@latest`. The live wire shape is unchanged — cc-drift-template-watch ran `capture-and-bake --check` against live CC v2.1.221 and found zero shape drift vs the bundle — so this is a label refresh, not a re-capture (`_captured` stays at the last real capture). Auto-merged; clears the `sdk-drift` early-warning signal.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "5.4.25",
+  "version": "5.4.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "5.4.25",
+      "version": "5.4.28",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.4.27",
+  "version": "5.4.28",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/health-response.ts
+++ b/src/health-response.ts
@@ -31,6 +31,13 @@ export interface HealthStatusLike {
   sessions?:
     | { mode: 'pool'; stickyBindings: number }
     | { mode: 'single'; active: number };
+  /**
+   * Request-queue snapshot (dario#905), surfaced to internal callers only.
+   * `active === maxConcurrent` with `queued > 0` for a sustained period is
+   * the slot-exhaustion signature — before this field existed, that state
+   * was invisible from outside the process while every request 504'd.
+   */
+  queue?: { active: number; queued: number; maxConcurrent: number; maxQueued: number };
 }
 
 export interface HealthResponse {
@@ -144,6 +151,7 @@ export function buildHealthResponse(
         expiresIn: s.expiresIn,
         requests: requestCount,
         ...(s.sessions ? { sessions: s.sessions } : {}),
+        ...(s.queue ? { queue: s.queue } : {}),
         ...(s.refreshFailures ? { refreshFailures: s.refreshFailures } : {}),
       }
     : liveness;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -920,6 +920,12 @@ interface ProxyOptions {
   /** Max ms a queued request waits before it times out with 504. Default 60000. dario#80. */
   queueTimeoutMs?: number;
   /**
+   * Max ms before the upstream fetch is aborted. Default 300000 (5 min,
+   * matching the Anthropic SDK). Injectable so tests can exercise the
+   * timeout → slot-release path without waiting 5 minutes (dario#905).
+   */
+  upstreamTimeoutMs?: number;
+  /**
    * Override the outbound `output_config.effort` value on non-haiku
    * requests. Default (undefined) pins `'high'`, matching CC 2.1.116's
    * wire value. `'client'` passes through whatever the client sent (or
@@ -1733,6 +1739,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
     maxQueued: opts.maxQueued ?? DEFAULT_MAX_QUEUED,
     queueTimeoutMs: opts.queueTimeoutMs ?? DEFAULT_QUEUE_TIMEOUT_MS,
   });
+  const upstreamTimeoutMs = opts.upstreamTimeoutMs ?? UPSTREAM_TIMEOUT_MS;
 
   // Cache context-1m beta availability. Set false once per account after the
   // first "long context" rejection, so we skip sending context-1m on every
@@ -1845,7 +1852,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
   // disconnect no longer aborts the upstream fetch — we keep consuming
   // the SSE so Anthropic sees a CC-shaped read-to-EOF pattern. See
   // src/stream-drain.ts for the rationale + tradeoff.
-  const { decideOnClientClose, resolveDrainOnClose } = await import('./stream-drain.js');
+  const { decideOnClientClose, resolveDrainOnClose, waitForClientDrain } = await import('./stream-drain.js');
   const drainOnClose = resolveDrainOnClose(opts.drainOnClose);
   if (verbose) {
     console.log(`[dario] drain-on-close: ${drainOnClose ? 'enabled' : 'disabled'}`);
@@ -2045,6 +2052,9 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           sessions: pool.size === 0
             ? { mode: 'single', active: sessionRegistry.size() }
             : { mode: 'pool', stickyBindings: pool.stickyCount() },
+          // Concurrency-slot visibility (dario#905): active pinned at
+          // maxConcurrent with queued > 0 is the slot-exhaustion signature.
+          queue: queue.snapshot(),
         },
         requestCount,
         includeInternal,
@@ -2192,7 +2202,10 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
     // Always-on as of v4 (pre-v4 this was gated to pool mode).
     if (urlPath === '/analytics' && req.method === 'GET') {
       res.writeHead(200, JSON_HEADERS);
-      res.end(JSON.stringify(analytics.summary()));
+      // `queue` rides along the summary (dario#905): request-queue.ts always
+      // documented snapshot() as "exposed for /analytics", but it was never
+      // actually wired in, so slot exhaustion was invisible from outside.
+      res.end(JSON.stringify({ ...analytics.summary(), queue: queue.snapshot() }));
       return;
     }
 
@@ -2595,7 +2608,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
             requestCount++;
             await forwardToOpenAI(
               req, res, body, openaiBackend, corsOrigin, SECURITY_HEADERS,
-              UPSTREAM_TIMEOUT_MS, verbose,
+              upstreamTimeoutMs, verbose,
             );
             return;
           }
@@ -2624,7 +2637,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
         await forwardToOpenAI(
           req, res, fallbackBody, openaiBackend, corsOrigin,
           { ...SECURITY_HEADERS, 'x-dario-pool-fallback': poolFallbackModel },
-          UPSTREAM_TIMEOUT_MS, verbose,
+          upstreamTimeoutMs, verbose,
         );
         return;
       }
@@ -3088,7 +3101,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           upstreamAbortReason = 'timeout';
           upstreamAbort.abort();
         }
-      }, UPSTREAM_TIMEOUT_MS);
+      }, upstreamTimeoutMs);
       onClientClose = () => {
         const action = decideOnClientClose(
           res.writableEnded,
@@ -3497,7 +3510,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
             await forwardToOpenAI(
               req, res, fallbackBody, openaiBackend, corsOrigin,
               { ...SECURITY_HEADERS, 'x-dario-pool-fallback': poolFallbackModel },
-              UPSTREAM_TIMEOUT_MS, verbose,
+              upstreamTimeoutMs, verbose,
             );
             return;
           }
@@ -3645,12 +3658,11 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           if (clientDisconnected) return;
           if (res.write(chunk) === false) needsDrain = true;
         };
-        // Resolves on 'close' too, so a vanished client can't wedge the loop.
-        const waitForDrain = () => new Promise<void>((resolve) => {
-          const done = () => { res.off('drain', done); res.off('close', done); resolve(); };
-          res.once('drain', done);
-          res.once('close', done);
-        });
+        // Resolves on 'close' (vanished client) AND on upstream abort. The
+        // abort arm is what keeps a connected-but-not-reading client from
+        // parking this handler forever and leaking its queue slot — the
+        // dario#905 wedge. See waitForClientDrain in src/stream-drain.ts.
+        const waitForDrain = () => waitForClientDrain(res, upstreamAbort.signal);
         try {
           let buffer = '';
           const MAX_LINE_LENGTH = 1_000_000; // 1MB max per SSE line
@@ -3874,10 +3886,10 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
         if (verbose) console.log(`[dario] #${requestCount} aborted (client disconnected)`);
         writeLogLine(logFileStream, { ...errLogBase, reject: 'client-closed' });
       } else if (upstreamAbortReason === 'timeout') {
-        console.error(`[dario] #${requestCount} upstream timeout after ${UPSTREAM_TIMEOUT_MS / 1000}s`);
+        console.error(`[dario] #${requestCount} upstream timeout after ${upstreamTimeoutMs / 1000}s`);
         if (!res.headersSent) {
           res.writeHead(504, JSON_HEADERS);
-          res.end(JSON.stringify({ error: 'Upstream timeout', message: `Anthropic did not respond within ${UPSTREAM_TIMEOUT_MS / 1000}s` }));
+          res.end(JSON.stringify({ error: 'Upstream timeout', message: `Anthropic did not respond within ${upstreamTimeoutMs / 1000}s` }));
         } else if (!res.writableEnded) {
           res.end();
         }

--- a/src/stream-drain.ts
+++ b/src/stream-drain.ts
@@ -75,3 +75,52 @@ export function resolveDrainOnClose(
   const v = (env.DARIO_DRAIN_ON_CLOSE ?? '').toLowerCase();
   return v === '1' || v === 'true' || v === 'yes';
 }
+
+/**
+ * Minimal event surface of `http.ServerResponse` that the drain wait needs —
+ * structural so tests can pass a plain EventEmitter.
+ */
+export interface DrainWaitable {
+  once(event: 'drain' | 'close', listener: () => void): unknown;
+  off(event: 'drain' | 'close', listener: () => void): unknown;
+}
+
+/**
+ * Wait out client-socket backpressure after `res.write()` returned false
+ * (dario#905). Settles on the first of:
+ *
+ *   - `'drain'` on `res`  — the client consumed its buffer; resume streaming.
+ *   - `'close'` on `res`  — the client connection is gone; the loop resumes
+ *                           and the gated writer / next read handles teardown.
+ *   - `signal` aborts     — the upstream AbortController fired (upstream
+ *                           timeout, client-close abort, SSE overflow).
+ *
+ * The abort arm is the load-bearing one. Without it, a client that stays
+ * connected but stops reading (dead peer behind an open TCP window, wedged
+ * consumer) parks the request handler on this promise forever: the upstream
+ * timeout still fires, but it only aborts the upstream fetch — which nothing
+ * is awaiting — so the handler's `finally` never runs and its concurrency
+ * slot leaks. Leaked slots accumulate until `active === maxConcurrent`, at
+ * which point every request 504s with `queue-timeout` while `/health` stays
+ * green (dario#905). With the abort arm, the wait resolves, the next
+ * `reader.read()` rejects on the aborted body, and normal teardown releases
+ * the slot.
+ *
+ * Resolves immediately when the signal is already aborted, and removes all
+ * three listeners on settle so repeated waits within one response never
+ * accumulate listeners on the shared signal.
+ */
+export function waitForClientDrain(res: DrainWaitable, signal: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (signal.aborted) { resolve(); return; }
+    const done = () => {
+      res.off('drain', done);
+      res.off('close', done);
+      signal.removeEventListener('abort', done);
+      resolve();
+    };
+    res.once('drain', done);
+    res.once('close', done);
+    signal.addEventListener('abort', done);
+  });
+}

--- a/test/queue-slot-leak.mjs
+++ b/test/queue-slot-leak.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+// dario#905 — request-queue slot leak on a connected-but-not-reading client.
+//
+// The wedge: a streaming client whose socket stays OPEN but which stops
+// reading. res.write() returns false, the stream loop parks in the drain
+// wait, and pre-fix that wait resolved only on res 'drain'/'close' — events
+// a silent-but-alive client never fires. The upstream timeout aborted the
+// upstream fetch, but nothing was awaiting the reader, so the handler's
+// finally never ran and the concurrency slot leaked until process restart.
+// Ten leaks = every request 504s `queue-timeout` while /health stays green.
+//
+// Hermetic: scripted upstream via ProxyOptions.fetchImpl (an infinite SSE
+// that errors its stream on abort, like a real fetch body), API-key mode so
+// no OAuth pool or network, and the injectable upstreamTimeoutMs added for
+// exactly this test so the timeout → release path runs in seconds.
+//
+// Also locks down the #905 observability ask: /health and /analytics now
+// carry the queue snapshot (active/queued/maxConcurrent/maxQueued).
+
+import net from 'node:net';
+import { startProxy } from '../dist/proxy.js';
+
+let pass = 0, fail = 0;
+const check = (name, cond, detail) => {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else { console.log(`  FAIL ${name}${detail ? ' :: ' + detail : ''}`); fail++; }
+};
+const header = (n) => console.log(`\n=== ${n} ===`);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Stay clear of dario's 3456-3460 range and other test files' ports.
+const PORT = 38773;
+const BASE = `http://127.0.0.1:${PORT}`;
+const UPSTREAM_TIMEOUT_MS = 3_000;
+
+// ---------------------------------------------------------------------------
+// Scripted upstream.
+//   - stream:true  → infinite SSE; the ReadableStream errors when the abort
+//     signal fires, mirroring a real aborted fetch body.
+//   - otherwise    → immediate JSON OK.
+// ---------------------------------------------------------------------------
+const OK_BODY = {
+  id: 'msg_test', type: 'message', role: 'assistant', model: 'claude-opus-4-5',
+  content: [{ type: 'text', text: 'OK' }], stop_reason: 'end_turn', stop_sequence: null,
+  usage: { input_tokens: 5, output_tokens: 2 },
+};
+// One well-formed SSE event, repeated forever. Small event, big chunks, so
+// the client socket buffer fills fast once the client stops reading.
+const SSE_EVENT = 'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"x"}}\n\n';
+const SSE_CHUNK = new TextEncoder().encode(SSE_EVENT.repeat(300)); // ~35KB
+
+const fakeFetch = async (url, init) => {
+  const body = init?.body ? Buffer.from(init.body).toString('utf8') : '';
+  let parsed = {};
+  try { parsed = JSON.parse(body); } catch { /* non-JSON — fine */ }
+  if (parsed.stream === true) {
+    const stream = new ReadableStream({
+      start(controller) {
+        init?.signal?.addEventListener('abort', () => {
+          try { controller.error(new Error('upstream aborted')); } catch { /* already closed */ }
+        });
+      },
+      pull(controller) {
+        if (init?.signal?.aborted) return;
+        controller.enqueue(SSE_CHUNK);
+      },
+    });
+    return new Response(stream, { status: 200, headers: { 'content-type': 'text/event-stream' } });
+  }
+  return new Response(JSON.stringify(OK_BODY), { status: 200, headers: { 'content-type': 'application/json' } });
+};
+
+await startProxy({
+  port: PORT,
+  host: '127.0.0.1',
+  upstreamApiKey: 'sk-ant-test-not-a-real-key',
+  noClaudeAuth: true,
+  fetchImpl: fakeFetch,
+  maxConcurrent: 1,       // one leaked slot = total wedge, so the leak is directly observable
+  queueTimeoutMs: 1_500,  // a wedged queue surfaces as a fast 504, not a hung test
+  upstreamTimeoutMs: UPSTREAM_TIMEOUT_MS,
+});
+for (let i = 0; i < 50; i++) {
+  try { await fetch(`${BASE}/health`); break; } catch { await sleep(100); }
+}
+
+const health = async () => (await fetch(`${BASE}/health`)).json();
+
+// ---------------------------------------------------------------------------
+header('/health and /analytics expose the queue snapshot (the #905 ask)');
+{
+  const h = await health();
+  check('/health has queue', typeof h.queue === 'object' && h.queue !== null, JSON.stringify(h));
+  check('/health queue shape', h.queue && h.queue.active === 0 && h.queue.queued === 0
+    && h.queue.maxConcurrent === 1 && h.queue.maxQueued === 128, JSON.stringify(h.queue));
+  const a = await (await fetch(`${BASE}/analytics`)).json();
+  check('/analytics has queue', typeof a.queue === 'object' && a.queue !== null, JSON.stringify(Object.keys(a)));
+  check('/analytics queue shape', a.queue && a.queue.maxConcurrent === 1
+    && typeof a.queue.active === 'number' && typeof a.queue.queued === 'number', JSON.stringify(a.queue));
+}
+
+// ---------------------------------------------------------------------------
+header('a connected-but-not-reading streaming client cannot leak its slot');
+{
+  // Client A: raw socket so we control reading. Send a streaming request,
+  // take the first data event, then pause() forever — socket stays open,
+  // no 'drain', no 'close'. This is the #905 wedge client.
+  const reqBody = JSON.stringify({
+    model: 'claude-opus-4-5', max_tokens: 64, stream: true,
+    messages: [{ role: 'user', content: 'hi' }],
+  });
+  const sock = net.connect(PORT, '127.0.0.1');
+  let sawData = false;
+  await new Promise((resolve, reject) => {
+    sock.on('connect', () => {
+      sock.write(
+        `POST /v1/messages HTTP/1.1\r\nHost: 127.0.0.1:${PORT}\r\n` +
+        `content-type: application/json\r\nanthropic-version: 2023-06-01\r\n` +
+        `content-length: ${Buffer.byteLength(reqBody)}\r\n\r\n` + reqBody,
+      );
+    });
+    sock.once('data', () => { sawData = true; sock.pause(); resolve(); });
+    sock.once('error', reject);
+    setTimeout(() => reject(new Error('no response bytes within 5s')), 5_000);
+  });
+  check('client A got first response bytes, then stopped reading', sawData);
+
+  // Give the proxy time to fill A's socket buffer and park in the drain wait.
+  await sleep(1_000);
+  let h = await health();
+  check('mid-stream: slot held (queue.active === 1)', h.queue?.active === 1, JSON.stringify(h.queue));
+
+  // Upstream timeout fires at 3s. Pre-fix: the drain wait never resolves, the
+  // slot stays held forever, and every later request 504s queue-timeout.
+  // Post-fix: the abort settles the wait, teardown runs, the slot releases.
+  const deadline = Date.now() + UPSTREAM_TIMEOUT_MS + 5_000;
+  let released = false;
+  while (Date.now() < deadline) {
+    h = await health();
+    if (h.queue?.active === 0) { released = true; break; }
+    await sleep(250);
+  }
+  check('slot released after upstream timeout despite silent client', released, JSON.stringify(h.queue));
+
+  // The real victim in #905: the NEXT request. It must get a slot and a 200,
+  // not a 504 queue-timeout.
+  const res = await fetch(`${BASE}/v1/messages`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'anthropic-version': '2023-06-01' },
+    body: JSON.stringify({ model: 'claude-opus-4-5', max_tokens: 8, messages: [{ role: 'user', content: 'ping' }] }),
+  });
+  const resBody = await res.json().catch(() => ({}));
+  check('follow-up request admitted and served (200, not 504 queue-timeout)', res.status === 200, `got ${res.status} ${JSON.stringify(resBody)}`);
+  check('follow-up got real content', resBody?.content?.[0]?.text === 'OK');
+
+  sock.destroy();
+}
+
+// ---------------------------------------------------------------------------
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/test/stream-drain.mjs
+++ b/test/stream-drain.mjs
@@ -3,7 +3,8 @@
 // `decideOnClientClose` without any sockets; `resolveDrainOnClose` is tested
 // against a synthetic env map.
 
-import { decideOnClientClose, resolveDrainOnClose } from '../dist/stream-drain.js';
+import { EventEmitter } from 'node:events';
+import { decideOnClientClose, resolveDrainOnClose, waitForClientDrain } from '../dist/stream-drain.js';
 
 let pass = 0, fail = 0;
 function check(label, cond) {
@@ -125,6 +126,93 @@ header('resolveDrainOnClose — anything else is false');
   check('env unset → false', resolveDrainOnClose(undefined, {}) === false);
   check('env="banana" → false (strict truthy set, not JS truthy)', resolveDrainOnClose(undefined, { DARIO_DRAIN_ON_CLOSE: 'banana' }) === false);
   check('env="2" → false (only "1" counts, not every numeric)', resolveDrainOnClose(undefined, { DARIO_DRAIN_ON_CLOSE: '2' }) === false);
+}
+
+// ======================================================================
+//  waitForClientDrain — the dario#905 slot-leak fix
+// ======================================================================
+// A fake res is just an EventEmitter (the function only uses once/off).
+// Settlement is observed via a .then flag plus a timer turn.
+const settledFlag = (p) => { const s = { done: false }; p.then(() => { s.done = true; }); return s; };
+const tick = (ms = 0) => new Promise((r) => setTimeout(r, ms));
+
+header('waitForClientDrain — resolves on res "drain"');
+{
+  const res = new EventEmitter();
+  const ac = new AbortController();
+  const s = settledFlag(waitForClientDrain(res, ac.signal));
+  await tick();
+  check('pending before any event', s.done === false);
+  res.emit('drain');
+  await tick();
+  check('resolved after drain', s.done === true);
+  check('drain/close listeners removed on settle', res.listenerCount('drain') === 0 && res.listenerCount('close') === 0);
+}
+
+header('waitForClientDrain — resolves on res "close" (client vanished)');
+{
+  const res = new EventEmitter();
+  const ac = new AbortController();
+  const s = settledFlag(waitForClientDrain(res, ac.signal));
+  res.emit('close');
+  await tick();
+  check('resolved after close', s.done === true);
+  check('listeners removed on settle', res.listenerCount('drain') === 0 && res.listenerCount('close') === 0);
+}
+
+header('waitForClientDrain — resolves on upstream abort (the #905 arm)');
+{
+  // The wedge scenario: client connected but not reading — no 'drain', no
+  // 'close', ever. Pre-fix this promise never settled, the handler's finally
+  // never ran, and the request's concurrency slot leaked until process
+  // restart. The upstream-timeout abort must settle it.
+  const res = new EventEmitter();
+  const ac = new AbortController();
+  const s = settledFlag(waitForClientDrain(res, ac.signal));
+  await tick(20);
+  check('still pending with a silent-but-open client', s.done === false);
+  ac.abort();
+  await tick();
+  check('resolved by the abort signal', s.done === true);
+  check('res listeners removed on settle', res.listenerCount('drain') === 0 && res.listenerCount('close') === 0);
+}
+
+header('waitForClientDrain — already-aborted signal resolves immediately');
+{
+  // After the abort fires, writeToClient can fill the buffer again and
+  // re-enter the wait on the same aborted signal; it must not park.
+  const res = new EventEmitter();
+  const ac = new AbortController();
+  ac.abort();
+  const s = settledFlag(waitForClientDrain(res, ac.signal));
+  await tick();
+  check('resolved without any event', s.done === true);
+  check('no listeners were installed', res.listenerCount('drain') === 0 && res.listenerCount('close') === 0);
+}
+
+header('waitForClientDrain — repeated waits do not accumulate listeners');
+{
+  // One long stream backpressures many times against the SAME AbortSignal.
+  // Every settle must remove its abort listener, or listeners pile up on
+  // the shared signal for the stream's lifetime (MaxListeners warning).
+  const res = new EventEmitter();
+  const ac = new AbortController();
+  let warned = false;
+  const onWarn = (w) => { if (String(w?.name).includes('MaxListeners')) warned = true; };
+  process.on('warning', onWarn);
+  for (let i = 0; i < 50; i++) {
+    const p = waitForClientDrain(res, ac.signal);
+    res.emit('drain');
+    await p;
+  }
+  await tick(20);
+  process.off('warning', onWarn);
+  check('res listeners fully cleaned after 50 waits', res.listenerCount('drain') === 0 && res.listenerCount('close') === 0);
+  check('no MaxListeners warning from the shared signal', warned === false);
+  const s = settledFlag(waitForClientDrain(res, ac.signal));
+  ac.abort();
+  await tick();
+  check('abort after many drain cycles still resolves', s.done === true);
 }
 
 // ======================================================================


### PR DESCRIPTION
## Summary

Fixes #905. Diagnosis, confirmed with a reproduction, not a hunch:

A streaming client that stays **connected but stops reading** (a wedged consumer, or a dead peer behind an open TCP window) can permanently hold a request-queue concurrency slot:

1. `res.write()` returns `false` once the client's socket buffer fills, and the SSE forwarding loop parks in a drain wait.
2. Pre-fix, that wait resolved only on `res` `'drain'`/`'close'` — events a silent-but-alive client never fires.
3. The 5-minute upstream timeout still fires and calls `upstreamAbort.abort()`, but nothing is awaiting `reader.read()` at that moment, so the abort has no effect on the parked handler.
4. The handler's `finally` — where `queue.release()` lives — never runs. The slot leaks until process restart.

Enough of these accumulate over hours/days and pin `active` at `maxConcurrent`; every subsequent request then queues and 504s `queue-timeout`, while `/health` stays green throughout (it's an unrelated fast path). This matches all four episodes in #905 exactly, including `/health` staying healthy and only a restart clearing it.

The original report also correctly ruled out the queue accounting itself (`decideAdmit`/`release()` pairing is sound) and asked for `queue.snapshot()` to actually be wired into `/health`/`/analytics` — it had documented itself as "exposed for /analytics + tests" since dario#80 but never was.

## Fix

- `waitForClientDrain` (new, `src/stream-drain.ts`) resolves the drain wait on `res` `'drain'`, `res` `'close'`, **or the upstream `AbortSignal` firing** — the same signal the existing timeout/client-close/SSE-overflow paths already abort through. Once resolved, the next `reader.read()` rejects on the aborted body (a mechanism those other abort reasons already rely on), normal error teardown runs, and the slot releases. Worst-case slot hold time is now bounded by the upstream timeout instead of unbounded.
- `/health` and `/analytics` both now include `queue: { active, queued, maxConcurrent, maxQueued }` for authenticated/internal callers.
- `ProxyOptions.upstreamTimeoutMs` (new, optional) makes the previously-hardcoded 5-minute constant injectable, so the repro doesn't need to wait 5 real minutes.

## Verification

- `test/queue-slot-leak.mjs` (new): spins a real `startProxy()` with a scripted infinite-SSE upstream, connects a raw-socket client that reads the first bytes then pauses forever, and asserts (a) the slot is held mid-stream, (b) it releases once the upstream timeout fires despite the silent client, and (c) a follow-up request is served 200 rather than 504. Also asserts the `/health`/`/analytics` queue fields.
- `test/stream-drain.mjs`: 5 new cases for `waitForClientDrain` — resolves on drain, on close, on abort (the fix), immediately if already aborted, and no listener accumulation across 50 repeated waits on one signal.
- **Confirmed the new test actually catches the bug**: ran it against unmodified `master` (git stash A/B) and it fails in exactly the way #905 describes (slot stuck at `active:1`, follow-up request 504s `queue-timeout`). Then confirmed it passes with the fix applied.
- Full suite: 126/128 passing. The 2 failures (`template-interactive-tools.mjs`, `tool-advertise-respects-client.mjs`) are pre-existing — verified failing identically on unmodified master via the same A/B stash check, unrelated to this change.
- `npm run build` clean, `npm run audit` 0 vulnerabilities.

Bumps 5.4.27 → 5.4.28 per the in-PR version-bump convention (a PR that doesn't touch `package.json` merges but ships nothing).

## Test plan

- [x] `npm run build`
- [x] `npm test` (126/128, 2 pre-existing unrelated failures)
- [x] `node test/queue-slot-leak.mjs` — reproduces the wedge and confirms the fix
- [x] `node test/stream-drain.mjs`
- [x] `npm run audit`
