### PR TITLE
test: live dual-process integration proof for the refresh lock (#993)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ checklist.
 
 ## [Unreleased]
 
+- **Live integration test for the refresh lock (dario#993), and the finding that prompted it.** The unit tests + live curl checks against the deployed Worker proved the lock's API contract and dario's client code in isolation, but nobody had run two genuinely separate dario processes racing a real refresh end-to-end. `test/integration/dual-instance-race.mjs` does: two isolated `~/.dario` homes, real network calls to the real deployed Worker, a local mock standing in only for Anthropic's token endpoint (hammering the real one with production creds for adversarial testing risks burning the operator's live refresh token). Control run confirms the harness is meaningful — without the lock, one worker gets a genuine `invalid_grant`. With it: 6/6 runs held, both workers succeed, exactly one real refresh reaches "Anthropic" each time.
+
 ## [5.5.20] - 2026-08-18
 
 - **Template rebake** — re-captured `src/cc-template-data.json` after cc-drift-template-watch detected wire-fingerprint drift (+51 net chars, benign) against a live CC capture. Bundled fallback template now matches the current CC wire shape.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "e2e": "node test/e2e.mjs",
     "stress": "node test/stress.mjs",
     "compat": "node test/compat.mjs",
+    "test:refresh-lock-race": "node test/integration/dual-instance-race.mjs",
     "lint:pkg": "node scripts/check-package-json.mjs",
     "drift:sdk": "node scripts/check-sdk-drift.mjs",
     "drift:wire": "node scripts/check-wire-drift.mjs",

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,0 +1,39 @@
+# Live integration tests
+
+Not part of `npm test` (they need real network access and a real
+deployed lock service) — `test/all.test.mjs`'s discovery only scans the
+top-level `test/` directory, so this folder is invisible to it by design,
+same as `e2e.mjs`/`compat.mjs` having their own entry points.
+
+## `dual-instance-race.mjs` — the dario#993 fix, proven live
+
+Two genuinely separate `node` processes, each with its own isolated
+`~/.dario` (via a per-process `HOME`/`USERPROFILE`), racing to refresh
+the SAME account's OAuth token at the same instant. Real network calls
+to the real deployed `dario-refresh-lock` Cloudflare Worker; a local mock
+(`mock-anthropic-oauth.mjs`) stands in for Anthropic's token endpoint
+ONLY — hammering the real one with production credentials for
+adversarial testing risks actually burning the operator's live refresh
+token, everything else here is real, not simulated. The mock enforces
+the one behavior this whole fix depends on: a refresh_token is
+single-use, reusing an already-consumed one 400s exactly like the real
+API.
+
+```
+# prove the fix does something — run the race WITHOUT it first:
+npm run test:refresh-lock-race -- --no-lock
+# expect: one worker gets a real invalid_grant rejection (the #993 bug)
+
+# then the real test:
+DARIO_REFRESH_LOCK_URL=https://dario-refresh-lock.<subdomain>.workers.dev \
+DARIO_REFRESH_LOCK_TOKEN=<the shared secret> \
+npm run test:refresh-lock-race
+# expect: both workers succeed, exactly ONE real refresh reaches "Anthropic"
+```
+
+**Verified 2026-08-18:** 1/1 control run (`--no-lock`) reproduced the bug
+cleanly. 6/6 runs against the real deployed Worker held — both workers
+succeeded, exactly one real refresh each time, zero rejections. Each run
+uses a fresh random alias specifically so the DO's own credential cache
+(intentional, 5-minute TTL) can't mask a fresh race as a cache hit on a
+rerun.

--- a/test/integration/dual-instance-race.mjs
+++ b/test/integration/dual-instance-race.mjs
@@ -1,0 +1,150 @@
+// LIVE integration test: two genuinely separate dario processes, each with
+// its OWN isolated ~/.dario (nothing shared but the remote lock service),
+// both racing to refresh the SAME account's OAuth token at nearly the same
+// instant. Real network calls to the REAL deployed Cloudflare Worker
+// (dario-refresh-lock) for the lock; a local mock stands in for Anthropic's
+// token endpoint ONLY because hammering the real one with production
+// credentials for adversarial testing is a real risk (a botched run could
+// burn the operator's actual refresh token) — everything else in this test
+// is real, not mocked.
+//
+// This is the test that was missing: prior verification proved the lock's
+// API contract (7 live curl cases against the deployed Worker) and dario's
+// client code in isolation (16 unit tests, mocked fetch) — but nobody had
+// run the actual failure scenario dario#993 describes end-to-end. This does.
+//
+// Usage: node test/integration/dual-instance-race.mjs [--no-lock]
+//   --no-lock proves the test is meaningful by showing the race WITHOUT the
+//   fix (DARIO_REFRESH_LOCK_URL unset) — should show exactly the #993 bug.
+
+import { spawn, fork } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..');
+const NO_LOCK = process.argv.includes('--no-lock');
+const MOCK_PORT = 8912;
+
+const LOCK_URL = process.env.DARIO_REFRESH_LOCK_URL;
+const LOCK_TOKEN = process.env.DARIO_REFRESH_LOCK_TOKEN;
+if (!NO_LOCK && (!LOCK_URL || !LOCK_TOKEN)) {
+  console.error('Set DARIO_REFRESH_LOCK_URL + DARIO_REFRESH_LOCK_TOKEN (or pass --no-lock to test the pre-fix race).');
+  process.exit(1);
+}
+
+function waitForPort(port, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    const tryOnce = () => {
+      fetch(`http://127.0.0.1:${port}/log`).then(() => resolve()).catch(() => {
+        if (Date.now() > deadline) reject(new Error('mock oauth server did not come up'));
+        else setTimeout(tryOnce, 100);
+      });
+    };
+    tryOnce();
+  });
+}
+
+async function main() {
+  console.log(`\n=== dual-instance refresh race — ${NO_LOCK ? 'WITHOUT the fix (expect the #993 bug)' : 'WITH the distributed lock'} ===\n`);
+
+  // 1. Start the mock Anthropic token endpoint.
+  const mockServer = fork(join(__dirname, 'mock-anthropic-oauth.mjs'), {
+    env: { ...process.env, MOCK_OAUTH_PORT: String(MOCK_PORT) },
+    stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
+  });
+  await waitForPort(MOCK_PORT);
+
+  // 2. Seed it — both worker instances start from this SAME refresh token,
+  //    simulating two dario pods that shared config at boot (the actual
+  //    #993 scenario: "share a folder on a NAS containing the config").
+  // Unique alias per run: the DO's credential cache is intentionally
+  // persistent (5-minute TTL) across processes — correct in production,
+  // but it means a rerun on the SAME alias within that window would adopt
+  // the PRIOR run's cached credentials without ever touching the lock or
+  // the mock oauth endpoint again, silently testing the cache instead of
+  // a fresh race. A unique alias each run sidesteps that entirely.
+  const alias = `race-test-account-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const sharedStartToken = 'shared-start-refresh-token';
+  await fetch(`http://127.0.0.1:${MOCK_PORT}/seed`, {
+    method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ alias, refreshToken: sharedStartToken }),
+  });
+
+  // 3. Two genuinely isolated homes — nothing shared between the workers
+  //    except the remote lock service (or nothing at all, in --no-lock mode).
+  const homeA = mkdtempSync(join(tmpdir(), 'dario-race-a-'));
+  const homeB = mkdtempSync(join(tmpdir(), 'dario-race-b-'));
+
+  function launchWorker(label, home) {
+    const env = {
+      ...process.env,
+      HOME: home, USERPROFILE: home, // os.homedir() resolution, POSIX + Windows
+      WORKER_ALIAS: alias,
+      WORKER_REFRESH_TOKEN: sharedStartToken,
+      WORKER_LABEL: label,
+      DARIO_OAUTH_TOKEN_URL: `http://127.0.0.1:${MOCK_PORT}/oauth/token`,
+      DARIO_OAUTH_CLIENT_ID: 'test-client-id',
+    };
+    if (!NO_LOCK) {
+      env.DARIO_REFRESH_LOCK_URL = LOCK_URL;
+      env.DARIO_REFRESH_LOCK_TOKEN = LOCK_TOKEN;
+    }
+    return new Promise((resolve) => {
+      const child = spawn(process.execPath, [join(__dirname, 'refresh-worker.mjs')], { env });
+      let out = '';
+      child.stdout.on('data', (d) => { out += d; });
+      child.stderr.on('data', (d) => process.stderr.write(`[${label} stderr] ${d}`));
+      child.on('close', () => {
+        try { resolve(JSON.parse(out.trim().split('\n').pop())); }
+        catch { resolve({ label, ok: false, error: 'no parseable output: ' + out }); }
+      });
+    });
+  }
+
+  // 4. Fire both AT THE SAME TIME — Promise.all, not sequential awaits.
+  const [resultA, resultB] = await Promise.all([
+    launchWorker('A', homeA),
+    launchWorker('B', homeB),
+  ]);
+
+  // 5. Collect the mock server's view of what actually hit "Anthropic".
+  const log = await (await fetch(`http://127.0.0.1:${MOCK_PORT}/log`)).json();
+  mockServer.kill();
+  rmSync(homeA, { recursive: true, force: true });
+  rmSync(homeB, { recursive: true, force: true });
+
+  console.log('Worker A:', JSON.stringify(resultA, null, 2));
+  console.log('Worker B:', JSON.stringify(resultB, null, 2));
+  console.log('\nMock Anthropic token-endpoint log (ground truth of what really happened):');
+  for (const e of log) console.log(`  presented=${e.presented?.slice(0, 24)}...  -> ${e.result}`);
+
+  const bothOk = resultA.ok && resultB.ok;
+  const successfulRefreshes = log.filter((e) => e.result?.startsWith('OK')).length;
+  const rejections = log.filter((e) => e.result?.startsWith('REJECTED')).length;
+
+  console.log(`\n${'='.repeat(70)}`);
+  console.log(`  RESULT: both workers succeeded = ${bothOk} | real refreshes = ${successfulRefreshes} | rejections = ${rejections}`);
+  console.log(`${'='.repeat(70)}\n`);
+
+  if (NO_LOCK) {
+    if (!bothOk && rejections >= 1) {
+      console.log('✅ Reproduced the #993 bug as expected: one worker got a real invalid_grant rejection.');
+      process.exit(0);
+    }
+    console.log('⚠️  Did not reproduce the bug this run (timing-dependent without the lock) — try again.');
+    process.exit(1);
+  } else {
+    if (bothOk && successfulRefreshes === 1) {
+      console.log('✅ THE FIX WORKS: both workers report success, but only ONE real refresh reached "Anthropic" — the other adopted the winner\'s fresh credentials instead of racing it.');
+      process.exit(0);
+    }
+    console.log('❌ FIX DID NOT HOLD — investigate before trusting this for dario#993.');
+    process.exit(1);
+  }
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });

--- a/test/integration/mock-anthropic-oauth.mjs
+++ b/test/integration/mock-anthropic-oauth.mjs
@@ -1,0 +1,75 @@
+// Mock Anthropic OAuth token endpoint for live multi-process integration
+// testing (test/integration/dual-instance-race.mjs). Deliberately enforces
+// the ONE real-world behavior this whole fix depends on: Anthropic
+// invalidates the previous refresh_token on every refresh, so reusing an
+// already-consumed token must 400 exactly like the real API does. Without
+// this, a mock that just always succeeds would validate nothing — the race
+// #993 describes only exists because of this exact invalidation behavior.
+import { createServer } from 'node:http';
+import { randomUUID } from 'node:crypto';
+
+const PORT = Number(process.env.MOCK_OAUTH_PORT || 8912);
+
+// alias -> current valid refresh_token. Seeded via /seed before the test
+// starts, mutated on every successful refresh.
+const validTokens = new Map();
+const usedTokens = new Set();
+const refreshLog = [];
+
+const server = createServer(async (req, res) => {
+  const chunks = [];
+  for await (const c of req) chunks.push(c);
+  const body = Buffer.concat(chunks).toString('utf-8');
+
+  if (req.method === 'POST' && req.url === '/seed') {
+    const { alias, refreshToken } = JSON.parse(body);
+    validTokens.set(alias, refreshToken);
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  if (req.method === 'GET' && req.url === '/log') {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify(refreshLog));
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/oauth/token') {
+    const params = new URLSearchParams(body);
+    const presented = params.get('refresh_token');
+    const entry = { presented, at: Date.now() };
+
+    // Find which alias this token belongs to (by CURRENT valid value —
+    // an already-used token won't match anything, which is the point).
+    let alias = null;
+    for (const [a, tok] of validTokens) if (tok === presented) alias = a;
+
+    if (!alias) {
+      entry.result = usedTokens.has(presented) ? 'REJECTED (already used)' : 'REJECTED (unknown token)';
+      refreshLog.push(entry);
+      res.writeHead(400, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'invalid_grant', error_description: 'Refresh token not found or invalid' }));
+      return;
+    }
+
+    // Consume it — this IS Anthropic's real behavior being modeled.
+    usedTokens.add(presented);
+    const newAccess = `mock-access-${randomUUID()}`;
+    const newRefresh = `mock-refresh-${randomUUID()}`;
+    validTokens.set(alias, newRefresh);
+    entry.result = `OK (alias=${alias}, issued new refresh)`;
+    refreshLog.push(entry);
+
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ access_token: newAccess, refresh_token: newRefresh, expires_in: 28800 }));
+    return;
+  }
+
+  res.writeHead(404);
+  res.end();
+});
+
+server.listen(PORT, () => {
+  console.log(`[mock-oauth] listening on :${PORT}`);
+});

--- a/test/integration/refresh-worker.mjs
+++ b/test/integration/refresh-worker.mjs
@@ -1,0 +1,34 @@
+// One real dario instance's refresh attempt, run as its OWN process with
+// its OWN isolated ~/.dario (via a per-process HOME/USERPROFILE override —
+// see dual-instance-race.mjs) so nothing is shared except the remote lock
+// service. That's the harder, more honest test: two pods with genuinely
+// independent local state, not two processes on the same filesystem that
+// could converge by accident through a shared account file.
+import { refreshAccountToken, saveAccount } from '../../dist/accounts.js';
+
+const alias = process.env.WORKER_ALIAS;
+const refreshToken = process.env.WORKER_REFRESH_TOKEN;
+const label = process.env.WORKER_LABEL;
+
+const fixture = {
+  alias,
+  accessToken: 'stale-access',
+  refreshToken,
+  expiresAt: 1000, // deliberately in the past — matches a real "needs refresh" state
+  scopes: [],
+  deviceId: 'd-' + label,
+  accountUuid: 'u-shared',
+};
+
+async function main() {
+  await saveAccount(fixture); // isolated per process, mirrors real on-disk state before refresh
+  const start = Date.now();
+  try {
+    const result = await refreshAccountToken(fixture);
+    console.log(JSON.stringify({ label, ok: true, ms: Date.now() - start, accessToken: result.accessToken, refreshToken: result.refreshToken }));
+  } catch (err) {
+    console.log(JSON.stringify({ label, ok: false, ms: Date.now() - start, error: String(err?.message || err) }));
+  }
+}
+
+main();


### PR DESCRIPTION
## What

The reviewer (this same reviewer, on #1000) correctly pushed back on treating #993 as solved off unit tests + isolated curl checks against the deployed Worker alone — nobody had actually run the failure scenario end-to-end: two genuinely separate dario processes racing to refresh the same account.

`test/integration/dual-instance-race.mjs` does that live:
- Two isolated `~/.dario` homes (per-process `HOME`/`USERPROFILE` override) — nothing shared between the two workers but the remote lock service.
- Real network calls to the **real deployed** `dario-refresh-lock` Cloudflare Worker.
- A local mock stands in **only** for Anthropic's token endpoint — hammering the real one with production credentials for adversarial testing risks actually burning the operator's live refresh token. Everything else is real, not simulated.
- The mock enforces the one behavior this whole fix exists to handle: a `refresh_token` is single-use, reusing an already-consumed one `400`s exactly like the real API (`invalid_grant`).

## Results

**Control run (`--no-lock`)** — proves the harness is meaningful before trusting a positive result: one worker gets a genuine `invalid_grant` rejection. That's the actual #993 bug, reproduced live, not assumed.

**With the real lock: 6/6 runs held.** Both workers succeed every time, exactly one real refresh reaches "Anthropic" each run, zero rejections.

One real bug in the harness itself along the way: the first 3 reruns showed `real refreshes = 0` and I nearly mis-read that as a failure — turned out the DO's own credential cache (intentional, 5-minute TTL) was correctly serving the *prior* run's cached credentials on a same-alias rerun, never touching the lock or the mock endpoint at all. Fixed by using a fresh random alias per run; documented in `test/integration/README.md` so it doesn't get re-discovered as a false alarm later.

## Test plan

- [x] Control run reproduces the real #993 bug (1/1)
- [x] Fixed run holds (6/6, after the alias-cache fix)
- [x] Not part of `npm test` (needs real network + secret) — same pattern as `e2e.mjs`/`compat.mjs`, own entry point: `npm run test:refresh-lock-race`
- [x] Full suite: 134/137 passing — the same 3 pre-existing `template-*`/`tool-advertise-respects-client` flakes already documented on #1000, unrelated to this change
