### PR TITLE
feat: Codex/ChatGPT-subscription account scaffolding — the "altman" engine (#1009)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 *.tgz
 .env
 credentials.json
+test/manual/.codex-race-creds.json
 
 # drift-watch scratch artifacts — written to the repo root on the runner by
 # capture-and-bake.mjs --check / cc-drift-template-watch.yml; never commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ checklist.
 
 ## [Unreleased]
 
+- **Codex/ChatGPT-subscription account scaffolding — the "altman" engine (dario#1009).** `src/codex-oauth.ts` + `src/codex-accounts.ts` add a fully separate, isolated OAuth account pool for Codex CLI's ChatGPT Plus/Pro subscription flow, alongside `dario codex add/list/remove`. Deliberately NOT a generalization of the Claude engine (two providers isn't enough to know what a good shared abstraction looks like) and NOT wired into request routing yet — this is scaffolding, gated on one open question: does OpenAI invalidate the previous refresh_token on every refresh the way Anthropic does, which is what actually drove all of dario#993's pool/lock complexity for Claude. No public source documents this behavior for Codex. `test/manual/codex-refresh-race.mjs` is a ready-to-run live test (not part of `npm test` — needs a real ChatGPT Plus/Pro login) that answers it directly: fires two concurrent refreshes against the same token and reports whether one fails (rotating, same architecture Claude needs) or both succeed (tolerant, may need much less).
+
 ## [5.5.83] - 2026-08-29
 
 - **Template label refresh** — `_version`, `_supportedMaxTested`, and the `user-agent` header bumped to `2.1.251` to track `@anthropic-ai/claude-code@latest`. The live wire shape is unchanged — cc-drift-template-watch ran `capture-and-bake --check` against live CC v2.1.251 and found zero shape drift vs the bundle — so this is a label refresh, not a re-capture (`_captured` stays at the last real capture). Auto-merged; clears the `sdk-drift` early-warning signal.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 <p><strong>One local endpoint. Every AI tool you own. The subscription you already pay for.</strong></p>
 
-<sub><code>npm i -g @askalf/dario</code> · <strong>0</strong> runtime deps · <a href="https://www.npmjs.com/package/@askalf/dario">SLSA-attested</a> every release · nothing phones home · ~25k lines you can read in a weekend · independent, unofficial, third-party (<a href="DISCLAIMER.md">DISCLAIMER.md</a>)</sub>
+<sub><code>npm i -g @askalf/dario</code> · <strong>0</strong> runtime deps · <a href="https://www.npmjs.com/package/@askalf/dario">SLSA-attested</a> every release · nothing phones home · ~26k lines you can read in a weekend · independent, unofficial, third-party (<a href="DISCLAIMER.md">DISCLAIMER.md</a>)</sub>
 
 <sub>Part of <a href="#own-your-stack"><strong>Own Your Stack</strong></a> — 12 open tools for owning your AI infra: <a href="https://github.com/askalf/truecopy">truecopy</a> · <a href="https://github.com/askalf/strongroom">strongroom</a> · <a href="https://github.com/askalf/fieldpass">fieldpass</a> · <a href="https://github.com/askalf/plumbline">plumbline</a> · <a href="#own-your-stack">full family ↓</a></sub>
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,10 +23,11 @@ import { realpathSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { pathToFileURL } from 'node:url';
-import { startAutoOAuthFlow, startManualOAuthFlow, detectHeadlessEnvironment, getStatus, refreshTokens, loadCredentials } from './oauth.js';
+import { startAutoOAuthFlow, startManualOAuthFlow, detectHeadlessEnvironment, getStatus, refreshTokens, loadCredentials, readLineFromStdin, parseManualPaste } from './oauth.js';
 import { startProxy, sanitizeError, parseModelAliasSpecs } from './proxy.js';
 import { VALID_EFFORT_VALUES, type EffortValue } from './cc-template.js';
 import { listAccountAliases, loadAllAccounts, addAccountViaOAuth, addAccountViaManualOAuth, addAccountFromKeychain, KeychainImportError, removeAccount, ensureLoginCredentialsInPool, resyncLoginFromCredentialsIfStale, MIGRATED_LOGIN_ALIAS } from './accounts.js';
+import { listCodexAccountAliases, loadAllCodexAccounts, startAddCodexAccount, completeAddCodexAccount, removeCodexAccount } from './codex-accounts.js';
 import { listBackends, saveBackend, removeBackend, type BackendCredentials } from './openai-backend.js';
 import { parseOutboundProxy, installOutboundProxyWrapper, type OutboundProxyConfig } from './outbound-proxy.js';
 
@@ -1101,6 +1102,109 @@ async function accounts() {
   process.exit(1);
 }
 
+/**
+ * The "altman" engine (dario#1009) — a Codex/ChatGPT-subscription account
+ * pool, structurally parallel to `accounts()` above but for a fully
+ * separate provider. Manual-paste only (no localhost callback server):
+ * simpler, and matches the flow OpenAI's own `codex` CLI already trains
+ * users on. Not wired into request routing yet — see codex-accounts.ts's
+ * header comment.
+ */
+async function codex() {
+  const sub = args[1];
+
+  if (!sub || sub === 'list') {
+    const aliases = await listCodexAccountAliases();
+    console.log('');
+    console.log('  dario — Codex accounts (altman engine)');
+    console.log('  ───────────────────────────────────────');
+    console.log('');
+    if (aliases.length === 0) {
+      console.log('  No Codex accounts yet.');
+      console.log('    dario codex add <alias>');
+      console.log('');
+      return;
+    }
+    const loaded = await loadAllCodexAccounts();
+    const now = Date.now();
+    console.log(`  ${aliases.length} account${aliases.length === 1 ? '' : 's'}`);
+    console.log('');
+    for (const a of loaded) {
+      const msLeft = Math.max(0, a.expiresAt - now);
+      const mins = Math.floor(msLeft / 60000);
+      const expiry = msLeft > 0 ? `${mins}m` : 'expired';
+      console.log(`    ${a.alias.padEnd(20)} token expires in ${expiry}`);
+    }
+    console.log('');
+    return;
+  }
+
+  if (sub === 'add') {
+    const alias = args[2];
+    if (!alias) {
+      console.error('');
+      console.error('  Usage: dario codex add <alias>');
+      console.error('');
+      process.exit(1);
+    }
+    if (!/^[a-zA-Z0-9._-]+$/.test(alias)) {
+      console.error('[dario] Invalid alias. Use letters, numbers, dot, underscore, dash only.');
+      process.exit(1);
+    }
+    const existing = await listCodexAccountAliases();
+    if (existing.includes(alias)) {
+      console.error(`[dario] Codex account "${alias}" already exists. Remove it first with \`dario codex remove ${alias}\`.`);
+      process.exit(1);
+    }
+
+    const { authorizeUrl, codeVerifier } = await startAddCodexAccount(alias);
+    console.log('');
+    console.log('  Open this URL, log in with your ChatGPT Plus/Pro account, and');
+    console.log('  paste the resulting code (or the full redirect URL) back here:');
+    console.log('');
+    console.log(`  ${authorizeUrl}`);
+    console.log('');
+    const pasted = await readLineFromStdin('  Code: ');
+    const { code } = parseManualPaste(pasted);
+    if (!code) {
+      console.error('[dario] No code provided.');
+      process.exit(1);
+    }
+    try {
+      await completeAddCodexAccount(alias, code, codeVerifier);
+      console.log('');
+      console.log(`  Added Codex account "${alias}".`);
+      console.log('');
+    } catch (err) {
+      console.error(`[dario] Failed to add Codex account: ${(err as Error).message}`);
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (sub === 'remove' || sub === 'rm') {
+    const alias = args[2];
+    if (!alias) {
+      console.error('');
+      console.error('  Usage: dario codex remove <alias>');
+      console.error('');
+      process.exit(1);
+    }
+    const ok = await removeCodexAccount(alias);
+    if (ok) {
+      console.log(`[dario] Codex account "${alias}" removed.`);
+    } else {
+      console.error(`[dario] No Codex account "${alias}" found.`);
+      process.exit(1);
+    }
+    return;
+  }
+
+  console.error(`[dario] Unknown codex subcommand: ${sub}`);
+  console.error('Usage: dario codex [list|add <alias>|remove <alias>]');
+  process.exit(1);
+}
+
 async function backend() {
   const sub = args[1];
 
@@ -1244,6 +1348,12 @@ async function help() {
                              entry by its platform identifier (Linux account
                              attribute, Windows TargetName).
     dario accounts remove N  Remove an account from the pool
+    dario codex list         List Codex/ChatGPT-subscription accounts (the
+                             "altman" engine, dario#1009) — experimental,
+                             not yet wired into request routing.
+    dario codex add NAME     Add a Codex account (manual-paste OAuth flow —
+                             prints an authorize URL, reads the code back).
+    dario codex remove NAME  Remove a Codex account.
     dario backend list       List configured OpenAI-compat backends
     dario backend add NAME --key=sk-... [--base-url=...]
                              Add an OpenAI-compat backend (OpenAI, OpenRouter, Groq, etc.)
@@ -2185,6 +2295,7 @@ const commands: Record<string, () => Promise<void>> = {
   resume,
   logout,
   accounts,
+  codex,
   backend,
   shim,
   subagent,

--- a/src/codex-accounts.ts
+++ b/src/codex-accounts.ts
@@ -1,0 +1,157 @@
+/**
+ * Codex account storage — the "altman" engine (dario#1009).
+ *
+ * Deliberately isolated from accounts.ts: separate directory
+ * (~/.dario/codex-accounts/), separate types, no shared code path with the
+ * Claude pool. Not wired into pool.ts or proxy.ts's request routing —
+ * this module only manages credentials on disk. Routing a request through
+ * a Codex account is a later step, gated on actually knowing whether this
+ * needs pool/lock machinery at all (see codex-oauth.ts's header comment
+ * and test/manual/codex-refresh-race.mjs).
+ */
+import { readFile, mkdir, readdir, unlink } from 'node:fs/promises';
+import { join, basename } from 'node:path';
+import { homedir } from 'node:os';
+import { randomBytes } from 'node:crypto';
+import {
+  generateCodexPKCE,
+  buildCodexAuthorizeUrl,
+  exchangeCodexAuthorizationCode,
+  refreshCodexAccessToken,
+  type CodexTokens,
+} from './codex-oauth.js';
+import { durableWriteFile } from './durable-write.js';
+
+const DARIO_DIR = join(homedir(), '.dario');
+const CODEX_ACCOUNTS_DIR = join(DARIO_DIR, 'codex-accounts');
+
+export interface CodexAccountCredentials {
+  alias: string;
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  idToken?: string;
+}
+
+/** Same alias charset/traversal guard as accounts.ts's safeAliasPath. */
+function safeAliasPath(alias: string): string | null {
+  if (typeof alias !== 'string' || alias.length === 0) return null;
+  const leaf = basename(alias);
+  if (leaf !== alias) return null;
+  if (leaf === '.' || leaf === '..') return null;
+  if (!/^[A-Za-z0-9][A-Za-z0-9_\-.]{0,63}$/.test(leaf)) return null;
+  return join(CODEX_ACCOUNTS_DIR, `${leaf}.json`);
+}
+
+async function ensureDir(): Promise<void> {
+  await mkdir(CODEX_ACCOUNTS_DIR, { recursive: true, mode: 0o700 });
+}
+
+export async function listCodexAccountAliases(): Promise<string[]> {
+  try {
+    await ensureDir();
+    const entries = await readdir(CODEX_ACCOUNTS_DIR);
+    return entries.filter(f => f.endsWith('.json')).map(f => f.replace('.json', ''));
+  } catch {
+    return [];
+  }
+}
+
+export async function loadCodexAccount(alias: string): Promise<CodexAccountCredentials | null> {
+  const path = safeAliasPath(alias);
+  if (!path) return null;
+  try {
+    const raw = await readFile(path, 'utf-8');
+    return JSON.parse(raw) as CodexAccountCredentials;
+  } catch {
+    return null;
+  }
+}
+
+export async function loadAllCodexAccounts(): Promise<CodexAccountCredentials[]> {
+  const aliases = await listCodexAccountAliases();
+  const loaded = await Promise.all(aliases.map(a => loadCodexAccount(a)));
+  return loaded.filter((a): a is CodexAccountCredentials => a !== null);
+}
+
+export async function saveCodexAccount(creds: CodexAccountCredentials): Promise<void> {
+  const path = safeAliasPath(creds.alias);
+  if (!path) throw new Error(`invalid codex account alias: ${creds.alias}`);
+  await ensureDir();
+  await durableWriteFile(path, JSON.stringify(creds, null, 2), 0o600);
+}
+
+export async function removeCodexAccount(alias: string): Promise<boolean> {
+  const path = safeAliasPath(alias);
+  if (!path) return false;
+  try {
+    await unlink(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function getCodexAccountsDir(): string {
+  return CODEX_ACCOUNTS_DIR;
+}
+
+function base64url(buf: Buffer): string {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export async function startAddCodexAccount(
+  alias: string,
+): Promise<{ authorizeUrl: string; codeVerifier: string; state: string }> {
+  if (!safeAliasPath(alias)) {
+    throw new Error(`invalid account alias "${alias}" (allowed: letters, digits, _-. — up to 64 chars, no path separators)`);
+  }
+  const { codeVerifier, codeChallenge } = generateCodexPKCE();
+  const state = base64url(randomBytes(32));
+  const authorizeUrl = buildCodexAuthorizeUrl(codeChallenge, state);
+  return { authorizeUrl, codeVerifier, state };
+}
+
+export async function completeAddCodexAccount(
+  alias: string,
+  code: string,
+  codeVerifier: string,
+): Promise<CodexAccountCredentials> {
+  if (!safeAliasPath(alias)) {
+    throw new Error(`invalid account alias "${alias}"`);
+  }
+  const tokens: CodexTokens = await exchangeCodexAuthorizationCode(code, codeVerifier);
+  const creds: CodexAccountCredentials = {
+    alias,
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken,
+    expiresAt: tokens.expiresAt,
+    idToken: tokens.idToken,
+  };
+  await saveCodexAccount(creds);
+  return creds;
+}
+
+/**
+ * Refresh 30 min before expiry — same buffer as oauth.ts's Claude path.
+ * No single-flight or distributed-lock wrapping here (unlike accounts.ts's
+ * refreshAccountToken) — see codex-oauth.ts's header for why.
+ */
+const REFRESH_BUFFER_MS = 30 * 60 * 1000;
+
+export function codexAccountNeedsRefresh(creds: CodexAccountCredentials): boolean {
+  return Date.now() >= creds.expiresAt - REFRESH_BUFFER_MS;
+}
+
+export async function refreshCodexAccount(creds: CodexAccountCredentials): Promise<CodexAccountCredentials> {
+  const tokens = await refreshCodexAccessToken(creds.refreshToken);
+  const updated: CodexAccountCredentials = {
+    ...creds,
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken,
+    expiresAt: tokens.expiresAt,
+    idToken: tokens.idToken,
+  };
+  await saveCodexAccount(updated);
+  return updated;
+}

--- a/src/codex-oauth.ts
+++ b/src/codex-oauth.ts
@@ -1,0 +1,135 @@
+/**
+ * Codex OAuth primitives — the "altman" engine (dario#1009).
+ *
+ * A deliberately separate, standalone module from oauth.ts/accounts.ts,
+ * not a generalization of them. Two providers isn't enough to know what a
+ * good shared abstraction looks like yet; forcing one now would mean
+ * guessing at the shape from a single example. See the dario#993/#1009
+ * scoping discussion for the reasoning.
+ *
+ * Unlike Claude's OAuth config (auto-detected from the installed CC binary
+ * — see cc-oauth-detect.ts — because Anthropic rotates client_id/URLs
+ * between CC releases), Codex's values below are stable, publicly known
+ * constants used by OpenAI's own `codex` CLI. Hardcoded here the same way
+ * every other OSS OAuth client for this flow does (e.g.
+ * numman-ali/opencode-openai-codex-auth), with an env override escape
+ * hatch in case that changes.
+ *
+ * THE OPEN QUESTION THIS MODULE EXISTS TO ANSWER (see
+ * test/manual/codex-refresh-race.mjs): does OpenAI invalidate the previous
+ * refresh_token on every refresh, the way Anthropic does? That single fact
+ * determines whether Codex needs pool/lock machinery at all, or something
+ * much simpler. Not yet known — no public source documents it, because
+ * every existing OAuth client for this flow (this codebase's own
+ * inspiration included) is single-instance, single-user, and has never
+ * had a reason to race two refreshes against the same token.
+ */
+import { randomBytes, createHash } from 'node:crypto';
+
+// OAuth constants — from OpenAI's own `codex` CLI, reused unmodified by
+// every third-party client for this flow (Cline, opencode's codex-auth
+// plugin). Not dario-specific; not secret.
+export const CODEX_CLIENT_ID = process.env.DARIO_CODEX_CLIENT_ID || 'app_EMoamEEZ73f0CkXaXp7hrann';
+export const CODEX_AUTHORIZE_URL = process.env.DARIO_CODEX_AUTHORIZE_URL || 'https://auth.openai.com/oauth/authorize';
+export const CODEX_TOKEN_URL = process.env.DARIO_CODEX_TOKEN_URL || 'https://auth.openai.com/oauth/token';
+export const CODEX_REDIRECT_URI = process.env.DARIO_CODEX_REDIRECT_URI || 'http://localhost:1455/auth/callback';
+export const CODEX_SCOPE = 'openid profile email offline_access';
+
+export interface CodexTokens {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  idToken?: string;
+}
+
+function base64url(buf: Buffer): string {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function generateCodexPKCE(): { codeVerifier: string; codeChallenge: string } {
+  const codeVerifier = base64url(randomBytes(32));
+  const codeChallenge = base64url(createHash('sha256').update(codeVerifier).digest());
+  return { codeVerifier, codeChallenge };
+}
+
+/**
+ * Build the authorize URL for a manual-paste login flow (same shape as
+ * accounts.ts's startAddAccount — dario has no localhost callback server
+ * running by default, so the manual copy-paste flow is the primary path,
+ * not a fallback).
+ */
+export function buildCodexAuthorizeUrl(codeChallenge: string, state: string): string {
+  const url = new URL(CODEX_AUTHORIZE_URL);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('client_id', CODEX_CLIENT_ID);
+  url.searchParams.set('redirect_uri', CODEX_REDIRECT_URI);
+  url.searchParams.set('scope', CODEX_SCOPE);
+  url.searchParams.set('code_challenge', codeChallenge);
+  url.searchParams.set('code_challenge_method', 'S256');
+  url.searchParams.set('state', state);
+  return url.toString();
+}
+
+interface CodexTokenResponse {
+  access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
+  id_token?: string;
+}
+
+function parseTokenResponse(json: CodexTokenResponse): CodexTokens {
+  if (!json?.access_token || !json?.refresh_token || typeof json?.expires_in !== 'number') {
+    throw new Error(`Codex token response missing required fields: ${JSON.stringify(Object.keys(json ?? {}))}`);
+  }
+  return {
+    accessToken: json.access_token,
+    refreshToken: json.refresh_token,
+    expiresAt: Date.now() + json.expires_in * 1000,
+    idToken: json.id_token,
+  };
+}
+
+export async function exchangeCodexAuthorizationCode(code: string, codeVerifier: string): Promise<CodexTokens> {
+  const res = await fetch(CODEX_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: CODEX_CLIENT_ID,
+      code,
+      code_verifier: codeVerifier,
+      redirect_uri: CODEX_REDIRECT_URI,
+    }),
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Codex code->token exchange failed (${res.status}): ${body.slice(0, 200)}`);
+  }
+  return parseTokenResponse(await res.json());
+}
+
+/**
+ * Refresh a Codex access token. Deliberately NOT wrapped in any
+ * single-flight/lock machinery yet — that's exactly the thing
+ * test/manual/codex-refresh-race.mjs exists to determine the need for.
+ * Adding pool/lock complexity before that answer is known would be
+ * guessing at a solution to an unconfirmed problem.
+ */
+export async function refreshCodexAccessToken(refreshToken: string): Promise<CodexTokens> {
+  const res = await fetch(CODEX_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+      client_id: CODEX_CLIENT_ID,
+    }),
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Codex token refresh failed (${res.status}): ${body.slice(0, 200)}`);
+  }
+  return parseTokenResponse(await res.json());
+}

--- a/test/codex-accounts.mjs
+++ b/test/codex-accounts.mjs
@@ -1,0 +1,87 @@
+// Storage-layer tests for the "altman" Codex account pool (dario#1009).
+// Isolation strategy identical to ensure-login-in-pool.mjs: HOME/USERPROFILE
+// pointed at a mkdtemp'd dir BEFORE importing the module under test, since
+// CODEX_ACCOUNTS_DIR is computed at module-evaluation time from homedir().
+// No network calls in this file — see codex-oauth.mjs for the OAuth
+// primitives and test/manual/codex-refresh-race.mjs for live-account tests.
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let pass = 0, fail = 0;
+function check(label, cond) {
+  if (cond) { console.log(`  ✅ ${label}`); pass++; }
+  else { console.log(`  ❌ ${label}`); fail++; }
+}
+function header(label) {
+  console.log(`\n======================================================================`);
+  console.log(`  ${label}`);
+  console.log(`======================================================================`);
+}
+
+const tmpHome = await mkdtemp(join(tmpdir(), 'dario-codex-accounts-test-'));
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+
+const {
+  listCodexAccountAliases,
+  loadCodexAccount,
+  loadAllCodexAccounts,
+  saveCodexAccount,
+  removeCodexAccount,
+  getCodexAccountsDir,
+  codexAccountNeedsRefresh,
+} = await import('../dist/codex-accounts.js');
+
+header('empty pool');
+{
+  check('no aliases yet', (await listCodexAccountAliases()).length === 0);
+  check('load of unknown alias returns null', await loadCodexAccount('nope') === null);
+}
+
+header('save / load / list round-trip');
+{
+  const creds = { alias: 'work', accessToken: 'a1', refreshToken: 'r1', expiresAt: Date.now() + 3600_000 };
+  await saveCodexAccount(creds);
+  check('alias appears in list', (await listCodexAccountAliases()).includes('work'));
+  const loaded = await loadCodexAccount('work');
+  check('loaded accessToken matches', loaded?.accessToken === 'a1');
+  check('loaded refreshToken matches', loaded?.refreshToken === 'r1');
+  const all = await loadAllCodexAccounts();
+  check('loadAllCodexAccounts returns it', all.some(a => a.alias === 'work'));
+  check('storage dir is under ~/.dario, separate from Claude accounts/', getCodexAccountsDir().replace(/\\/g, '/').endsWith('.dario/codex-accounts'));
+}
+
+header('remove');
+{
+  const ok = await removeCodexAccount('work');
+  check('remove returns true for existing alias', ok === true);
+  check('alias gone from list', !(await listCodexAccountAliases()).includes('work'));
+  const okAgain = await removeCodexAccount('work');
+  check('remove of already-gone alias returns false, does not throw', okAgain === false);
+}
+
+header('alias safety — traversal and unsafe chars rejected');
+{
+  let threw = false;
+  try { await saveCodexAccount({ alias: '../escape', accessToken: 'x', refreshToken: 'y', expiresAt: 0 }); }
+  catch { threw = true; }
+  check('save with path-traversal alias throws rather than writing outside codex-accounts/', threw);
+  check('load with traversal alias returns null (not the escaped file)', await loadCodexAccount('../escape') === null);
+}
+
+header('codexAccountNeedsRefresh — 30 min buffer, same as Claude side');
+{
+  const now = Date.now();
+  check('expires in 5 min → needs refresh', codexAccountNeedsRefresh({ expiresAt: now + 5 * 60_000 }));
+  check('expires in 2h → does not need refresh yet', !codexAccountNeedsRefresh({ expiresAt: now + 2 * 3600_000 }));
+  check('already expired → needs refresh', codexAccountNeedsRefresh({ expiresAt: now - 1000 }));
+}
+
+console.log(`\n======================================================================`);
+console.log(`  Results: ${pass} passed, ${fail} failed`);
+console.log(`======================================================================\n`);
+
+await rm(tmpHome, { recursive: true, force: true });
+if (fail > 0) process.exit(1);

--- a/test/codex-oauth.mjs
+++ b/test/codex-oauth.mjs
@@ -1,0 +1,132 @@
+// Unit tests for the "altman" Codex OAuth engine (dario#1009).
+// No real network calls (monkeypatched global fetch, same strategy as
+// account-refresh-distributed-lock.mjs) and no real ~/.dario writes for
+// the storage tests (HOME/USERPROFILE overridden to a temp dir).
+//
+// What this does NOT test: whether OpenAI invalidates the previous
+// refresh_token on refresh (the actual open question — see
+// codex-oauth.ts's header comment). That requires a live account and
+// lives in test/manual/codex-refresh-race.mjs instead.
+
+import {
+  generateCodexPKCE,
+  buildCodexAuthorizeUrl,
+  exchangeCodexAuthorizationCode,
+  refreshCodexAccessToken,
+  CODEX_CLIENT_ID,
+  CODEX_TOKEN_URL,
+} from '../dist/codex-oauth.js';
+
+let pass = 0, fail = 0;
+function check(label, cond) {
+  if (cond) { console.log(`  ✅ ${label}`); pass++; }
+  else { console.log(`  ❌ ${label}`); fail++; }
+}
+function header(label) {
+  console.log(`\n======================================================================`);
+  console.log(`  ${label}`);
+  console.log(`======================================================================`);
+}
+
+const originalFetch = globalThis.fetch;
+function restoreFetch() { globalThis.fetch = originalFetch; }
+
+// ======================================================================
+//  PKCE
+// ======================================================================
+header('generateCodexPKCE — verifier/challenge shape');
+{
+  const { codeVerifier, codeChallenge } = generateCodexPKCE();
+  check('codeVerifier is base64url (no +/=)', /^[A-Za-z0-9_-]+$/.test(codeVerifier));
+  check('codeChallenge is base64url (no +/=)', /^[A-Za-z0-9_-]+$/.test(codeChallenge));
+  check('codeChallenge derived from codeVerifier (differs, both present)', codeChallenge !== codeVerifier && codeChallenge.length > 0);
+  const second = generateCodexPKCE();
+  check('two calls produce different verifiers (not reusing entropy)', second.codeVerifier !== codeVerifier);
+}
+
+// ======================================================================
+//  Authorize URL
+// ======================================================================
+header('buildCodexAuthorizeUrl — required params present');
+{
+  const url = new URL(buildCodexAuthorizeUrl('test-challenge', 'test-state'));
+  check('response_type=code', url.searchParams.get('response_type') === 'code');
+  check('client_id matches CODEX_CLIENT_ID', url.searchParams.get('client_id') === CODEX_CLIENT_ID);
+  check('code_challenge passed through', url.searchParams.get('code_challenge') === 'test-challenge');
+  check('code_challenge_method=S256', url.searchParams.get('code_challenge_method') === 'S256');
+  check('state passed through', url.searchParams.get('state') === 'test-state');
+  check('scope includes offline_access (required for a refresh_token)', (url.searchParams.get('scope') || '').includes('offline_access'));
+  check('authorize host is auth.openai.com', url.hostname === 'auth.openai.com');
+}
+
+// ======================================================================
+//  Code exchange — success and failure shapes
+// ======================================================================
+header('exchangeCodexAuthorizationCode');
+{
+  globalThis.fetch = async (url, opts) => {
+    check('exchange POSTs to CODEX_TOKEN_URL', String(url) === CODEX_TOKEN_URL);
+    const body = new URLSearchParams(opts.body);
+    check('grant_type=authorization_code', body.get('grant_type') === 'authorization_code');
+    check('code_verifier forwarded', body.get('code_verifier') === 'verifier-abc');
+    return new Response(JSON.stringify({ access_token: 'a1', refresh_token: 'r1', expires_in: 3600 }),
+      { status: 200, headers: { 'content-type': 'application/json' } });
+  };
+  const tokens = await exchangeCodexAuthorizationCode('code-abc', 'verifier-abc');
+  check('returns accessToken', tokens.accessToken === 'a1');
+  check('returns refreshToken', tokens.refreshToken === 'r1');
+  check('expiresAt is ~3600s out', tokens.expiresAt > Date.now() + 3500_000 && tokens.expiresAt <= Date.now() + 3600_000);
+  restoreFetch();
+}
+
+header('exchangeCodexAuthorizationCode — non-2xx throws, does not swallow');
+{
+  globalThis.fetch = async () => new Response('invalid_grant', { status: 400 });
+  let threw = false;
+  try { await exchangeCodexAuthorizationCode('bad-code', 'v'); } catch { threw = true; }
+  check('throws on 400', threw);
+  restoreFetch();
+}
+
+header('exchangeCodexAuthorizationCode — missing fields in 200 response throws');
+{
+  globalThis.fetch = async () => new Response(JSON.stringify({ access_token: 'a1' }),
+    { status: 200, headers: { 'content-type': 'application/json' } });
+  let threw = false;
+  try { await exchangeCodexAuthorizationCode('code-abc', 'v'); } catch { threw = true; }
+  check('throws when refresh_token/expires_in missing (would otherwise store a broken account)', threw);
+  restoreFetch();
+}
+
+// ======================================================================
+//  Refresh
+// ======================================================================
+header('refreshCodexAccessToken — request shape and response parsing');
+{
+  globalThis.fetch = async (url, opts) => {
+    check('refresh POSTs to CODEX_TOKEN_URL', String(url) === CODEX_TOKEN_URL);
+    const body = new URLSearchParams(opts.body);
+    check('grant_type=refresh_token', body.get('grant_type') === 'refresh_token');
+    check('refresh_token forwarded', body.get('refresh_token') === 'old-refresh');
+    check('client_id included', body.get('client_id') === CODEX_CLIENT_ID);
+    return new Response(JSON.stringify({ access_token: 'a2', refresh_token: 'r2', expires_in: 1800 }),
+      { status: 200, headers: { 'content-type': 'application/json' } });
+  };
+  const tokens = await refreshCodexAccessToken('old-refresh');
+  check('returns the NEW refreshToken (rotation — caller must persist this, not reuse old-refresh)', tokens.refreshToken === 'r2');
+  restoreFetch();
+}
+
+header('refreshCodexAccessToken — non-2xx throws');
+{
+  globalThis.fetch = async () => new Response(JSON.stringify({ error: 'invalid_grant' }), { status: 400 });
+  let threw = false;
+  try { await refreshCodexAccessToken('dead-token'); } catch { threw = true; }
+  check('throws on 400 (this is the response we expect IF OpenAI rotates like Anthropic — see manual race test)', threw);
+  restoreFetch();
+}
+
+console.log(`\n======================================================================`);
+console.log(`  Results: ${pass} passed, ${fail} failed`);
+console.log(`======================================================================\n`);
+if (fail > 0) process.exit(1);

--- a/test/manual/codex-refresh-race.mjs
+++ b/test/manual/codex-refresh-race.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+// Manual, live-account test — answers the ONE open question the "altman"
+// engine (dario#1009) is blocked on: does OpenAI invalidate the previous
+// refresh_token when it's used to refresh, the way Anthropic does for
+// Claude? No public source documents this (see codex-oauth.ts's header) —
+// every existing third-party OAuth client for this flow is single-instance
+// and has never had a reason to find out.
+//
+// NOT auto-discovered by `npm test` (lives outside test/'s flat scan, which
+// all.test.mjs readdirSync's non-recursively — see that file's EXCLUDED
+// comment for the same pattern used by overage-guard-e2e-live.mjs).
+// Requires a real ChatGPT Plus/Pro account and makes real calls to
+// auth.openai.com. Deliberately ONE round of live requests, not a loop —
+// the plugin this flow's constants come from explicitly warns against
+// "high-volume automated requests" against this endpoint, and answering
+// this question doesn't need more than a handful of real calls.
+//
+// Usage:
+//   1. First run: node test/manual/codex-refresh-race.mjs login
+//      Prints an authorize URL, prompts for the pasted code, stores
+//      tokens locally at test/manual/.codex-race-creds.json (gitignored —
+//      see the entry added alongside this file). Does not touch
+//      ~/.dario/codex-accounts/ — fully separate from the real pool.
+//   2. Then: node test/manual/codex-refresh-race.mjs race
+//      Loads the stored refresh_token and fires TWO concurrent refresh
+//      calls against it — the same shape as the real bug two dario
+//      instances would hit. Reports plainly which of two outcomes
+//      happened:
+//        - ROTATING: one call succeeds, the other gets invalid_grant.
+//          Codex needs the same pool/lock architecture Claude does.
+//        - TOLERANT: both calls succeed (whether they return the same or
+//          different new refresh_tokens). Codex may not need a
+//          distributed lock at all — worth confirming with a second
+//          run before concluding, since a flaky single result isn't proof.
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  generateCodexPKCE,
+  buildCodexAuthorizeUrl,
+  exchangeCodexAuthorizationCode,
+  refreshCodexAccessToken,
+} from '../../dist/codex-oauth.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CREDS_PATH = join(__dirname, '.codex-race-creds.json');
+
+async function readLineFromStdin(prompt) {
+  const { createInterface } = await import('node:readline/promises');
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    return (await rl.question(prompt)).trim();
+  } finally {
+    rl.close();
+  }
+}
+
+function parseManualPaste(input) {
+  const trimmed = (input || '').trim();
+  if (!trimmed) return { code: '', state: null };
+  const hashIdx = trimmed.indexOf('#');
+  if (hashIdx === -1) return { code: trimmed, state: null };
+  return { code: trimmed.slice(0, hashIdx).trim(), state: trimmed.slice(hashIdx + 1).trim() };
+}
+
+async function login() {
+  const { codeVerifier, codeChallenge } = generateCodexPKCE();
+  const state = Math.random().toString(36).slice(2);
+  const url = buildCodexAuthorizeUrl(codeChallenge, state);
+  console.log('\nOpen this URL, log in with the ChatGPT Plus/Pro account, and paste the code back:\n');
+  console.log(`  ${url}\n`);
+  const pasted = await readLineFromStdin('Code: ');
+  const { code } = parseManualPaste(pasted);
+  if (!code) { console.error('No code provided.'); process.exit(1); }
+  const tokens = await exchangeCodexAuthorizationCode(code, codeVerifier);
+  await writeFile(CREDS_PATH, JSON.stringify(tokens, null, 2), { mode: 0o600 });
+  console.log(`\nStored tokens at ${CREDS_PATH}. Run with "race" next.`);
+}
+
+async function race() {
+  let stored;
+  try {
+    stored = JSON.parse(await readFile(CREDS_PATH, 'utf-8'));
+  } catch {
+    console.error(`No stored credentials at ${CREDS_PATH}. Run with "login" first.`);
+    process.exit(1);
+  }
+
+  console.log('\nFiring two concurrent refresh calls against the SAME refresh_token...\n');
+  const results = await Promise.allSettled([
+    refreshCodexAccessToken(stored.refreshToken),
+    refreshCodexAccessToken(stored.refreshToken),
+  ]);
+
+  results.forEach((r, i) => {
+    if (r.status === 'fulfilled') {
+      console.log(`  Call ${i + 1}: SUCCESS — new refresh_token=${r.value.refreshToken.slice(0, 12)}...`);
+    } else {
+      console.log(`  Call ${i + 1}: FAILED — ${r.reason?.message || r.reason}`);
+    }
+  });
+
+  const successes = results.filter(r => r.status === 'fulfilled');
+  console.log('');
+  if (successes.length === 1) {
+    console.log('RESULT: ROTATING — one call won, one got invalid_grant. Same failure mode as');
+    console.log('dario#993 for Claude. Codex needs the same pool/lock architecture.');
+    // Persist the winner's fresh token so a re-run of "race" still works.
+    await writeFile(CREDS_PATH, JSON.stringify(successes[0].value, null, 2), { mode: 0o600 });
+  } else if (successes.length === 2) {
+    console.log('RESULT: TOLERANT — both calls succeeded. Codex may not need a distributed');
+    console.log('lock at all. Re-run this once more before concluding (a single result isn\'t');
+    console.log('proof either way) — and note whether the two calls returned the SAME or');
+    console.log('DIFFERENT new refresh_tokens, since that changes what "tolerant" implies.');
+    await writeFile(CREDS_PATH, JSON.stringify(successes[1].value, null, 2), { mode: 0o600 });
+  } else {
+    console.log('RESULT: INCONCLUSIVE — both calls failed. Check the errors above; this may');
+    console.log('be an expired/dead token rather than a rotation-race result. Run "login" again.');
+  }
+}
+
+const cmd = process.argv[2];
+if (cmd === 'login') await login();
+else if (cmd === 'race') await race();
+else {
+  console.error('Usage: node test/manual/codex-refresh-race.mjs [login|race]');
+  process.exit(1);
+}


### PR DESCRIPTION
Scoping/scaffolding for #1009 — not a finished feature, and not wired into request routing.

`src/codex-oauth.ts` + `src/codex-accounts.ts` add a fully isolated OAuth account pool for Codex CLI's ChatGPT Plus/Pro subscription flow (`dario codex add/list/remove`), structurally parallel to the Claude engine but deliberately **not** a shared abstraction with it — two providers isn't enough to know what a good generalization looks like yet, and this shouldn't touch the mature, battle-tested Claude path.

**This is gated on one open question**, same root cause as everything #993 built for Claude: does OpenAI invalidate the previous `refresh_token` on every refresh? No public source documents this — every existing third-party OAuth client for this flow (including the one this code's constants come from) is single-instance, single-user, and has never had a reason to find out. If OpenAI rotates like Anthropic does, this needs the same pool/lock architecture #993/#1008 built. If it's more forgiving, it may need much less.

`test/manual/codex-refresh-race.mjs` answers that directly — not part of `npm test`, needs a real ChatGPT Plus/Pro login. Fires two concurrent refreshes against the same token and reports which of the two outcomes happened.

40 new unit tests (`test/codex-oauth.mjs`, `test/codex-accounts.mjs`) cover everything that doesn't need live credentials: PKCE, authorize-URL construction, token-response parsing/error handling (monkeypatched fetch, no real network), and storage round-trip (isolated temp `$HOME`).

Holding this open rather than merging immediately — next step is running the live race test once a subscription is available, which may change the shape of what comes after this.