### PR TITLE
ci: label issues and PRs — path-based (PRs) and content-based (both)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,46 @@
+# Path-based PR labels — actions/labeler config for .github/workflows/labeler.yml.
+# `dependencies`, `javascript`, `github_actions` stay Dependabot's own; not
+# duplicated here (see dependabot.yml).
+
+auth:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/accounts.ts'
+          - 'src/oauth.ts'
+          - 'src/cc-oauth-detect.ts'
+          - 'src/cc-authorize-probe.ts'
+          - 'src/pool.ts'
+
+mcp:
+  - changed-files:
+      - any-glob-to-any-file: 'src/mcp/**'
+
+tui:
+  - changed-files:
+      - any-glob-to-any-file: 'src/tui/**'
+
+docker:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Dockerfile'
+          - 'docker-compose*.yml'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file: '.github/**'
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '*.md'
+          - 'docs/**'
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file: 'test/**'
+
+fuzz:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'fuzz/**'
+          - '.clusterfuzzlite/**'

--- a/.github/workflows/content-labeler.yml
+++ b/.github/workflows/content-labeler.yml
@@ -1,0 +1,69 @@
+name: Content-label issues and PRs
+
+# Keyword labels from title + body — the thing labeler.yml (path-based)
+# cannot do, since an issue has no changed files and a PR's *description*
+# of what it fixes doesn't necessarily overlap the paths it touches.
+#
+# Additive only: never removes a label, never touches one a human already
+# set, and skips bot-authored items (github-actions[bot] opens the
+# cc-drift / sdk-drift / cc-watcher-liveness family and those already carry
+# the precise label their own workflow assigned — a generic keyword pass
+# re-scanning "CC drift detected: v2.1.234" adds nothing and risks a bad
+# match on unrelated text in the auto-filed body).
+
+on:
+  issues:
+    types: [opened, edited]
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    # Same fork guard as labeler.yml — a fork PR's GITHUB_TOKEN is read-only
+    # regardless of the permissions block, so this would 403 for forks;
+    # issues have no fork concept and always pass.
+    if: github.event_name == 'issues' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const RULES = [
+              { label: 'security', pattern: /\b(security|vulnerab\w*|CVE-\d{4}-\d+|exploit\w*|\bRCE\b|secrets?\s+(leak|expos\w*)|credential\s+leak)\b/i },
+              { label: 'auth', pattern: /\b(oauth|refresh[- ]?token|access[- ]?token|re-?auth\w*|authentication|\b401\b|login\s+fail\w*)\b/i },
+              { label: 'bug', pattern: /\b(bug|crash(es|ed|ing)?|broken|doesn'?t work|not working|stack\s+trace|regression|unexpectedly\s+(fail|error|exit))\b/i },
+              { label: 'enhancement', pattern: /\b(feature\s+request|enhancement|would\s+be\s+(great|nice|awesome)|please\s+add|proposal|feature\s+idea)\b/i },
+              { label: 'documentation', pattern: /\b(docs?\b|documentation|readme|typo\s+in\s+(the\s+)?docs)\b/i },
+              { label: 'compatibility', pattern: /\b(cursor|cline|aider|windows|macos|linux|docker|kubernetes|k8s|compat\w*)\b/i },
+            ];
+
+            const isIssue = context.eventName === 'issues';
+            const target = isIssue ? context.payload.issue : context.payload.pull_request;
+            if (!target) return;
+            if (target.user?.type === 'Bot') {
+              console.log(`Skipping bot-authored ${isIssue ? 'issue' : 'PR'} #${target.number}.`);
+              return;
+            }
+
+            const text = `${target.title}\n${target.body ?? ''}`;
+            const existing = new Set((target.labels ?? []).map((l) => l.name));
+            const toAdd = RULES.filter((r) => r.pattern.test(text) && !existing.has(r.label)).map((r) => r.label);
+
+            if (toAdd.length === 0) {
+              console.log('No new content labels matched.');
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: target.number,
+              labels: toAdd,
+            });
+            console.log(`Added labels to #${target.number}: ${toAdd.join(', ')}`);

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,27 @@
+name: Label PRs
+
+# Path-based labels from .github/labeler.yml — which area of the tree a PR
+# touches. Content-based labels (bug/security/auth/... from title+body, on
+# both issues and PRs) are the separate content-labeler.yml job; this one
+# only knows file paths.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    # Same-repo refs only. actions/labeler needs a write-scoped GITHUB_TOKEN
+    # to add labels; a fork PR's token is read-only regardless of the
+    # permissions block above, so this would just fail for forks anyway —
+    # skipping it explicitly is clearer than letting the step 403.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Two new label-automation workflows, since path-based and content-based labeling need different mechanisms:

- **`labeler.yml`** + **`.github/labeler.yml`** — `actions/labeler`, path-based, PRs only. Labels by which area of the tree changed: `auth`, `mcp`, `tui`, `docker`, `ci`, `documentation`, `tests`, `fuzz`. Same shape already used in platform/strongroom (`actions/labeler@v7.0.0`, same-repo fork guard).
- **`content-labeler.yml`** — keyword match against title + body, on **both** issues and PRs, via `actions/github-script`. Covers `bug` / `security` / `auth` / `enhancement` / `documentation` / `compatibility` — labels a file diff can't infer, and the only way an issue (no changed files at all) gets labeled beyond what a human sets by hand.

Additive only: never removes a label, never touches one already set, skips bot-authored items (`github-actions[bot]`'s `cc-drift` / `sdk-drift` / `cc-watcher-liveness` issues already carry the precise label their own workflow assigned).

Pre-created the six new area labels (`ci`, `docker`, `mcp`, `tui`, `tests`, `fuzz`) with explicit colors rather than relying on `actions/labeler`'s create-on-first-use fallback.

## Test plan

- [x] YAML validated locally (`yaml.safe_load` on all three files)
- [ ] CI (including `actionlint`, a required check) green on this PR
- [ ] Manually verify on next real PR/issue that labels land as expected
