### PR TITLE
ci(health-watch): stop spending codeload budget on every probe run

### DIFF
--- a/.github/workflows/cc-oauth-health.yml
+++ b/.github/workflows/cc-oauth-health.yml
@@ -39,8 +39,21 @@ name: dario serving health alert (self-hosted)
 # box updates; it must never page because a field it wanted wasn't there.
 
 on:
+  # TWO clocks, deliberately, with the cron as the thin backstop.
+  #
+  # The real cadence comes from platform's tools/watch-kick.sh — a systemd
+  # timer on the box that workflow_dispatches this file every 10 min, because
+  # GH's free-tier scheduler throttles hard (this `*/5` was observed firing
+  # roughly once per 30 min, not 6x/hr).
+  #
+  # It was `*/5` here, which on top of the 10-min kick meant two independent
+  # clocks racing for the same job. Thinned to `*/30` — its actual observed
+  # rate anyway — so the cron stops adding load while still covering the case
+  # watch-kick.sh cannot: if the box's timer dies (or the box does), this is
+  # the fleet's last-resort auth watcher and nothing else would notice. Not
+  # deleted for exactly that reason; watch-kick.sh is a single point of failure.
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '*/30 * * * *'
   workflow_dispatch:
 
 permissions:
@@ -53,23 +66,64 @@ concurrency:
 jobs:
   probe:
     permissions:
+      # A job-level `permissions:` block REPLACES the workflow-level one, so
+      # `contents: read` has to be restated here — the fetch step below reads
+      # scripts/health-verdict.sh through the contents API with this token.
+      contents: read
       issues: write
     runs-on: [self-hosted, dario-drift]
     timeout-minutes: 4
     steps:
-      # Needed only for scripts/health-verdict.sh — the parsing/verdict logic
-      # lives in the repo so it can be unit-tested rather than being trapped in
-      # this `run:` block. No build, no npm; the script is dependency-free
-      # POSIX sh, so a sparse shallow checkout is the whole cost.
+      # Fetch scripts/health-verdict.sh via the REST contents API — NOT an
+      # action, and NOT a checkout.
       #
-      # `scripts` — a DIRECTORY, not the single file. checkout-with-retry does
-      # not expose sparse-checkout-cone-mode, so the inner actions/checkout
-      # always runs in cone mode, where every pattern must be a directory; a
-      # file path dies with `fatal: '...' is not a directory` (run
-      # #31239237095). Checking out the whole dir costs nothing here.
-      - uses: askalf/checkout-with-retry@115a6407547e9711edbc2e915838d495cad9583f  # v1.1.0
-        with:
-          sparse-checkout: scripts
+      # This workflow is the highest-frequency job on the box's runner (a
+      # 10-min kick from platform's watch-kick.sh, plus this file's own cron),
+      # and every run used to pull a fresh askalf/checkout-with-retry tarball
+      # from codeload.github.com. codeload throttles per runner on a budget the
+      # action-download path cannot survive: on 2026-08-17 13:30-14:50Z eight
+      # consecutive runs died in "Prepare all required actions" with 429 Too
+      # Many Requests, after the runner's own 3-attempt backoff (14s, 28s) was
+      # already exhausted. There is no knob for that retry — it is internal to
+      # the runner — so the only fix is to stop spending codeload budget here.
+      #
+      # api.github.com has a separate, far larger budget (5000/hr authenticated)
+      # and one raw-content GET is a fraction of a tarball. `?ref=` pins the
+      # script to the exact commit this workflow was dispatched at, so the
+      # parsing logic can never drift from the workflow that calls it.
+      #
+      # This also retires the sparse-checkout cone-mode footgun the old step
+      # carried: checkout-with-retry does not expose sparse-checkout-cone-mode,
+      # so a FILE pattern died with `fatal: '...' is not a directory` (run
+      # #31239237095) and the whole `scripts` dir had to be checked out to
+      # fetch one dependency-free POSIX-sh file. Now we fetch just the file.
+      - name: Fetch health-verdict script
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          REF: ${{ github.sha }}
+        run: |
+          set -uo pipefail
+          dest="$RUNNER_TEMP/health-verdict.sh"
+          # Three attempts with linear backoff. Unlike the action-download path
+          # this retry is ours, so a transient 429/5xx here is survivable rather
+          # than fatal — and a watcher that cannot fetch its own verdict logic
+          # must fail loudly (see the exit 1 below), never silently pass.
+          for attempt in 1 2 3; do
+            if gh api "repos/$REPO/contents/scripts/health-verdict.sh?ref=$REF" \
+                 -H 'Accept: application/vnd.github.raw' > "$dest" 2>/dev/null \
+               && [ -s "$dest" ]; then
+              echo "fetched health-verdict.sh at $REF (attempt $attempt)"
+              exit 0
+            fi
+            echo "attempt $attempt: could not fetch health-verdict.sh"
+            # if/fi, not `&& sleep`: this step runs under the runner's default
+            # `bash -e {0}`, so on the last pass a false test would be the loop's
+            # exit status and kill the step BEFORE the ::error:: below is printed.
+            if [ "$attempt" -lt 3 ]; then sleep $((attempt * 10)); fi
+          done
+          echo "::error::could not fetch scripts/health-verdict.sh after 3 attempts"
+          exit 1
 
       - name: Probe local /health and alert on any unhealthy axis
         env:
@@ -102,11 +156,12 @@ jobs:
           # the empty-body case kills the job RIGHT HERE and the
           # oauth=unreachable alert below (the whole point of this
           # watcher) never fires.
-          # Parsing + verdict live in scripts/health-verdict.sh so they can be
+          # Parsing + verdict live in scripts/health-verdict.sh (fetched to
+          # $RUNNER_TEMP by the step above) so they can be
           # unit-tested (test/health-verdict.mjs). A watcher that silently stops
           # matching reports "healthy" forever; that has to be testable without
           # firing this workflow against a real broken proxy.
-          verdict="$(printf '%s' "$body" | sh "$GITHUB_WORKSPACE/scripts/health-verdict.sh" || true)"
+          verdict="$(printf '%s' "$body" | sh "$RUNNER_TEMP/health-verdict.sh" || true)"
           oauth="$(printf '%s\n' "$verdict" | sed -n '1p')"
           probe_ok="$(printf '%s\n' "$verdict" | sed -n '2p')"
           probe_reason="$(printf '%s\n' "$verdict" | sed -n '3p')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,11 @@ checklist.
 
 ## [Unreleased]
 
-<<<<<<< HEAD
 - **Serving-health watcher no longer dies on codeload rate limits.** `cc-oauth-health.yml` fetched `scripts/health-verdict.sh` by way of `askalf/checkout-with-retry`, so every run pulled an action tarball from `codeload.github.com`. As the highest-frequency job on the box's runner (a 10-min `workflow_dispatch` kick from platform's `watch-kick.sh` *plus* this file's own cron) it saturated the per-runner action-download budget: on 2026-08-17 13:30–14:50Z eight consecutive runs failed in "Prepare all required actions" with `429 Too Many Requests` after the runner's internal 3-attempt backoff (14s, 28s) was exhausted. That retry is not configurable, so the fix is to stop spending codeload budget — the script is now fetched with one authenticated `gh api .../contents/...` raw GET (separate 5000/hr budget), pinned to `?ref=${{ github.sha }}` so verdict logic cannot drift from the workflow calling it, with our own 3-attempt backoff that fails loudly rather than passing silently. Incidentally retires the sparse-checkout cone-mode footgun that forced checking out all of `scripts/` to read one file. The workflow's cron is thinned `*/5` → `*/30`, matching the rate GitHub's free-tier scheduler actually delivered and removing the duplicate clock racing the 10-min kick; it is kept, not deleted, as the backstop for `watch-kick.sh` (a single point of failure) dying with the box.
 
-=======
 ## [5.5.18] - 2026-08-17
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.233` → `2.1.234` for CC v2.1.234. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.
->>>>>>> origin/master
 ## [5.5.17] - 2026-08-15
 
 - **Template rebake** — re-captured `src/cc-template-data.json` after cc-drift-template-watch detected wire-fingerprint drift against a live CC capture. Bundled fallback template now matches the current CC wire shape.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ checklist.
 
 ## [Unreleased]
 
+- **Serving-health watcher no longer dies on codeload rate limits.** `cc-oauth-health.yml` fetched `scripts/health-verdict.sh` by way of `askalf/checkout-with-retry`, so every run pulled an action tarball from `codeload.github.com`. As the highest-frequency job on the box's runner (a 10-min `workflow_dispatch` kick from platform's `watch-kick.sh` *plus* this file's own cron) it saturated the per-runner action-download budget: on 2026-08-17 13:30–14:50Z eight consecutive runs failed in "Prepare all required actions" with `429 Too Many Requests` after the runner's internal 3-attempt backoff (14s, 28s) was exhausted. That retry is not configurable, so the fix is to stop spending codeload budget — the script is now fetched with one authenticated `gh api .../contents/...` raw GET (separate 5000/hr budget), pinned to `?ref=${{ github.sha }}` so verdict logic cannot drift from the workflow calling it, with our own 3-attempt backoff that fails loudly rather than passing silently. Incidentally retires the sparse-checkout cone-mode footgun that forced checking out all of `scripts/` to read one file. The workflow's cron is thinned `*/5` → `*/30`, matching the rate GitHub's free-tier scheduler actually delivered and removing the duplicate clock racing the 10-min kick; it is kept, not deleted, as the backstop for `watch-kick.sh` (a single point of failure) dying with the box.
+
 ## [5.5.17] - 2026-08-15
 
 - **Template rebake** — re-captured `src/cc-template-data.json` after cc-drift-template-watch detected wire-fingerprint drift against a live CC capture. Bundled fallback template now matches the current CC wire shape.


### PR DESCRIPTION
## Problem

`cc-oauth-health.yml` ("dario serving health alert") failed 8 consecutive times on 2026-08-17 between 13:30Z and 14:50Z. The error was **not** in the probe — it was in `Prepare all required actions`:

```
Download action repository 'askalf/checkout-with-retry@115a640'
##[warning]Failed to download action 'https://codeload.github.com/askalf/checkout-with-retry/tar.gz/115a640'.
  Error: Response status code does not indicate success: 429 (Too Many Requests).
##[warning]Back off 14.109 seconds before retry.
##[warning]... 429 ... Back off 28.397 seconds before retry.
##[error]Failed to download archive '...' after 3 attempts.
```

Failing runs: 32039258026, 32038687325, 32038473167, 32038097823, 32037470540, 32036866452, 32036790725, 32036211103.

## Root cause

This workflow is the highest-frequency job on the box's self-hosted runner, and **every run** pulled an action tarball from `codeload.github.com` — solely to sparse-checkout `scripts/` for one dependency-free POSIX-sh file. Two independent clocks drive it:

- `workflow_dispatch` **every 10 min** from platform's `tools/watch-kick.sh` (systemd timer on the box)
- this file's own `schedule: */5`, which GitHub's free-tier scheduler actually delivered about once per 30 min (13:49, 14:16, 14:49, 15:14, 15:44Z)

~8 runs/hr of tarball downloads saturates the per-runner codeload budget. Nothing else on that runner pulls this action more often than `*/30`.

Critically, **"add backoff" is not an available fix**: the runner's own action-download retry is internal, already does 3 attempts with 14s/28s backoff, and was exhausted in every failing run. There is no knob. The only fix is to stop spending codeload budget here.

## Fix

**1. Remove the codeload dependency (primary).** Fetch `scripts/health-verdict.sh` with one authenticated `gh api repos/.../contents/...` raw GET. Different, far larger budget (5000/hr authenticated), and a raw file is a fraction of a tarball. Pinned to `?ref=${{ github.sha }}`, so the verdict logic can never drift from the workflow dispatching it. Our own 3-attempt linear backoff — and unlike the silent-healthy failure mode this watcher is built to avoid, a failure to load the verdict logic exits 1 loudly.

Side benefit: retires the sparse-checkout cone-mode footgun documented in the old step's comment (`fatal: '...' is not a directory`, run #31239237095) — no cone mode, so we fetch just the one file instead of the whole directory.

**2. Consolidate the duplicate clock (secondary).** `*/5` → `*/30`. That matches the cadence GitHub was actually delivering, so this removes load without reducing real coverage. The cron is **deliberately kept, not deleted**: `watch-kick.sh` is a single point of failure, and if the box's systemd timer dies this is the fleet's last-resort auth watcher — nothing else would notice.

Two bugs caught while writing the new step, either of which would have broken it in CI:
- A job-level `permissions:` block **replaces** the workflow-level one, so `contents: read` had to be restated at job level or the contents API 403s.
- `[ "$attempt" -lt 3 ] && sleep ...` as the loop's last statement is fatal under the runner's default `bash -e` — a false test on the final pass becomes the loop's exit status and kills the step *before* the `::error::` annotation prints. Uses `if/fi`.

## Test plan

Verified locally before pushing:

- **Real fetch:** `gh api repos/askalf/dario/contents/scripts/health-verdict.sh?ref=5c6d03e -H 'Accept: application/vnd.github.raw'` → 2878 bytes.
- **Verdict unchanged from the temp path** (the behaviour that matters — this watcher's failure mode is silence):
  - healthy body → `healthy / true / ok / 0 / <empty axis>` → no alert
  - `"oauth":"broken"` → axis `OAuth broken` → alerts
  - empty body (container down) → axis `OAuth unreachable` → alerts
- **Retry loop under `bash -e`** with a stubbed-failing `gh`: printed all three attempts, then the `::error::` annotation, exit 1. Confirms the `if/fi` fix.
- `test/health-verdict.mjs` is untouched and still covers the script itself; `actionlint` (required check) validates the workflow YAML.
- First green scheduled/kicked run on `master` post-merge is the real confirmation.

Source ticket: `01M0867F4H2WH1TVRX9YKY8QQ6`
