### PR TITLE
Tighten dario#lock-step: single-source variant families, bake gate, doctor coverage (v5.5.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.6] - 2026-08-09
+
+- **Lock-step tightened: per-model prompt variants get a single source of truth, a bake gate, and doctor coverage (dario#lock-step).** Three loosenesses in the mechanism that keeps dario's per-model system prompts (fable / opus-5 / sonnet-5) byte-aligned with CC's:
+  - **One table drives everything.** The variant families lived in two hand-maintained lists — `VARIANT_MODELS` in `scripts/capture-and-bake.mjs` and the hardcoded selection arms in `systemPromptForModel` — the exact divergence class that shipped `tool_names` ≠ `tools` twice. Both now derive from `VARIANT_FAMILIES` (`src/live-fingerprint.ts`, next to `TEMPLATE_BASE_MODEL` for the same reason): key, capture model, and matcher in one place, matcher-precedence order preserved (fable before the bounded `-5` arms). `test/template-invariants.mjs` asserts the shipped bundle against the table — every family carried and distinct from the base, no orphan variant keys — so a divergence can no longer ship quietly.
+  - **The bake refuses to ship silent variant loss.** A variant capture that failed with no previous variant to keep used to log a warning and bake anyway — the bundle would then serve that family the shared base prompt with no other symptom, and in `--check` the absence masqueraded as "N → 0 chars" variant drift, handing the watch workflow a rebake PR that strips the variant. That outcome is now exit 1 (infra failure, same philosophy as the older-CC guard from #635), with `--allow-missing-variant` as the deliberate bypass. Captured-and-matches-base still passes — that's a measured result, and a genuine variant retirement remains reportable drift. Kept-previous variants now log a note that the kept text may lag the freshly captured base.
+  - **Degraded lock-step is visible at runtime.** `describeTemplate` (doctor's Template row + the proxy startup line) now appends variant coverage (`variants: fable+opus-5+sonnet-5` / `variants: none`), and `dario doctor` gains a "Prompt variants" row: ok when every family in the table is carried by the loaded template, warn naming the missing families — the state a variant-less bundle or a pre-variants live cache shadowing the bundle used to reach invisibly (requests still 200, wrong prompt).
+
 ## [5.5.5] - 2026-08-08
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.225` → `2.1.226` for CC v2.1.226. Auto-drafted by `cc-drift-watch.yml`; rebased onto master after 5.5.4 shipped the *template* label refresh (`_supportedMaxTested` → `2.1.226`) without this *code* constant, which left `check-cc-drift.mjs` still flagging live CC v2.1.226 as beyond `maxTested` and users on it getting a soft "untested-above" warning from `dario doctor`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.1",
+  "version": "5.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "5.5.1",
+      "version": "5.5.6",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.5",
+  "version": "5.5.6",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/scripts/capture-and-bake.mjs
+++ b/scripts/capture-and-bake.mjs
@@ -12,6 +12,7 @@
  *   node scripts/capture-and-bake.mjs              # capture + scrub + write
  *   node scripts/capture-and-bake.mjs --check      # capture + diff; exit 2 on shape drift, 3 on label-only drift, 0 on full match
  *   node scripts/capture-and-bake.mjs --allow-older-cc  # bypass the stale-binary guard (deliberate downgrade bake)
+ *   node scripts/capture-and-bake.mjs --allow-missing-variant  # bypass the lock-step gate (ship a family with NO variant)
  *
  * The --check mode is non-destructive: it captures + scrubs but does not
  * write to disk. Useful from a scheduled cron (see docs/drift-monitor.md)
@@ -27,7 +28,11 @@
  *       or installed CC OLDER than the bundle's capture — stale runner; an older
  *       binary re-captures yesterday's wire shape and would report it as drift,
  *       which reached the ship gate as a template downgrade in PR #632. Bypass
- *       for a deliberate downgrade bake with --allow-older-cc)
+ *       for a deliberate downgrade bake with --allow-older-cc. Also: a
+ *       VARIANT_FAMILIES capture failed with no previous variant to keep —
+ *       shipping would silently serve that family the base prompt, and in
+ *       --check the absence would masquerade as variant drift. Bypass with
+ *       --allow-missing-variant)
  *   2 — --check mode only: wire-SHAPE drift vs current OUT (tools / system_prompt /
  *       beta / field order changed — needs a real re-bake; human-reviewed)
  *   3 — --check mode only: LABEL-only drift — wire shape matches but the bundled
@@ -43,7 +48,7 @@ import { writeFileSync, readFileSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { captureLiveTemplateAsync, findInstalledCC, promptVariantsOf, TEMPLATE_BASE_MODEL } from '../dist/live-fingerprint.js';
+import { captureLiveTemplateAsync, findInstalledCC, promptVariantsOf, TEMPLATE_BASE_MODEL, VARIANT_FAMILIES } from '../dist/live-fingerprint.js';
 import { scrubTemplate, findUserPathHits } from '../dist/scrub-template.js';
 import { PLATFORM_ONLY_TOOLS, INTERACTIVE_ONLY_TOOLS } from '../dist/cc-template.js';
 import { computeDrift, formatDriftReport, interpretDrift, formatDriftSummary, stripModelConditionalBetas, isOlderCCVersion, detectIssue881Residue, formatIssue881Warning } from './drift-report.mjs';
@@ -55,6 +60,7 @@ const OUT = join(repoRoot, 'src/cc-template-data.json');
 const CHECK_MODE = process.argv.includes('--check');
 const ALLOW_OLDER_CC = process.argv.includes('--allow-older-cc');
 const ALLOW_NON_LINUX = process.argv.includes('--allow-non-linux-bake');
+const ALLOW_MISSING_VARIANT = process.argv.includes('--allow-missing-variant');
 
 function log(msg) {
   console.error(`[bake] ${msg}`);
@@ -77,13 +83,12 @@ const BASE_MODEL = TEMPLATE_BASE_MODEL;
 // Models CC ships a DIFFERENT system prompt to. Measured on CC 2.1.220
 // (2026-07-25), two byte-identical passes each, raw chars vs the opus-4-8
 // base at 6664: fable-5 11084, opus-5 9990, sonnet-5 28156. A variant is
-// stored only when it differs from the base after scrubbing, so adding a
-// model here is safe even if it turns out to share the base prompt.
-const VARIANT_MODELS = [
-  { key: 'fable', model: 'claude-fable-5' },
-  { key: 'opus-5', model: 'claude-opus-5' },
-  { key: 'sonnet-5', model: 'claude-sonnet-5' },
-];
+// stored only when it differs from the base after scrubbing.
+//
+// Derived from VARIANT_FAMILIES, the same table systemPromptForModel selects
+// from at runtime — a family added there is captured here with no second
+// hand-maintained list to forget (the tool_names ≠ tools divergence class).
+const VARIANT_MODELS = VARIANT_FAMILIES.map((f) => ({ key: f.key, model: f.captureModel }));
 async function captureForModel(model, label) {
   const saved = process.env.ANTHROPIC_MODEL;
   process.env.ANTHROPIC_MODEL = model;
@@ -277,8 +282,17 @@ if (residue881.detected) {
 // Stored ONLY when it differs from the base — otherwise runtime falls back to base.
 const prevVariants = promptVariantsOf(prev);
 const variants = {};
+// Per-family outcome, consumed by the lock-step gate below: 'fresh'
+// (captured, differs from base), 'base' (captured, matches base — the
+// family legitimately has no variant), 'kept' (capture failed, previous
+// bundle's variant retained), 'missing' (capture failed AND there is no
+// previous variant to keep).
+const variantOutcomes = {};
 for (const { key, model } of VARIANT_MODELS) {
-  const keepPrevious = () => { if (prevVariants[key]) variants[key] = prevVariants[key]; };
+  const keepPrevious = () => {
+    if (prevVariants[key]) { variants[key] = prevVariants[key]; variantOutcomes[key] = 'kept'; }
+    else variantOutcomes[key] = 'missing';
+  };
   try {
     const capturedVariant = await captureForModel(model, `${key}-variant`);
     if (!capturedVariant) {
@@ -289,6 +303,7 @@ for (const { key, model } of VARIANT_MODELS) {
     const vScrubbed = scrubTemplate(capturedVariant);
     if (!vScrubbed.system_prompt || vScrubbed.system_prompt === scrubbed.system_prompt) {
       log(`${key}-variant matches base — no separate variant stored.`);
+      variantOutcomes[key] = 'base';
       continue;
     }
     const vResidual = findUserPathHits(vScrubbed.system_prompt);
@@ -298,11 +313,38 @@ for (const { key, model } of VARIANT_MODELS) {
       continue;
     }
     variants[key] = vScrubbed.system_prompt;
+    variantOutcomes[key] = 'fresh';
     log(`${key} system-prompt variant: base ${scrubbed.system_prompt.length} → ${key} ${variants[key].length} chars`);
   } catch (e) {
     log(`warning: ${key}-variant capture error (${e.message}) — keeping previous variant if any.`);
     keepPrevious();
   }
+}
+
+// ── Lock-step gate (dario#lock-step) ─────────────────────────────────
+// A family whose capture failed with no previous variant to keep must not
+// ship — or diff — as if CC had retired the variant. Baked, the bundle
+// would silently serve that family the BASE prompt; in --check, the
+// absence would read as "N → 0 chars" variant drift and hand the watch
+// workflow a rebake PR that strips it. Same philosophy as the older-CC
+// guard (#635): an infra failure exits 1 loudly instead of masquerading
+// as drift. A captured-and-matches-base outcome stays allowed — that is
+// a measured result, and prev-had-one → variant-retired is real drift
+// for --check to report.
+const missingVariants = VARIANT_MODELS.map((v) => v.key).filter((k) => variantOutcomes[k] === 'missing');
+if (missingVariants.length > 0) {
+  if (ALLOW_MISSING_VARIANT) {
+    log(`WARNING: proceeding WITHOUT a variant for: ${missingVariants.join(', ')} (--allow-missing-variant) — those families will be served the base prompt.`);
+  } else {
+    log(`error: variant capture failed with no previous variant to keep: ${missingVariants.join(', ')}.`);
+    log('error: a bundle baked now would silently serve those families the BASE system prompt.');
+    log('error: infra failure, not CC drift — fix the capture, or bypass deliberately with --allow-missing-variant.');
+    process.exit(1);
+  }
+}
+const keptVariants = VARIANT_MODELS.map((v) => v.key).filter((k) => variantOutcomes[k] === 'kept');
+if (keptVariants.length > 0) {
+  log(`note: carrying the previous bundle's variant for: ${keptVariants.join(', ')} — re-capture failed this run, so the kept text may lag the freshly captured base (CC v${captured._version}).`);
 }
 if (Object.keys(variants).length > 0) scrubbed.system_prompt_variants = variants;
 

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -8,7 +8,7 @@
  * action required. See src/live-fingerprint.ts for the capture pipeline.
  */
 
-import { loadTemplate, promptVariantsOf, TemplateData } from './live-fingerprint.js';
+import { loadTemplate, promptVariantsOf, TemplateData, VARIANT_FAMILIES } from './live-fingerprint.js';
 
 // Load template at module init — prefer live cache, fall back to bundled.
 const TEMPLATE: TemplateData = loadTemplate({ silent: true });
@@ -151,17 +151,21 @@ export const CC_SYSTEM_PROMPT_OPUS5: string = _variants['opus-5'] ?? CC_SYSTEM_P
 export const CC_SYSTEM_PROMPT_SONNET5: string = _variants['sonnet-5'] ?? CC_SYSTEM_PROMPT;
 
 /**
- * The system prompt CC would send for `model`: Fable-family gets the Fable
- * variant, every other model gets the shared base. Keeps dario byte-aligned with
- * CC's per-model system prompt (dario#lock-step). Mirrors betaForModel's shape.
+ * The system prompt CC would send for `model`: a family in VARIANT_FAMILIES
+ * gets its captured variant, every other model gets the shared base. Keeps
+ * dario byte-aligned with CC's per-model system prompt (dario#lock-step).
+ *
+ * Selection iterates VARIANT_FAMILIES (live-fingerprint.ts) — the same table
+ * the bake captures from — so the two sides cannot drift apart. A family
+ * whose variant is absent from the loaded template falls back to the base;
+ * `dario doctor`'s "Prompt variants" row surfaces that state instead of
+ * letting it pass silently.
  */
 export function systemPromptForModel(model?: string): string {
   const m = (model ?? '').toLowerCase();
-  if (m.includes('fable')) return CC_SYSTEM_PROMPT_FABLE;
-  // `-5` bounded so a future opus-50 doesn't match, and so the `[1m]` tag
-  // (which is not a digit) still does.
-  if (/opus-5(?!\d)/.test(m)) return CC_SYSTEM_PROMPT_OPUS5;
-  if (/sonnet-5(?!\d)/.test(m)) return CC_SYSTEM_PROMPT_SONNET5;
+  for (const f of VARIANT_FAMILIES) {
+    if (f.matches(m)) return _variants[f.key] ?? CC_SYSTEM_PROMPT;
+  }
   return CC_SYSTEM_PROMPT;
 }
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -27,9 +27,11 @@ import {
   detectDrift,
   checkCCCompat,
   findInstalledCC,
+  missingVariantFamilies,
   SUPPORTED_CC_RANGE,
   CURRENT_SCHEMA_VERSION,
   compareVersions,
+  VARIANT_FAMILIES,
 } from './live-fingerprint.js';
 import { detectCCOAuthConfig } from './cc-oauth-detect.js';
 import { runAuthorizeProbe } from './cc-authorize-probe.js';
@@ -464,6 +466,31 @@ export async function runChecks(opts: RunChecksOptions = {}): Promise<Check[]> {
     });
   } catch (err) {
     checks.push({ status: 'fail', label: 'Template', detail: `load failed: ${(err as Error).message}` });
+  }
+
+  // ---- Per-model prompt variants (dario#lock-step)
+  // CC ships several model families a different system prompt than the shared
+  // base. A template missing a family's variant silently serves that family
+  // the base prompt — a wire-fidelity degradation with no other symptom
+  // (requests still 200). Known causes: a bundle baked while variant capture
+  // failed, or a pre-variants live cache shadowing the bundle.
+  try {
+    const missing = missingVariantFamilies(CC_TEMPLATE);
+    if (missing.length === 0) {
+      checks.push({
+        status: 'ok',
+        label: 'Prompt variants',
+        detail: `all ${VARIANT_FAMILIES.length} model families carried (${VARIANT_FAMILIES.map((f) => f.key).join(', ')})`,
+      });
+    } else {
+      checks.push({
+        status: 'warn',
+        label: 'Prompt variants',
+        detail: `missing: ${missing.join(', ')} — those models get the shared base prompt, not CC's model-specific one. Re-bake the template, or remove a pre-variants live cache (~/.dario/cc-template.live.json) and restart.`,
+      });
+    }
+  } catch (err) {
+    checks.push({ status: 'warn', label: 'Prompt variants', detail: `check failed: ${(err as Error).message}` });
   }
 
   // ---- Per-request overhead surfacing.

--- a/src/live-fingerprint.ts
+++ b/src/live-fingerprint.ts
@@ -192,6 +192,55 @@ export interface TemplateData {
 export const TEMPLATE_BASE_MODEL = 'claude-opus-4-8';
 
 /**
+ * One model family CC ships a distinct system prompt to (dario#lock-step).
+ */
+export interface VariantFamily {
+  /** Key into `system_prompt_variants`. */
+  key: string;
+  /** Model id the bake pins (via ANTHROPIC_MODEL) to capture this family. */
+  captureModel: string;
+  /** True when a lowercased model id belongs to this family. */
+  matches: (model: string) => boolean;
+}
+
+/**
+ * The model families CC ships a DIFFERENT system prompt than the shared
+ * base, in matcher-precedence order (first match wins — fable stays ahead
+ * of the `-5` arms so a hypothetical fable-5 never falls into them).
+ *
+ * This table is the single source of truth for dario#lock-step: the
+ * runtime selection (cc-template.ts:systemPromptForModel), the bake's
+ * capture loop (scripts/capture-and-bake.mjs), the doctor's coverage row,
+ * and the template invariants all derive from it — the same reason
+ * TEMPLATE_BASE_MODEL lives here. Before this table, the bake's model
+ * list and the selection arms were maintained by hand in two files, the
+ * exact divergence class that shipped tool_names ≠ tools twice.
+ *
+ * Adding a family here is safe even if it turns out to share the base
+ * prompt: the bake stores a variant only when the capture differs.
+ */
+export const VARIANT_FAMILIES: readonly VariantFamily[] = [
+  { key: 'fable', captureModel: 'claude-fable-5', matches: (m) => m.includes('fable') },
+  // `-5` bounded so a future opus-50 doesn't match, and so the `[1m]` tag
+  // (which is not a digit) still does.
+  { key: 'opus-5', captureModel: 'claude-opus-5', matches: (m) => /opus-5(?!\d)/.test(m) },
+  { key: 'sonnet-5', captureModel: 'claude-sonnet-5', matches: (m) => /sonnet-5(?!\d)/.test(m) },
+];
+
+/**
+ * Families from VARIANT_FAMILIES that `t` carries no variant for — i.e.
+ * models that would silently get the shared BASE prompt instead of CC's
+ * model-specific one. Non-empty on a healthy current bundle means the
+ * lock-step is degraded: a bad bake, an unreadable bundle behind a live
+ * capture, or a pre-variants live cache shadowing the bundle.
+ */
+export function missingVariantFamilies(t: TemplateData): string[] {
+  const have = promptVariantsOf(t);
+  return VARIANT_FAMILIES.filter((f) => !(typeof have[f.key] === 'string' && have[f.key].length > 0))
+    .map((f) => f.key);
+}
+
+/**
  * A template's prompt variants, with the legacy `system_prompt_fable` slot
  * folded in under the `fable` key. Callers should always go through this
  * rather than reading either field directly.
@@ -1022,7 +1071,12 @@ export function formatCaptureAge(capturedIso: string, now: number = Date.now()):
 export function describeTemplate(t: TemplateData): string {
   const source = t._source ?? 'bundled';
   const age = formatCaptureAge(t._captured);
-  return `${source} capture, CC v${t._version} (${age} old)`;
+  // Variant coverage is part of the template's identity: a template that
+  // lost its per-model variants serves every family the base prompt, and
+  // that degradation is otherwise invisible (dario#lock-step).
+  const keys = Object.keys(promptVariantsOf(t)).sort();
+  const variants = keys.length > 0 ? keys.join('+') : 'none';
+  return `${source} capture, CC v${t._version} (${age} old), variants: ${variants}`;
 }
 
 export interface DriftResult {

--- a/test/drift-detection.mjs
+++ b/test/drift-detection.mjs
@@ -110,6 +110,15 @@ header('describeTemplate — one-line summary');
 
   const undefSource = templateFixture({ _source: undefined });
   check('undefined _source falls back to "bundled"', describeTemplate(undefSource).startsWith('bundled'));
+
+  // Variant coverage (dario#lock-step): the summary line is where a
+  // variant-less template — every family silently on the base prompt —
+  // becomes visible in doctor and the proxy startup line.
+  check('no variants → "variants: none"', describeTemplate(t).includes('variants: none'));
+  const withVariants = templateFixture({ system_prompt_variants: { fable: 'F', 'opus-5': 'O' } });
+  check('variant keys are listed', describeTemplate(withVariants).includes('variants: fable+opus-5'));
+  const legacyFable = templateFixture({ system_prompt_fable: 'F' });
+  check('legacy system_prompt_fable folds into the listing', describeTemplate(legacyFable).includes('variants: fable'));
 }
 
 // ======================================================================

--- a/test/per-model-system-prompt.mjs
+++ b/test/per-model-system-prompt.mjs
@@ -3,7 +3,8 @@
 // model-specific system prompt than the shared base. dario must inject Fable's
 // prompt for Fable requests and the base for everything else.
 
-import { buildCCRequest, systemPromptForModel, resolveSystemPrompt, CC_SYSTEM_PROMPT, CC_SYSTEM_PROMPT_FABLE, CC_SYSTEM_PROMPT_OPUS5, CC_SYSTEM_PROMPT_SONNET5 } from '../dist/cc-template.js';
+import { buildCCRequest, systemPromptForModel, resolveSystemPrompt, CC_SYSTEM_PROMPT, CC_SYSTEM_PROMPT_FABLE, CC_SYSTEM_PROMPT_OPUS5, CC_SYSTEM_PROMPT_SONNET5, CC_TEMPLATE } from '../dist/cc-template.js';
+import { VARIANT_FAMILIES, missingVariantFamilies } from '../dist/live-fingerprint.js';
 
 let pass = 0, fail = 0;
 function check(name, cond, detail) {
@@ -96,6 +97,24 @@ header('opus-5 / sonnet-5 variants (CC 2.1.220, 2026-07-25)');
   check('sonnet-51 → base (bounded match)', systemPromptForModel('claude-sonnet-51') === CC_SYSTEM_PROMPT);
   // fable is checked first: a hypothetical fable-5 must not fall into the -5 arms
   check('fable-5 still wins over the -5 arms', systemPromptForModel('claude-fable-5') === CC_SYSTEM_PROMPT_FABLE);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('VARIANT_FAMILIES is the single source of truth (dario#lock-step)');
+{
+  // Every family the bake captures must be served by a selection arm — the
+  // routing below goes through the SAME table the bake derives its model
+  // list from, so this asserts the loaded template actually carries what
+  // the table promises rather than falling back to the base.
+  for (const f of VARIANT_FAMILIES) {
+    check(`${f.key}: capture model routes to a non-base variant`,
+      systemPromptForModel(f.captureModel) !== CC_SYSTEM_PROMPT);
+  }
+  check('matcher precedence: fable is first (never falls into the -5 arms)',
+    VARIANT_FAMILIES[0]?.key === 'fable');
+  const missing = missingVariantFamilies(CC_TEMPLATE);
+  check('loaded template misses no family', missing.length === 0,
+    missing.length > 0 ? `missing: ${missing.join(', ')}` : undefined);
 }
 
 console.log(`\n${pass} pass, ${fail} fail`);

--- a/test/template-invariants.mjs
+++ b/test/template-invariants.mjs
@@ -19,6 +19,7 @@
 // loudly instead of shipping and getting caught downstream.
 
 import { buildCCRequest } from '../dist/cc-template.js';
+import { VARIANT_FAMILIES } from '../dist/live-fingerprint.js';
 import { readFileSync } from 'node:fs';
 
 let pass = 0, fail = 0;
@@ -329,6 +330,37 @@ header('bundled artifact: tool_names agrees with tools');
   check('the two lists are the same length',
     names.length === fromTools.length,
     names.length !== fromTools.length ? `tool_names=${names.length} tools=${fromTools.length}` : undefined);
+}
+
+// ─────────────────────────────────────────────────────────────
+header('bundled artifact: variant families agree with VARIANT_FAMILIES (dario#lock-step)');
+// The selection arms (systemPromptForModel) and the bake's capture loop both
+// derive from VARIANT_FAMILIES, but the shipped bundle is a build artifact —
+// asserting it against the table is what makes a divergence impossible to
+// ship quietly, exactly like the tool_names/tools invariant above:
+//   - a family in the table but not the bundle = that family silently gets
+//     the base prompt (the bake's lock-step gate exists to stop this, but a
+//     --allow-missing-variant bake or a hand-edited bundle can still do it);
+//   - a variant key in the bundle but not the table = dead weight no
+//     selection arm can ever serve.
+{
+  const bundled = JSON.parse(
+    readFileSync(new URL('../dist/cc-template-data.json', import.meta.url), 'utf8'),
+  );
+  const variants = bundled.system_prompt_variants ?? {};
+  for (const f of VARIANT_FAMILIES) {
+    check(`bundle carries a ${f.key} variant`,
+      typeof variants[f.key] === 'string' && variants[f.key].length > 0);
+    check(`${f.key} variant differs from the base`,
+      variants[f.key] !== bundled.system_prompt);
+    check(`${f.key} matcher accepts its own capture model`,
+      f.matches(f.captureModel.toLowerCase()));
+  }
+  const known = new Set(VARIANT_FAMILIES.map((f) => f.key));
+  const orphans = Object.keys(variants).filter((k) => !known.has(k));
+  check('no orphan variant keys — every bundle key has a selection arm',
+    orphans.length === 0,
+    orphans.length > 0 ? `in bundle but not VARIANT_FAMILIES: ${orphans.join(', ')}` : undefined);
 }
 
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Tightens dario#lock-step — the mechanism keeping dario's per-model system prompts (fable / opus-5 / sonnet-5) byte-aligned with CC's — on three axes.

## 1. Single source of truth for variant families

The families lived in two hand-maintained lists: `VARIANT_MODELS` in `scripts/capture-and-bake.mjs` and the hardcoded selection arms in `systemPromptForModel`. That is the exact divergence class that shipped `tool_names` ≠ `tools` twice (#859's second-occurrence note). A family added to one side and not the other either bakes a variant no arm can serve, or adds an arm that silently falls back to the base forever.

Both now derive from `VARIANT_FAMILIES` in `src/live-fingerprint.ts` (next to `TEMPLATE_BASE_MODEL`, which exists there for the same reason): key, capture model, and matcher in one table, matcher-precedence order preserved (fable ahead of the bounded `-5` arms). `test/template-invariants.mjs` asserts the shipped bundle against the table — every family carried and distinct from the base, no orphan keys — so a divergence can't ship quietly a third time.

## 2. The bake refuses silent variant loss

A variant capture that failed with no previous variant to keep used to log a warning and bake anyway. Two consequences:

- baked: the bundle serves that family the shared base prompt with no other symptom (requests still 200);
- in `--check`: the absence reads as "N → 0 chars" variant drift, handing the watch workflow a rebake PR that *strips* the variant.

That outcome is now exit 1 — infra failure, the #635 older-CC-guard philosophy — with `--allow-missing-variant` as the deliberate bypass. Captured-and-matches-base still passes: that's a measured result, and a genuine variant retirement stays reportable drift. Kept-previous variants log a note that the kept text may lag the freshly captured base.

## 3. Degraded lock-step is visible at runtime

`describeTemplate` (doctor Template row + proxy startup line) now appends variant coverage (`variants: fable+opus-5+sonnet-5` / `variants: none`), and `dario doctor` gains a "Prompt variants" row: ok when the loaded template carries every family, warn naming the missing ones. This is the state the live-cache shadow already reached once (verified live back then: `CC_SYSTEM_PROMPT_FABLE === CC_SYSTEM_PROMPT` with a fresh cache present) — it is now visible instead of silent.

## Trade-offs

- **A red watch is now possible where it was green-with-warning.** If a NEW family is added to the table and the drift runner's capture for it fails with nothing previous to keep, `cc-drift-template-watch` goes red (exit 1) until fixed or bypassed. Deliberate: for the three current families the gate cannot fire (all have previous variants to keep), so this only bites on genuinely new families or a wiped bundle.
- **Retiring a variant becomes a reviewed table edit.** If CC ever unifies a family's prompt into the base, the invariants fail on the rebake PR until the family is removed from `VARIANT_FAMILIES`, and doctor warns meanwhile. Chosen over silent disappearance.
- **`describeTemplate` output format changed** (variants suffix). Doctor detail and the startup log line are human-facing; the drift-detection tests cover the new shape.

Version bump to 5.5.6 included (release gate). Within-minor, so autodeploy applies it unattended.

## Tests

- `test/template-invariants.mjs`: new bundled-artifact section (family coverage, base-distinctness, matcher self-consistency, no orphans).
- `test/per-model-system-prompt.mjs`: table-driven routing checks + `missingVariantFamilies(CC_TEMPLATE)` empty on the shipped bundle.
- `test/drift-detection.mjs`: `describeTemplate` variant-coverage lines, including the legacy `system_prompt_fable` fold.
- Full suite: 130/132 files pass; the 2 failures (`template-interactive-tools`, `tool-advertise-respects-client`) reproduce identically on pristine master in a clean worktree and pass standalone — pre-existing suite-level flake, not introduced here (details in comments if needed).
