### PR TITLE
chore(ci): re-pin checkout-with-retry to v1.1.0 (sparse-checkout-cone-mode fix)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -25,7 +25,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: askalf/checkout-with-retry@744195501c3e2b794c50370b753a7b8c93d084f5  # v1.0.0
+      - uses: askalf/checkout-with-retry@115a6407547e9711edbc2e915838d495cad9583f  # v1.1.0
 
       - name: Install actionlint v1.7.1
         # Official release tarball, pinned to a specific version. Skipping

--- a/.github/workflows/cc-billing-classifier-canary.yml
+++ b/.github/workflows/cc-billing-classifier-canary.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: [self-hosted, dario-drift]
     timeout-minutes: 5
     steps:
-      - uses: askalf/checkout-with-retry@744195501c3e2b794c50370b753a7b8c93d084f5  # v1.0.0
+      - uses: askalf/checkout-with-retry@115a6407547e9711edbc2e915838d495cad9583f  # v1.1.0
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0

--- a/.github/workflows/cc-drift-auto-release.yml
+++ b/.github/workflows/cc-drift-auto-release.yml
@@ -120,7 +120,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout master (post-merge state)
-        uses: askalf/checkout-with-retry@744195501c3e2b794c50370b753a7b8c93d084f5  # v1.0.0
+        uses: askalf/checkout-with-retry@115a6407547e9711edbc2e915838d495cad9583f  # v1.1.0
         with:
           ref: master
           fetch-depth: 2  # need HEAD^1 for the pull_request fast-exit

--- a/.github/workflows/cc-drift-template-watch.yml
+++ b/.github/workflows/cc-drift-template-watch.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: [self-hosted, dario-drift]
     timeout-minutes: 8
     steps:
-      - uses: askalf/checkout-with-retry@744195501c3e2b794c50370b753a7b8c93d084f5  # v1.0.0
+      - uses: askalf/checkout-with-retry@115a6407547e9711edbc2e915838d495cad9583f  # v1.1.0
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0

--- a/.github/workflows/cc-drift-watch.yml
+++ b/.github/workflows/cc-drift-watch.yml
@@ -110,7 +110,7 @@ jobs:
     if: needs.version_check.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: askalf/checkout-with-retry@744195501c3e2b794c50370b753a7b8c93d084f5  # v1.0.0
+      - uses: askalf/checkout-with-retry@115a6407547e9711edbc2e915838d495cad9583f  # v1.1.0
         with:
           # Persist the drift-bot PAT so the later `git push origin bot/cc-drift-*`
           # and `gh pr create` are attributed to a real user identity rather than

--- a/.github/workflows/cc-drift-watcher-liveness.yml
+++ b/.github/workflows/cc-drift-watcher-liveness.yml
@@ -45,7 +45,7 @@ jobs:
       # repo (otherwise `gh issue list` exits with "fatal: not a git
       # repository"). actions/checkout supplies it; we don't actually
       # need any files from the checkout, just the .git directory.
-      - uses: askalf/checkout-with-retry@744195501c3e2b794c50370b753a7b8c93d084f5  # v1.0.0
+      - uses: askalf/checkout-with-retry@115a6407547e9711edbc2e915838d495cad9583f  # v1.1.0
         with:
           fetch-depth: 1
 

--- a/.github/workflows/cc-oauth-health.yml
+++ b/.github/workflows/cc-oauth-health.yml
@@ -67,7 +67,7 @@ jobs:
       # always runs in cone mode, where every pattern must be a directory; a
       # file path dies with `fatal: '...' is not a directory` (run
       # #31239237095). Checking out the whole dir costs nothing here.
-      - uses: askalf/checkout-with-retry@744195501c3e2b794c50370b753a7b8c93d084f5  # v1.0.0
+      - uses: askalf/checkout-with-retry@115a6407547e9711edbc2e915838d495cad9583f  # v1.1.0
         with:
           sparse-checkout: scripts
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   validate-package-json:
     runs-on: ubuntu-latest
     steps:
-      - uses: askalf/checkout-with-retry@744195501c3e2b794c50370b753a7b8c93d084f5  # v1.0.0
+      - uses: askalf/checkout-with-retry@115a6407547e9711edbc2e915838d495cad9583f  # v1.1.0
       - name: package.json is valid JSON and canonically formatted
         run: node scripts/check-package-json.mjs
 
@@ -30,7 +30,7 @@ jobs:
       matrix:
         node-version: [18, 20, 22]
     steps:
-      - uses: askalf/checkout-with-retry@744195501c3e2b794c50370b753a7b8c93d084f5  # v1.0.0
+      - uses: askalf/checkout-with-retry@115a6407547e9711edbc2e915838d495cad9583f  # v1.1.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
@@ -53,7 +53,7 @@ jobs:
     needs: validate-package-json
     runs-on: ubuntu-latest
     steps:
-      - uses: askalf/checkout-with-retry@744195501c3e2b794c50370b753a7b8c93d084f5  # v1.0.0
+      - uses: askalf/checkout-with-retry@115a6407547e9711edbc2e915838d495cad9583f  # v1.1.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
@@ -71,7 +71,7 @@ jobs:
     needs: validate-package-json
     runs-on: ubuntu-latest
     steps:
-      - uses: askalf/checkout-with-retry@744195501c3e2b794c50370b753a7b8c93d084f5  # v1.0.0
+      - uses: askalf/checkout-with-retry@115a6407547e9711edbc2e915838d495cad9583f  # v1.1.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
       security-events: write
     runs-on: ubuntu-latest
     steps:
-      - uses: askalf/checkout-with-retry@744195501c3e2b794c50370b753a7b8c93d084f5  # v1.0.0
+      - uses: askalf/checkout-with-retry@115a6407547e9711edbc2e915838d495cad9583f  # v1.1.0
       - uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: javascript-typescript

--- a/.github/workflows/compat-test-self-hosted.yml
+++ b/.github/workflows/compat-test-self-hosted.yml
@@ -79,7 +79,7 @@ jobs:
     env:
       COMPAT_API_KEY: ${{ secrets.ANTHROPIC_COMPAT_API_KEY }}
     steps:
-      - uses: askalf/checkout-with-retry@744195501c3e2b794c50370b753a7b8c93d084f5  # v1.0.0
+      - uses: askalf/checkout-with-retry@115a6407547e9711edbc2e915838d495cad9583f  # v1.1.0
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0

--- a/.github/workflows/dario-doctor-watch.yml
+++ b/.github/workflows/dario-doctor-watch.yml
@@ -45,7 +45,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: askalf/checkout-with-retry@744195501c3e2b794c50370b753a7b8c93d084f5  # v1.0.0
+      - uses: askalf/checkout-with-retry@115a6407547e9711edbc2e915838d495cad9583f  # v1.1.0
 
       - name: Run dario doctor drift check
         id: check

--- a/.github/workflows/sdk-drift-watch.yml
+++ b/.github/workflows/sdk-drift-watch.yml
@@ -45,7 +45,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: askalf/checkout-with-retry@744195501c3e2b794c50370b753a7b8c93d084f5  # v1.0.0
+      - uses: askalf/checkout-with-retry@115a6407547e9711edbc2e915838d495cad9583f  # v1.1.0
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0

--- a/.github/workflows/wire-drift-self-hosted.yml
+++ b/.github/workflows/wire-drift-self-hosted.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: [self-hosted, dario-drift]
     timeout-minutes: 10
     steps:
-      - uses: askalf/checkout-with-retry@744195501c3e2b794c50370b753a7b8c93d084f5  # v1.0.0
+      - uses: askalf/checkout-with-retry@115a6407547e9711edbc2e915838d495cad9583f  # v1.1.0
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0


### PR DESCRIPTION
Follow-up to #932. That PR worked around the overnight `cc-oauth-health` failures by switching to a directory sparse-checkout pattern — but the actual bug was upstream: `askalf/checkout-with-retry` silently drops any `actions/checkout` input it doesn't explicitly declare (`sparse-checkout-cone-mode` among them), with only a non-blocking warning. Fixed there in [checkout-with-retry#9](https://github.com/askalf/checkout-with-retry/pull/9), tagged `v1.1.0`.

This re-pins all 13 workflows in this repo that use the wrapper, from the pre-fix commit (`744195501c...`, `v1.0.0`) to the fix (`115a6407...`, `v1.1.0`), so any future single-file sparse-checkout here gets the real fix instead of depending on every workflow author remembering to avoid file patterns.

Mechanical only — SHA + version-comment swap, no workflow logic changed. 16/16 occurrences updated, 0 old-pin references remain, all 13 files parse as valid YAML.

`v1` (the moving major tag) was also advanced to the same commit, so any repo pinning `@v1` instead of a SHA picks this up automatically.
