### PR TITLE
ci(cc-drift): close the drift PRs a new one supersedes

### DIFF
--- a/.github/workflows/cc-drift-watch.yml
+++ b/.github/workflows/cc-drift-watch.yml
@@ -284,6 +284,32 @@ jobs:
           # preserved for inspection.
           gh pr merge "$PR_URL" --auto --squash --delete-branch
 
+          # Close the drift PRs this one supersedes.
+          #
+          # The skip above only covers THIS branch. When CC moves again before
+          # the previous drift PR merges, that PR is left open carrying a LOWER
+          # maxTested and an OLDER package version -- merging it would walk
+          # master backwards. #966 sat open a full day that way, went
+          # conflicted, still collected an approving review, and had to be
+          # closed by hand.
+          #
+          # Runs AFTER the new PR is open and auto-merging, so a failure here
+          # can never leave the repo with nothing queued. Every call is
+          # `|| true` for the same reason: tidying is not worth failing a run
+          # whose real work already succeeded. The selection is unit-tested in
+          # test/close-superseded-drift-prs.mjs -- notably that it refuses to
+          # close a NEWER PR, which is the one mistake that would lose work.
+          gh pr list --state open --json number,headRefName \
+            | node scripts/close-superseded-drift-prs.mjs "$BRANCH" \
+            | while read -r OLD_PR; do
+                [ -n "$OLD_PR" ] || continue
+                echo "Closing #$OLD_PR -- superseded by $PR_URL"
+                gh pr comment "$OLD_PR" --body \
+                  "Superseded by $PR_URL, which carries a newer \`maxTested\`. This PR proposes an older value, so merging it would move \`master\` backwards. Closed automatically by \`cc-drift-watch.yml\`." \
+                  || true
+                gh pr close "$OLD_PR" --delete-branch || true
+              done || true
+
       - name: Close resolved drift issues
         if: steps.drift.outputs.exit_code == '0'
         env:

--- a/scripts/close-superseded-drift-prs.mjs
+++ b/scripts/close-superseded-drift-prs.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// Pick out the cc-drift PRs that a newly-opened one supersedes.
+//
+// WHY THIS EXISTS. cc-drift-watch runs hourly. It already skips re-drafting
+// when a PR for *its own* branch is open, but it never looked at the older
+// sibling branches — so whenever CC moved again before the previous drift PR
+// merged, the old PR stayed open forever.
+//
+// That is not merely untidy, it is actively wrong. An older drift PR carries a
+// LOWER `maxTested` and an OLDER package version, so merging it walks master
+// backwards. #966 (maxTested 2.1.231, v5.5.14) sat open for a day while #970
+// (2.1.232, same v5.5.14) and then #973 (v5.5.15) landed. It went conflicted,
+// still collected an approving review, and had to be closed by hand.
+//
+// The selection is kept pure and tested here; the actual `gh pr close` calls
+// stay in the workflow. Same split as scripts/resolve-release-conflicts.mjs.
+//
+// CLI: reads `gh pr list --json number,headRefName` on stdin, takes the new
+// branch as argv[2], prints one PR number per line (nothing when none apply).
+//
+//   gh pr list --state open --json number,headRefName \
+//     | node scripts/close-superseded-drift-prs.mjs "bot/cc-drift-v2.1.232"
+
+import { pathToFileURL } from 'node:url';
+import { isOlderThan } from './_drift-patch-helpers.mjs';
+
+export const DRIFT_BRANCH_PREFIX = 'bot/cc-drift-v';
+
+/** Version out of `bot/cc-drift-v2.1.231`, or null when it is not one of ours. */
+export function versionFromBranch(branch) {
+  if (typeof branch !== 'string' || !branch.startsWith(DRIFT_BRANCH_PREFIX)) return null;
+  const v = branch.slice(DRIFT_BRANCH_PREFIX.length);
+  // Guard against `bot/cc-drift-vfoo` and against a trailing suffix that would
+  // make isOlderThan's parseInt silently read NaN -> 0 and mis-rank the branch.
+  return /^\d+(\.\d+)*$/.test(v) ? v : null;
+}
+
+/**
+ * Which open PRs does `newBranch` supersede?
+ *
+ * Strictly older only. A same-version PR is the caller's own (the workflow
+ * already exits early on that), and a NEWER one must never be closed — if the
+ * watcher ever runs out of order, silently closing the ahead PR would be the
+ * expensive failure, so the comparison refuses rather than guesses.
+ *
+ * @param {Array<{number:number, headRefName:string}>} openPrs
+ * @param {string} newBranch
+ * @returns {Array<{number:number, branch:string, version:string}>}
+ */
+export function selectSupersededPrs(openPrs, newBranch) {
+  const newVersion = versionFromBranch(newBranch);
+  if (!newVersion) return [];
+
+  const out = [];
+  for (const pr of Array.isArray(openPrs) ? openPrs : []) {
+    if (!pr || typeof pr.number !== 'number') continue;
+    if (pr.headRefName === newBranch) continue;
+    const version = versionFromBranch(pr.headRefName);
+    if (!version) continue;
+    if (!isOlderThan(version, newVersion)) continue;
+    out.push({ number: pr.number, branch: pr.headRefName, version });
+  }
+  // Oldest first, so the log reads in the order they were overtaken.
+  out.sort((a, b) => (isOlderThan(a.version, b.version) ? -1 : 1));
+  return out;
+}
+
+// ── CLI ────────────────────────────────────────────────────────────────────
+// Run the CLI only when invoked directly, so the test can import the pure
+// helpers above without this block swallowing stdin.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const newBranch = process.argv[2];
+  if (!newBranch) {
+    console.error('usage: close-superseded-drift-prs.mjs <new-branch>  (PR JSON on stdin)');
+    process.exit(2);
+  }
+  let raw = '';
+  for await (const chunk of process.stdin) raw += chunk;
+  let parsed = [];
+  try {
+    parsed = JSON.parse(raw || '[]');
+  } catch {
+    // A malformed listing must not fail the run: the new PR is already open and
+    // auto-merging by this point. Emit nothing and let the workflow continue.
+    console.error('could not parse PR listing; closing nothing');
+    process.exit(0);
+  }
+  for (const pr of selectSupersededPrs(parsed, newBranch)) {
+    console.log(pr.number);
+  }
+}

--- a/test/close-superseded-drift-prs.mjs
+++ b/test/close-superseded-drift-prs.mjs
@@ -1,0 +1,91 @@
+// Unit tests for scripts/close-superseded-drift-prs.mjs.
+//
+// THE INCIDENT THIS PINS. cc-drift-watch skipped re-drafting when a PR for its
+// OWN branch existed, but never looked at older sibling branches. #966
+// (maxTested 2.1.231, v5.5.14) stayed open while #970 (2.1.232) and #973
+// (v5.5.15) landed on master. Because a drift PR carries a LOWER maxTested and
+// an OLDER package version, merging the stale one walks master backwards — so
+// it went conflicted, still collected an approving review, and had to be closed
+// by hand a day later.
+//
+// The dangerous direction is closing too much: a superseded PR left open costs
+// a manual close, but closing a NEWER PR silently discards the fix that should
+// ship. Every "not superseded" case below is guarding that direction.
+
+import {
+  selectSupersededPrs,
+  versionFromBranch,
+  DRIFT_BRANCH_PREFIX,
+} from '../scripts/close-superseded-drift-prs.mjs';
+
+let pass = 0;
+let fail = 0;
+function check(name, cond) {
+  if (cond) { console.log(`  ok   ${name}`); pass++; }
+  else { console.log(`  FAIL ${name}`); fail++; }
+}
+const nums = (rows) => rows.map((r) => r.number);
+
+console.log('\n  versionFromBranch');
+check('parses a drift branch', versionFromBranch('bot/cc-drift-v2.1.231') === '2.1.231');
+check('prefix constant matches', DRIFT_BRANCH_PREFIX === 'bot/cc-drift-v');
+check('rejects a non-drift branch', versionFromBranch('bot/template-rebake-v2.1.231') === null);
+check('rejects a feature branch', versionFromBranch('fix/whatever') === null);
+check('rejects a non-numeric version', versionFromBranch('bot/cc-drift-vfoo') === null);
+// parseInt('231-rc1') === 231, so a suffix would rank as a plain 231 and could
+// close a PR it does not actually supersede. Reject rather than mis-rank.
+check('rejects a suffixed version', versionFromBranch('bot/cc-drift-v2.1.231-rc1') === null);
+check('rejects null / undefined', versionFromBranch(null) === null && versionFromBranch(undefined) === null);
+
+console.log('\n  selectSupersededPrs — the #966 case');
+{
+  const open = [
+    { number: 966, headRefName: 'bot/cc-drift-v2.1.231' },
+    { number: 970, headRefName: 'bot/cc-drift-v2.1.232' },
+  ];
+  check('the newer PR supersedes the older', nums(selectSupersededPrs(open, 'bot/cc-drift-v2.1.232')).join() === '966');
+}
+
+console.log('\n  selectSupersededPrs — never closes what it must not');
+{
+  const open = [
+    { number: 966, headRefName: 'bot/cc-drift-v2.1.231' },
+    { number: 980, headRefName: 'bot/cc-drift-v2.1.240' },
+  ];
+  check('a NEWER open PR is never closed', nums(selectSupersededPrs(open, 'bot/cc-drift-v2.1.232')).join() === '966');
+}
+check('never closes its own branch',
+  selectSupersededPrs([{ number: 970, headRefName: 'bot/cc-drift-v2.1.232' }], 'bot/cc-drift-v2.1.232').length === 0);
+check('equal version on a different number is left alone',
+  selectSupersededPrs([{ number: 969, headRefName: 'bot/cc-drift-v2.1.232' }], 'bot/cc-drift-v2.1.232').length === 0);
+check('ignores unrelated bot branches',
+  selectSupersededPrs([{ number: 900, headRefName: 'bot/template-rebake-v2.1.100' }], 'bot/cc-drift-v2.1.232').length === 0);
+check('ignores human branches',
+  selectSupersededPrs([{ number: 901, headRefName: 'fix/approval-identity' }], 'bot/cc-drift-v2.1.232').length === 0);
+
+console.log('\n  selectSupersededPrs — degenerate input never throws');
+check('empty list', selectSupersededPrs([], 'bot/cc-drift-v2.1.232').length === 0);
+check('non-array', selectSupersededPrs(null, 'bot/cc-drift-v2.1.232').length === 0);
+check('rows missing a number', selectSupersededPrs([{ headRefName: 'bot/cc-drift-v2.1.1' }], 'bot/cc-drift-v2.1.232').length === 0);
+check('null rows', selectSupersededPrs([null, undefined], 'bot/cc-drift-v2.1.232').length === 0);
+check('unparseable new branch closes nothing',
+  selectSupersededPrs([{ number: 966, headRefName: 'bot/cc-drift-v2.1.231' }], 'bot/cc-drift-vfoo').length === 0);
+check('empty new branch closes nothing',
+  selectSupersededPrs([{ number: 966, headRefName: 'bot/cc-drift-v2.1.231' }], '').length === 0);
+
+console.log('\n  selectSupersededPrs — multiple stragglers, oldest first');
+{
+  const open = [
+    { number: 3, headRefName: 'bot/cc-drift-v2.1.230' },
+    { number: 1, headRefName: 'bot/cc-drift-v2.1.9' },
+    { number: 2, headRefName: 'bot/cc-drift-v2.1.229' },
+  ];
+  // 2.1.9 < 2.1.229 numerically, though it sorts after as a string — the
+  // comparison must be component-wise, not lexicographic.
+  check('all three, ordered oldest first', nums(selectSupersededPrs(open, 'bot/cc-drift-v2.1.232')).join() === '1,2,3');
+}
+check('major/minor differences compare correctly',
+  nums(selectSupersededPrs([{ number: 5, headRefName: 'bot/cc-drift-v1.9.99' }], 'bot/cc-drift-v2.0.0')).join() === '5');
+
+console.log(`\n  ${pass} passed, ${fail} failed\n`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
The watcher runs hourly and already skips re-drafting when a PR for its **own** branch is open. It never looked at the older sibling branches — so whenever CC moved again before the previous drift PR merged, that PR stayed open indefinitely.

That is not untidy, it is wrong. An older drift PR carries a **lower** `maxTested` and an **older** package version, so merging it walks `master` backwards.

## The worked example: #966

| | maxTested | version |
|---|---|---|
| `master` (after #970, #973) | `2.1.232` | 5.5.15 |
| #966 proposed | `2.1.231` | 5.5.14 |

#966 sat open for a day while #970 — the same drift bump regenerated against a newer upstream — merged, and #973 took master to v5.5.15. It went `CONFLICTING`, **still collected an approving review** from the reviewer agent, and had to be closed by hand, along with the reviewer ticket that had been tracking it as genuine outstanding work.

The rate-cap made it visible, but nothing about it required a cap: any hour where CC moves twice before a merge produces the same stale pair.

## Change

After opening the new PR and enabling auto-merge, the workflow asks `scripts/close-superseded-drift-prs.mjs` which open `bot/cc-drift-v*` PRs the new one supersedes, then comments and closes each with `--delete-branch`.

Two deliberate choices:

- **Ordering.** The tidy-up runs *after* the new PR is queued, so a failure here can never leave the repo with nothing to ship.
- **Failure handling.** Every `gh` call is `|| true`, and a malformed PR listing exits 0 closing nothing. Tidying is not worth failing a run whose real work already succeeded.

## Tests

21 assertions in `test/close-superseded-drift-prs.mjs`, auto-discovered by `test/all.test.mjs`.

The selection is pure and split from the `gh` calls, the same shape as `scripts/resolve-release-conflicts.mjs`. The tests weight the dangerous direction — closing too little costs a manual close, closing a **newer** PR discards the fix that should ship:

- a newer open PR is never closed, even when one is also older
- never closes its own branch, or an equal-version PR
- ignores `bot/template-rebake-*` and human branches
- rejects version strings it cannot parse component-wise, so `bot/cc-drift-v2.1.231-rc1` is skipped rather than ranked as `231` by `parseInt`
- `2.1.9 < 2.1.229` — comparison is component-wise, not lexicographic
- degenerate input (null, non-array, missing fields, unparseable branch) returns empty rather than throwing

Reuses the existing `isOlderThan` from `_drift-patch-helpers.mjs` rather than adding a second comparator.

Verified against the real shape: feeding the actual #966 / #973 listing with `bot/cc-drift-v2.1.232` emits exactly `966`.

CI-only — no runtime change, so no version bump, matching #964.
