### PR TITLE
ci(dario): fix cc-oauth-health checkout — sparse-checkout needs a directory

### DIFF
--- a/.github/workflows/cc-oauth-health.yml
+++ b/.github/workflows/cc-oauth-health.yml
@@ -63,8 +63,7 @@ jobs:
       # POSIX sh, so a sparse shallow checkout is the whole cost.
       - uses: askalf/checkout-with-retry@744195501c3e2b794c50370b753a7b8c93d084f5  # v1.0.0
         with:
-          sparse-checkout: scripts/health-verdict.sh
-          sparse-checkout-cone-mode: false
+          sparse-checkout: scripts
 
       - name: Probe local /health and alert on any unhealthy axis
         env:


### PR DESCRIPTION
The `dario serving health alert (self-hosted)` workflow has failed on every run since #929 (runs 3215/3216/3217, run 31239600170) at the checkout step.

Two stacked problems, one line each:

1. `sparse-checkout-cone-mode: false` is NOT an input of `askalf/checkout-with-retry` — its declared inputs are `[ref, repository, token, fetch-depth, path, sparse-checkout, persist-credentials]`. Composite-action passthrough is explicit, never automatic, so the value is dropped with only `##[warning]Unexpected input(s) ...` and the inner `actions/checkout` runs with cone-mode at its DEFAULT (true).
2. In cone mode, sparse-checkout patterns must be DIRECTORIES. `scripts/health-verdict.sh` is a file, hence `fatal: 'scripts/health-verdict.sh' is not a directory` (exit 128).

Fix: drop the unsupported input and sparse-checkout the `scripts` directory instead. Same fix shape as #932.

Note on why this looked like a flake: on the self-hosted persistent workspace the same SHA passed once at 04:10Z and has failed every run since — `git sparse-checkout set <file>` only trips the cone-mode directory check once that path exists as a file in the working tree, and the 04:10 run predated #929's new file. It is deterministic, not transient; GitHub Executor confirmed a rerun fails identically.

**Test plan:** merge, then let the next scheduled run of `.github/workflows/cc-oauth-health.yml` execute (every 10 min) — the checkout step should succeed and the three health axes (oauth status, serving probe, queue stalledForMs) should actually be probed. `scripts/health-verdict.sh` is present under the checked-out `scripts` dir.

Source ticket: 00MSJZAESM9A2BF3B6C7C1EAFC (upstream: 00MSJVO9TR131FBC7E52ABBAE2)