### PR TITLE
fix(ci): wire-drift check forces a fresh live capture before measuring (#914)

### DIFF
--- a/scripts/check-wire-drift.mjs
+++ b/scripts/check-wire-drift.mjs
@@ -51,7 +51,9 @@ import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { betaForModel, startProxy } from '../dist/proxy.js';
+// live-fingerprint.js does not import cc-template.js (no circularity), so this
+// is safe to import and use BEFORE proxy.js/cc-template.js ever load.
+import { refreshLiveFingerprintAsync } from '../dist/live-fingerprint.js';
 import { hasCchSeed } from '../dist/cch.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -59,6 +61,25 @@ const repoRoot = join(__dirname, '..');
 const CC_BIN = process.env.DARIO_CLAUDE_BIN || 'claude';
 const useShell = process.platform === 'win32' && !/[\\/]/.test(CC_BIN);
 const cleanHome = mkdtempSync(join(tmpdir(), 'wire-drift-'));
+
+// Force a fresh live capture onto ~/.dario/cc-template.live.json BEFORE proxy.js
+// is ever imported. cc-template.ts loads CC_TEMPLATE synchronously, ONCE, at
+// module init (`const TEMPLATE = loadTemplate(...)`) — refreshLiveFingerprintAsync
+// writes a fresh capture to disk but is explicitly "picked up on the next dario
+// startup" (its own docstring), never live-reloaded into an already-running
+// process. Importing proxy.js first (as this script used to) meant every
+// header.values comparison below was measuring whatever cache happened to be on
+// disk at import time, not what dario would actually emit on its next start —
+// so a runner whose cache predates a just-released CC version always reported a
+// spurious "the overlay is not reaching these keys" drift (dario#914) that a
+// process restart alone would have cleared. Forcing the capture here, and only
+// THEN importing proxy.js, makes this check measure the same "if dario
+// restarted right now" fidelity as a real deploy, closing that false-positive
+// class without weakening genuine persistent drift.
+await refreshLiveFingerprintAsync({ force: true, silent: false }).catch((err) => {
+  console.error(`[wire-drift] pre-check live capture failed (continuing with whatever cache is on disk): ${err instanceof Error ? err.message : err}`);
+});
+const { betaForModel, startProxy } = await import('../dist/proxy.js');
 
 // The families dario transforms betaForModel for. Opus is the base.
 // claude-opus-5 added 2026-07-25: the runner probed every family EXCEPT the


### PR DESCRIPTION
## Summary
- Closes #914. `CC_TEMPLATE` loads synchronously, once, at `proxy.js`'s module-init time (`cc-template.ts`: `const TEMPLATE = loadTemplate(...)`). The background live-fingerprint refresh (`refreshLiveFingerprintAsync`) writes a fresh capture to `~/.dario/cc-template.live.json`, but per its own docstring that result is "picked up on the next dario startup" — never hot-reloaded into an already-running process.
- `check-wire-drift.mjs` statically imported `proxy.js` at the top of the file, so `CC_TEMPLATE` was whatever happened to be cached on disk at that instant. On a runner whose cache predates a just-released CC version, this made the check compare "what dario would emit if it never restarted" against "what the freshly-installed CC actually sends" — a mismatch a real restart alone would clear, not a defect in `overlayTemplateHeaderValues`.
- **Verified this was the actual mechanism, not a guess**: staled the local live cache to CC 2.1.221 (backed up first), ran the unfixed script, reproduced #914's exact finding byte-for-byte (same `user-agent` pair). Re-staled the same cache and ran the fixed script: `findings: []`, exit 0. Restored the original cache after.
- Fix: force-refresh the live capture (`refreshLiveFingerprintAsync({force:true})`, awaited) BEFORE `proxy.js` is ever imported — `live-fingerprint.js` has no import of `cc-template.js`, so this doesn't create a cycle. The check now measures "if dario restarted right now" fidelity, which is the fidelity that actually matters, and closes this false-positive class without touching the overlay/`betaForModel` logic the finding's own generic message pointed at.
- Not a runtime/proxy change — `scripts/` isn't in `package.json`'s `files` allowlist, so no version bump.

## Test plan
- [x] `tsc --noEmit` — clean
- [x] Full suite — 126/128 (2 pre-existing failures, `template-interactive-tools.mjs` + `tool-advertise-respects-client.mjs`, unrelated — same class already triaged during #912 this morning)
- [x] Manual A/B against a deliberately staled cache: unfixed script reproduces #914 exactly, fixed script clears it
