### PR TITLE
ci(auto-merge): add an hourly sweep and share the version gate

### DIFF
--- a/.github/workflows/auto-merge-bot-prs.yml
+++ b/.github/workflows/auto-merge-bot-prs.yml
@@ -114,11 +114,13 @@ jobs:
           # The rule itself lives in scripts/version-advances.sh so this path
           # and the hourly sweep cannot drift apart, and so both directions of
           # it stay unit-testable (test/version-advances.mjs).
+          # head/tail rather than printf+sed: the script's contract is exactly
+          # two lines, and this keeps backslash escapes out of a shell block
+          # nested inside YAML, where one mangled \n silently becomes a real
+          # newline and breaks the parse.
           verdict=$(sh scripts/version-advances.sh "$base_ver" "$head_ver" "$tip_ver")
-          safe=$(printf '%s
-' "$verdict" | sed -n '1p')
-          reason=$(printf '%s
-' "$verdict" | sed -n '2p')
+          safe=$(echo "$verdict" | head -1)
+          reason=$(echo "$verdict" | tail -1)
 
           echo "safe=$safe" >> "$GITHUB_OUTPUT"
           if [ "$safe" = "true" ]; then

--- a/.github/workflows/auto-merge-bot-prs.yml
+++ b/.github/workflows/auto-merge-bot-prs.yml
@@ -75,6 +75,18 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Checks out the BASE branch only (actions/checkout's default ref on
+      # pull_request_target), never the PR head. This workflow runs with write
+      # scopes and repository secrets, so checking out and executing head code
+      # would be the classic fork-PR RCE. Sparse: the one script is the whole
+      # need, matching cc-oauth-health.yml.
+      - name: Fetch the version-gate script
+        uses: askalf/checkout-with-retry@744195501c3e2b794c50370b753a7b8c93d084f5  # v1.0.0
+        with:
+          sparse-checkout: scripts/version-advances.sh
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
       - name: Check the version advances past the base tip
         id: version_gate
         env:
@@ -86,11 +98,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          # No checkout on this runner, so read package.json at each ref
-          # through the contents API rather than from a working tree.
+          # Read package.json through the contents API rather than from the
+          # checkout: the sparse checkout deliberately holds only the script,
+          # and the three versions live at three different refs anyway.
           version_at() {
-            gh api "repos/${REPO}/contents/package.json?ref=$1" --jq '.content' 2>/dev/null \
-              | base64 -d 2>/dev/null | jq -r '.version // empty'
+            gh api "repos/${REPO}/contents/package.json?ref=$1" --jq '.content' 2>/dev/null               | base64 -d 2>/dev/null | jq -r '.version // empty'
           }
 
           base_ver=$(version_at "$BASE_SHA")     # what this PR branched from
@@ -99,34 +111,20 @@ jobs:
 
           echo "base(${BASE_SHA:0:8})=${base_ver:-?}  head(${HEAD_SHA:0:8})=${head_ver:-?}  tip(${BASE_REF})=${tip_ver:-?}"
 
-          if [ -z "$head_ver" ] || [ -z "$tip_ver" ] || [ -z "$base_ver" ]; then
-            # Fail CLOSED. Skipping one arming run is cheap — the next
-            # synchronize re-runs this — whereas guessing risks the exact
-            # silent-release failure the gate exists to prevent.
-            echo "safe=false" >> "$GITHUB_OUTPUT"
-            echo "Could not read package.json at every ref; not arming auto-merge."
-            exit 0
-          fi
+          # The rule itself lives in scripts/version-advances.sh so this path
+          # and the hourly sweep cannot drift apart, and so both directions of
+          # it stay unit-testable (test/version-advances.mjs).
+          verdict=$(sh scripts/version-advances.sh "$base_ver" "$head_ver" "$tip_ver")
+          safe=$(printf '%s
+' "$verdict" | sed -n '1p')
+          reason=$(printf '%s
+' "$verdict" | sed -n '2p')
 
-          if [ "$head_ver" = "$base_ver" ]; then
-            # The PR does not touch the version (typical Dependabot action
-            # bump). No ordering hazard exists, so the gate must not block it.
-            echo "safe=true" >> "$GITHUB_OUTPUT"
-            echo "PR does not change the version — no ordering hazard."
-            exit 0
-          fi
-
-          # The PR bumps the version, so it must land ABOVE the current tip.
-          # sort -V orders semver correctly; require strictly greater, since
-          # equal means another PR already published this version and the
-          # duplicate-tag guard would turn this merge into a no-op release.
-          highest=$(printf '%s\n%s\n' "$tip_ver" "$head_ver" | sort -V | tail -1)
-          if [ "$head_ver" != "$tip_ver" ] && [ "$highest" = "$head_ver" ]; then
-            echo "safe=true" >> "$GITHUB_OUTPUT"
-            echo "Version advances ${tip_ver} -> ${head_ver}."
+          echo "safe=$safe" >> "$GITHUB_OUTPUT"
+          if [ "$safe" = "true" ]; then
+            echo "Arming: $reason."
           else
-            echo "safe=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::Not arming auto-merge: this PR proposes ${head_ver} but ${BASE_REF} is already at ${tip_ver}. Another PR claimed that version first. Update this branch and re-bump above ${tip_ver}; auto-merge re-arms on the next push."
+            echo "::warning::Not arming auto-merge — $reason. Update this branch and re-bump above ${tip_ver:-the tip}; auto-merge re-arms on the next push."
           fi
 
       - name: Enable auto-merge

--- a/.github/workflows/auto-merge-sweep.yml
+++ b/.github/workflows/auto-merge-sweep.yml
@@ -1,0 +1,143 @@
+name: Auto-merge sweep (webhook-loss fallback)
+
+# Reconciler for auto-merge-bot-prs.yml, which triggers on
+# `pull_request_target` ONLY and therefore depends entirely on webhook
+# delivery.
+#
+# WHY THIS EXISTS. In the 2026-08-06 Actions incident GitHub's webhook
+# throughput fell to roughly 15%, and GitHub confirmed the missed trigger
+# events could not be replayed automatically — recovery meant manually
+# re-running, pushing a commit, or updating the PR. A drift-bot PR whose
+# `opened` event is dropped never gets armed and simply sits open, green and
+# ignored, until somebody notices. Nothing else catches that: the self-healing
+# supervisor retries runs that FAILED, and a run that never started is absent
+# rather than failed.
+#
+# This is the same shape cc-drift-auto-release.yml already uses — an hourly
+# tick beside the event trigger, with an idempotent gate — applied to the one
+# workflow in the release path that lacked it. `gh pr merge --auto` on a PR
+# that is already armed is a no-op, so a healthy hour costs one API listing.
+#
+# SCOPE: drift-bot branches only (`bot/cc-drift-`, `bot/template-label-`).
+# Dependabot is deliberately excluded. Its major-version exclusion comes from
+# dependabot/fetch-metadata, which needs the PR event payload and cannot run
+# on a schedule; title-parsing is not an acceptable substitute (a grouped
+# "non-major" title contains the literal substring "major", which is exactly
+# the false-positive that gating already had to be moved off). Dependabot also
+# rebases and recreates its PRs, which re-fires `synchronize` and self-heals
+# the dropped-webhook case. Drift-bot PRs are one-shot, so they are the ones
+# that stay stuck.
+
+on:
+  schedule:
+    # 27 past the hour: clear of cc-drift-watch (:00), cc-drift-auto-release
+    # (:15), cc-drift-template-watch (:41), and the repo's daily crons.
+    - cron: '27 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: auto-merge-sweep
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Schedule runs against the default branch, so there is no PR head in
+      # play here at all — but pin persist-credentials off for the same reason
+      # the sibling workflow does.
+      - name: Fetch the version-gate script
+        uses: askalf/checkout-with-retry@744195501c3e2b794c50370b753a7b8c93d084f5  # v1.0.0
+        with:
+          sparse-checkout: scripts/version-advances.sh
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Arm auto-merge on any unarmed drift-bot PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          version_at() {
+            gh api "repos/${REPO}/contents/package.json?ref=$1" --jq '.content' 2>/dev/null \
+              | base64 -d 2>/dev/null | jq -r '.version // empty'
+          }
+
+          # Open, non-draft, same-repo, drift-bot-branch PRs that do not
+          # already have auto-merge enabled. autoMergeRequest is null when
+          # unarmed, so the whole filter is one listing.
+          candidates=$(gh pr list --repo "$REPO" --state open --limit 50 \
+            --json number,isDraft,headRefName,headRepositoryOwner,baseRefName,autoMergeRequest \
+            --jq '[.[]
+                   | select(.isDraft == false)
+                   | select(.autoMergeRequest == null)
+                   | select(.headRepositoryOwner.login == "'"${REPO%%/*}"'")
+                   | select(.headRefName | startswith("bot/cc-drift-") or startswith("bot/template-label-"))]')
+
+          count=$(printf '%s' "$candidates" | jq 'length')
+          echo "Unarmed drift-bot PRs: $count"
+          if [ "$count" -eq 0 ]; then
+            echo "Nothing to do."
+            exit 0
+          fi
+
+          armed=0
+          skipped=0
+          for i in $(seq 0 $((count - 1))); do
+            pr=$(printf '%s' "$candidates" | jq -r ".[$i].number")
+            base_ref=$(printf '%s' "$candidates" | jq -r ".[$i].baseRefName")
+
+            # baseRefOid is the base commit the PR is measured against, and
+            # headRefOid its current head — the same two refs the event path
+            # reads from the webhook payload.
+            shas=$(gh pr view "$pr" --repo "$REPO" --json baseRefOid,headRefOid \
+              --jq '.baseRefOid + " " + .headRefOid')
+            base_sha=${shas%% *}
+            head_sha=${shas##* }
+
+            base_ver=$(version_at "$base_sha")
+            head_ver=$(version_at "$head_sha")
+            tip_ver=$(version_at "$base_ref")
+
+            verdict=$(sh scripts/version-advances.sh "$base_ver" "$head_ver" "$tip_ver")
+            safe=$(printf '%s\n' "$verdict" | sed -n '1p')
+            reason=$(printf '%s\n' "$verdict" | sed -n '2p')
+
+            if [ "$safe" != "true" ]; then
+              echo "  #$pr SKIP — $reason"
+              skipped=$((skipped + 1))
+              continue
+            fi
+
+            # Squash: master requires linear history. Idempotent by
+            # construction (we filtered to unarmed PRs) and harmless if the
+            # event path armed it in between.
+            if gh pr merge "$pr" --repo "$REPO" --squash --auto --delete-branch >/dev/null 2>&1; then
+              echo "  #$pr ARMED — $reason (webhook for this PR was likely missed)"
+              armed=$((armed + 1))
+            else
+              # Most often: already merged, or required checks still pending
+              # in a way that rejects arming. Not fatal — next tick retries.
+              echo "  #$pr could not arm (already merged, or not yet armable) — will retry next tick"
+              skipped=$((skipped + 1))
+            fi
+          done
+
+          echo "armed=$armed skipped=$skipped"
+
+          # An armed PR here means the event-driven path missed one. That is
+          # worth seeing in the run list rather than only in this log, but it
+          # is recovery working as designed, not a failure — so a notice, not
+          # a warning, and never a failed run.
+          if [ "$armed" -gt 0 ]; then
+            echo "::notice::Sweep armed $armed drift-bot PR(s) the pull_request_target trigger did not. Expected after a webhook-delivery incident."
+          fi

--- a/.github/workflows/auto-merge-sweep.yml
+++ b/.github/workflows/auto-merge-sweep.yml
@@ -108,9 +108,12 @@ jobs:
             head_ver=$(version_at "$head_sha")
             tip_ver=$(version_at "$base_ref")
 
+            # head/tail rather than printf+sed — see the sibling workflow: the
+            # contract is exactly two lines, and this keeps backslash escapes
+            # out of a shell block nested inside YAML.
             verdict=$(sh scripts/version-advances.sh "$base_ver" "$head_ver" "$tip_ver")
-            safe=$(printf '%s\n' "$verdict" | sed -n '1p')
-            reason=$(printf '%s\n' "$verdict" | sed -n '2p')
+            safe=$(echo "$verdict" | head -1)
+            reason=$(echo "$verdict" | tail -1)
 
             if [ "$safe" != "true" ]; then
               echo "  #$pr SKIP — $reason"

--- a/scripts/version-advances.sh
+++ b/scripts/version-advances.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# Decide whether a PR's package.json version may be auto-merged.
+#
+# Extracted from auto-merge-bot-prs.yml so it can be TESTED, and so the
+# event-driven path and the hourly sweep cannot drift apart. Two copies of
+# this rule would be worse than none: the sweep would quietly become a way
+# around the gate the moment either copy was edited alone.
+#
+# THE RULE. Two bot PRs can independently bump package.json to the SAME
+# version, because each is drafted off the current release without seeing the
+# other (#954 and #955 both took 5.5.10 off 5.5.9, with different dates).
+# Whichever merges SECOND is the casualty:
+#
+#   - equal to the released version -> cc-drift-auto-release's duplicate-tag
+#     guard fast-exits green and ships NOTHING, a release that silently did
+#     not happen on a chore PR nobody re-reads after merge;
+#   - lower -> the base branch version moves BACKWARDS below a published tag.
+#
+# So a PR that CHANGES the version must carry one strictly greater than the
+# base branch tip. A PR that leaves the version alone (the common Dependabot
+# action bump) is unaffected — which is why base is compared as well as tip.
+#
+# Usage:  version-advances.sh <base_ver> <head_ver> <tip_ver>
+#
+# Writes exactly TWO lines to stdout:
+#   1  safe    "true" | "false"
+#   2  reason  short human-readable explanation
+#
+# Exit status is 0 for a decision of either kind; a non-zero exit means the
+# script could not decide (bad arguments), which callers must treat as unsafe.
+#
+# Fixed-position lines rather than KEY=VALUE + eval, matching
+# health-verdict.sh: these values come from repository content, and evaluating
+# anything derived from that is not worth the convenience.
+
+base_ver="$1"
+head_ver="$2"
+tip_ver="$3"
+
+# Fail CLOSED on missing input. A caller that could not read one of the three
+# package.json files must not fall through to "arm" — skipping one arming run
+# is cheap because the next push (or the next sweep) re-runs this, whereas
+# guessing risks exactly the silent no-op release the rule exists to prevent.
+if [ -z "$base_ver" ] || [ -z "$head_ver" ] || [ -z "$tip_ver" ]; then
+  printf 'false\n'
+  printf 'could not read package.json at every ref\n'
+  exit 0
+fi
+
+if [ "$head_ver" = "$base_ver" ]; then
+  printf 'true\n'
+  printf 'PR does not change the version - no ordering hazard\n'
+  exit 0
+fi
+
+# The PR bumps the version, so it must land ABOVE the current tip.
+#
+# sort -V, not a string compare: 5.5.99 must not outrank 5.6.0. Require
+# strictly greater — equal means another PR already published this version,
+# and the duplicate-tag guard would turn this merge into a no-op release.
+highest="$(printf '%s\n%s\n' "$tip_ver" "$head_ver" | sort -V | tail -1)"
+
+if [ "$head_ver" != "$tip_ver" ] && [ "$highest" = "$head_ver" ]; then
+  printf 'true\n'
+  printf 'version advances %s -> %s\n' "$tip_ver" "$head_ver"
+else
+  printf 'false\n'
+  printf 'proposes %s but base is already at %s\n' "$head_ver" "$tip_ver"
+fi

--- a/test/version-advances.mjs
+++ b/test/version-advances.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// Tests for scripts/version-advances.sh — the rule deciding whether a bot PR
+// may be armed for auto-merge.
+//
+// Worth testing rather than living in a YAML `run:` block for the same reason
+// health-verdict.sh was extracted: both failure directions are quiet. Too
+// permissive and it silently re-admits the #954/#955 collision, whose visible
+// symptom is a release that fast-exits GREEN having shipped nothing. Too
+// strict and every routine drift PR stops arming, which looks like the bots
+// went idle rather than like a gate misfiring. Neither shows up as a red run.
+//
+// The gate's permissive direction was confirmed live on #960 (5.5.11 ->
+// 5.5.12, armed). The blocking direction needs two bot PRs colliding on a
+// version, which the gate now prevents from happening — so it is only ever
+// exercised here.
+
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), '..', 'scripts', 'version-advances.sh');
+
+let pass = 0, fail = 0;
+const check = (name, cond, detail) => {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else { console.log(`  FAIL ${name}${detail ? ' :: ' + detail : ''}`); fail++; }
+};
+const header = (n) => console.log(`\n=== ${n} ===`);
+
+/** Run the gate over three versions, return { safe, reason }. */
+function gate(base, head, tip) {
+  const r = spawnSync('sh', [SCRIPT, base, head, tip], { encoding: 'utf8' });
+  if (r.error) {
+    console.log(`  SKIP — no POSIX sh available: ${r.error.message}`);
+    process.exit(0);
+  }
+  const [safe, reason] = (r.stdout ?? '').split('\n');
+  return { safe, reason, status: r.status };
+}
+
+header('version unchanged by the PR');
+{
+  // The common Dependabot action bump: package.json is untouched, so the
+  // ordering hazard does not exist and the gate must not block it.
+  const g = gate('5.5.11', '5.5.11', '5.5.11');
+  check('arms when head == base', g.safe === 'true', g.reason);
+  check('says why', /does not change the version/.test(g.reason), g.reason);
+
+  // Untouched version while the tip has moved on is still safe: the PR is
+  // behind, but merging it cannot move the version anywhere.
+  const behind = gate('5.5.9', '5.5.9', '5.5.12');
+  check('arms when head == base even if tip advanced', behind.safe === 'true', behind.reason);
+}
+
+header('version bumped by the PR');
+{
+  const ok = gate('5.5.11', '5.5.12', '5.5.11');
+  check('arms when it advances past the tip', ok.safe === 'true', ok.reason);
+  check('names both versions', /5\.5\.11 -> 5\.5\.12/.test(ok.reason), ok.reason);
+
+  // The #954/#955 shape: another PR already claimed this version. Merging
+  // would hit the duplicate-tag guard and ship nothing.
+  const dup = gate('5.5.9', '5.5.10', '5.5.10');
+  check('blocks when equal to the tip', dup.safe === 'false', dup.reason);
+  check('explains the collision', /already at 5\.5\.10/.test(dup.reason), dup.reason);
+
+  // Would move the base branch below an already-published tag.
+  const back = gate('5.5.9', '5.5.10', '5.5.11');
+  check('blocks when below the tip', back.safe === 'false', back.reason);
+}
+
+header('semver ordering, not string ordering');
+{
+  // The case a lexical compare gets backwards: "5.5.99" > "5.6.0" as strings.
+  const lex = gate('5.5.98', '5.5.99', '5.6.0');
+  check('blocks 5.5.99 against a 5.6.0 tip', lex.safe === 'false', lex.reason);
+
+  const minor = gate('5.5.12', '5.6.0', '5.5.12');
+  check('arms a minor bump past a patch tip', minor.safe === 'true', minor.reason);
+
+  // Double-digit patch vs single-digit: 5.5.9 -> 5.5.10 is an advance.
+  const twoDigit = gate('5.5.8', '5.5.10', '5.5.9');
+  check('arms 5.5.10 against a 5.5.9 tip', twoDigit.safe === 'true', twoDigit.reason);
+}
+
+header('fails closed on unreadable input');
+{
+  for (const [label, args] of [
+    ['missing tip', ['5.5.11', '5.5.12', '']],
+    ['missing head', ['5.5.11', '', '5.5.11']],
+    ['missing base', ['', '5.5.12', '5.5.11']],
+    ['all missing', ['', '', '']],
+  ]) {
+    const g = gate(...args);
+    check(`blocks on ${label}`, g.safe === 'false', g.reason);
+  }
+  const g = gate('', '', '');
+  check('exits 0 so the caller reads the verdict', g.status === 0, `status=${g.status}`);
+}
+
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## The gap

`auto-merge-bot-prs.yml` triggers on `pull_request_target` **only**, so it depends entirely on webhook delivery.

In the [2026-08-06 Actions incident](https://www.githubstatus.com/) GitHub's webhook throughput fell to roughly **15%**, and GitHub confirmed the missed trigger events **could not be replayed automatically** — recovery meant manually re-running, pushing a commit, or updating the PR. A drift-bot PR whose `opened` event is dropped never gets armed. It just sits open, green and ignored, until a human notices.

Nothing currently catches that. `self-healing-supervisor` retries runs that **failed**; a run that never started is *absent*, not failed.

This is the same silent-no-ship class as the version collision fixed in #958, arriving by a different route.

## The fix

`auto-merge-sweep.yml`, hourly at `27 * * * *` (clear of `cc-drift-watch` `:00`, `cc-drift-auto-release` `:15`, `cc-drift-template-watch` `:41`).

It's the shape `cc-drift-auto-release.yml` already uses — an hourly tick beside the event trigger, with an idempotent gate — applied to the one workflow in the release path that lacked one. It lists open, non-draft, same-repo, **unarmed** drift-bot PRs and arms them. A healthy hour costs a single API listing; `autoMergeRequest == null` does the filtering server-side.

Every candidate goes through the **same version gate** as the event path, so the sweep can't become a way around it.

## Scope: drift-bot branches only

Dependabot is deliberately excluded, for two reasons:

1. Its major-version exclusion comes from `dependabot/fetch-metadata`, which needs the PR event payload and **cannot run on a schedule**. Title-parsing is not an acceptable substitute — a grouped `non-major` title contains the literal substring `major`, which is the exact false positive this workflow's gating was already moved off.
2. Dependabot rebases and recreates its PRs, which re-fires `synchronize` and self-heals the dropped-webhook case anyway. Drift-bot PRs are one-shot, so they're the ones that stay stuck.

## The version rule moved to a shared script

`scripts/version-advances.sh` now holds the rule; both the event path and the sweep call it.

Two copies would have been worse than none — the sweep would silently become a bypass the moment either copy was edited alone.

Extracting it also makes the rule **testable**, which follows the precedent of `scripts/health-verdict.sh` (pulled out of `cc-oauth-health.yml` for exactly this reason). `test/version-advances.mjs` adds 16 assertions, picked up automatically by `test/all.test.mjs`:

| case | expected |
|---|---|
| head == base (Dependabot action bump) | arm |
| head == base while tip advanced | arm |
| head > tip | arm |
| head == tip (the #954/#955 collision) | block |
| head < tip | block |
| `5.5.99` vs a `5.6.0` tip | **block** — `sort -V`, not string compare |
| `5.5.10` vs a `5.5.9` tip | arm |
| any version unreadable | block (fails closed) |

That matters because the gate's blocking direction is one the gate itself now prevents from occurring in the wild. The permissive direction was confirmed live on #960 (`5.5.11 → 5.5.12`, armed); the blocking direction is only ever exercised here.

## Security note

Both workflows `sparse-checkout` only that one script, from the **base branch, never the PR head**. `pull_request_target` runs with write scopes and repository secrets, so checking out and executing head code would be the classic fork-PR RCE. `persist-credentials: false` on both.

## Scope

Workflow + script + test. No version bump — none of these paths are in the package `files` list, so this ships nothing.
