### PR TITLE
[#881 residue?] auto-rebake: template drift detected 2026-08-16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.18] - 2026-08-16
+
+- **Template rebake** — re-captured `src/cc-template-data.json` after cc-drift-template-watch detected wire-fingerprint drift against a live CC capture. Bundled fallback template now matches the current CC wire shape.
 ## [5.5.17] - 2026-08-15
 
 - **Template rebake** — re-captured `src/cc-template-data.json` after cc-drift-template-watch detected wire-fingerprint drift against a live CC capture. Bundled fallback template now matches the current CC wire shape.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.17",
+  "version": "5.5.18",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template-data.json
+++ b/src/cc-template-data.json
@@ -1,6 +1,6 @@
 {
   "_version": "2.1.233",
-  "_captured": "2026-08-15T04:59:39.819Z",
+  "_captured": "2026-08-16T23:50:32.289Z",
   "_source": "bundled",
   "_schemaVersion": 3,
   "agent_identity": "You are a Claude agent, built on Anthropic's Claude Agent SDK.",


### PR DESCRIPTION
## Auto-rebake from class-B drift detection

Generated by [`cc-drift-template-watch.yml`](.github/workflows/cc-drift-template-watch.yml) on 2026-08-16T23:50:56+00:00.

The watcher's `--check` exited 2 against a live capture from the self-hosted runner. This PR contains the freshly-baked `src/cc-template-data.json` from that capture (with the v4.2.2 platform-superset preservation applied), plus a patch version bump to `v5.5.18` and a CHANGELOG entry — so merging ships the rebake to npm via `cc-drift-auto-release.yml`.

> [!CAUTION]
> ## ⚠ This rebake is dario#881 residue — do NOT treat it as a genuine CC prompt change
>
> The base system-prompt capture behind this PR matched the known [#881](https://github.com/askalf/dario/issues/881) signature: the extra `# Context management` paragraph beginning "When you have enough information to act, act.", which appears in roughly **1 local capture in 10** and had **never** reached CI before this run. See the `::warning::` annotation on the run for the exact clause that matched and the captured-vs-bundled lengths.
>
> **What to do:** re-dispatch `cc-drift-template-watch.yml`. If the next capture comes back clean, this PR is the anomaly — close it. Merging it bakes the residue into the shipped wire-shape contract and cuts a release for a prompt change that did not happen upstream.
>
> **Either way, comment the outcome on #881.** Whether the tripwire caught a real CI occurrence or a false positive, that is exactly the data the issue is open for. #881 defers the bake-time normalisation deliberately, so nothing here strips the paragraph — this is detection only.

### Summary

**Verdict:** ✅ Benign

- **system_prompt:** +279 chars net (text-content drift — see unified diff below)

### Drift report

```
[bake] using CC at /usr/bin/claude (version 2.1.233) [--check mode: dry-run]
[bake] spawning CC (base: claude-opus-4-8) against loopback MITM to capture /v1/messages...
[bake] captured: CC v2.1.233, 24 tools, 6413 char system prompt
[bake] scrubbed:
[bake]   tools: 24 → 24 (dropped 0 mcp__* tools)
[bake]   system_prompt: 6413 → 5030 chars
[bake] preserved 3 other-platform tools from previous bundle: Glob, Grep, PowerShell
[bake] preserved 3 interactive-only tools from previous bundle (headless capture omits them): AskUserQuestion, EnterPlanMode, ExitPlanMode
[bake] preserved 4 config-scoped tools from previous bundle (this capture's CC config omits them): TaskCreate, TaskGet, TaskList, TaskUpdate
[bake] previous baked template: CC v2.1.233 captured 2026-08-15T04:59:39.819Z, 34 tools, 4751 char system prompt
::warning title=dario#881 base-prompt residue::Base system prompt captured at 5030 chars vs 4751 bundled — matches the KNOWN dario#881 anomaly (the "When you have enough information to act, act." marker sentence is in the capture but not the bundle). Any rebake PR from this run is #881 residue, NOT a genuine CC prompt change. Do not merge without reading https://github.com/askalf/dario/issues/881

TRIPWIRE: dario#881 — intermittent +279-char base-prompt residue
  captured base: 5030 chars
  bundled base:  4751 chars
  matched via:   marker clause (the "When you have enough information to act, act." marker sentence is in the capture but not the bundle)

  This capture carries the extra "# Context management" paragraph that #881
  documents as appearing in roughly 1 local capture in 10 and never (until now)
  in CI. Treat any resulting rebake PR as #881 residue until proven otherwise:
  the base prompt did not change upstream, this run captured it wrong.

  Do NOT merge the rebake on the assumption that CC edited its prompt. Re-run the
  workflow; if the next capture comes back clean, this was the anomaly. Comment the
  outcome on #881 either way — the correlating conditions are what that issue needs.
[bake] spawning CC (fable-variant: claude-fable-5) against loopback MITM to capture /v1/messages...
[bake] fable system-prompt variant: base 5030 → fable 9220 chars
[bake] spawning CC (opus-5-variant: claude-opus-5) against loopback MITM to capture /v1/messages...
[bake] opus-5 system-prompt variant: base 5030 → opus-5 8086 chars
[bake] spawning CC (sonnet-5-variant: claude-sonnet-5) against loopback MITM to capture /v1/messages...
[bake] sonnet-5 system-prompt variant: base 5030 → sonnet-5 13346 chars
[bake] check: drift detected — 1 differing slot (verdict: benign):
[bake] **Verdict:** ✅ Benign
[bake] 
[bake] - **system_prompt:** +279 chars net (text-content drift — see unified diff below)
[bake] 
[bake] check: per-slot detail:
[bake]   • system_prompt content changed (4720 → 4999 chars, delta +279)
[bake]         …
[bake]        # Context management
[bake]        When the conversation grows long, some or all of the current context is summarized; the summary, along with any remaining unsummarized context, is provided in the next context window so work can continue — you don't need to wrap up early or hand off mid-task.
[bake]       +
[bake]       +When you have enough information to act, act. Do not re-derive facts already established in the conversation, re-litigate a decision the user has already made, or narrate options you will not pursue. If you are weighing a choice, give a recommendation, not an exhaustive survey
[bake]        
[bake] wrote drift-summary.md for workflow embedding
[bake] check: bundled template is stale relative to live CC. Run `node scripts/capture-and-bake.mjs` to re-bake.
```

### Validation

Compat-test (`compat-test-self-hosted.yml`) will auto-fire on this PR because it touches `src/cc-template-data.json`. If it goes green, this is mergeable as-is. If it fails, the rebake captured something Anthropic isn't ready to ship — close the PR, investigate manually.

### Why not auto-merged

The bundled template is the wire-shape contract for non-CC clients. compat-test exercises passthrough mode; it cannot validate the rebuild-from-canonical path, so a human approves the bake. Approving + merging bumps the patch version and triggers `cc-drift-auto-release.yml` — approval is the ship gate.

Background: [v4.2.1 CHANGELOG entry](https://github.com/askalf/dario/blob/master/CHANGELOG.md#421---2026-05-17) documents this drift class — same CC binary, different runtime wire shape via remote configuration.
