### PR TITLE
fix(health): an unkeyed proxy must not disclose OAuth internals to tunnel callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.1] - 2026-08-07
+
+- **Security: an unkeyed proxy no longer discloses OAuth internals to tunnel callers (#642 follow-up).** `shouldDiscloseHealthInternals` granted the internal view to any caller `authenticateRequest()` accepted — and `authenticateRequest()` short-circuits to `true` when no `DARIO_API_KEY` is configured. That short-circuit is deliberate and stays (the common setup is loopback-only, and requiring a key there would break `dario doctor` and every docker healthcheck), but it made `authenticated` **vacuous** on an unkeyed proxy: every caller satisfied it, the auth branch returned before `cf-ray` was ever consulted, and an unkeyed dario published through a Cloudflare tunnel handed its OAuth status, token countdown, request volume, session counts, queue snapshot and refresh-failure count to anyone who asked. #642 closed the spoofable-header direction of this gate; this was the same fail-open re-entering through a side door.
+
+  The gate now requires `authenticated && keyConfigured`, so the auth branch can only be taken by a caller that actually presented the operator's secret. Unkeyed proxies fall through to the transport rules, where **bare loopback is still trusted** — docker `HEALTHCHECK`, `dario doctor` and the TUI are unchanged — and the tunnel is not. `keyConfigured` is a required field rather than an optional with a default, so every call site has to state it.
+
+  Behaviour change worth knowing before upgrading: if you monitor `/health` **through a tunnel on a proxy with no `DARIO_API_KEY` set**, you will now get the liveness verdict only (`{"status":"ok"}`) instead of the full body. Set `DARIO_API_KEY` and send it to keep the detail, or query from loopback. The HTTP status (200/503) is unchanged either way, so status-code uptime checks are unaffected.
+
+  Found by the end-to-end test added in 5.5.0 (`test/health-probe-e2e.mjs`), which counted the disclosure while pinning the serving probe's own gate.
+
 ## [5.5.0] - 2026-08-07
 
 - **`/health` can now prove dario actually serves, not just that it looks configured (#905).** Both existing health surfaces are structural: `/livez` says the HTTP server is accepting connections, `/health` says credentials and the pool look serviceable. Neither can catch the shape that produced ~14h of downtime in #905 — dario green from the outside while every real request failed — which is why that reporter's remediation was an external watchdog sending real inference calls. That check is now in-house.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -150,9 +150,10 @@ Notes that matter in production:
 
 - **The probe is opt-in and never runs on a plain `/health`.** Existing docker
   healthchecks and uptime monitors keep costing nothing.
-- **Only trusted callers can trigger it** — authenticated, or loopback that did
-  not arrive through a Cloudflare tunnel (the same gate that governs the OAuth
-  internals). A world-readable `/health` is not a button for spending tokens.
+- **Only trusted callers can trigger it** — and never a caller that arrived
+  through a Cloudflare tunnel, even an authenticated one. A `/health` reachable
+  from the internet is not a button for spending tokens, and the probe's own
+  cache means one request per TTL would be enough to keep it running.
 - **Results are cached and single-flighted** (`DARIO_PROBE_TTL_MS`, default
   60000), so polling every second still costs at most one probe per minute.
 - **A rate-limited or overloaded upstream is not an outage.** 429 and 529 keep
@@ -163,6 +164,27 @@ Notes that matter in production:
   A busy proxy legitimately sits at its concurrency cap with a backlog; the
   failure mode in dario#905 was slots that stopped turning over entirely. Any
   release resets the stall clock, so sustained load never trips it.
+
+### Who sees what
+
+`/health` is auth-free by design — a docker healthcheck has to work before any
+key is configured. The response body is therefore split two ways, while the HTTP
+status (200/503) is identical for everyone, so uptime checks are unaffected:
+
+| Caller | Gets |
+|---|---|
+| Presented a configured `DARIO_API_KEY` | full detail |
+| Bare loopback (docker healthcheck, `dario doctor`) | full detail |
+| Arrived through a Cloudflare tunnel (`cf-ray`) | `{"status": "ok"}` only |
+| Anything else (LAN, another container, WAN) | `{"status": "ok"}` only |
+
+> **Changed in 5.5.1.** "Presented a configured key" previously read as "passed
+> the API-key check" — which every caller passes when **no** `DARIO_API_KEY` is
+> set. On an unkeyed proxy published through a tunnel, that disclosed the OAuth
+> countdown, request volume and refresh-failure count to anyone who asked. If
+> you monitor `/health` through a tunnel with no key configured, you now get the
+> liveness verdict only; set `DARIO_API_KEY` and send it, or query from
+> loopback, to keep the detail.
 
 A watchdog wants the probe; a container healthcheck usually does not:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "5.5.0",
+      "version": "5.5.1",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/health-response.ts
+++ b/src/health-response.ts
@@ -239,18 +239,21 @@ export function probeRequested(url: string | undefined): boolean {
  * Deliberately stricter than shouldDiscloseHealthInternals, because this is
  * not a disclosure decision — it spends the operator's money.
  *
- * The disclosure gate treats "authenticated" as sufficient, and
- * `authenticateRequest` returns TRUE when no DARIO_API_KEY is configured at
- * all. That is a reasonable convenience for the common loopback setup, and
- * harmless for a read-only field. It is not harmless here: an unkeyed dario
- * published through a Cloudflare tunnel would otherwise expose `?probe=1` as a
- * button any anonymous caller could press to bill the operator, once per TTL,
- * forever.
+ * The disclosure gate grants access to a caller that proved a configured
+ * DARIO_API_KEY, wherever it came from. That is the right answer for reading a
+ * field. It is not the right answer for an action that bills per call: a
+ * leaked or shared key becomes a metered spend endpoint reachable from the
+ * public internet, and the probe's own cache means an attacker needs only one
+ * request per TTL to keep it running indefinitely.
  *
  * So the probe additionally refuses anything that arrived through the tunnel,
- * whatever `authenticated` says. This only ever DENIES — it cannot widen
- * access — and it makes the spend path independent of whether an API key
- * happens to be configured.
+ * whatever the disclosure gate concluded. This only ever DENIES — it cannot
+ * widen access.
+ *
+ * (An unkeyed proxy is handled a layer up: shouldDiscloseHealthInternals now
+ * requires `keyConfigured`, so vacuous authentication no longer reaches here
+ * at all. This gate does not depend on that fix — it would refuse the tunnel
+ * caller either way — but the two are the same defence at different depths.)
  *
  * Accepted trade-off: an operator who authenticates THROUGH the tunnel is also
  * refused, and has to probe from beside the proxy instead. For a flag whose
@@ -271,20 +274,44 @@ export function shouldRunServingProbe(opts: {
  *
  * /health is intentionally auth-free (docker healthchecks need it before a
  * key is configured), so we cannot simply gate on the API key. Trust model:
- *   - authenticated (valid DARIO_API_KEY)      -> internal (an internal caller)
+ *   - PROVED a configured DARIO_API_KEY        -> internal (an internal caller)
  *   - came via the Cloudflare tunnel (cf-ray)  -> public   (world-reachable)
  *   - otherwise bare loopback                  -> internal (docker HC / doctor)
  *   - otherwise (LAN, other container, WAN)    -> public
- * The cf-ray check is now only ever used to DENY (force public), never to
- * grant, so spoofing it cannot widen disclosure — the previous fail-open
- * direction is closed.
+ * The cf-ray check is only ever used to DENY (force public), never to grant,
+ * so spoofing it cannot widen disclosure.
+ *
+ * `keyConfigured` is load-bearing and is why `authenticated` alone is not
+ * enough. `authenticateRequest()` short-circuits to TRUE when no
+ * DARIO_API_KEY is set — a deliberate convenience, since the common setup is
+ * loopback-only and requiring a key there would break `dario doctor` and every
+ * docker healthcheck. But it means "authenticated" is VACUOUS on an unkeyed
+ * proxy: every caller satisfies it, the first branch returns before cf-ray is
+ * ever consulted, and an unkeyed dario published through a Cloudflare tunnel
+ * hands its OAuth countdown, request volume and refresh-failure count to
+ * anyone who asks. That is the #642 fail-open re-entering through a side door
+ * — #642 closed the spoofable-header direction, not this one.
+ *
+ * Requiring both means the auth branch can only be taken by a caller that
+ * actually presented the operator's secret. Unkeyed proxies fall through to
+ * the transport rules, where loopback is still trusted (healthchecks and
+ * doctor keep working, unchanged) and the tunnel is not.
+ *
+ * `keyConfigured` is a REQUIRED field rather than an optional with a default:
+ * for a security predicate, every call site should be forced to state it.
+ *
+ * The HTTP status (200/503) is unaffected either way, so uptime monitoring
+ * that keys on the status code sees no change from this.
  */
 export function shouldDiscloseHealthInternals(opts: {
+  /** Passed authenticateRequest — which is vacuously true when unkeyed. */
   authenticated: boolean;
+  /** Whether a DARIO_API_KEY exists at all, i.e. whether `authenticated` means anything. */
+  keyConfigured: boolean;
   loopback: boolean;
   viaCfRay: boolean;
 }): boolean {
-  if (opts.authenticated) return true;
+  if (opts.authenticated && opts.keyConfigured) return true;
   if (opts.viaCfRay) return false;
   return opts.loopback;
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2042,6 +2042,9 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
       const viaCfRay = req.headers['cf-ray'] !== undefined;
       const includeInternal = shouldDiscloseHealthInternals({
         authenticated: authenticateRequest(req.headers, apiKeyBuf),
+        // Without this, `authenticated` is vacuously true on an unkeyed proxy
+        // and the tunnel check below is never reached — see the gate's docs.
+        keyConfigured: apiKeyBuf !== null,
         loopback: isLoopbackAddr(req.socket?.remoteAddress),
         viaCfRay,
       });

--- a/test/health-probe-e2e.mjs
+++ b/test/health-probe-e2e.mjs
@@ -120,14 +120,26 @@ header('THE exposure that must not exist — a public caller cannot spend tokens
   const { body } = await getHealth('/health?probe=1', { 'cf-ray': '8f0000000000-IAD' });
   check('NO upstream request sent for a tunnel caller', probeCount() === before, `sent ${probeCount() - before}`);
   check('no probe field disclosed', !('probe' in body));
-  // Note the gap this pins: this proxy runs with NO DARIO_API_KEY, so
-  // authenticateRequest() returns true for everyone and the #642 disclosure
-  // gate short-circuits before it ever looks at cf-ray — `oauth` IS visible
-  // here. That is pre-existing and unchanged. The probe must NOT inherit it,
-  // because disclosing a field is not the same as spending money, which is
-  // exactly why shouldRunServingProbe refuses cf-ray unconditionally.
-  check('the money path is closed even where disclosure is open', !('probe' in body));
-  check('  (disclosure itself unchanged by this PR)', 'oauth' in body);
+  // This proxy runs with NO DARIO_API_KEY, so authenticateRequest() returns
+  // true for every caller. Before the keyConfigured fix, that short-circuited
+  // the #642 gate before it ever looked at cf-ray, and a tunnel caller got the
+  // full internal view. Both surfaces are now closed for it.
+  check('no OAuth internals disclosed to a tunnel caller', !('oauth' in body), JSON.stringify(body));
+  check('no expiresIn', !('expiresIn' in body));
+  check('no request volume', !('requests' in body));
+  check('no queue snapshot', !('queue' in body));
+  check('liveness verdict only', Object.keys(body).length === 1 && body.status !== undefined, JSON.stringify(body));
+}
+
+header('an unkeyed proxy still serves its own healthcheck in full');
+{
+  // The reason the fix routes through the transport rules instead of just
+  // demanding a key: docker HEALTHCHECK and `dario doctor` hit loopback with
+  // no key and no cf-ray, and must keep seeing everything.
+  const { body } = await getHealth('/health');
+  check('bare loopback still gets OAuth internals', 'oauth' in body, JSON.stringify(body));
+  check('bare loopback still gets the queue snapshot', typeof body.queue === 'object');
+  check('bare loopback still gets version', typeof body.version === 'string');
 }
 
 // ---------------------------------------------------------------------------

--- a/test/health-response.mjs
+++ b/test/health-response.mjs
@@ -96,12 +96,55 @@ header('buildHealthResponse — sessions on internal, hidden from public');
 header('shouldDiscloseHealthInternals — closed to the cf-ray fail-open');
 {
   const D = shouldDiscloseHealthInternals;
-  check('authenticated caller -> internal', D({ authenticated: true, loopback: false, viaCfRay: false }) === true);
-  check('authenticated wins even via CF', D({ authenticated: true, loopback: false, viaCfRay: true }) === true);
-  check('bare loopback (docker HC / doctor) -> internal', D({ authenticated: false, loopback: true, viaCfRay: false }) === true);
-  check('loopback but via CF tunnel -> public (sidecar case)', D({ authenticated: false, loopback: true, viaCfRay: true }) === false);
-  check('THE #642 BUG: non-loopback, no cf-ray, unauthed -> public (was fail-open)', D({ authenticated: false, loopback: false, viaCfRay: false }) === false);
-  check('public tunnel, unauthed -> public', D({ authenticated: false, loopback: false, viaCfRay: true }) === false);
+  // A key IS configured here, so `authenticated` means the caller proved it.
+  const keyed = (o) => D({ keyConfigured: true, ...o });
+  check('authenticated caller -> internal', keyed({ authenticated: true, loopback: false, viaCfRay: false }) === true);
+  check('authenticated wins even via CF', keyed({ authenticated: true, loopback: false, viaCfRay: true }) === true);
+  check('bare loopback (docker HC / doctor) -> internal', keyed({ authenticated: false, loopback: true, viaCfRay: false }) === true);
+  check('loopback but via CF tunnel -> public (sidecar case)', keyed({ authenticated: false, loopback: true, viaCfRay: true }) === false);
+  check('THE #642 BUG: non-loopback, no cf-ray, unauthed -> public (was fail-open)', keyed({ authenticated: false, loopback: false, viaCfRay: false }) === false);
+  check('public tunnel, unauthed -> public', keyed({ authenticated: false, loopback: false, viaCfRay: true }) === false);
+}
+
+header('shouldDiscloseHealthInternals — UNKEYED proxy cannot vacuously authenticate');
+{
+  const D = shouldDiscloseHealthInternals;
+  // authenticateRequest() returns true for EVERY caller when no DARIO_API_KEY
+  // is set, so this is the shape an unkeyed proxy actually produces.
+  const unkeyed = (o) => D({ keyConfigured: false, authenticated: true, ...o });
+
+  check('THE GAP: unkeyed + via CF tunnel -> public, not internal',
+    unkeyed({ loopback: false, viaCfRay: true }) === false);
+  check('unkeyed + tunnel + loopback socket (CF sidecar) -> public',
+    unkeyed({ loopback: true, viaCfRay: true }) === false);
+  check('unkeyed + LAN/WAN, no tunnel -> public',
+    unkeyed({ loopback: false, viaCfRay: false }) === false);
+
+  // The whole point of the auth-free /health: these must keep working, and
+  // they are the reason the fix routes through the transport rules rather
+  // than simply demanding a key.
+  check('unkeyed + bare loopback (docker HC) -> STILL internal',
+    unkeyed({ loopback: true, viaCfRay: false }) === true);
+  check('unkeyed + bare loopback (dario doctor) -> STILL internal',
+    D({ keyConfigured: false, authenticated: true, loopback: true, viaCfRay: false }) === true);
+}
+
+header('shouldDiscloseHealthInternals — keyConfigured only ever narrows');
+{
+  const D = shouldDiscloseHealthInternals;
+  // For every transport shape, dropping the key can never GRANT access that a
+  // configured key would have denied.
+  let widened = 0;
+  for (const authenticated of [true, false]) {
+    for (const loopback of [true, false]) {
+      for (const viaCfRay of [true, false]) {
+        const withKey = D({ authenticated, keyConfigured: true, loopback, viaCfRay });
+        const noKey = D({ authenticated, keyConfigured: false, loopback, viaCfRay });
+        if (noKey && !withKey) widened++;
+      }
+    }
+  }
+  check('no transport shape gains disclosure by removing the key', widened === 0);
 }
 
 // ── derivePoolStatus — pool-aware /status + /health (#636) ────────────────


### PR DESCRIPTION
## The gap

`shouldDiscloseHealthInternals` grants the internal view to any caller `authenticateRequest()` accepts:

```ts
if (opts.authenticated) return true;   // ← returns before cf-ray is consulted
if (opts.viaCfRay) return false;
return opts.loopback;
```

And `authenticateRequest()` short-circuits:

```ts
if (!apiKeyBuf) return true;           // no DARIO_API_KEY configured
```

That short-circuit is deliberate and stays — the common setup is loopback-only, and requiring a key there would break `dario doctor` and every docker healthcheck. But it makes `authenticated` **vacuous** on an unkeyed proxy: *every* caller satisfies it, so the auth branch returns before `cf-ray` is ever reached.

Net effect: an unkeyed dario published through a Cloudflare tunnel hands `oauth`, `expiresIn`, `requests`, `sessions`, `queue` and `refreshFailures` to anyone who asks.

#642 closed this gate's *spoofable-header* direction — a caller can't grant itself the internal view by omitting `cf-ray`. This is the same fail-open re-entering through a side door: the auth branch simply never reaches the check.

## The fix

```ts
if (opts.authenticated && opts.keyConfigured) return true;
if (opts.viaCfRay) return false;
return opts.loopback;
```

The auth branch is now reachable only by a caller that actually presented the operator's secret. Unkeyed proxies fall through to the transport rules — where **bare loopback is still trusted**, which is why docker `HEALTHCHECK`, `dario doctor` and the TUI are unchanged.

`keyConfigured` is a **required** field rather than an optional with a default: for a security predicate, every call site should be forced to state it. One call site, in `proxy.ts`.

## Behaviour change

If you monitor `/health` **through a tunnel on a proxy with no `DARIO_API_KEY`**, you now get `{"status":"ok"}` instead of the full body. Set `DARIO_API_KEY` and send it, or query from loopback, to keep the detail.

The HTTP status (200/503) is unchanged for every caller, so status-code uptime checks are unaffected — that invariant is stated in the module docstring and is why the split is safe to tighten.

Documented in `docs/usage.md` with a who-sees-what table and an upgrade note.

## Also

`shouldRunServingProbe` (added in #922) justified itself partly by this bug, so its docstring is refreshed rather than left citing a fixed premise. Its remaining job is narrower and still real: refusing tunnel callers that *did* present a key, since a leaked key on a per-call billed endpoint needs only one request per cache TTL to keep running. It would have refused the unkeyed caller either way — the two are the same defence at different depths.

## Tests

- Existing gate suite now states `keyConfigured` explicitly; all six original assertions unchanged in meaning.
- New suite for the unkeyed shapes: tunnel denied, tunnel+loopback-socket (CF sidecar) denied, LAN denied, **bare loopback still granted** — the docker/doctor regression case.
- Property check: no transport shape gains disclosure by removing the key, i.e. `keyConfigured` can only ever narrow.
- `health-probe-e2e.mjs` flips from asserting the gap to asserting it's closed (real `startProxy()`, unkeyed, `cf-ray` set → single-key body), and adds a case proving an unkeyed proxy still serves its own healthcheck in full.

`health-response.mjs` 95 → 101, `health-probe-e2e.mjs` 29 → 35. Full suite **129/131** — the two failures (`template-interactive-tools`, `tool-advertise-respects-client`) reproduce identically on pristine `origin/master` on this machine and are unrelated.

Version 5.5.0 → **5.5.1** in-PR per the release gate.

Follow-up to #642. Found by the end-to-end test added in #922.
