### PR TITLE
feat(health): prove dario can serve, not just that it looks configured (#905)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.0] - 2026-08-07
+
+- **`/health` can now prove dario actually serves, not just that it looks configured (#905).** Both existing health surfaces are structural: `/livez` says the HTTP server is accepting connections, `/health` says credentials and the pool look serviceable. Neither can catch the shape that produced ~14h of downtime in #905 — dario green from the outside while every real request failed — which is why that reporter's remediation was an external watchdog sending real inference calls. That check is now in-house.
+
+  `GET /health?probe=1` sends a minimal `max_tokens: 1` request to Anthropic using the same auth the request path uses (pool bearer, or `x-api-key` in upstream-API-key mode) and folds the verdict into the response. A failed probe forces 503 even when the structural read is clean, so a status-code-only uptime monitor starts seeing outages it previously could not — including the case `/health` provably cannot see: an unexpired, refreshable token whose accountUuid has drifted, so upstream 401s every request.
+
+  Three guards, because a probe is a real billed request: it is **opt-in** (a plain `/health` never spends a token, so existing docker healthchecks and monitors keep costing nothing); it is honoured only for callers passing a gate **deliberately stricter than the #642 disclosure rule** — that rule treats "authenticated" as sufficient and `authenticateRequest` returns true when no `DARIO_API_KEY` is configured at all, which is harmless for a read-only field but would turn `?probe=1` on an unkeyed tunnel-published dario into a button any anonymous caller could press to bill the operator; `shouldRunServingProbe` therefore refuses anything arriving with `cf-ray` regardless of what `authenticated` says, and can only ever deny, never widen; and results are **cached and single-flighted** (`DARIO_PROBE_TTL_MS`, default 60s), so a monitor polling every second still costs at most one probe per minute.
+
+  Verdict semantics answer "would a restart or an alert help?", not "did it return 200". Rate-limited (429) and upstream-overloaded (529) stay `ok: true` — dario is working, and a watchdog that restarts on them just thrashes, the same lesson `/livez` already encodes. Auth rejection, 5xx, network failure and timeout set `ok: false`. The probe deliberately does not route through dario's own proxy path and never takes a concurrency slot: one that queued behind real traffic would report unhealthy during a legitimate burst and hand a watchdog a reason to restart a busy-but-fine dario.
+
+  Knobs: `DARIO_PROBE_MODEL` (default `claude-haiku-4-5`), `DARIO_PROBE_TTL_MS`, `DARIO_PROBE_TIMEOUT_MS`. See `docs/usage.md`.
+
+- **Queue slot exhaustion is now distinguishable from a busy queue (#905).** #910 put `active`/`queued` on `/health`, which made saturation visible but not diagnosable: a 14h wedge and a healthy one-second burst produce an identical sample (`active === maxConcurrent, queued > 0`). The distinguishing property is turnover, not depth — a busy dario runs at its cap with a backlog all day and is fine, while the #905 wedge held slots for hours with no release at all.
+
+  `queue.stalledSince` (plus a precomputed `queue.stalledForMs`, since #905's reporter was writing his monitor in bash) is the epoch ms since which the queue has been at capacity with requests waiting *and not one slot released*. Any release resets it, so sustained legitimate load never accumulates age; arrivals deliberately do not reset it, since a steady arrival rate would otherwise mask a permanent wedge. One sample is now enough to tell the two apart.
+
 ## [5.4.31] - 2026-08-07
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.223` → `2.1.224` for CC v2.1.224. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -121,3 +121,58 @@ const backends = await listBackends();
 ```bash
 curl http://localhost:3456/health
 ```
+
+dario has three health surfaces, and they answer different questions:
+
+| Endpoint | Answers | Costs |
+|---|---|---|
+| `GET /livez` | Is the HTTP server accepting connections? Always 200. | nothing |
+| `GET /health` | Do credentials and the pool look serviceable? 503 when not. | nothing |
+| `GET /health?probe=1` | Did a real request to Anthropic just succeed? | one tiny billed request per TTL |
+
+`/health` inspects state; it does not prove anything end-to-end. Adding
+`?probe=1` sends a real `max_tokens: 1` request upstream and folds the verdict
+into the response, so a proxy whose credentials look fine but whose requests all
+fail returns 503 instead of `ok`:
+
+```json
+{
+  "status": "degraded",
+  "oauth": "valid",
+  "probe": { "ok": false, "reason": "auth-rejected", "status": 401,
+             "latencyMs": 233, "ageMs": 4812, "model": "claude-haiku-4-5" },
+  "queue": { "active": 10, "queued": 4, "maxConcurrent": 10,
+             "stalledSince": 1754790000000, "stalledForMs": 28800000 }
+}
+```
+
+Notes that matter in production:
+
+- **The probe is opt-in and never runs on a plain `/health`.** Existing docker
+  healthchecks and uptime monitors keep costing nothing.
+- **Only trusted callers can trigger it** — authenticated, or loopback that did
+  not arrive through a Cloudflare tunnel (the same gate that governs the OAuth
+  internals). A world-readable `/health` is not a button for spending tokens.
+- **Results are cached and single-flighted** (`DARIO_PROBE_TTL_MS`, default
+  60000), so polling every second still costs at most one probe per minute.
+- **A rate-limited or overloaded upstream is not an outage.** 429 and 529 keep
+  `ok: true`; restarting dario cannot help either, and a watchdog that keys on
+  them just thrashes. Only auth rejection, 5xx, network failure and timeout set
+  `ok: false`.
+- **`queue.stalledForMs` is the slot-exhaustion signal**, not `active`/`queued`.
+  A busy proxy legitimately sits at its concurrency cap with a backlog; the
+  failure mode in dario#905 was slots that stopped turning over entirely. Any
+  release resets the stall clock, so sustained load never trips it.
+
+A watchdog wants the probe; a container healthcheck usually does not:
+
+```bash
+# liveness — restart only if the process itself is gone
+curl -sf http://localhost:3456/livez
+
+# real serving check, e.g. every 5 minutes
+curl -sf 'http://localhost:3456/health?probe=1' >/dev/null || alert
+```
+
+Knobs: `DARIO_PROBE_MODEL` (default `claude-haiku-4-5`),
+`DARIO_PROBE_TTL_MS` (default `60000`), `DARIO_PROBE_TIMEOUT_MS` (default `15000`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "5.4.29",
+  "version": "5.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "5.4.29",
+      "version": "5.5.0",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.4.31",
+  "version": "5.5.0",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/health-response.ts
+++ b/src/health-response.ts
@@ -37,7 +37,41 @@ export interface HealthStatusLike {
    * the slot-exhaustion signature — before this field existed, that state
    * was invisible from outside the process while every request 504'd.
    */
-  queue?: { active: number; queued: number; maxConcurrent: number; maxQueued: number };
+  queue?: {
+    active: number;
+    queued: number;
+    maxConcurrent: number;
+    maxQueued: number;
+    /**
+     * Epoch ms since the queue has been at capacity with NO slot released
+     * (dario#905). Null when not at capacity; reset by any release, so
+     * sustained legitimate load never accumulates age here. See
+     * request-queue.ts for why turnover — not depth — is the wedge signal.
+     */
+    stalledSince?: number | null;
+  };
+  /**
+   * Verdict from the opt-in serving probe (`/health?probe=1`), when the caller
+   * asked for one and was trusted enough to be given it. Absent otherwise —
+   * a plain /health never spends a token, so its absence means "not asked
+   * for", never "failed".
+   */
+  probe?: ServingProbeLike;
+}
+
+/**
+ * The subset of serving-probe.ts's ProbeResult that /health renders. Declared
+ * structurally rather than imported so this module stays free of the probe's
+ * network machinery and remains unit-testable as a pure function.
+ */
+export interface ServingProbeLike {
+  ok: boolean;
+  reason: string;
+  checkedAt: number;
+  latencyMs: number;
+  model: string;
+  status?: number;
+  detail?: string;
 }
 
 export interface HealthResponse {
@@ -123,15 +157,37 @@ export function derivePoolStatus(
   };
 }
 
+/**
+ * Render `stalledSince` as an elapsed duration alongside the raw stamp. The
+ * stamp alone forces every consumer to subtract against its own clock, which
+ * is exactly the arithmetic a shell-based healthcheck can't do — and #905's
+ * reporter was writing his monitor in bash.
+ */
+function withStalledFor(
+  q: NonNullable<HealthStatusLike['queue']>,
+  now: number,
+): Record<string, unknown> {
+  const { stalledSince, ...rest } = q;
+  if (stalledSince === null || stalledSince === undefined) return { ...rest, stalledSince: null };
+  return { ...rest, stalledSince, stalledForMs: Math.max(0, now - stalledSince) };
+}
+
 export function buildHealthResponse(
   s: HealthStatusLike,
   requestCount: number,
   includeInternal: boolean,
+  now: number = Date.now(),
 ): HealthResponse {
-  const dead =
+  const structurallyDead =
     s.status === 'broken' ||
     s.status === 'none' ||
     (s.status === 'expired' && s.canRefresh === false);
+  // A failed round-trip is authoritative over a clean structural read: the
+  // whole point of the probe (dario#905) is the state where local inspection
+  // says healthy and every real request fails. When one was run and it came
+  // back false, /health must say degraded — that is what makes an existing
+  // status-code-only uptime monitor start seeing the outage it used to miss.
+  const dead = structurallyDead || s.probe?.ok === false;
   const httpStatus = dead ? 503 : 200;
   const liveness = { status: dead ? 'degraded' : 'ok' };
   // Only trusted callers (authenticated, or bare loopback not via the CF
@@ -151,11 +207,63 @@ export function buildHealthResponse(
         expiresIn: s.expiresIn,
         requests: requestCount,
         ...(s.sessions ? { sessions: s.sessions } : {}),
-        ...(s.queue ? { queue: s.queue } : {}),
+        ...(s.queue ? { queue: withStalledFor(s.queue, now) } : {}),
+        ...(s.probe ? { probe: { ...s.probe, ageMs: Math.max(0, now - s.probe.checkedAt) } } : {}),
         ...(s.refreshFailures ? { refreshFailures: s.refreshFailures } : {}),
       }
     : liveness;
   return { httpStatus, body };
+}
+
+/**
+ * Did this caller ask for a serving probe? (`/health?probe=1`, dario#905.)
+ *
+ * Accepts `probe=1` / `probe=true` / bare `probe`, rejects `probe=0` and
+ * `probe=false` — a monitor templating the flag from a boolean config should
+ * get the behaviour it wrote, not a probe on every poll because the parameter
+ * was merely present. Anything unparseable is treated as "not asked": the
+ * failure direction for a token-spending flag has to be off.
+ */
+export function probeRequested(url: string | undefined): boolean {
+  const q = url?.indexOf('?') ?? -1;
+  if (q < 0) return false;
+  const v = new URLSearchParams(url!.slice(q + 1)).get('probe');
+  if (v === null) return false;
+  if (v === '') return true; // bare `?probe`
+  return v === '1' || v.toLowerCase() === 'true';
+}
+
+/**
+ * Decide whether to actually RUN a serving probe for this caller (dario#905).
+ *
+ * Deliberately stricter than shouldDiscloseHealthInternals, because this is
+ * not a disclosure decision — it spends the operator's money.
+ *
+ * The disclosure gate treats "authenticated" as sufficient, and
+ * `authenticateRequest` returns TRUE when no DARIO_API_KEY is configured at
+ * all. That is a reasonable convenience for the common loopback setup, and
+ * harmless for a read-only field. It is not harmless here: an unkeyed dario
+ * published through a Cloudflare tunnel would otherwise expose `?probe=1` as a
+ * button any anonymous caller could press to bill the operator, once per TTL,
+ * forever.
+ *
+ * So the probe additionally refuses anything that arrived through the tunnel,
+ * whatever `authenticated` says. This only ever DENIES — it cannot widen
+ * access — and it makes the spend path independent of whether an API key
+ * happens to be configured.
+ *
+ * Accepted trade-off: an operator who authenticates THROUGH the tunnel is also
+ * refused, and has to probe from beside the proxy instead. For a flag whose
+ * failure direction is "silently spends money", off is the right default.
+ */
+export function shouldRunServingProbe(opts: {
+  requested: boolean;
+  discloseInternals: boolean;
+  viaCfRay: boolean;
+}): boolean {
+  if (!opts.requested) return false;
+  if (opts.viaCfRay) return false;
+  return opts.discloseInternals;
 }
 
 /**

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,7 +6,8 @@ import { homedir } from 'node:os';
 import { setDefaultResultOrder } from 'node:dns';
 import { arch, platform } from 'node:process';
 import { getAccessToken, getStatus, ignoreCcCredentials } from './oauth.js';
-import { buildHealthResponse, derivePoolStatus, shouldDiscloseHealthInternals } from './health-response.js';
+import { buildHealthResponse, derivePoolStatus, probeRequested, shouldDiscloseHealthInternals, shouldRunServingProbe } from './health-response.js';
+import { getServingProbe } from './serving-probe.js';
 import { darioVersion } from './version.js';
 import { buildCCRequest, applyCcPromptCaching, parseEffortSuffix, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, overlayTemplateHeaderValues, forwardClientCCIdentityHeaders, isMcpToolName, CC_TEMPLATE, CC_CACHE_CONTROL, effectiveCacheControl, withForced1hBeta, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
 import { stampCch, hasCchSeed } from './cch.js';
@@ -2038,15 +2039,37 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
       // key on the presence of the client-suppliable `cf-ray` header and failed
       // OPEN — a direct non-tunnel caller omits it and got the full internal
       // view. Now: authenticated, OR bare loopback that did not arrive via CF.
+      const viaCfRay = req.headers['cf-ray'] !== undefined;
       const includeInternal = shouldDiscloseHealthInternals({
         authenticated: authenticateRequest(req.headers, apiKeyBuf),
         loopback: isLoopbackAddr(req.socket?.remoteAddress),
-        viaCfRay: req.headers['cf-ray'] !== undefined,
+        viaCfRay,
       });
+      // Opt-in serving probe (#905). A real upstream round-trip costs a real
+      // (tiny) billed request, so it runs only when explicitly asked for and
+      // only for callers that clear shouldRunServingProbe — which is stricter
+      // than the disclosure gate on purpose (see its docstring: an unkeyed
+      // dario authenticates everyone, which must not turn `?probe=1` into a
+      // spend button for the public internet). Cached and single-flighted
+      // inside getServingProbe, so a monitor polling every second still costs
+      // at most one probe per TTL.
+      const wantsProbe = shouldRunServingProbe({
+        requested: probeRequested(req.url),
+        discloseInternals: includeInternal,
+        viaCfRay,
+      });
+      const probe = wantsProbe
+        ? await getServingProbe({
+            fetchImpl: upstreamFetch,
+            getToken: catalogDeps.getToken,
+            upstreamApiKey: upstreamApiKey || undefined,
+          })
+        : undefined;
       const { httpStatus, body } = buildHealthResponse(
         {
           ...s,
           version: darioVersion(),
+          ...(probe ? { probe } : {}),
           // pool.size === 0 is single-account mode (session-id registry drives
           // the SESSION_ID slot); a loaded pool routes via sticky bindings.
           sessions: pool.size === 0

--- a/src/request-queue.ts
+++ b/src/request-queue.ts
@@ -30,6 +30,32 @@ export interface QueueState {
   maxQueued: number;
 }
 
+/**
+ * QueueState plus the one derived field a monitor actually needs (dario#905).
+ *
+ * #910 put `active` / `queued` on /health so slot exhaustion stopped being
+ * invisible. But a raw sample cannot distinguish the 14h wedge from a healthy
+ * one-second burst — both read `active === maxConcurrent, queued > 0`. Polling
+ * fast enough to tell them apart is the monitor's problem, and it shouldn't be.
+ *
+ * The distinguishing signal is TURNOVER, not depth. A busy dario runs at its
+ * cap with a backlog all day and is perfectly healthy, because slots keep
+ * being released. The #905 wedge held `active` at `maxConcurrent` for hours
+ * with no release at all.
+ *
+ * So `stalledSince` is the epoch ms since which the queue has been at capacity
+ * with requests waiting AND NOT ONE SLOT HAS BEEN RELEASED. Any release resets
+ * it. Null when the queue isn't at capacity. A non-null value older than a
+ * request could plausibly take means slots are not turning over — one sample
+ * is enough to see it, and sustained legitimate load never trips it.
+ *
+ * This is also why the serving probe deliberately doesn't take a slot: the
+ * concurrency axis is covered here, for free and without false positives.
+ */
+export interface QueueSnapshot extends QueueState {
+  stalledSince: number | null;
+}
+
 export type AdmitDecision =
   | { action: 'admit' }
   | { action: 'enqueue' }
@@ -75,6 +101,8 @@ export interface RequestQueueOptions {
    * test is waiting for never arrives.
    */
   unrefTimers?: boolean;
+  /** Clock source for `saturatedSince`. Injectable so tests need no timers. */
+  now?: () => number;
 }
 
 export const DEFAULT_MAX_CONCURRENT = 10;
@@ -88,12 +116,30 @@ export class RequestQueue {
   readonly unrefTimers: boolean;
   private active = 0;
   private queue: QueueEntry[] = [];
+  private readonly now: () => number;
+  private stalledSince: number | null = null;
 
   constructor(opts: RequestQueueOptions = {}) {
     this.maxConcurrent = opts.maxConcurrent ?? DEFAULT_MAX_CONCURRENT;
     this.maxQueued = opts.maxQueued ?? DEFAULT_MAX_QUEUED;
     this.queueTimeoutMs = opts.queueTimeoutMs ?? DEFAULT_QUEUE_TIMEOUT_MS;
     this.unrefTimers = opts.unrefTimers ?? true;
+    this.now = opts.now ?? Date.now;
+  }
+
+  /**
+   * Re-evaluate the stall stamp. Called after every state change, so it marks
+   * when the stall BEGAN rather than when it was last observed — a caller that
+   * never polls still reads an accurate duration.
+   *
+   * Arrivals must NOT refresh the stamp: under a steady arrival rate that
+   * would reset the clock continuously and hide a permanent wedge. Only
+   * `release()` refreshes it, by clearing first (see there).
+   */
+  private updateStall(): void {
+    const atCapacity = this.active >= this.maxConcurrent && this.queue.length > 0;
+    if (!atCapacity) { this.stalledSince = null; return; }
+    if (this.stalledSince === null) this.stalledSince = this.now();
   }
 
   /**
@@ -106,17 +152,19 @@ export class RequestQueue {
     const decision = decideAdmit(this.snapshot());
     if (decision.action === 'admit') {
       this.active++;
+      this.updateStall();
       return;
     }
     if (decision.action === 'reject') {
       throw new QueueFullError();
     }
     return new Promise<void>((resolve, reject) => {
-      const enqueuedAt = Date.now();
+      const enqueuedAt = this.now();
       const timeoutHandle = setTimeout(() => {
         const idx = this.queue.indexOf(entry);
         if (idx >= 0) {
           this.queue.splice(idx, 1);
+          this.updateStall();
           reject(new QueueTimeoutError());
         }
       }, this.queueTimeoutMs);
@@ -126,6 +174,7 @@ export class RequestQueue {
       if (this.unrefTimers) timeoutHandle.unref?.();
       const entry: QueueEntry = { resolve, reject, enqueuedAt, timeoutHandle };
       this.queue.push(entry);
+      this.updateStall();
     });
   }
 
@@ -138,15 +187,23 @@ export class RequestQueue {
       this.active++;
       next.resolve();
     }
+    // A release IS turnover — the thing whose absence defines the wedge — so
+    // clear the stamp unconditionally before re-evaluating. A queue that is
+    // still at capacity immediately starts a FRESH stall window, which is why
+    // a saturated-but-flowing dario never accumulates age here while a
+    // genuinely wedged one does.
+    this.stalledSince = null;
+    this.updateStall();
   }
 
-  /** Snapshot of queue state — exposed for /analytics + tests. */
-  snapshot(): QueueState {
+  /** Snapshot of queue state — exposed for /health + /analytics + tests. */
+  snapshot(): QueueSnapshot {
     return {
       active: this.active,
       queued: this.queue.length,
       maxConcurrent: this.maxConcurrent,
       maxQueued: this.maxQueued,
+      stalledSince: this.stalledSince,
     };
   }
 }

--- a/src/serving-probe.ts
+++ b/src/serving-probe.ts
@@ -1,0 +1,247 @@
+/**
+ * serving-probe.ts — the "can dario actually serve a request?" check.
+ *
+ * WHY THIS EXISTS (dario#905, dario#921)
+ *
+ * dario's existing health surfaces are both STRUCTURAL — they inspect state,
+ * they never prove anything end-to-end:
+ *
+ *   /livez   the HTTP server is accepting connections. Always 200.
+ *   /health  credentials/pool look sane: token not expired, refresh not broken,
+ *            accounts not all in auth-cooldown, queue snapshot attached.
+ *
+ * Neither can catch the failure class that actually took a user down for ~14h
+ * across four episodes (#905): dario looking perfectly healthy from the outside
+ * while every real request failed. The reporter's remediation was an external
+ * watchdog that sends a real inference call and restarts the service when it
+ * doesn't come back — i.e. the user had to write the liveness check dario
+ * should own. This module is that check, brought in-house.
+ *
+ * It also covers a class /health provably cannot see: an account whose token is
+ * unexpired and refreshable (so `status: healthy`) but whose accountUuid has
+ * drifted, so upstream 401s every request. Structural inspection says fine;
+ * only a round-trip says otherwise.
+ *
+ * WHAT IT PROVES, AND WHAT IT DELIBERATELY DOES NOT
+ *
+ * The probe is a minimal `POST /v1/messages` (max_tokens 1) sent DIRECTLY to
+ * api.anthropic.com with the same auth the request path uses — pool bearer, or
+ * `x-api-key` in upstream-API-key mode. That proves: a token can be acquired,
+ * the network path is up, and upstream accepts our credential.
+ *
+ * It deliberately does NOT go through dario's own proxy path:
+ *   - No recursion, no self-deadlock, no port/auth assumptions.
+ *   - It must not take a concurrency slot. A probe that queues behind real
+ *     traffic would report "unhealthy" during a legitimate burst and hand a
+ *     watchdog a reason to restart a busy-but-fine dario. Slot exhaustion is
+ *     covered instead by `queue.saturatedSince` (request-queue.ts), which is
+ *     free, needs no tokens, and cannot false-positive on a short burst.
+ *
+ * So: the probe covers the credential/network axis, the queue snapshot covers
+ * the concurrency axis. Neither claims to cover the transform path.
+ *
+ * COST AND EXPOSURE
+ *
+ * A probe is a real billed request. Three guards, all load-bearing:
+ *   1. OPT-IN. Only runs when a caller explicitly asks (`/health?probe=1`).
+ *      A plain /health never spends a token — existing docker healthchecks and
+ *      uptime monitors keep their current cost profile, which is zero.
+ *   2. TRUSTED CALLERS ONLY. proxy.ts honours `?probe=1` only for callers that
+ *      already pass shouldDiscloseHealthInternals. A world-readable /health
+ *      behind a Cloudflare tunnel bypass must not be a button the internet can
+ *      press to spend the operator's tokens.
+ *   3. CACHED + SINGLE-FLIGHTED. Results are reused for `ttlMs` (default 60s)
+ *      and concurrent callers share one in-flight request, so a monitor polling
+ *      every second still costs at most one probe per minute.
+ *
+ * VERDICT SEMANTICS — why 429 is NOT a failure
+ *
+ * `ok` answers "would a restart or an alert help?", not "did the call return
+ * 200". Rate-limited (429) and upstream-overloaded (529) are healthy states:
+ * dario is working, the answer is legitimately "not right now", and a watchdog
+ * that restarts on them just thrashes. That is the same lesson /livez already
+ * encodes in proxy.ts — a shared-refresh-family outage once had dario restart
+ * -looping for 4h+ because the healthcheck keyed on a condition a restart
+ * cannot fix. Auth rejection, 5xx, network failure and timeout DO set ok=false.
+ */
+
+const ANTHROPIC_MESSAGES = 'https://api.anthropic.com/v1/messages';
+const ANTHROPIC_VERSION = '2023-06-01';
+const OAUTH_BETA = 'oauth-2025-04-20';
+
+/** Cheapest family, and the one doctor's own probe already uses. */
+export const DEFAULT_PROBE_MODEL = 'claude-haiku-4-5';
+export const DEFAULT_PROBE_TTL_MS = 60_000;
+export const DEFAULT_PROBE_TIMEOUT_MS = 15_000;
+
+/**
+ * Why the round-trip ended the way it did. Carried on both verdicts so an
+ * operator reading a green probe can still tell "served" from "rate-limited".
+ */
+export type ProbeReason =
+  | 'served'
+  | 'rate-limited'
+  | 'upstream-overloaded'
+  | 'no-token'
+  | 'auth-rejected'
+  | 'upstream-error'
+  | 'timeout'
+  | 'network-error';
+
+export interface ProbeResult {
+  /** False only for conditions where dario is the problem — see module header. */
+  ok: boolean;
+  reason: ProbeReason;
+  /** Epoch ms the round-trip completed. */
+  checkedAt: number;
+  /** Wall time of the round-trip, including token acquisition. */
+  latencyMs: number;
+  model: string;
+  /** Upstream HTTP status, when upstream answered at all. */
+  status?: number;
+  /** Short failure detail. Never carries a token or a raw body. */
+  detail?: string;
+}
+
+export interface ProbeDeps {
+  fetchImpl?: typeof fetch;
+  /** OAuth bearer source. Ignored when upstreamApiKey is set. */
+  getToken?: () => Promise<string>;
+  /** Per-token API mode — forwarded as x-api-key, mirroring request-path auth. */
+  upstreamApiKey?: string;
+  now?: () => number;
+  model?: string;
+  timeoutMs?: number;
+  ttlMs?: number;
+}
+
+let cache: ProbeResult | null = null;
+let inflight: Promise<ProbeResult> | null = null;
+
+function envInt(name: string, dflt: number): number {
+  const v = Number(process.env[name]);
+  return Number.isFinite(v) && v > 0 ? v : dflt;
+}
+
+/**
+ * Map an upstream HTTP status onto a verdict. Pure, so the whole policy
+ * ("which statuses mean dario is broken") is testable without a network.
+ */
+export function classifyProbeStatus(status: number): { ok: boolean; reason: ProbeReason } {
+  if (status >= 200 && status < 300) return { ok: true, reason: 'served' };
+  // Serving fine, just throttled — restarting cannot help, so do not fail.
+  if (status === 429) return { ok: true, reason: 'rate-limited' };
+  if (status === 529) return { ok: true, reason: 'upstream-overloaded' };
+  // The credential is being rejected even though local state looks valid.
+  // This is the accountUuid-drift signature /health structurally cannot see.
+  if (status === 401 || status === 403) return { ok: false, reason: 'auth-rejected' };
+  return { ok: false, reason: 'upstream-error' };
+}
+
+async function runProbe(deps: ProbeDeps): Promise<ProbeResult> {
+  const f = deps.fetchImpl ?? fetch;
+  const now = deps.now ?? Date.now;
+  const model = deps.model ?? process.env.DARIO_PROBE_MODEL ?? DEFAULT_PROBE_MODEL;
+  const timeoutMs = deps.timeoutMs ?? envInt('DARIO_PROBE_TIMEOUT_MS', DEFAULT_PROBE_TIMEOUT_MS);
+  const startedAt = now();
+
+  // Arm the deadline BEFORE token acquisition so a wedged refresh is bounded
+  // too, not just the fetch — the same trap model-catalog.ts hit in #642: a
+  // getToken() that never settles would leave `inflight` non-null forever and
+  // permanently wedge every future probe on a stale cached verdict.
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), timeoutMs);
+  const finish = (r: Omit<ProbeResult, 'checkedAt' | 'latencyMs' | 'model'>): ProbeResult => ({
+    ...r,
+    model,
+    checkedAt: now(),
+    latencyMs: now() - startedAt,
+  });
+
+  try {
+    const headers: Record<string, string> = {
+      'content-type': 'application/json',
+      'anthropic-version': ANTHROPIC_VERSION,
+    };
+    if (deps.upstreamApiKey) {
+      headers['x-api-key'] = deps.upstreamApiKey;
+    } else {
+      if (!deps.getToken) return finish({ ok: false, reason: 'no-token', detail: 'no token source configured' });
+      let token: string;
+      try {
+        token = await Promise.race([
+          deps.getToken(),
+          new Promise<never>((_, rej) => {
+            ctl.signal.addEventListener('abort', () => rej(new Error('token acquisition timed out')), { once: true });
+          }),
+        ]);
+      } catch (err) {
+        // An empty pool lands here — the message already says so (pool.ts /
+        // catalogDeps phrase it for the operator), so surface it verbatim.
+        return finish({ ok: false, reason: 'no-token', detail: errText(err) });
+      }
+      headers['authorization'] = `Bearer ${token}`;
+      headers['anthropic-beta'] = OAUTH_BETA;
+    }
+
+    const res = await f(ANTHROPIC_MESSAGES, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ model, max_tokens: 1, messages: [{ role: 'user', content: 'ping' }] }),
+      signal: ctl.signal,
+    });
+    // Drain so the socket is released back to the agent pool. The body is
+    // never inspected: a 200 is the whole signal, and the content could carry
+    // model output we have no reason to log.
+    await res.text().catch(() => '');
+    const verdict = classifyProbeStatus(res.status);
+    return finish({ ...verdict, status: res.status });
+  } catch (err) {
+    const aborted = ctl.signal.aborted || (err as Error)?.name === 'AbortError';
+    return finish({
+      ok: false,
+      reason: aborted ? 'timeout' : 'network-error',
+      detail: aborted ? `no upstream response within ${timeoutMs}ms` : errText(err),
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * The cached verdict, refreshing it when stale. Never throws — a health
+ * surface that can 500 is worse than useless, so every failure path becomes a
+ * `ok: false` verdict with a reason instead of an exception.
+ *
+ * Concurrent callers past the TTL share one in-flight probe; the loser of the
+ * race gets the same result rather than sending a second billed request.
+ */
+export async function getServingProbe(deps: ProbeDeps = {}): Promise<ProbeResult> {
+  const now = (deps.now ?? Date.now)();
+  const ttl = deps.ttlMs ?? envInt('DARIO_PROBE_TTL_MS', DEFAULT_PROBE_TTL_MS);
+  if (cache !== null && now - cache.checkedAt < ttl) return cache;
+  if (inflight !== null) return inflight;
+  inflight = runProbe(deps)
+    .then((r) => {
+      cache = r;
+      return r;
+    })
+    .finally(() => {
+      inflight = null;
+    });
+  return inflight;
+}
+
+/** Age of the cached verdict, for the `ageMs` field callers see. */
+export function probeAgeMs(result: ProbeResult, now: number): number {
+  return Math.max(0, now - result.checkedAt);
+}
+
+export function _resetServingProbeForTest(): void {
+  cache = null;
+  inflight = null;
+}

--- a/test/health-probe-e2e.mjs
+++ b/test/health-probe-e2e.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+// dario#905 — end-to-end wiring for the opt-in serving probe on /health.
+//
+// serving-probe.mjs covers the verdict policy and health-response.mjs covers
+// the rendering. What NEITHER covers is the part that lives in proxy.ts and is
+// the easiest to get wrong, because both of its failure directions are silent:
+//
+//   - opt-in leaking: a plain /health quietly starts spending tokens on every
+//     docker healthcheck. Nothing breaks; the bill just grows.
+//   - the trust gate leaking: a /health left world-readable through a
+//     Cloudflare tunnel becomes a button the internet can press to spend the
+//     operator's tokens. That is #642's fail-open, re-introduced on a surface
+//     that costs money.
+//
+// So this drives a REAL startProxy() and counts actual upstream probe calls.
+//
+// Hermetic: API-key mode (no OAuth pool, no credentials.json) and a scripted
+// upstream through ProxyOptions.fetchImpl — the same shape queue-slot-leak.mjs
+// uses. No network, no tokens, no live account.
+
+import { startProxy } from '../dist/proxy.js';
+import { _resetServingProbeForTest } from '../dist/serving-probe.js';
+
+let pass = 0, fail = 0;
+const check = (name, cond, detail) => {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else { console.log(`  FAIL ${name}${detail ? ' :: ' + detail : ''}`); fail++; }
+};
+const header = (n) => console.log(`\n=== ${n} ===`);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const PORT = 38781;
+const BASE = `http://127.0.0.1:${PORT}`;
+
+// Every probe the proxy sends, in order. A probe is the only POST to
+// /v1/messages this test ever provokes — it never sends a client request.
+const probeCalls = [];
+let probeStatus = 200;
+
+const fakeFetch = async (url, init) => {
+  const u = String(url);
+  if (u.includes('/v1/messages') && init?.method === 'POST') {
+    probeCalls.push({ url: u, headers: init.headers, body: JSON.parse(init.body) });
+    return new Response(JSON.stringify({ id: 'msg_probe', content: [] }), {
+      status: probeStatus,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+  // Model-catalog prewarm and anything else — irrelevant here.
+  return new Response(JSON.stringify({ data: [] }), {
+    status: 200, headers: { 'content-type': 'application/json' },
+  });
+};
+
+await startProxy({
+  port: PORT,
+  host: '127.0.0.1',
+  upstreamApiKey: 'sk-ant-test-not-a-real-key',
+  noClaudeAuth: true,
+  fetchImpl: fakeFetch,
+});
+for (let i = 0; i < 50; i++) {
+  try { await fetch(`${BASE}/health`); break; } catch { await sleep(100); }
+}
+
+const getHealth = async (path, headers = {}) => {
+  const res = await fetch(`${BASE}${path}`, { headers });
+  return { status: res.status, body: await res.json() };
+};
+const probeCount = () => probeCalls.length;
+
+// ---------------------------------------------------------------------------
+header('a plain /health never spends a token');
+{
+  _resetServingProbeForTest();
+  const before = probeCount();
+  const { body } = await getHealth('/health');
+  check('no probe field', !('probe' in body), JSON.stringify(body));
+  check('NO upstream request sent', probeCount() === before);
+  check('queue snapshot still there (#910)', typeof body.queue === 'object' && body.queue !== null);
+  check('stall field present on the snapshot', 'stalledSince' in body.queue, JSON.stringify(body.queue));
+  check('idle queue is not stalled', body.queue.stalledSince === null);
+}
+
+// ---------------------------------------------------------------------------
+header('?probe=1 from loopback runs exactly one real round-trip');
+{
+  _resetServingProbeForTest();
+  const before = probeCount();
+  const { body } = await getHealth('/health?probe=1');
+  check('exactly one upstream request', probeCount() === before + 1, `sent ${probeCount() - before}`);
+  check('probe verdict attached', body.probe && body.probe.ok === true, JSON.stringify(body.probe));
+  check('reason served', body.probe?.reason === 'served');
+  check('ageMs rendered', typeof body.probe?.ageMs === 'number');
+
+  const sent = probeCalls[probeCalls.length - 1];
+  check('went to api.anthropic.com', sent.url === 'https://api.anthropic.com/v1/messages');
+  check('max_tokens 1 — stays cheap', sent.body.max_tokens === 1);
+  check('api-key mode auth mirrored', sent.headers['x-api-key'] === 'sk-ant-test-not-a-real-key');
+  check('no CC system prompt injected', sent.body.system === undefined);
+}
+
+// ---------------------------------------------------------------------------
+header('the verdict is cached — a per-second monitor bills once per TTL');
+{
+  const before = probeCount();
+  await getHealth('/health?probe=1');
+  await getHealth('/health?probe=1');
+  await getHealth('/health?probe=1');
+  check('three polls, zero extra upstream requests', probeCount() === before, `sent ${probeCount() - before}`);
+}
+
+// ---------------------------------------------------------------------------
+header('THE exposure that must not exist — a public caller cannot spend tokens');
+{
+  _resetServingProbeForTest();
+  const before = probeCount();
+  // cf-ray marks the request as having arrived through the Cloudflare tunnel,
+  // i.e. from the public internet — the same signal that gates OAuth internals.
+  const { body } = await getHealth('/health?probe=1', { 'cf-ray': '8f0000000000-IAD' });
+  check('NO upstream request sent for a tunnel caller', probeCount() === before, `sent ${probeCount() - before}`);
+  check('no probe field disclosed', !('probe' in body));
+  // Note the gap this pins: this proxy runs with NO DARIO_API_KEY, so
+  // authenticateRequest() returns true for everyone and the #642 disclosure
+  // gate short-circuits before it ever looks at cf-ray — `oauth` IS visible
+  // here. That is pre-existing and unchanged. The probe must NOT inherit it,
+  // because disclosing a field is not the same as spending money, which is
+  // exactly why shouldRunServingProbe refuses cf-ray unconditionally.
+  check('the money path is closed even where disclosure is open', !('probe' in body));
+  check('  (disclosure itself unchanged by this PR)', 'oauth' in body);
+}
+
+// ---------------------------------------------------------------------------
+header('a failing probe surfaces on the trusted surface');
+{
+  _resetServingProbeForTest();
+  probeStatus = 401;
+  const { body } = await getHealth('/health?probe=1');
+  check('probe reports failure', body.probe?.ok === false, JSON.stringify(body.probe));
+  check('reason auth-rejected', body.probe?.reason === 'auth-rejected');
+  check('status carried', body.probe?.status === 401);
+  check('body reads degraded', body.status === 'degraded');
+  probeStatus = 200;
+}
+
+// ---------------------------------------------------------------------------
+header('a throttled upstream does not read as an outage');
+{
+  _resetServingProbeForTest();
+  probeStatus = 429;
+  const { body } = await getHealth('/health?probe=1');
+  check('429 keeps the probe ok', body.probe?.ok === true, JSON.stringify(body.probe));
+  check('reason still visible', body.probe?.reason === 'rate-limited');
+  probeStatus = 200;
+}
+
+// ---------------------------------------------------------------------------
+header('falsey spellings do not trigger a billed request');
+{
+  _resetServingProbeForTest();
+  const before = probeCount();
+  for (const q of ['?probe=0', '?probe=false', '?probe=yes', '?verbose=1']) {
+    const { body } = await getHealth(`/health${q}`);
+    check(`${q} → no probe`, !('probe' in body));
+  }
+  check('no upstream requests for any of them', probeCount() === before, `sent ${probeCount() - before}`);
+}
+
+console.log(`\nhealth-probe-e2e: ${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/test/health-response.mjs
+++ b/test/health-response.mjs
@@ -4,7 +4,7 @@
 // ONLY the liveness verdict; internal loopback callers get full OAuth detail.
 // The HTTP status code is identical for both so external uptime checks still work.
 
-import { buildHealthResponse, derivePoolStatus, shouldDiscloseHealthInternals } from '../dist/health-response.js';
+import { buildHealthResponse, derivePoolStatus, probeRequested, shouldDiscloseHealthInternals, shouldRunServingProbe } from '../dist/health-response.js';
 
 let pass = 0, fail = 0;
 function check(name, cond) {
@@ -175,6 +175,128 @@ header('derivePoolStatus — expired-but-usable clamps to 0h 0m');
   const s = derivePoolStatus([{ expiresAt: NOW - HOUR, inAuthCooldown: false }], NOW, false);
   check('healthy (background refresh will roll it)', s.status === 'healthy');
   check('expiresIn clamped, not negative', s.expiresIn === '0h 0m');
+}
+
+// ── serving probe on /health (#905) ──────────────────────────────────────
+//
+// The probe is what turns /health from "state looks fine" into "a request
+// actually completed". Its verdict has to be authoritative over the structural
+// read — that combination (clean locally, failing upstream) is the entire
+// reason the probe exists — and it must stay off the public surface, because a
+// probe is a real billed request and /health can be world-readable.
+
+const okProbe   = { ok: true,  reason: 'served',        checkedAt: NOW - 5_000, latencyMs: 812, model: 'claude-haiku-4-5', status: 200 };
+const failProbe = { ok: false, reason: 'auth-rejected', checkedAt: NOW - 5_000, latencyMs: 233, model: 'claude-haiku-4-5', status: 401, detail: 'upstream rejected the credential' };
+
+header('probe verdict overrides a clean structural read');
+{
+  // This is the #905 shape: OAuth valid, refresh fine, nothing structurally
+  // wrong — and every real request failing.
+  const { httpStatus, body } = buildHealthResponse({ ...healthy, probe: failProbe }, 9, true, NOW);
+  check('failed probe → 503 despite healthy OAuth', httpStatus === 503);
+  check('body says degraded', body.status === 'degraded');
+  check('oauth still reports valid (not masked)', body.oauth === 'valid');
+  check('probe reason surfaced', body.probe.reason === 'auth-rejected');
+  check('probe status surfaced', body.probe.status === 401);
+  check('ageMs computed against the supplied clock', body.probe.ageMs === 5_000);
+}
+
+header('a passing probe does not rescue dead OAuth');
+{
+  const { httpStatus, body } = buildHealthResponse({ ...dead, probe: okProbe }, 1, true, NOW);
+  check('structural death still 503', httpStatus === 503);
+  check('degraded', body.status === 'degraded');
+}
+
+header('passing probe on a healthy proxy — 200, verdict attached');
+{
+  const { httpStatus, body } = buildHealthResponse({ ...healthy, probe: okProbe }, 1, true, NOW);
+  check('200', httpStatus === 200);
+  check('status ok', body.status === 'ok');
+  check('probe ok', body.probe.ok === true);
+  check('latency carried', body.probe.latencyMs === 812);
+}
+
+header('a throttled probe is NOT an outage (anti restart-loop)');
+{
+  const throttled = { ...okProbe, reason: 'rate-limited', status: 429 };
+  const { httpStatus, body } = buildHealthResponse({ ...healthy, probe: throttled }, 1, true, NOW);
+  check('429 verdict keeps /health at 200', httpStatus === 200);
+  check('but the reason is visible to an operator', body.probe.reason === 'rate-limited');
+}
+
+header('probe is internal-only, and absent means "not asked for"');
+{
+  const pub = buildHealthResponse({ ...healthy, probe: failProbe }, 1, false, NOW);
+  check('public body carries no probe detail', !('probe' in pub.body));
+  check('public STILL 503 so uptime monitors see the outage', pub.httpStatus === 503);
+
+  const noProbe = buildHealthResponse(healthy, 1, true, NOW);
+  check('no probe field when none was run', !('probe' in noProbe.body));
+  check('and that is not treated as a failure', noProbe.httpStatus === 200);
+}
+
+// ── queue stall rendering (#905) ─────────────────────────────────────────
+
+header('queue.stalledSince renders an elapsed duration too');
+{
+  const q = { active: 10, queued: 4, maxConcurrent: 10, maxQueued: 128, stalledSince: NOW - 8 * HOUR };
+  const { body } = buildHealthResponse({ ...healthy, queue: q }, 1, true, NOW);
+  check('raw stamp preserved', body.queue.stalledSince === NOW - 8 * HOUR);
+  check('elapsed precomputed for shell healthchecks', body.queue.stalledForMs === 8 * HOUR);
+  check('depth fields untouched', body.queue.active === 10 && body.queue.queued === 4);
+}
+
+header('a flowing queue reports no stall');
+{
+  const q = { active: 10, queued: 4, maxConcurrent: 10, maxQueued: 128, stalledSince: null };
+  const { body } = buildHealthResponse({ ...healthy, queue: q }, 1, true, NOW);
+  check('stalledSince null', body.queue.stalledSince === null);
+  check('no stalledForMs to misread', !('stalledForMs' in body.queue));
+  check('saturated depth alone never sets 503', buildHealthResponse({ ...healthy, queue: q }, 1, true, NOW).httpStatus === 200);
+}
+
+header('queue stays internal-only');
+{
+  const q = { active: 10, queued: 4, maxConcurrent: 10, maxQueued: 128, stalledSince: NOW - 1000 };
+  const pub = buildHealthResponse({ ...healthy, queue: q }, 1, false, NOW);
+  check('public body hides queue', !('queue' in pub.body));
+}
+
+// ── probeRequested — the opt-in gate (#905) ──────────────────────────────
+
+header('probeRequested — off by default, and off on falsey spellings');
+{
+  const P = probeRequested;
+  check('no url → false', P(undefined) === false);
+  check('no query → false', P('/health') === false);
+  check('unrelated query → false', P('/health?verbose=1') === false);
+  check('probe=1 → true', P('/health?probe=1') === true);
+  check('probe=true → true', P('/health?probe=true') === true);
+  check('probe=TRUE → true', P('/health?probe=TRUE') === true);
+  check('bare ?probe → true', P('/health?probe') === true);
+  check('probe=0 → false (templated boolean must mean what it says)', P('/health?probe=0') === false);
+  check('probe=false → false', P('/health?probe=false') === false);
+  check('probe=yes → false (unparseable defaults OFF — it spends tokens)', P('/health?probe=yes') === false);
+  check('works alongside other params', P('/health?foo=bar&probe=1') === true);
+}
+
+header('shouldRunServingProbe — stricter than disclosure, because it spends money');
+{
+  const R = shouldRunServingProbe;
+  check('not requested → never runs', R({ requested: false, discloseInternals: true, viaCfRay: false }) === false);
+  check('trusted loopback + requested → runs', R({ requested: true, discloseInternals: true, viaCfRay: false }) === true);
+  check('untrusted caller → refused', R({ requested: true, discloseInternals: false, viaCfRay: false }) === false);
+  // The case the disclosure gate alone gets wrong: authenticateRequest returns
+  // true when NO api key is configured, so discloseInternals can be true for a
+  // caller off the public internet. Disclosing a field is survivable; billing
+  // the operator on demand is not.
+  check('via CF tunnel → refused EVEN when disclosure says internal',
+    R({ requested: true, discloseInternals: true, viaCfRay: true }) === false);
+  check('via CF tunnel and untrusted → refused', R({ requested: true, discloseInternals: false, viaCfRay: true }) === false);
+  check('gate can only ever deny, never widen',
+    [true, false].every((d) => [true, false].every((c) =>
+      R({ requested: true, discloseInternals: d, viaCfRay: c }) === (d && !c))));
 }
 
 console.log(`\nhealth-response: ${pass} passed, ${fail} failed`);

--- a/test/queue-stall.mjs
+++ b/test/queue-stall.mjs
@@ -1,0 +1,168 @@
+// Tests for RequestQueue.snapshot().stalledSince — the #905 wedge signal.
+//
+// #910 exposed `active` / `queued` on /health, which made slot exhaustion
+// visible but not DIAGNOSABLE: a 14h wedge and a healthy one-second burst
+// produce the identical sample (`active === maxConcurrent, queued > 0`).
+//
+// The distinguishing property is turnover, not depth. These tests pin exactly
+// that: a queue running flat-out at its cap must never accumulate stall age so
+// long as slots keep being released, and a queue whose slots stop turning over
+// must accumulate it from the moment the stall began — not from the moment
+// someone happened to look.
+//
+// The clock is injected, so none of this depends on timers or wall time.
+
+import { RequestQueue } from '../dist/request-queue.js';
+
+let pass = 0, fail = 0;
+function check(name, cond) {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else      { console.log(`  FAIL ${name}`); fail++; }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+/** A queue on an injected clock. Timeouts are far out of the way. */
+function makeQueue(clockRef, opts = {}) {
+  return new RequestQueue({
+    maxConcurrent: 2,
+    maxQueued: 10,
+    queueTimeoutMs: 10_000_000,
+    unrefTimers: true,
+    now: () => clockRef.t,
+    ...opts,
+  });
+}
+/** Enqueue without awaiting — these only settle on release. */
+function enqueue(q) {
+  const p = q.acquire();
+  p.catch(() => {});
+  return p;
+}
+
+// ---------------------------------------------------------------------------
+header('idle and busy-with-headroom are not stalls');
+{
+  const clock = { t: 1000 };
+  const q = makeQueue(clock);
+  check('fresh queue → null', q.snapshot().stalledSince === null);
+  await q.acquire();
+  check('one active, headroom left → null', q.snapshot().stalledSince === null);
+  await q.acquire();
+  check('at cap but NOTHING waiting → null', q.snapshot().stalledSince === null);
+  check('  (nothing is being denied, so nothing is stalled)', q.snapshot().active === 2 && q.snapshot().queued === 0);
+}
+
+// ---------------------------------------------------------------------------
+header('at capacity WITH a backlog starts the clock');
+{
+  const clock = { t: 1000 };
+  const q = makeQueue(clock);
+  await q.acquire(); await q.acquire();
+  enqueue(q);
+  check('stamped on entering the stall', q.snapshot().stalledSince === 1000);
+  check('queued reflects the waiter', q.snapshot().queued === 1);
+
+  clock.t = 1500;
+  enqueue(q);
+  check('a LATER arrival does not refresh the stamp', q.snapshot().stalledSince === 1000);
+  check('  (otherwise steady traffic would mask a permanent wedge)', q.snapshot().queued === 2);
+}
+
+// ---------------------------------------------------------------------------
+header('THE wedge — no turnover, age accumulates from where it began');
+{
+  const clock = { t: 1000 };
+  const q = makeQueue(clock);
+  await q.acquire(); await q.acquire();
+  enqueue(q); enqueue(q);
+  check('stall opens at 1000', q.snapshot().stalledSince === 1000);
+
+  // Hours pass. Nothing is ever released — this is #905.
+  clock.t = 1000 + 8 * 3600 * 1000;
+  const s = q.snapshot();
+  check('stamp unchanged after 8h', s.stalledSince === 1000);
+  check('still pinned at capacity', s.active === 2 && s.queued === 2);
+  check('a single sample shows an 8h stall', clock.t - s.stalledSince === 28_800_000);
+}
+
+// ---------------------------------------------------------------------------
+header('THE false positive it must not produce — saturated but flowing');
+{
+  const clock = { t: 1000 };
+  const q = makeQueue(clock);
+  await q.acquire(); await q.acquire();
+  enqueue(q); enqueue(q);
+  check('stall window opens at 1000', q.snapshot().stalledSince === 1000);
+
+  // Real traffic: a slot frees and is immediately refilled from the backlog.
+  // Depth is unchanged — still at cap, still a waiter — but this is turnover.
+  clock.t = 2000;
+  q.release();
+  const s = q.snapshot();
+  check('still at capacity with a waiter', s.active === 2 && s.queued === 1);
+  check('but the stamp RESET to the release (fresh window)', s.stalledSince === 2000);
+  check('so measured stall age is 0, not 1000', clock.t - s.stalledSince === 0);
+
+  // Keep serving. A busy dario must never accumulate age here.
+  for (let i = 0; i < 5; i++) {
+    clock.t += 500;
+    enqueue(q);
+    q.release();
+  }
+  const busy = q.snapshot();
+  check('after sustained flat-out service, age stays ~one service interval',
+    busy.stalledSince !== null && (clock.t - busy.stalledSince) <= 500);
+}
+
+// ---------------------------------------------------------------------------
+header('draining clears the stall entirely');
+{
+  const clock = { t: 1000 };
+  const q = makeQueue(clock);
+  await q.acquire(); await q.acquire();
+  enqueue(q);
+  check('stalled', q.snapshot().stalledSince === 1000);
+
+  clock.t = 2000;
+  q.release(); // hands the slot to the waiter — queue now empty
+  check('no waiters left → null', q.snapshot().stalledSince === null);
+  check('  active still at cap, but nothing denied', q.snapshot().active === 2 && q.snapshot().queued === 0);
+
+  clock.t = 3000;
+  q.release();
+  check('below cap → still null', q.snapshot().stalledSince === null);
+}
+
+// ---------------------------------------------------------------------------
+header('a queue-timeout eviction re-evaluates the stall');
+{
+  const clock = { t: 1000 };
+  const q = new RequestQueue({
+    maxConcurrent: 1, maxQueued: 10, queueTimeoutMs: 20,
+    unrefTimers: false, now: () => clock.t,
+  });
+  await q.acquire();
+  const waiter = q.acquire();
+  check('stalled while the waiter waits', q.snapshot().stalledSince === 1000);
+
+  let rejected = false;
+  await waiter.catch(() => { rejected = true; });
+  check('waiter timed out', rejected === true);
+  check('evicting the last waiter clears the stall', q.snapshot().stalledSince === null);
+  check('queued back to 0', q.snapshot().queued === 0);
+}
+
+// ---------------------------------------------------------------------------
+header('snapshot keeps its existing shape');
+{
+  const q = makeQueue({ t: 0 });
+  const s = q.snapshot();
+  check('active', s.active === 0);
+  check('queued', s.queued === 0);
+  check('maxConcurrent', s.maxConcurrent === 2);
+  check('maxQueued', s.maxQueued === 10);
+  check('stalledSince present', 'stalledSince' in s);
+}
+
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);

--- a/test/serving-probe.mjs
+++ b/test/serving-probe.mjs
@@ -1,0 +1,224 @@
+// Tests for serving-probe.ts — the opt-in "can dario actually serve?" check (dario#905).
+//
+// The behaviours that matter here are policy, not plumbing:
+//   1. 429/529 must NOT be failures. A watchdog that restarts on a throttle
+//      thrashes a healthy dario — the same trap /livez already documents.
+//   2. 401/403 MUST be failures. That is the accountUuid-drift signature that
+//      structural /health provably cannot see: token unexpired, refresh fine,
+//      upstream rejecting every request.
+//   3. It must never throw. A health surface that can 500 is worse than none.
+//   4. It must be cached and single-flighted. Every probe is a real billed
+//      request; a monitor polling per-second must not spend per-second.
+//
+// Everything is driven through an injected fetch — no network, no tokens.
+
+import {
+  getServingProbe,
+  classifyProbeStatus,
+  probeAgeMs,
+  _resetServingProbeForTest,
+  DEFAULT_PROBE_MODEL,
+} from '../dist/serving-probe.js';
+
+let pass = 0, fail = 0;
+function check(name, cond) {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else      { console.log(`  FAIL ${name}`); fail++; }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+/** A fetch stand-in that answers with `status` and counts its calls. */
+function stubFetch(status, opts = {}) {
+  const calls = [];
+  const impl = async (url, init) => {
+    calls.push({ url, init });
+    if (opts.delayMs) await new Promise((r) => setTimeout(r, opts.delayMs));
+    return {
+      status,
+      ok: status >= 200 && status < 300,
+      text: async () => opts.body ?? '{}',
+    };
+  };
+  impl.calls = calls;
+  return impl;
+}
+
+const token = async () => 'tok-abc';
+
+// ---------------------------------------------------------------------------
+header('classifyProbeStatus — the verdict policy, pure');
+{
+  check('200 → ok/served', classifyProbeStatus(200).ok === true && classifyProbeStatus(200).reason === 'served');
+  check('299 → ok', classifyProbeStatus(299).ok === true);
+  check('429 → ok (rate-limited, NOT a failure)', classifyProbeStatus(429).ok === true && classifyProbeStatus(429).reason === 'rate-limited');
+  check('529 → ok (upstream overloaded, NOT a failure)', classifyProbeStatus(529).ok === true && classifyProbeStatus(529).reason === 'upstream-overloaded');
+  check('401 → fail/auth-rejected', classifyProbeStatus(401).ok === false && classifyProbeStatus(401).reason === 'auth-rejected');
+  check('403 → fail/auth-rejected', classifyProbeStatus(403).ok === false && classifyProbeStatus(403).reason === 'auth-rejected');
+  check('500 → fail/upstream-error', classifyProbeStatus(500).ok === false && classifyProbeStatus(500).reason === 'upstream-error');
+  check('400 → fail/upstream-error', classifyProbeStatus(400).ok === false && classifyProbeStatus(400).reason === 'upstream-error');
+}
+
+// ---------------------------------------------------------------------------
+header('happy path — a served round-trip');
+{
+  _resetServingProbeForTest();
+  const f = stubFetch(200);
+  const r = await getServingProbe({ fetchImpl: f, getToken: token, now: () => 1000 });
+  check('ok', r.ok === true);
+  check('reason served', r.reason === 'served');
+  check('status carried', r.status === 200);
+  check('default model', r.model === DEFAULT_PROBE_MODEL);
+  check('checkedAt stamped from injected clock', r.checkedAt === 1000);
+  check('one upstream call', f.calls.length === 1);
+
+  const { url, init } = f.calls[0];
+  check('hits api.anthropic.com/v1/messages', url === 'https://api.anthropic.com/v1/messages');
+  check('POST', init.method === 'POST');
+  check('bearer from getToken', init.headers['authorization'] === 'Bearer tok-abc');
+  check('oauth beta set', init.headers['anthropic-beta'] === 'oauth-2025-04-20');
+  check('no x-api-key in OAuth mode', init.headers['x-api-key'] === undefined);
+
+  const body = JSON.parse(init.body);
+  check('max_tokens 1 — the probe stays cheap', body.max_tokens === 1);
+  check('single user turn', body.messages.length === 1 && body.messages[0].role === 'user');
+  check('no system prompt injected (probe bypasses the CC transform)', body.system === undefined);
+}
+
+// ---------------------------------------------------------------------------
+header('upstream-API-key mode mirrors request-path auth');
+{
+  _resetServingProbeForTest();
+  const f = stubFetch(200);
+  await getServingProbe({ fetchImpl: f, upstreamApiKey: 'sk-test', getToken: token, now: () => 1 });
+  const h = f.calls[0].init.headers;
+  check('x-api-key forwarded', h['x-api-key'] === 'sk-test');
+  check('no bearer when api key is set', h['authorization'] === undefined);
+  check('getToken not consulted', true); // no throw / no bearer proves the branch
+}
+
+// ---------------------------------------------------------------------------
+header('throttled upstream is NOT an outage (anti restart-loop)');
+{
+  _resetServingProbeForTest();
+  const r = await getServingProbe({ fetchImpl: stubFetch(429), getToken: token, now: () => 1 });
+  check('429 → ok true', r.ok === true);
+  check('429 reason surfaced for the operator', r.reason === 'rate-limited');
+}
+{
+  _resetServingProbeForTest();
+  const r = await getServingProbe({ fetchImpl: stubFetch(529), getToken: token, now: () => 1 });
+  check('529 → ok true', r.ok === true);
+}
+
+// ---------------------------------------------------------------------------
+header('auth rejection IS an outage — the drift case /health cannot see');
+{
+  _resetServingProbeForTest();
+  const r = await getServingProbe({ fetchImpl: stubFetch(401), getToken: token, now: () => 1 });
+  check('401 → ok false', r.ok === false);
+  check('reason auth-rejected', r.reason === 'auth-rejected');
+  check('status carried for triage', r.status === 401);
+}
+
+// ---------------------------------------------------------------------------
+header('never throws — every failure becomes a verdict');
+{
+  _resetServingProbeForTest();
+  const boom = async () => { throw new Error('ECONNREFUSED 1.2.3.4:443'); };
+  let threw = false;
+  let r;
+  try { r = await getServingProbe({ fetchImpl: boom, getToken: token, now: () => 1 }); }
+  catch { threw = true; }
+  check('no exception escapes', threw === false);
+  check('network failure → ok false', r.ok === false);
+  check('reason network-error', r.reason === 'network-error');
+  check('detail carries the cause', /ECONNREFUSED/.test(r.detail));
+}
+{
+  _resetServingProbeForTest();
+  const r = await getServingProbe({ fetchImpl: stubFetch(200), now: () => 1 });
+  check('no token source → ok false', r.ok === false);
+  check('reason no-token', r.reason === 'no-token');
+}
+
+// ---------------------------------------------------------------------------
+header('timeout is bounded, and bounds token acquisition too');
+{
+  _resetServingProbeForTest();
+  // fetch that only settles when the caller aborts it.
+  const hangs = (_url, init) => new Promise((_, rej) => {
+    init.signal.addEventListener('abort', () => {
+      const e = new Error('aborted'); e.name = 'AbortError'; rej(e);
+    }, { once: true });
+  });
+  const r = await getServingProbe({ fetchImpl: hangs, getToken: token, timeoutMs: 20 });
+  check('hung upstream → ok false', r.ok === false);
+  check('reason timeout', r.reason === 'timeout');
+  check('detail names the budget', /20ms/.test(r.detail));
+}
+{
+  _resetServingProbeForTest();
+  // A getToken that never settles must not wedge the probe forever — the
+  // model-catalog #642 trap: an un-bounded token wait leaves the in-flight
+  // guard non-null and every future probe returns the stale cached verdict.
+  const neverResolves = () => new Promise(() => {});
+  const r = await getServingProbe({ fetchImpl: stubFetch(200), getToken: neverResolves, timeoutMs: 20 });
+  check('hung getToken settles', r.ok === false);
+  check('detail says token acquisition timed out', /token acquisition timed out/.test(r.detail));
+}
+
+// ---------------------------------------------------------------------------
+header('cached — a per-second monitor does not bill per second');
+{
+  _resetServingProbeForTest();
+  const f = stubFetch(200);
+  let clock = 10_000;
+  const deps = { fetchImpl: f, getToken: token, now: () => clock, ttlMs: 60_000 };
+  const a = await getServingProbe(deps);
+  clock = 40_000; // 30s later — inside TTL
+  const b = await getServingProbe(deps);
+  check('still one upstream call inside TTL', f.calls.length === 1);
+  check('same verdict object returned', b.checkedAt === a.checkedAt);
+
+  clock = 100_000; // 90s after the probe — past TTL
+  await getServingProbe(deps);
+  check('re-probes once past TTL', f.calls.length === 2);
+}
+
+// ---------------------------------------------------------------------------
+header('single-flighted — concurrent callers share one billed request');
+{
+  _resetServingProbeForTest();
+  const f = stubFetch(200, { delayMs: 25 });
+  const deps = { fetchImpl: f, getToken: token };
+  const [x, y, z] = await Promise.all([
+    getServingProbe(deps), getServingProbe(deps), getServingProbe(deps),
+  ]);
+  check('exactly one upstream call for three callers', f.calls.length === 1);
+  check('all three get the same verdict', x.checkedAt === y.checkedAt && y.checkedAt === z.checkedAt);
+}
+
+// ---------------------------------------------------------------------------
+header('a failed probe does not poison the next one');
+{
+  _resetServingProbeForTest();
+  let status = 500;
+  const f = async () => ({ status, ok: false, text: async () => '{}' });
+  let clock = 1000;
+  const deps = { fetchImpl: f, getToken: token, now: () => clock, ttlMs: 100 };
+  const bad = await getServingProbe(deps);
+  check('first probe failed', bad.ok === false);
+  status = 200; clock = 2000; // past TTL, upstream recovered
+  const good = await getServingProbe(deps);
+  check('recovers to ok once upstream does', good.ok === true);
+}
+
+// ---------------------------------------------------------------------------
+header('probeAgeMs');
+{
+  check('age from checkedAt', probeAgeMs({ checkedAt: 500 }, 2_000) === 1_500);
+  check('never negative on clock skew', probeAgeMs({ checkedAt: 5_000 }, 1_000) === 0);
+}
+
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## The gap

dario's two health surfaces are both structural:

| Endpoint | Answers |
|---|---|
| `GET /livez` | Is the HTTP server accepting connections? |
| `GET /health` | Do credentials and the pool look serviceable? |

Neither proves a request can complete. That is exactly the shape #905 reported: `/health` returning `{"status":"ok"}` in 2ms while every `POST /v1/messages` 504'd, for ~14h across four episodes. #910 fixed that specific drain bug and wired the queue snapshot in, but the *class* is still uncovered — and the reporter's remediation is still an external watchdog sending real inference calls and restarting the service. The user is writing the liveness check dario should own.

There is also a failure `/health` **provably** cannot see: an account whose token is unexpired and refreshable (so `status: healthy`) but whose `accountUuid` has drifted, so upstream 401s every request. Structural inspection says fine. Only a round-trip says otherwise.

## What this adds

**`GET /health?probe=1`** — a minimal `max_tokens: 1` request to Anthropic using the same auth the request path uses (pool bearer, or `x-api-key` in upstream-API-key mode), folded into the response. A failed probe forces 503 even when the structural read is clean, so existing status-code-only monitors start catching outages they previously missed.

```json
{
  "status": "degraded",
  "oauth": "valid",
  "probe": { "ok": false, "reason": "auth-rejected", "status": 401,
             "latencyMs": 233, "ageMs": 4812, "model": "claude-haiku-4-5" },
  "queue": { "active": 10, "queued": 4, "maxConcurrent": 10,
             "stalledSince": 1754790000000, "stalledForMs": 28800000 }
}
```

**`queue.stalledSince` / `stalledForMs`** — the wedge signal, separate from the probe and free.

## Design notes worth reviewing

**Why a probe costs nothing unless you ask.** Three guards: opt-in (a plain `/health` never spends a token, so docker healthchecks keep their current zero cost); gated to trusted callers; cached + single-flighted (`DARIO_PROBE_TTL_MS`, default 60s), so polling every second bills at most once per minute.

**The gate is stricter than #642 disclosure, on purpose.** The disclosure rule treats `authenticated` as sufficient — and `authenticateRequest` returns `true` when no `DARIO_API_KEY` is configured. Harmless for a read-only field; not harmless for an action that spends money, since an unkeyed dario published through a Cloudflare tunnel would expose `?probe=1` as a button any anonymous caller could press to bill the operator. `shouldRunServingProbe` refuses anything carrying `cf-ray` regardless of what `authenticated` says. It can only ever deny, never widen.

> This was found by the E2E test, not by reading. Pre-existing note, unchanged here and **not** fixed by this PR: on an unkeyed proxy the same short-circuit means `oauth`/`expiresIn`/`requests` are disclosed to tunnel callers too. Worth its own issue — I didn't want to change #642 semantics inside a feature PR.

**429 and 529 are not outages.** `ok` answers "would a restart or an alert help?", not "did it return 200". A throttled dario is working; a watchdog that restarts on it just thrashes — the same lesson `/livez` already encodes in its docstring after a shared-refresh-family outage restart-looped for 4h+. Auth rejection, 5xx, network failure and timeout set `ok: false`.

**The probe never takes a concurrency slot.** One that queued behind real traffic would report unhealthy during a legitimate burst and hand a watchdog a reason to restart a busy-but-fine dario. The concurrency axis is covered by `stalledSince` instead.

**Why stall, not saturation.** A busy dario runs at its cap with a backlog all day and is healthy — depth alone cannot distinguish it from the #905 wedge, since both sample as `active === maxConcurrent, queued > 0`. Turnover can. `stalledSince` is reset by any *release* and deliberately **not** by arrivals: refreshing on arrival would let a steady arrival rate mask a permanent wedge. `queue-stall.mjs` pins that false positive explicitly.

**What it does not claim.** The probe covers the credential/network axis; `stalledSince` covers concurrency. Neither exercises the CC transform path, and the module header says so rather than implying end-to-end coverage it doesn't have.

## Tests

- `test/serving-probe.mjs` (51) — verdict policy, caching, single-flight, bounded token acquisition, never-throws. Injected fetch, no network.
- `test/queue-stall.mjs` (30) — wedge vs busy on an injected clock, including the 8h-wedge single-sample case and the busy-but-flowing false positive.
- `test/health-probe-e2e.mjs` (29) — real `startProxy()`, counts actual upstream calls to pin both silent failure directions. This is what caught the `authenticateRequest` short-circuit.
- `test/health-response.mjs` extended 74 → 95.

Full suite: **129 pass / 131**. The two failures (`template-interactive-tools`, `tool-advertise-respects-client`) reproduce identically on pristine `origin/master` (`f3c9377`) on this machine and are unrelated — verified in a clean worktree before opening this.

Version bumped 5.4.31 → **5.5.0** in-PR per the release gate; `[Unreleased]` promoted.

Addresses #905.
