### PR TITLE
perf(proxy): skip orchestration scrub on tag-free message blocks (v5.5.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.7] - 2026-08-09
+
+- **Perf: skip the orchestration-tag scrub on message blocks that can't contain a tag.** `sanitizeMessages` runs on every request (including byte-faithful CC traffic), and `sanitizeContent` applied all ~28 orchestration-tag regexes to every text block unconditionally. Every one of those patterns is anchored on a literal `<`, so a block with none — the common case: prose user turns, command/tool output — cannot match any of them. `sanitizeContent` now guards the loop with a single `indexOf('<')` check and skips straight to the trailing whitespace normalization when there's no `<`. On a realistic message mix this cuts the scrub's CPU ~80% (measured 5.85× on the loop) while producing byte-identical output — the loop is skipped only when it provably cannot change the string, and the whitespace-collapse/trim still runs for every block exactly as before. `test/sanitize-messages.mjs` adds a parity check asserting the guarded path matches the unconditional loop across tag-free and tag-bearing inputs, plus a guard that tag-free code containing a bare `<` comparison is preserved verbatim.
+
 ## [5.5.6] - 2026-08-09
 
 - **Lock-step tightened: per-model prompt variants get a single source of truth, a bake gate, and doctor coverage (dario#lock-step).** Three loosenesses in the mechanism that keeps dario's per-model system prompts (fable / opus-5 / sonnet-5) byte-aligned with CC's:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.6",
+  "version": "5.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "5.5.6",
+      "version": "5.5.7",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.6",
+  "version": "5.5.7",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -632,9 +632,20 @@ const ORCHESTRATION_PATTERNS_DEFAULT = buildOrchestrationPatterns();
 /** Strip orchestration wrapper tags from message content. */
 function sanitizeContent(text: string, patterns: RegExp[]): string {
   let result = text;
-  for (const pattern of patterns) {
-    pattern.lastIndex = 0;
-    result = result.replace(pattern, '');
+  // Fast path: every pattern in buildOrchestrationPatterns is anchored on a
+  // literal `<`, so a body with no `<` cannot match any of them — skip the
+  // ~28 full-string regex passes. sanitizeMessages runs on EVERY request,
+  // including byte-faithful CC traffic, and most message blocks (prose user
+  // turns, command/tool output) carry no tag; on a realistic mix this drops
+  // ~80% of the scrub's CPU while producing byte-identical output (the loop
+  // is skipped only when it provably cannot change the string). The trailing
+  // whitespace normalization still runs so no-tag blocks are treated exactly
+  // as before.
+  if (result.indexOf('<') !== -1) {
+    for (const pattern of patterns) {
+      pattern.lastIndex = 0;
+      result = result.replace(pattern, '');
+    }
   }
   return result.replace(/\n{3,}/g, '\n\n').trim();
 }

--- a/test/sanitize-messages.mjs
+++ b/test/sanitize-messages.mjs
@@ -258,5 +258,53 @@ header('dario#78 — resolvePreserveOrchestrationTags parses CLI + env');
     body.messages.length === 1 && body.messages[0].content[0].text.includes('system-reminder'));
 }
 
+// ─────────────────────────────────────────────────────────────
+header('no-`<` fast path — output identical to the full regex loop');
+{
+  // sanitizeContent skips the ~28 orchestration-tag passes when the text has
+  // no `<` (every pattern is anchored on one). The skip must be a pure
+  // optimization: re-derive the pre-guard behavior (loop always runs) and
+  // assert byte-for-byte parity across tag-free AND tag-bearing inputs.
+  const patterns = buildOrchestrationPatterns();
+  const loopThenNormalize = (text) => {
+    let r = text;
+    for (const p of patterns) { p.lastIndex = 0; r = r.replace(p, ''); }
+    return r.replace(/\n{3,}/g, '\n\n').trim();
+  };
+  const samples = [
+    'plain prose with no angle brackets at all',
+    '  leading and trailing whitespace, three\n\n\nblank lines collapse  ',
+    'code with generics: Array<Item> and a comparison a < b > c',
+    'line1\n\n\n\nline2\n\n\n\nline3',
+    '<system-reminder>drop me</system-reminder>keep',
+    'text before <env>x</env> and after',
+    '', // empty string
+  ];
+  // Drive the real code path through sanitizeMessages (string content) so the
+  // guard inside sanitizeContent is what actually runs.
+  let allMatch = true;
+  const mismatches = [];
+  for (const s of samples) {
+    const body = { messages: [{ role: 'user', content: s }] };
+    sanitizeMessages(body);
+    const viaGuarded = body.messages.length ? body.messages[0].content : '';
+    const expected = loopThenNormalize(s);
+    // sanitizeMessages drops a message whose string content emptied to '';
+    // account for that when the expected result is empty.
+    const got = expected === '' ? '' : viaGuarded;
+    if (got !== expected) { allMatch = false; mismatches.push(`${JSON.stringify(s)} -> ${JSON.stringify(got)} != ${JSON.stringify(expected)}`); }
+  }
+  check('guarded fast path is byte-identical to the unconditional loop', allMatch);
+  if (!allMatch) for (const m of mismatches) console.log(`     ${m}`);
+
+  // A tag-free block with interior '<' from generics must still be preserved
+  // verbatim (the guard runs the loop because a '<' is present, and no pattern
+  // matches a bare comparison).
+  const codeBody = { messages: [{ role: 'user', content: 'const x: Map<string, number> = new Map(); if (a < b) {}' }] };
+  sanitizeMessages(codeBody);
+  check('tag-free code with `<` is preserved verbatim',
+    codeBody.messages[0].content === 'const x: Map<string, number> = new Map(); if (a < b) {}');
+}
+
 console.log(`\n${pass} pass, ${fail} fail`);
 process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## What

`sanitizeContent` (the orchestration-tag scrub in `sanitizeMessages`) applied all ~28 tag regexes to every text block on every request — including byte-faithful CC traffic, since `sanitizeMessages` runs before `buildCCRequest`'s genuine-CC branch. Every one of those patterns is anchored on a literal `<` (`<tag…>…</tag>` and `<tag…/>`), so a block with no `<` — the common case: prose user turns, command/tool output — cannot match any of them.

Guarded the loop with a single `indexOf('<')` check. When there's no `<`, the ~28 regex passes are skipped and the block goes straight to the existing trailing whitespace-collapse/trim.

## Why it's safe

The loop is skipped **only** when it provably cannot change the string. The whitespace normalization (`/\n{3,}/g` → `\n\n`, `.trim()`) still runs for every block, so output is byte-identical for all inputs — tag-free, tag-bearing, and code with a bare `<` comparison alike.

## Measured

Benchmarked the current vs guarded `sanitizeContent` over a realistic 8-block message mix (long prose turn, a question, a large tag-free tool_result, one `<system-reminder>`-bearing block, repeated):

```
parity: IDENTICAL across 8 inputs
current: 544.32µs / 8-block request
guarded:  93.01µs / 8-block request
speedup: 5.85x  (83% less CPU on this mix)
```

This is on the fleet-dominant path — a real CC conversation with a long history runs `sanitizeMessages` over every turn before forwarding.

## Tests

`test/sanitize-messages.mjs` gains:
- a **parity check** that re-derives the pre-guard behavior (loop always runs) and asserts byte-for-byte equality against the guarded path via the real `sanitizeMessages` entry point, across tag-free AND tag-bearing inputs (including empty string, whitespace, and generics like `Array<Item>`);
- a guard that tag-free code containing a bare `<` (`Map<string, number>`, `if (a < b)`) is preserved verbatim.

`38 pass, 0 fail` locally. Full suite: 130/132 files pass; the 2 failures (`template-interactive-tools`, `tool-advertise-respects-client`) reproduce identically on pristine master in a clean worktree and are a pre-existing Windows-only suite-parallelism flake — unrelated to this change, which touches neither.

Version bump to 5.5.7 (release gate). Patch → within-minor, so box autodeploy applies it unattended.
