### PR TITLE
drift-watch: gate auto-rebake PRs on a real content diff (#990)

### DIFF
--- a/.github/workflows/cc-drift-template-watch.yml
+++ b/.github/workflows/cc-drift-template-watch.yml
@@ -221,12 +221,20 @@ jobs:
           fi
           echo "issue_881=$issue_881" >> "$GITHUB_OUTPUT"
 
-          # Sanity: did the bake actually change the bundle?
-          if git diff --quiet -- src/cc-template-data.json; then
-            echo "::warning::--check reported drift but bake produced no diff vs HEAD — likely a transient capture; skipping PR"
+          # Sanity: did the bake actually change the bundle's CONTENT?
+          #
+          # `git diff --quiet` cannot answer this (dario#990): capture-and-bake
+          # restamps `_captured` on every run, so the file is ALWAYS textually
+          # dirty and this gate never fired. PR #990 reached the ship gate with
+          # a bundle byte-identical to v5.5.17 apart from that timestamp,
+          # carrying a patch bump and a CHANGELOG entry for drift that was not
+          # in its diff. check-rebake-content.mjs compares key by key and
+          # ignores only the transient provenance stamp.
+          if ! changed_keys=$(node scripts/check-rebake-content.mjs); then
             echo "skipped=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "bake changed template keys: $changed_keys"
 
           branch="bot/template-rebake-$(date -u +%Y%m%d-%H%M%S)"
           git config user.email "actions@github.com"

--- a/scripts/check-rebake-content.mjs
+++ b/scripts/check-rebake-content.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Content-diff gate for an auto-rebake of the bundled CC template (dario#990).
+ *
+ * cc-drift-template-watch.yml runs this between capture-and-bake.mjs and
+ * rebake-release-prep.mjs, in place of the `git diff --quiet` sanity check
+ * that step used to rely on. That check asked the right question — "did the
+ * bake actually change the bundle?" — of the wrong thing: `_captured` is
+ * restamped by every bake, so the file is always textually dirty and the gate
+ * could never fire.
+ *
+ * PR #990 is what that costs. A transient `--check` capture (whose base
+ * matched the dario#881 residue signature) opened a rebake PR whose
+ * src/cc-template-data.json was byte-identical to the previous release apart
+ * from `_captured` — carrying a patch bump and a CHANGELOG entry announcing a
+ * "wire-fingerprint drift" that was not in the diff. The tripwire warned a
+ * human to check; nothing stopped the PR from existing.
+ *
+ * Compares the freshly-baked working-tree bundle against the committed one
+ * key by key, ignoring TRANSIENT_TEMPLATE_FIELDS.
+ *
+ * Exits: 0 the bake ships real content (changed keys listed on stdout)
+ *        1 content-empty — caller should skip the PR
+ *        2 usage / git error (also treated as skip-worthy by the caller)
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { meaningfulTemplateKeys, TRANSIENT_TEMPLATE_FIELDS } from './drift-report.mjs';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const REL = 'src/cc-template-data.json';
+
+let committed;
+try {
+  committed = JSON.parse(
+    execFileSync('git', ['show', `HEAD:${REL}`], { cwd: repoRoot, encoding: 'utf-8' }),
+  );
+} catch (err) {
+  console.error(`error: cannot read HEAD:${REL} — ${err.message}`);
+  process.exit(2);
+}
+
+let baked;
+try {
+  baked = JSON.parse(readFileSync(join(repoRoot, REL), 'utf-8'));
+} catch (err) {
+  console.error(`error: cannot read the freshly-baked ${REL} — ${err.message}`);
+  process.exit(2);
+}
+
+const changed = meaningfulTemplateKeys(committed, baked);
+
+if (changed.length === 0) {
+  const ignored = [...TRANSIENT_TEMPLATE_FIELDS].join(', ');
+  console.error(
+    `::warning title=content-empty rebake::--check reported drift but the bake produced no content change vs HEAD (only ${ignored} moved) — transient capture, skipping PR. See dario#990.`,
+  );
+  console.error('');
+  console.error('CONTENT-EMPTY REBAKE (dario#990)');
+  console.error(`  every key of ${REL} except ${ignored} is identical to HEAD.`);
+  console.error('  The --check capture that triggered this rebake did not survive');
+  console.error('  the bake\'s own capture, so there is nothing to ship. Opening a PR');
+  console.error('  here would cut a release whose CHANGELOG claims a wire-shape change');
+  console.error('  that is not in its diff.');
+  process.exit(1);
+}
+
+console.log(changed.join(' '));

--- a/scripts/drift-report.mjs
+++ b/scripts/drift-report.mjs
@@ -575,3 +575,54 @@ export function formatIssue881Warning(detection) {
     '  outcome on #881 either way — the correlating conditions are what that issue needs.',
   ];
 }
+
+// ──────────────────────────────────────────────────────────────────────
+// Content-empty rebake guard (dario#990)
+// ──────────────────────────────────────────────────────────────────────
+//
+// `cc-drift-template-watch.yml`'s auto-rebake step gates on
+// `git diff --quiet -- src/cc-template-data.json` to answer "did the bake
+// actually change the bundle?". That gate CANNOT fire: every
+// `capture-and-bake` run stamps a fresh `_captured` timestamp, so the file is
+// always textually dirty even when the wire shape is byte-identical. A
+// transient `--check` capture therefore reaches the ship gate as a PR with a
+// version bump and a "wire-fingerprint drift" CHANGELOG entry describing a
+// change that isn't in the diff.
+//
+// Live case: PR #990 (v5.5.18). Every content key — tools, system_prompt,
+// system_prompt_variants, anthropic_beta, header_order, header_values,
+// body_field_order, agent_identity — was identical to v5.5.17; only
+// `_captured` moved. The `--check` capture had matched the dario#881 residue
+// signature, the bake's own capture had not, and nothing downstream noticed
+// that the two disagreed to the point of an empty bundle.
+
+/**
+ * Fields a bake rewrites unconditionally, independent of wire shape. Only
+ * `_captured` qualifies: it is a provenance stamp for WHEN the capture ran,
+ * never a statement about what the capture found.
+ *
+ * Deliberately narrow. `_version` / `_supportedMaxTested` / the user-agent
+ * header are NOT here — when those move the bundle genuinely ships something
+ * (that is the whole content of a label-sync PR), so a rebake carrying only a
+ * version-label move is still worth opening.
+ */
+export const TRANSIENT_TEMPLATE_FIELDS = new Set(['_captured']);
+
+/**
+ * Top-level keys whose value differs between two baked templates, ignoring
+ * `TRANSIENT_TEMPLATE_FIELDS`. Compared by canonical JSON so key order inside
+ * a nested object never reads as a change.
+ *
+ * An empty result means the freshly-baked bundle ships nothing: the capture
+ * that triggered the rebake was transient, and merging would cut a release for
+ * a wire-shape change that did not happen upstream.
+ */
+export function meaningfulTemplateKeys(prev, now) {
+  const keys = new Set([...Object.keys(prev || {}), ...Object.keys(now || {})]);
+  const changed = [];
+  for (const k of keys) {
+    if (TRANSIENT_TEMPLATE_FIELDS.has(k)) continue;
+    if (JSON.stringify(prev?.[k]) !== JSON.stringify(now?.[k])) changed.push(k);
+  }
+  return changed.sort();
+}

--- a/test/bake-drift-report.mjs
+++ b/test/bake-drift-report.mjs
@@ -3,7 +3,7 @@
 // test runner spawns each file via node:test which is fine for imports
 // too, but the existing pattern groups script-imports in serial).
 
-import { unifiedDiff, computeDrift, describeTool, formatDriftReport, interpretDrift, formatDriftSummary, MODEL_CONDITIONAL_BETAS, REMOTE_CONFIG_CONDITIONAL_BETAS, normalizeMemoryPath, stripModelConditionalBetas, isOlderCCVersion, detectIssue881Residue, formatIssue881Warning, ISSUE_881_MARKER, ISSUE_881_BASELINE_LEN, ISSUE_881_ANOMALY_LEN } from '../scripts/drift-report.mjs';
+import { unifiedDiff, computeDrift, meaningfulTemplateKeys, TRANSIENT_TEMPLATE_FIELDS, describeTool, formatDriftReport, interpretDrift, formatDriftSummary, MODEL_CONDITIONAL_BETAS, REMOTE_CONFIG_CONDITIONAL_BETAS, normalizeMemoryPath, stripModelConditionalBetas, isOlderCCVersion, detectIssue881Residue, formatIssue881Warning, ISSUE_881_MARKER, ISSUE_881_BASELINE_LEN, ISSUE_881_ANOMALY_LEN } from '../scripts/drift-report.mjs';
 
 let pass = 0;
 let fail = 0;
@@ -563,6 +563,78 @@ header('41. formatIssue881Warning — the Actions annotation');
 
   const byLength = formatIssue881Warning(detectIssue881Residue('y'.repeat(ISSUE_881_ANOMALY_LEN), 'y'.repeat(ISSUE_881_BASELINE_LEN)));
   check('the length clause renders its own explanation', byLength[0].includes(`exactly ${ISSUE_881_ANOMALY_LEN} chars`));
+}
+
+// ──────────────────────────────────────────────────────────────────────
+header('42. meaningfulTemplateKeys — the content-empty rebake gate (dario#990)');
+{
+  // The exact shape of PR #990: every content key identical to the previous
+  // release, only the provenance stamp moved. This must read as "ships
+  // nothing" or the workflow cuts a release for drift that did not happen.
+  const v5517 = {
+    _captured: '2026-08-15T04:59:39.819Z',
+    _version: '2.1.233',
+    _source: 'bundled',
+    _schemaVersion: 1,
+    agent_identity: 'You are Claude Code',
+    system_prompt: 'base prompt',
+    tools: [{ name: 'Bash', description: 'run a command' }],
+    tool_names: ['Bash'],
+    header_order: ['a', 'b'],
+    anthropic_beta: 'oauth-2025-04-20',
+    header_values: { 'user-agent': 'claude-cli/2.1.233' },
+    body_field_order: ['model', 'messages'],
+    _supportedMaxTested: '2.1.233',
+    system_prompt_variants: { fable: 'v' },
+  };
+  const v5518 = { ...v5517, _captured: '2026-08-16T23:50:32.289Z' };
+
+  check('only _captured moved → no meaningful keys', meaningfulTemplateKeys(v5517, v5518).length === 0);
+  check('identical objects → no meaningful keys', meaningfulTemplateKeys(v5517, v5517).length === 0);
+  check('_captured is the transient set', TRANSIENT_TEMPLATE_FIELDS.has('_captured'));
+
+  // A real prompt edit still surfaces — the gate must not swallow genuine drift.
+  check(
+    'system_prompt change is reported',
+    meaningfulTemplateKeys(v5517, { ...v5518, system_prompt: 'base prompt EDITED' }).join() === 'system_prompt',
+  );
+  check(
+    'tools change is reported',
+    meaningfulTemplateKeys(v5517, { ...v5518, tools: [] }).join() === 'tools',
+  );
+  check(
+    'anthropic_beta change is reported',
+    meaningfulTemplateKeys(v5517, { ...v5518, anthropic_beta: 'oauth-2025-04-20,afk-mode-2026-01-31' }).join() === 'anthropic_beta',
+  );
+  check(
+    'a nested variant change is reported',
+    meaningfulTemplateKeys(v5517, { ...v5518, system_prompt_variants: { fable: 'CHANGED' } }).join() === 'system_prompt_variants',
+  );
+
+  // A label-only move is NOT transient — that IS the content of a label-sync
+  // PR, so it must still open one.
+  check(
+    '_version move is reported (label-sync must still ship)',
+    meaningfulTemplateKeys(v5517, { ...v5518, _version: '2.1.234' }).join() === '_version',
+  );
+
+  // Added / removed keys count as drift in both directions.
+  const { anthropic_beta, ...missingBeta } = v5518;
+  check('a removed key is reported', meaningfulTemplateKeys(v5517, missingBeta).join() === 'anthropic_beta');
+  check('an added key is reported', meaningfulTemplateKeys(v5517, { ...v5518, brand_new: 1 }).join() === 'brand_new');
+
+  // Multiple changes come back sorted and complete.
+  const multi = meaningfulTemplateKeys(v5517, { ...v5518, tools: [], system_prompt: 'x' });
+  check('multiple changes are all reported, sorted', multi.join() === 'system_prompt,tools');
+
+  // Key order inside a nested object is not a content change.
+  check(
+    'nested key order is not drift',
+    meaningfulTemplateKeys(
+      { ...v5517, header_values: { a: '1', b: '2' } },
+      { ...v5518, header_values: { a: '1', b: '2' } },
+    ).length === 0,
+  );
 }
 
 // ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Why

`cc-drift-template-watch.yml`'s auto-rebake step asks the right question — "did the bake actually change the bundle?" — of the wrong thing:

```bash
if git diff --quiet -- src/cc-template-data.json; then ... skip PR ... fi
```

`capture-and-bake.mjs` restamps `_captured` on **every** run, so the file is always textually dirty. That gate can never fire.

#990 is what that costs. Its `src/cc-template-data.json` is byte-identical to v5.5.17 apart from the `_captured` timestamp — verified key by key at both SHAs:

| | |
|---|---|
| `_captured` | **DIFF** (`2026-08-15T04:59:39.819Z` → `2026-08-16T23:50:32.289Z`) |
| `tools` (111682 B), `system_prompt` (4799 B), `system_prompt_variants` (30920 B), `anthropic_beta`, `header_order`, `header_values`, `body_field_order`, `tool_names`, `agent_identity`, `_version`, `_supportedMaxTested`, `_source`, `_schemaVersion` | identical |

Both files are exactly 168034 bytes. Yet the PR carries a patch bump to `v5.5.18` and a CHANGELOG entry announcing a "wire-fingerprint drift … now matches the current CC wire shape" — describing a change that is not in its own diff. Merging would cut an npm release for a wire-shape change that did not happen upstream.

The dario#881 tripwire did its job: it warned a human to look. Nothing *stopped* the content-empty PR from existing, and the tripwire only covers the one known residue signature — any transient capture reaches the ship gate the same way.

## What changed

- **`scripts/drift-report.mjs`** — new `meaningfulTemplateKeys(prev, now)` + `TRANSIENT_TEMPLATE_FIELDS`. Compares top-level keys by canonical JSON, ignoring only `_captured`. Deliberately narrow: `_version` / `_supportedMaxTested` / the user-agent token are **not** transient, because a label move is exactly the content of a label-sync PR and must still ship.
- **`scripts/check-rebake-content.mjs`** (new) — compares the freshly-baked working-tree bundle against `HEAD`. Exit 0 with the changed keys on stdout; exit 1 with a `::warning::` annotation when content-empty; exit 2 on git/parse error.
- **`.github/workflows/cc-drift-template-watch.yml`** — the auto-rebake step's `git diff --quiet` sanity check now calls that script, and logs the changed keys when it proceeds.

Only the *shape*-rebake path changes. The exit-3 label-sync path keeps its own `git diff --quiet` check, which is correct there: `label-sync.mjs` does not re-capture, so it never touches `_captured`.

## Test plan

`test/bake-drift-report.mjs`: **132 → 144 assertions, 0 fail** (`node test/bake-drift-report.mjs`). New case 42 covers the #990 shape (only `_captured` moved → empty), that genuine drift in each axis still surfaces (`system_prompt`, `tools`, `anthropic_beta`, `system_prompt_variants`), added/removed keys, multi-key sorting, nested key-order insensitivity, and that a `_version` move still reports so label-sync is unaffected.

End-to-end against the real artifacts, not fixtures:

- #990's actual head bundle in the working tree → `check-rebake-content.mjs` exits **1** and prints the content-empty annotation.
- same bundle plus one appended sentence in `system_prompt` → exits **0**, stdout `system_prompt`.

## Re-dispatch outcome

Re-dispatched `cc-drift-template-watch.yml` per #990's own instructions: run [31981172851](https://github.com/askalf/dario/actions/runs/31981172851). The #881 residue did **not** reproduce (scrubbed base 4802 vs 4751 bundled = +51; the #881 signature is +279 and its marker clause was absent). #990 is the anomaly and should be closed rather than merged.

That run did surface a *different* transient — the capture carried a trailing `<total_tokens>15000000 tokens left</total_tokens>` line after the `# Context management` paragraph. Unrelated to this gate, filed separately; it is a per-session budget counter, not wire shape. No new rebake PR was opened, because the de-dup saw #990 still open.

Source ticket: `00MSWH41FA60F7465256F288C9`. Refs #990, #881.
