### PR TITLE
template: preserve config-scoped Task* tools across rebakes (unblocks #984)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ checklist.
 ## [5.5.17] - 2026-08-15
 
 - **Template rebake** — re-captured `src/cc-template-data.json` after cc-drift-template-watch detected wire-fingerprint drift against a live CC capture. Bundled fallback template now matches the current CC wire shape.
+- **Config-scoped tool preservation** — the CC v2.1.233 capture omitted `TaskCreate`/`TaskGet`/`TaskList`/`TaskUpdate` (remote-config drift; `TaskOutput`/`TaskStop` were unaffected), which would have shrunk `CC_NATIVE_NAMES_UNION` and pushed a CC client declaring those tools into the unmapped round-robin — the v4.8.93 failure mode. New `CONFIG_SCOPED_TOOLS` set + a preservation merge in `scripts/capture-and-bake.mjs` carry them forward from the previous bundle, mirroring `PLATFORM_ONLY_TOOLS` and `INTERACTIVE_ONLY_TOOLS`. Guarded by `test/template-config-scoped-tools.mjs`.
 ## [5.5.16] - 2026-08-14
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.232` → `2.1.233` for CC v2.1.233. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.

--- a/scripts/capture-and-bake.mjs
+++ b/scripts/capture-and-bake.mjs
@@ -50,7 +50,7 @@ import { fileURLToPath } from 'node:url';
 
 import { captureLiveTemplateAsync, findInstalledCC, promptVariantsOf, TEMPLATE_BASE_MODEL, VARIANT_FAMILIES } from '../dist/live-fingerprint.js';
 import { scrubTemplate, findUserPathHits } from '../dist/scrub-template.js';
-import { PLATFORM_ONLY_TOOLS, INTERACTIVE_ONLY_TOOLS } from '../dist/cc-template.js';
+import { PLATFORM_ONLY_TOOLS, INTERACTIVE_ONLY_TOOLS, CONFIG_SCOPED_TOOLS } from '../dist/cc-template.js';
 import { computeDrift, formatDriftReport, interpretDrift, formatDriftSummary, stripModelConditionalBetas, isOlderCCVersion, detectIssue881Residue, formatIssue881Warning } from './drift-report.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -229,10 +229,28 @@ if (preservedInteractiveTools.length > 0) {
   scrubbed.tools = [...scrubbed.tools, ...preservedInteractiveTools].sort((a, b) => a.name.localeCompare(b.name));
 }
 
-// Re-derive tool_names AFTER both preservation merges. scrubTemplate() sets it
+// Preserve config-scoped tools from the previous bundle. Same superset rule as
+// the two merges above, different cause: CC's REMOTE config decides whether it
+// advertises these at all, so the same binary in the same headless mode can
+// capture them one week and not the next (v2.1.232 carried TaskCreate/TaskGet/
+// TaskList/TaskUpdate, v2.1.233 dropped all four while keeping TaskOutput and
+// TaskStop). Dropping them shrinks CC_NATIVE_NAMES_UNION, and a client that
+// still declares TaskCreate then falls into the unmapped round-robin and gets
+// renamed onto a fallback slot — the v4.8.93 failure mode. Preserving is safe
+// in the other direction because advertise is an intersection with the client's
+// declared tools, so an entry no client declares is never sent.
+const preservedConfigScopedTools = (prev.tools || []).filter(
+  (t) => CONFIG_SCOPED_TOOLS.has(t.name) && !scrubbed.tools.some((s) => s.name === t.name),
+);
+if (preservedConfigScopedTools.length > 0) {
+  log(`preserved ${preservedConfigScopedTools.length} config-scoped tool${preservedConfigScopedTools.length === 1 ? '' : 's'} from previous bundle (this capture's CC config omits them): ${preservedConfigScopedTools.map((t) => t.name).join(', ')}`);
+  scrubbed.tools = [...scrubbed.tools, ...preservedConfigScopedTools].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+// Re-derive tool_names AFTER every preservation merge. scrubTemplate() sets it
 // from `tools` (scrub-template.ts:50) and live-fingerprint does the same at
 // capture time (live-fingerprint.ts:757), so `tool_names === tools.map(name)` is
-// the contract everywhere. Both merges above mutate `tools` afterwards and
+// the contract everywhere. The merges above mutate `tools` afterwards and
 // nothing re-synced the list, so every bake shipped an artifact whose two tool
 // lists disagreed: a consumer trusting tool_names as the inventory concludes the
 // preserved tools aren't in the toolset while their full definitions sit right

--- a/src/cc-template-data.json
+++ b/src/cc-template-data.json
@@ -1090,6 +1090,69 @@
       }
     },
     {
+      "name": "TaskCreate",
+      "description": "Use this tool to create a structured task list for your current coding session. This helps you track progress, organize complex tasks, and demonstrate thoroughness to the user.\nIt also helps the user understand the progress of the task and overall progress of their requests.\n\n## When to Use This Tool\n\nUse this tool proactively in these scenarios:\n\n- Complex multi-step tasks - When a task requires 3 or more distinct steps or actions\n- Non-trivial and complex tasks - Tasks that require careful planning or multiple operations\n- Plan mode - When using plan mode, create a task list to track the work\n- User explicitly requests todo list - When the user directly asks you to use the todo list\n- User provides multiple tasks - When users provide a list of things to be done (numbered or comma-separated)\n- After receiving new instructions - Immediately capture user requirements as tasks\n- When you start working on a task - Mark it as in_progress BEFORE beginning work\n- After completing a task - Mark it as completed and add any new follow-up tasks discovered during implementation\n\n## When NOT to Use This Tool\n\nSkip using this tool when:\n- There is only a single, straightforward task\n- The task is trivial and tracking it provides no organizational benefit\n- The task can be completed in less than 3 trivial steps\n- The task is purely conversational or informational\n\nNOTE that you should not use this tool if there is only one trivial task to do. In this case you are better off just doing the task directly.\n\n## Task Fields\n\n- **subject**: A brief, actionable title in imperative form (e.g., \"Fix authentication bug in login flow\")\n- **description**: What needs to be done\n- **activeForm** (optional): Present continuous form shown in the spinner when the task is in_progress (e.g., \"Fixing authentication bug\"). If omitted, the spinner shows the subject instead.\n\nAll tasks are created with status `pending`.\n\n## Tips\n\n- Create tasks with clear, specific subjects that describe the outcome\n- After creating tasks, use TaskUpdate to set up dependencies (blocks/blockedBy) if needed\n- Check TaskList first to avoid creating duplicate tasks\n",
+      "input_schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "subject": {
+            "description": "A brief title for the task",
+            "type": "string"
+          },
+          "description": {
+            "description": "What needs to be done",
+            "type": "string"
+          },
+          "activeForm": {
+            "description": "Present continuous form shown in spinner when in_progress (e.g., \"Running tests\")",
+            "type": "string"
+          },
+          "metadata": {
+            "description": "Arbitrary metadata to attach to the task",
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {}
+          }
+        },
+        "required": [
+          "subject",
+          "description"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "TaskGet",
+      "description": "Use this tool to retrieve a task by its ID from the task list.\n\n## When to Use This Tool\n\n- When you need the full description and context before starting work on a task\n- To understand task dependencies (what it blocks, what blocks it)\n- After being assigned a task, to get complete requirements\n\n## Output\n\nReturns full task details:\n- **subject**: Task title\n- **description**: Detailed requirements and context\n- **status**: 'pending', 'in_progress', or 'completed'\n- **blocks**: Tasks waiting on this one to complete\n- **blockedBy**: Tasks that must complete before this one can start\n\n## Tips\n\n- After fetching a task, verify its blockedBy list is empty before beginning work.\n- Use TaskList to see all tasks in summary form.\n",
+      "input_schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "description": "The ID of the task to retrieve",
+            "type": "string"
+          }
+        },
+        "required": [
+          "taskId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "TaskList",
+      "description": "Use this tool to list all tasks in the task list.\n\n## When to Use This Tool\n\n- To see what tasks are available to work on (status: 'pending', no owner, not blocked)\n- To check overall progress on the project\n- To find tasks that are blocked and need dependencies resolved\n- After completing a task, to check for newly unblocked work or claim the next available task\n- **Prefer working on tasks in ID order** (lowest ID first) when multiple tasks are available, as earlier tasks often set up context for later ones\n\n## Output\n\nReturns a summary of each task:\n- **id**: Task identifier (use with TaskGet, TaskUpdate)\n- **subject**: Brief description of the task\n- **status**: 'pending', 'in_progress', or 'completed'\n- **owner**: Agent ID if assigned, empty if available\n- **blockedBy**: List of open task IDs that must be resolved first (tasks with blockedBy cannot be claimed until dependencies resolve)\n\nUse TaskGet with a specific task ID to view full details including description and comments.\n",
+      "input_schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+      }
+    },
+    {
       "name": "TaskOutput",
       "description": "DEPRECATED: Background tasks return their output file path in the tool result, and you receive a <task-notification> with the same path when the task completes.\n- For bash tasks: prefer using the Read tool on that output file path — it contains stdout/stderr.\n- For local_agent tasks: use the Agent tool result directly. Do NOT Read the .output file — it is a symlink to the full subagent conversation transcript (JSONL) and will overflow your context window.\n- For remote_agent tasks: prefer using the Read tool on the output file path — it contains the streamed remote session output (same as bash).\n\n- Retrieves output from a running or completed task (background shell, agent, or remote session)\n- Takes a task_id parameter identifying the task\n- Returns the task output along with status information\n- Use block=true (default) to wait for task completion\n- Use block=false for non-blocking check of current status\n- Task IDs can be found using the /tasks command\n- Works with all task types: background shells, async agents, and remote sessions",
       "input_schema": {
@@ -1137,6 +1200,79 @@
             "type": "string"
           }
         },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "TaskUpdate",
+      "description": "Use this tool to update a task in the task list.\n\n## When to Use This Tool\n\n**Mark tasks as resolved:**\n- When you have completed the work described in a task\n- When a task is no longer needed or has been superseded\n- IMPORTANT: Always mark your assigned tasks as resolved when you finish them\n- After resolving, call TaskList to find your next task\n\n- ONLY mark a task as completed when you have FULLY accomplished it\n- If you encounter errors, blockers, or cannot finish, keep the task as in_progress\n- When blocked, create a new task describing what needs to be resolved\n- Never mark a task as completed if:\n  - Tests are failing\n  - Implementation is partial\n  - You encountered unresolved errors\n  - You couldn't find necessary files or dependencies\n\n**Delete tasks:**\n- When a task is no longer relevant or was created in error\n- Setting status to `deleted` permanently removes the task\n\n**Update task details:**\n- When requirements change or become clearer\n- When establishing dependencies between tasks\n\n## Fields You Can Update\n\n- **status**: The task status (see Status Workflow below)\n- **subject**: Change the task title (imperative form, e.g., \"Run tests\")\n- **description**: Change the task description\n- **activeForm**: Present continuous form shown in spinner when in_progress (e.g., \"Running tests\")\n- **owner**: Change the task owner (agent name)\n- **metadata**: Merge metadata keys into the task (set a key to null to delete it)\n- **addBlocks**: Mark tasks that cannot start until this one completes\n- **addBlockedBy**: Mark tasks that must complete before this one can start\n\n## Status Workflow\n\nStatus progresses: `pending` → `in_progress` → `completed`\n\nUse `deleted` to permanently remove a task.\n\n## Staleness\n\nMake sure to read a task's latest state using `TaskGet` before updating it.\n\n## Examples\n\nMark task as in progress when starting work:\n```json\n{\"taskId\": \"1\", \"status\": \"in_progress\"}\n```\n\nMark task as completed after finishing work:\n```json\n{\"taskId\": \"1\", \"status\": \"completed\"}\n```\n\nDelete a task:\n```json\n{\"taskId\": \"1\", \"status\": \"deleted\"}\n```\n\nClaim a task by setting owner:\n```json\n{\"taskId\": \"1\", \"owner\": \"my-name\"}\n```\n\nSet up task dependencies:\n```json\n{\"taskId\": \"2\", \"addBlockedBy\": [\"1\"]}\n```\n",
+      "input_schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "description": "The ID of the task to update",
+            "type": "string"
+          },
+          "subject": {
+            "description": "New subject for the task",
+            "type": "string"
+          },
+          "description": {
+            "description": "New description for the task",
+            "type": "string"
+          },
+          "activeForm": {
+            "description": "Present continuous form shown in spinner when in_progress (e.g., \"Running tests\")",
+            "type": "string"
+          },
+          "status": {
+            "description": "New status for the task",
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "pending",
+                  "in_progress",
+                  "completed"
+                ]
+              },
+              {
+                "type": "string",
+                "const": "deleted"
+              }
+            ]
+          },
+          "addBlocks": {
+            "description": "Task IDs that this task blocks",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "addBlockedBy": {
+            "description": "Task IDs that block this task",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "owner": {
+            "description": "New owner for the task",
+            "type": "string"
+          },
+          "metadata": {
+            "description": "Metadata keys to merge into the task. Set a key to null to delete it.",
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {}
+          }
+        },
+        "required": [
+          "taskId"
+        ],
         "additionalProperties": false
       }
     },
@@ -1286,8 +1422,12 @@
     "ScheduleWakeup",
     "SendMessage",
     "Skill",
+    "TaskCreate",
+    "TaskGet",
+    "TaskList",
     "TaskOutput",
     "TaskStop",
+    "TaskUpdate",
     "WebFetch",
     "WebSearch",
     "Workflow",

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -73,6 +73,37 @@ export const INTERACTIVE_ONLY_TOOLS: Set<string> = new Set([
   'ExitPlanMode',
 ]);
 
+/**
+ * Tools CC advertises only under some runtime configurations. Unlike
+ * INTERACTIVE_ONLY_TOOLS (absent because the bake captures headlessly), these
+ * come and go with CC's REMOTE config for the same capture mode: the 2026-08-11
+ * bake on CC v2.1.232 captured all four headlessly, and the 2026-08-15 bake on
+ * v2.1.233 captured none of them — while TaskOutput/TaskStop, the rest of the
+ * task subsystem, stayed put. That is the v4.2.1 drift class (same binary,
+ * different wire shape via remote configuration), and it is not a signal that
+ * CC retired the tools.
+ *
+ * The bundle must stay a SUPERSET, so the bake preserves these from the previous
+ * bundle exactly as it does the platform- and interactive-only sets. The cost of
+ * the two directions is asymmetric, which is what settles it: a stale entry is
+ * INERT, because buildCCRequest advertises only the intersection of the bundle
+ * with what the client declared — no client declares it, nothing is advertised.
+ * Dropping one is NOT inert: CC_NATIVE_NAMES_UNION is derived from this bundle,
+ * so a client that does declare TaskCreate stops identity-mapping, falls into
+ * the unmapped round-robin, and is renamed onto a fallback slot with junk args
+ * (the v4.8.93 regression, caught here by issue-29-tool-translation.mjs).
+ *
+ * Add new config-scoped tools here as CC's remote config churns. Removing a name
+ * is a deliberate act: it means CC genuinely retired the tool, and it should be
+ * paired with the capture evidence that says so.
+ */
+export const CONFIG_SCOPED_TOOLS: Set<string> = new Set([
+  'TaskCreate',
+  'TaskGet',
+  'TaskList',
+  'TaskUpdate',
+]);
+
 /** CC's exact tool definitions for the current platform — filtered from the bundled union. */
 export const CC_TOOL_DEFINITIONS = filterToolsForPlatform(TEMPLATE.tools, process.platform);
 

--- a/test/template-config-scoped-tools.mjs
+++ b/test/template-config-scoped-tools.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * Regression: the bundled CC template must always carry the config-scoped tools
+ * (TaskCreate, TaskGet, TaskList, TaskUpdate).
+ *
+ * Bug (2026-08-15, auto-rebake PR #984): CC's REMOTE config — not its version,
+ * and not the headless capture mode — decides whether it advertises these. The
+ * 2026-08-11 bake on CC v2.1.232 captured all four; the 2026-08-15 bake on
+ * v2.1.233 captured none of them, while TaskOutput and TaskStop (the rest of the
+ * task subsystem) stayed put. The auto-rebake therefore proposed dropping four
+ * tools from src/cc-template-data.json.
+ *
+ * Why that is a regression and not a faithful capture: CC_NATIVE_NAMES_UNION is
+ * derived from the bundle, and buildCCRequest identity-maps only names in that
+ * set. Drop TaskCreate and a CC client that still declares it falls into the
+ * unmapped round-robin — renamed onto a fallback slot with junk args, which is
+ * exactly the v4.8.93 failure mode. The reverse is inert: advertise is the
+ * INTERSECTION of the bundle with the client's declared tools, so a bundle entry
+ * no client declares is never sent upstream.
+ *
+ * Fix: CONFIG_SCOPED_TOOLS in src/cc-template.ts + a preservation merge in
+ * scripts/capture-and-bake.mjs, mirroring PLATFORM_ONLY_TOOLS and
+ * INTERACTIVE_ONLY_TOOLS. This test guards the resulting invariant so a future
+ * config-scoped capture (or a manual edit) can't silently re-drop them.
+ *
+ * In-process — no proxy / OAuth / upstream.
+ */
+
+import {
+  CC_TEMPLATE,
+  CC_TOOL_DEFINITIONS,
+  CC_NATIVE_NAMES_UNION,
+  CONFIG_SCOPED_TOOLS,
+  INTERACTIVE_ONLY_TOOLS,
+  PLATFORM_ONLY_TOOLS,
+} from '../dist/cc-template.js';
+
+let pass = 0, fail = 0;
+function check(label, cond) {
+  if (cond) { pass++; console.log(`  ✅ ${label}`); }
+  else { fail++; console.log(`  ❌ ${label}`); }
+}
+function header(name) { console.log(`\n${'='.repeat(70)}\n  ${name}\n${'='.repeat(70)}`); }
+
+header('bundled template carries every config-scoped tool');
+{
+  check('CONFIG_SCOPED_TOOLS is non-empty', CONFIG_SCOPED_TOOLS.size > 0);
+
+  const templateNames = new Set((CC_TEMPLATE.tools || []).map((t) => t.name));
+  for (const name of CONFIG_SCOPED_TOOLS) {
+    check(`template tools[] contains ${name}`, templateNames.has(name));
+    const def = (CC_TEMPLATE.tools || []).find((t) => t.name === name);
+    check(`${name} has a non-empty description`,
+      !!def && typeof def.description === 'string' && def.description.length > 0);
+    check(`${name} has an input_schema`, !!def && typeof def.input_schema === 'object' && def.input_schema !== null);
+  }
+}
+
+header('config-scoped tools identity-map (the thing dropping them breaks)');
+{
+  // CC_NATIVE_NAMES_UNION is derived from the bundle and is what buildCCRequest
+  // consults before falling through to TOOL_MAP / the unmapped round-robin.
+  for (const name of CONFIG_SCOPED_TOOLS) {
+    check(`CC_NATIVE_NAMES_UNION contains ${name}`, CC_NATIVE_NAMES_UNION.has(name));
+  }
+}
+
+header('config-scoped tools are NOT platform-filtered (present on every host)');
+{
+  // Like the interactive-only set and unlike PowerShell/Glob/Grep, these are not
+  // registered in PLATFORM_ONLY_TOOLS — they must survive the per-host filter.
+  const platformScoped = new Set(Object.values(PLATFORM_ONLY_TOOLS).flatMap((s) => [...s]));
+  const ccNames = new Set(CC_TOOL_DEFINITIONS.map((t) => t.name));
+  for (const name of CONFIG_SCOPED_TOOLS) {
+    check(`${name} is not platform-scoped`, !platformScoped.has(name));
+    check(`CC_TOOL_DEFINITIONS (platform ${process.platform}) contains ${name}`, ccNames.has(name));
+  }
+}
+
+header('the preservation sets stay disjoint');
+{
+  // Each set drives its own merge in capture-and-bake.mjs. Overlap would double-
+  // add a definition, and the `!scrubbed.tools.some(...)` guard in each merge
+  // only dedupes against the capture — not against a sibling merge.
+  const overlap = [...CONFIG_SCOPED_TOOLS].filter((n) => INTERACTIVE_ONLY_TOOLS.has(n));
+  check('CONFIG_SCOPED_TOOLS ∩ INTERACTIVE_ONLY_TOOLS is empty', overlap.length === 0);
+  const platformScoped = new Set(Object.values(PLATFORM_ONLY_TOOLS).flatMap((s) => [...s]));
+  const platOverlap = [...CONFIG_SCOPED_TOOLS].filter((n) => platformScoped.has(n));
+  check('CONFIG_SCOPED_TOOLS ∩ PLATFORM_ONLY_TOOLS is empty', platOverlap.length === 0);
+}
+
+console.log(`\ntemplate-config-scoped-tools: ${pass} passed, ${fail} failed`);
+if (fail > 0) process.exit(1);


### PR DESCRIPTION
Fixes the failing `test` check on #984 and the root cause behind it. Targets #984's branch, so merging this makes #984 itself green and mergeable — its v5.5.17 bump and release path are untouched.

## What broke

The CC v2.1.233 auto-rebake captured 24 tools and dropped four from the bundle:

```
old (master) src/cc-template-data.json: 34 tools
new (#984 head):                        30 tools
removed: TaskCreate, TaskGet, TaskList, TaskUpdate    added: (none)
```

CI caught it — `test/issue-29-tool-translation.mjs:374`, `no CC-native tool is left unmapped`, 53 pass / 1 fail (run 31865844109).

## Why it's drift, not retirement

`TaskOutput` and `TaskStop` — the rest of the task subsystem — were unaffected, and the 2026-08-11 bake on CC v2.1.232 captured all four in the *same* headless mode. So this is CC's remote config deciding what to advertise for an unchanged binary: the v4.2.1 drift class, already documented in the CHANGELOG.

That distinction matters because the two directions cost differently:

- **Keeping a stale entry is inert.** `buildCCRequest` advertises the INTERSECTION of the bundle with the client's declared tools. Nothing declares it, nothing is sent.
- **Dropping a live one is not.** `CC_NATIVE_NAMES_UNION` is derived from the bundle, so a CC client that still declares `TaskCreate` stops identity-mapping, falls into the unmapped round-robin, and is renamed onto a fallback slot with junk args. That is the v4.8.93 regression, and it is exactly what the failing assertion measures.

The bundle's standing invariant is that it stays a SUPERSET. The bake already preserves two categories for this reason; this is a third cause with the same remedy.

## Changes

| File | Change |
|---|---|
| `src/cc-template.ts` | New `CONFIG_SCOPED_TOOLS` set, alongside `PLATFORM_ONLY_TOOLS` / `INTERACTIVE_ONLY_TOOLS`. |
| `scripts/capture-and-bake.mjs` | Preservation merge carrying them forward from the previous bundle — same shape as the existing two, placed before `tool_names` is re-derived so both lists stay in sync. |
| `src/cc-template-data.json` | The four definitions restored from master, sorted back into CC's alphabetical wire order. `tools` 34, `tool_names` 34. |
| `test/template-config-scoped-tools.mjs` | New regression guard. |

Adding the preservation merge to the bake is what stops the next rebake re-proposing the same drop.

## Test plan

- `test/issue-29-tool-translation.mjs` — the failing assertion. Verified directly against the corrected bundle: the probe set (`Read`, `Bash`, `Agent`, `AskUserQuestion`, `CronCreate`, `TaskCreate`, `NotebookEdit`, `Workflow`, `EnterPlanMode`) is now fully covered by the bundle's names, so `unmappedTools` is `[]`.
- `test/template-invariants.mjs` — `tool_names` ↔ `tools` agreement holds (34/34, verified).
- `test/template-config-scoped-tools.mjs` — new: bundle carries all four with description + `input_schema`, each is in `CC_NATIVE_NAMES_UNION`, none is platform-filtered out of `CC_TOOL_DEFINITIONS`, and the three preservation sets are pairwise disjoint (each drives its own merge, and the per-merge dedupe only guards against the capture, not against a sibling merge). Auto-discovered by `test/all.test.mjs` — no `package.json` change needed.
- No local build; CI compiles (`dist/` is what the tests import).

## Follow-up, not in scope here

The bake's `--check` verdict called the removal "🔴 Substantive — investigate before merging" and opened the PR anyway. That is working as designed, but a drop of a name in one of the three preservation sets is now knowably a no-op the bake can self-correct — worth considering whether `drift-report.mjs` should downgrade that case rather than escalate it.

Source ticket: `00MSTWZWYGEA1C28C6288164B1` (from Code Reviewer finding `00MSTWZWY862866383FEC3F776`).
