### PR TITLE
ci: resolve release conflicts deterministically instead of by hand

### DIFF
--- a/scripts/resolve-release-conflicts.mjs
+++ b/scripts/resolve-release-conflicts.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+// Resolve the ONE conflict shape our release automation produces.
+//
+// Two bot PRs drafted off the same release both add a section under
+// `## [Unreleased]` and both bump `package.json`, so merging master into
+// either one conflicts in exactly two files, in exactly two ways. Every such
+// conflict resolves the same way, and getting it wrong has a specific cost:
+// a version below an already-published tag makes cc-drift-auto-release's
+// duplicate-tag guard fast-exit green having shipped nothing.
+//
+// That is a rule, not a judgement, so it lives here rather than in a prompt.
+//
+//   package.json  keep the HIGHER version. Never downward.
+//   CHANGELOG.md  keep BOTH sides. Version sections descending, newest first;
+//                 loose text (bullets under `## [Unreleased]`) stays on top.
+//
+// REFUSES anything outside that shape — a conflict in another file, a
+// package.json conflict touching more than the version line, a version that
+// is not X.Y.Z. Refusing costs a hand-resolution; guessing costs a silent
+// no-op release.
+//
+// Usage:
+//   node scripts/resolve-release-conflicts.mjs [file...]   # default: both
+// Exit 0 = every conflict resolved (or none present), files rewritten.
+// Exit 1 = refused; the working tree is left exactly as it was found.
+
+import { readFileSync, writeFileSync, existsSync, realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const START = /^<{7} .*$/;
+const MID = /^={7}$/;
+const END = /^>{7} .*$/;
+
+// CRLF is not cosmetic here. A git checkout on Windows leaves markers as
+// "<<<<<<< HEAD\r", and in JavaScript `.` will not consume a carriage return
+// while `$` (no `m` flag) will not match before one — so every regex above
+// silently fails and the file reads as conflict-free. That is the worst
+// possible failure mode for this script: reporting success while leaving
+// markers in package.json. Normalize on the way in and restore on the way
+// out, so the file keeps whatever convention it already had.
+const detectEol = (text) => (text.includes('\r\n') ? '\r\n' : '\n');
+const toLf = (text) => text.replace(/\r\n/g, '\n');
+const restoreEol = (text, eol) => (eol === '\r\n' ? text.replace(/\n/g, '\r\n') : text);
+
+/** Parse "1.2.3" into comparable parts. Returns null when not X.Y.Z. */
+export function parseVersion(v) {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec((v ?? '').trim());
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+
+/** Semver compare. Numeric per component, so 5.5.99 < 5.6.0. */
+export function compareVersions(a, b) {
+  const pa = parseVersion(a), pb = parseVersion(b);
+  if (!pa || !pb) throw new Error(`not a X.Y.Z version: ${!pa ? a : b}`);
+  for (let i = 0; i < 3; i++) if (pa[i] !== pb[i]) return pa[i] - pb[i];
+  return 0;
+}
+
+/**
+ * Split text into conflict regions and the plain text between them.
+ * Returns [{ before, ours, theirs }..., { before }] — the last entry is the
+ * tail after the final conflict.
+ */
+function splitConflicts(text) {
+  const lines = text.split('\n');
+  const out = [];
+  let before = [], ours = null, theirs = null, mode = 'before';
+
+  for (const line of lines) {
+    if (mode === 'before' && START.test(line)) { ours = []; mode = 'ours'; continue; }
+    if (mode === 'ours' && MID.test(line)) { theirs = []; mode = 'theirs'; continue; }
+    if (mode === 'theirs' && END.test(line)) {
+      out.push({ before: before.join('\n'), ours: ours.join('\n'), theirs: theirs.join('\n') });
+      before = []; ours = null; theirs = null; mode = 'before';
+      continue;
+    }
+    if (mode === 'before') before.push(line);
+    else if (mode === 'ours') ours.push(line);
+    else theirs.push(line);
+  }
+  if (mode !== 'before') throw new Error('unterminated conflict marker');
+  out.push({ before: before.join('\n') });
+  return out;
+}
+
+export function hasConflicts(text) {
+  return toLf(text).split('\n').some((l) => START.test(l));
+}
+
+// ── package.json ───────────────────────────────────────────────────────────
+
+/** The only package.json conflict we accept: the version line, both sides. */
+function versionFromSide(side) {
+  const lines = side.split('\n').filter((l) => l.trim() !== '');
+  if (lines.length !== 1) return null;
+  const m = /^\s*"version"\s*:\s*"([^"]+)"\s*,?\s*$/.exec(lines[0]);
+  return m ? { version: m[1], line: lines[0] } : null;
+}
+
+export function resolvePackageJson(text) {
+  if (!hasConflicts(text)) return text;
+  const eol = detectEol(text);
+  const parts = splitConflicts(toLf(text));
+  let out = '';
+  for (const p of parts) {
+    out += p.before;
+    if (p.ours === undefined) continue;
+    const a = versionFromSide(p.ours);
+    const b = versionFromSide(p.theirs);
+    if (!a || !b) {
+      throw new Error('package.json conflict is not a lone "version" line on both sides');
+    }
+    // Keep the higher version, and keep the LINE from that side so its
+    // indentation and trailing comma survive untouched.
+    const winner = compareVersions(a.version, b.version) >= 0 ? a : b;
+    out += '\n' + winner.line + '\n';
+  }
+  return restoreEol(out, eol);
+}
+
+// ── CHANGELOG.md ───────────────────────────────────────────────────────────
+
+const SECTION = /^## \[([^\]]+)\]/;
+
+/**
+ * Split a chunk into { loose, sections } where `loose` is text before the
+ * first `## [` heading (bullets that belong under `## [Unreleased]`, which
+ * sits above the conflict region) and `sections` is one entry per version.
+ */
+function splitSections(chunk) {
+  const lines = chunk.split('\n');
+  const loose = [];
+  const sections = [];
+  let cur = null;
+  for (const line of lines) {
+    const m = SECTION.exec(line);
+    if (m) {
+      cur = { key: m[1], lines: [line] };
+      sections.push(cur);
+    } else if (cur) {
+      cur.lines.push(line);
+    } else {
+      loose.push(line);
+    }
+  }
+  return { loose: loose.join('\n'), sections };
+}
+
+const trimBlank = (s) => s.replace(/^\n+/, '').replace(/\n+$/, '');
+
+export function resolveChangelog(text) {
+  if (!hasConflicts(text)) return text;
+  const eol = detectEol(text);
+  const parts = splitConflicts(toLf(text));
+  let out = '';
+
+  for (let i = 0; i < parts.length; i++) {
+    const p = parts[i];
+    out += p.before;
+    if (p.ours === undefined) continue;
+
+    const A = splitSections(p.ours);
+    const B = splitSections(p.theirs);
+
+    // Git does not always put every unreleased bullet INSIDE the region. When
+    // only one side gained a bullet, the other's can land after the `>>>>>>>`
+    // line, before the next `## [` heading. Emitting the merged version
+    // sections first would then bury it inside the newest released section —
+    // observed live, an `## [Unreleased]` entry ending up under `## [5.5.13]`.
+    // Loose text directly after the region belongs to whichever section was
+    // open before it, which for these conflicts is Unreleased.
+    let hoisted = '';
+    const next = parts[i + 1];
+    if (next) {
+      const tail = splitSections(next.before);
+      if (trimBlank(tail.loose)) {
+        hoisted = trimBlank(tail.loose);
+        next.before = next.before.slice(tail.loose.length);
+      }
+    }
+
+    // Loose text from both sides, in order, de-duplicated. This is where an
+    // `## [Unreleased]` bullet lives, and dropping one loses a real entry.
+    const looseParts = [A.loose, B.loose, hoisted].map(trimBlank).filter(Boolean);
+    const loose = [...new Set(looseParts)].join('\n\n');
+
+    // Union the version sections. Identical versions on both sides collapse;
+    // when they differ in content, ours wins (it is the PR's own text).
+    const byVersion = new Map();
+    for (const s of [...B.sections, ...A.sections]) {
+      byVersion.set(s.key, trimBlank(s.lines.join('\n')));
+    }
+
+    const ordered = [...byVersion.entries()].sort((x, y) => {
+      const vx = parseVersion(x[0]), vy = parseVersion(y[0]);
+      if (vx && vy) return -compareVersions(x[0], y[0]);   // newest first
+      if (vx) return 1;                                     // non-versions
+      if (vy) return -1;                                    // (Unreleased) on top
+      return 0;
+    });
+
+    const blocks = [];
+    if (loose) blocks.push(loose);
+    for (const [, body] of ordered) blocks.push(body);
+    out += '\n' + blocks.join('\n\n') + '\n';
+  }
+  return restoreEol(out, eol);
+}
+
+// ── CLI ────────────────────────────────────────────────────────────────────
+
+const HANDLERS = {
+  'package.json': resolvePackageJson,
+  'CHANGELOG.md': resolveChangelog,
+};
+
+function main(argv) {
+  const targets = argv.length ? argv : Object.keys(HANDLERS);
+  const writes = [];
+
+  for (const file of targets) {
+    const handler = HANDLERS[file];
+    if (!handler) {
+      console.error(`refusing: no resolver for ${file} — resolve by hand`);
+      return 1;
+    }
+    if (!existsSync(file)) continue;
+    const before = readFileSync(file, 'utf8');
+    if (!hasConflicts(before)) { console.log(`${file}: no conflict`); continue; }
+    let after;
+    try {
+      after = handler(before);
+    } catch (e) {
+      console.error(`refusing: ${file} — ${e.message}`);
+      return 1;
+    }
+    if (hasConflicts(after)) {
+      console.error(`refusing: ${file} — markers survived resolution`);
+      return 1;
+    }
+    writes.push([file, after]);
+    console.log(`${file}: resolved`);
+  }
+
+  // Write only after EVERY file resolved cleanly, so a refusal leaves the
+  // tree exactly as it was found rather than half-applied.
+  for (const [file, content] of writes) writeFileSync(file, content);
+  return 0;
+}
+
+// Exact path identity, not a basename match: test/resolve-release-conflicts.mjs
+// shares this file's basename, and a suffix check made `import` run the CLI.
+function isMainModule() {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
+
+if (isMainModule()) process.exit(main(process.argv.slice(2)));

--- a/test/resolve-release-conflicts.mjs
+++ b/test/resolve-release-conflicts.mjs
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+// Tests for scripts/resolve-release-conflicts.mjs.
+//
+// The fixtures are REAL conflicts from 2026-08-12, when four PRs (#952, #955,
+// #960, #961) all had to be hand-resolved in a worktree within a few hours.
+// Every one came out the same two ways, which is why the rule is code now.
+//
+// Both failure directions are silent, so both are asserted:
+//   - resolving the version DOWNWARD publishes below an existing tag, and
+//     cc-drift-auto-release's duplicate-tag guard then fast-exits GREEN having
+//     shipped nothing;
+//   - dropping a CHANGELOG side loses an entry for a release that shipped, and
+//     nothing downstream notices.
+
+import {
+  resolvePackageJson, resolveChangelog, compareVersions, parseVersion, hasConflicts,
+} from '../scripts/resolve-release-conflicts.mjs';
+
+let pass = 0, fail = 0;
+const check = (name, cond, detail) => {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else { console.log(`  FAIL ${name}${detail ? ' :: ' + detail : ''}`); fail++; }
+};
+const header = (n) => console.log(`\n=== ${n} ===`);
+
+header('semver comparison');
+{
+  check('5.5.99 < 5.6.0 (not a string compare)', compareVersions('5.5.99', '5.6.0') < 0);
+  check('5.5.10 > 5.5.9', compareVersions('5.5.10', '5.5.9') > 0);
+  check('equal is 0', compareVersions('5.5.11', '5.5.11') === 0);
+  check('rejects non-X.Y.Z', parseVersion('5.5') === null);
+  let threw = false;
+  try { compareVersions('1.2.3', 'v1.2.4'); } catch { threw = true; }
+  check('compare throws on a bad version', threw);
+}
+
+header('package.json — the #955 conflict');
+{
+  // Verbatim shape from PR #955 after merging master (which carried #954).
+  const conflicted = `{
+  "name": "@askalf/dario",
+<<<<<<< HEAD
+  "version": "5.5.11",
+=======
+  "version": "5.5.10",
+>>>>>>> origin/master
+  "description": "…",
+  "type": "module"
+}
+`;
+  const out = resolvePackageJson(conflicted);
+  check('no markers survive', !hasConflicts(out));
+  check('keeps the HIGHER version', /"version": "5\.5\.11"/.test(out), out);
+  check('does not keep the lower one', !/"version": "5\.5\.10"/.test(out));
+  check('preserves surrounding lines', /"name": "@askalf\/dario"/.test(out) && /"type": "module"/.test(out));
+  check('valid JSON after resolution', (() => { try { JSON.parse(out); return true; } catch { return false; } })(), out);
+
+  // Same conflict with the sides swapped — the higher version must still win,
+  // so the outcome cannot depend on which branch happened to be "ours".
+  const swapped = conflicted
+    .replace('"version": "5.5.11",\n=======\n  "version": "5.5.10",', '"version": "5.5.10",\n=======\n  "version": "5.5.11",');
+  const out2 = resolvePackageJson(swapped);
+  check('order-independent: higher wins from either side', /"version": "5\.5\.11"/.test(out2), out2);
+}
+
+header('package.json — refuses anything else');
+{
+  const notJustVersion = `{
+<<<<<<< HEAD
+  "version": "5.5.11",
+  "main": "dist/a.js",
+=======
+  "version": "5.5.10",
+  "main": "dist/b.js",
+>>>>>>> origin/master
+}
+`;
+  let threw = false;
+  try { resolvePackageJson(notJustVersion); } catch { threw = true; }
+  check('refuses when more than the version conflicts', threw);
+}
+
+header('CHANGELOG — the #952 conflict (unreleased bullet vs new section)');
+{
+  const conflicted = `## [Unreleased]
+
+<<<<<<< HEAD
+- **check-overage-live.mjs no longer reports a false CLEAN.** Detail here.
+
+=======
+## [5.5.10] - 2026-08-11
+
+- **CC drift patch** — maxTested bumped.
+>>>>>>> origin/master
+## [5.5.9] - 2026-08-11
+
+- **Template rebake** — re-captured.
+`;
+  const out = resolveChangelog(conflicted);
+  check('no markers survive', !hasConflicts(out));
+  check('keeps the unreleased bullet', /false CLEAN/.test(out), out);
+  check('keeps the new version section', /## \[5\.5\.10\]/.test(out), out);
+  check('keeps the pre-existing section', /## \[5\.5\.9\]/.test(out));
+  check('unreleased bullet stays ABOVE the version sections',
+    out.indexOf('false CLEAN') < out.indexOf('## [5.5.10]'), out);
+}
+
+header('CHANGELOG — the #955 conflict (two version sections)');
+{
+  const conflicted = `## [Unreleased]
+
+<<<<<<< HEAD
+## [5.5.11] - 2026-08-12
+
+- **Template label refresh** — 2.1.228.
+=======
+## [5.5.10] - 2026-08-11
+
+- **CC drift patch** — maxTested.
+>>>>>>> origin/master
+## [5.5.9] - 2026-08-11
+
+- **Template rebake** — earlier.
+`;
+  const out = resolveChangelog(conflicted);
+  check('no markers survive', !hasConflicts(out));
+  check('keeps BOTH sections', /## \[5\.5\.11\]/.test(out) && /## \[5\.5\.10\]/.test(out), out);
+  check('newest first', out.indexOf('## [5.5.11]') < out.indexOf('## [5.5.10]'), out);
+  check('older section still below', out.indexOf('## [5.5.10]') < out.indexOf('## [5.5.9]'), out);
+  check('no duplicated heading', (out.match(/## \[5\.5\.10\]/g) || []).length === 1);
+}
+
+header('CHANGELOG — identical section on both sides collapses');
+{
+  const conflicted = `## [Unreleased]
+
+<<<<<<< HEAD
+## [5.5.12] - 2026-08-12
+
+- **CC drift patch** — same text.
+=======
+## [5.5.12] - 2026-08-12
+
+- **CC drift patch** — same text.
+>>>>>>> origin/master
+## [5.5.11] - 2026-08-12
+`;
+  const out = resolveChangelog(conflicted);
+  check('appears exactly once', (out.match(/## \[5\.5\.12\]/g) || []).length === 1, out);
+}
+
+header('unreleased bullet left OUTSIDE the region by git');
+{
+  // Real shape from the e2e run: git put one side's `## [Unreleased]` bullet
+  // AFTER the >>>>>>> line rather than inside the region. Emitting the merged
+  // version sections first buried it under ## [5.5.13].
+  const conflicted = `## [Unreleased]
+
+<<<<<<< HEAD
+## [5.5.14] - 2026-08-13
+
+- **Competing bump** — synthetic.
+=======
+## [5.5.13] - 2026-08-13
+
+- **Template label refresh** — labels.
+>>>>>>> origin/master
+- **check-overage-live.mjs no longer reports a false CLEAN.** Unreleased entry.
+
+## [5.5.12] - 2026-08-12
+
+- earlier.
+`;
+  const out = resolveChangelog(conflicted);
+  check('no markers survive', !hasConflicts(out));
+  check('the unreleased bullet survives', /false CLEAN/.test(out), out);
+  check('it sits ABOVE the newest version section',
+    out.indexOf('false CLEAN') < out.indexOf('## [5.5.14]'), out);
+  check('it is NOT buried under 5.5.13',
+    out.indexOf('false CLEAN') < out.indexOf('## [5.5.13]'), out);
+  check('both version sections still present',
+    /## \[5\.5\.14\]/.test(out) && /## \[5\.5\.13\]/.test(out));
+  check('ordering still descending',
+    out.indexOf('## [5.5.14]') < out.indexOf('## [5.5.13]')
+      && out.indexOf('## [5.5.13]') < out.indexOf('## [5.5.12]'), out);
+}
+
+header('CRLF — the checkout this actually runs on');
+{
+  // Found by an end-to-end run against a real `git merge`, NOT by the LF
+  // fixtures above, all of which passed while the script was blind to CRLF.
+  // In JS `.` will not consume a carriage return and `$` (no `m` flag) will
+  // not match before one, so "<<<<<<< HEAD\r" defeated every marker regex and
+  // the script reported "no conflict" on a genuinely conflicted file — the
+  // worst outcome available to it, since the caller then commits the markers.
+  const lf = `{
+  "name": "x",
+<<<<<<< HEAD
+  "version": "5.5.14",
+=======
+  "version": "5.5.13",
+>>>>>>> origin/master
+  "type": "module"
+}
+`;
+  const crlf = lf.replace(/\n/g, '\r\n');
+
+  check('detects conflicts in CRLF text', hasConflicts(crlf));
+  const out = resolvePackageJson(crlf);
+  check('resolves CRLF package.json', !hasConflicts(out));
+  check('still keeps the higher version', /"version": "5\.5\.14"/.test(out));
+  check('preserves CRLF endings', out.includes('\r\n') && !/[^\r]\n/.test(out));
+  check('valid JSON after CRLF resolution',
+    (() => { try { JSON.parse(out); return true; } catch { return false; } })());
+
+  const clLf = `## [Unreleased]
+
+<<<<<<< HEAD
+## [5.5.11] - 2026-08-12
+
+- ours.
+=======
+## [5.5.10] - 2026-08-11
+
+- theirs.
+>>>>>>> origin/master
+## [5.5.9] - 2026-08-11
+`;
+  const clOut = resolveChangelog(clLf.replace(/\n/g, '\r\n'));
+  check('resolves CRLF CHANGELOG', !hasConflicts(clOut));
+  check('keeps both sections under CRLF',
+    /## \[5\.5\.11\]/.test(clOut) && /## \[5\.5\.10\]/.test(clOut));
+  check('CHANGELOG keeps CRLF endings', clOut.includes('\r\n') && !/[^\r]\n/.test(clOut));
+
+  // And the converse: an LF file must not be silently converted to CRLF.
+  check('LF input stays LF', !resolvePackageJson(lf).includes('\r'));
+}
+
+header('no-op and passthrough');
+{
+  const clean = '## [Unreleased]\n\n- nothing conflicting\n';
+  check('clean CHANGELOG is returned unchanged', resolveChangelog(clean) === clean);
+  const cleanPkg = '{\n  "version": "1.0.0"\n}\n';
+  check('clean package.json is returned unchanged', resolvePackageJson(cleanPkg) === cleanPkg);
+  check('hasConflicts is false on clean text', !hasConflicts(clean));
+}
+
+header('malformed input is refused, not guessed');
+{
+  let threw = false;
+  try { resolveChangelog('<<<<<<< HEAD\nunterminated\n'); } catch { threw = true; }
+  check('unterminated marker throws', threw);
+}
+
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## Why this is a script and not a prompt

Four PRs needed hand-resolution in a worktree on 2026-08-12 — #952, #955, #960, #961 — and every one came out the same two ways:

- **`package.json`** — keep the **higher** version.
- **`CHANGELOG.md`** — keep **both** sides, version sections newest-first, unreleased bullets on top.

That is a rule, not a judgement. The input shape is fixed by our own drift bots, so the unpredictability an LLM is good at isn't present.

Getting it wrong is quiet in both directions. A version resolved **downward** lands below an already-published tag, and `cc-drift-auto-release`'s duplicate-tag guard then fast-exits **green** having shipped nothing — a release that silently did not happen, on a chore PR nobody re-reads after merge. Dropping a CHANGELOG side loses an entry for a release that did ship.

## What it refuses

Refusal is the default for anything outside the known shape:

- a conflict in a file other than `package.json` / `CHANGELOG.md`
- a `package.json` conflict touching more than the lone `"version"` line
- a version that isn't `X.Y.Z`
- markers surviving its own output

Nothing is written unless **every** requested file resolved cleanly, so a refusal leaves the working tree exactly as it was found. Refusing costs a hand-resolution; guessing costs a silent no-op release.

## Two defects the unit tests missed

Both were found by running against a **real `git merge`** rather than hand-written fixtures. 27 assertions were green at the time.

**CRLF.** Git on Windows leaves markers as `"<<<<<<< HEAD\r"`. In JavaScript the `.` metacharacter won't consume a carriage return, and `$` without the `m` flag won't match before one — so `/^<{7} .*$/` failed on every marker and the script reported **"no conflict" on a genuinely conflicted file**. That is the worst outcome available to it: the caller proceeds and commits the markers. Now normalized on the way in, with the file's own line endings restored on the way out (an LF file stays LF).

**Unreleased bullets left outside the region.** Git doesn't always put both sides' bullets inside the conflict. One landed after the `>>>>>>>` line, and emitting the merged version sections first buried an `## [Unreleased]` entry under `## [5.5.13]`. Loose text directly after a region is now hoisted back to the section that was open before it.

## Verification

**42 assertions**, auto-discovered by `test/all.test.mjs`: both resolution directions, the `5.5.99` vs `5.6.0` ordering case, identical-sections collapsing, CRLF *and* LF, line-ending preservation in both directions, and every refusal path.

**End-to-end against a real two-file conflict** — branch at `5.5.12`, ours `5.5.14`, master `5.5.13`:

```
conflicted: CHANGELOG.md package.json
package.json: resolved
CHANGELOG.md: resolved

version: 5.5.14
markers: CHANGELOG.md:0 package.json:0

## [Unreleased]
- **check-overage-live.mjs no longer reports a false CLEAN.**
## [5.5.14] - 2026-08-13
## [5.5.13] - 2026-08-13
## [5.5.12] - 2026-08-12

check-package-json OK
extract-release-notes OK
```

Identical to what was produced by hand, and it passes the repo's own validators.

## Usage

```
git merge origin/master            # conflicts
node scripts/resolve-release-conflicts.mjs
node scripts/check-package-json.mjs && node scripts/extract-release-notes.mjs <version>
git add -A && git commit
```

## Not wired into CI yet — deliberately

This is the resolver only. Calling it from `auto-merge-sweep.yml` would change that workflow from *arming* PRs to *pushing commits* to them, which is a real escalation in what the hourly job can do. Worth deciding separately rather than folding into this PR.

Standalone it already removes the manual editing, which was most of the cost.

`scripts/` and `test/` aren't in the package `files` list, so this ships nothing and carries no version bump.
