### PR TITLE
chore(cc-drift): v5.5.21 — maxTested → v2.1.235

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.21] - 2026-08-18
+
+- **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.234` → `2.1.235` for CC v2.1.235. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.
 - **Redis-backed alternative to the Cloudflare refresh lock (dario#993).** `redis-lock/` is a second reference implementation of the exact same `/lock/<alias>/acquire|release` contract as `cloudflare/refresh-lock`, for operators who can't or don't want a Cloudflare dependency (airgapped environments, or already running Redis). `src/accounts.ts` needs zero changes — it doesn't know which backend is behind `DARIO_REFRESH_LOCK_URL`. Zero new runtime deps: `resp-client.mjs` is a minimal hand-rolled RESP2 client over `node:net`, not the `redis`/`ioredis` packages. Verified against a live Redis instance with the same 7-case contract suite used against the Cloudflare Worker, plus `test/integration/dual-instance-race.mjs` pointed at this server: 6/6 clean runs.
 - **Live integration test for the refresh lock (dario#993), and the finding that prompted it.** The unit tests + live curl checks against the deployed Worker proved the lock's API contract and dario's client code in isolation, but nobody had run two genuinely separate dario processes racing a real refresh end-to-end. `test/integration/dual-instance-race.mjs` does: two isolated `~/.dario` homes, real network calls to the real deployed Worker, a local mock standing in only for Anthropic's token endpoint (hammering the real one with production creds for adversarial testing risks burning the operator's live refresh token). Control run confirms the harness is meaningful — without the lock, one worker gets a genuine `invalid_grant`. With it: 6/6 runs held, both workers succeed, exactly one real refresh reaches "Anthropic" each time.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.20",
+  "version": "5.5.21",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/live-fingerprint.ts
+++ b/src/live-fingerprint.ts
@@ -1145,7 +1145,7 @@ export function detectDrift(t: TemplateData, installedOverride?: string | null):
  */
 export const SUPPORTED_CC_RANGE = {
   min: '1.0.0',
-  maxTested: '2.1.234',
+  maxTested: '2.1.235',
 } as const;
 
 /**


### PR DESCRIPTION
## Auto-drafted by cc-drift-watch.yml

The drift watcher flagged CC v2.1.235 as outside the current supported range. This PR:

1. Bumps `SUPPORTED_CC_RANGE.maxTested` from `2.1.234` → `2.1.235` in `src/live-fingerprint.ts`
2. Bumps `package.json` version → `5.5.21`
3. Promotes `## [Unreleased]` in `CHANGELOG.md` to `## [5.5.21] - 2026-08-18` and appends the drift-fix bullet

### Items in the drift report

- **compat.range** (medium) — CC v2.1.235 is beyond SUPPORTED_CC_RANGE.maxTested (v2.1.234). Run the e2e suite against the new CC and bump maxTested in src/live-fingerprint.ts — users on the new CC currently get a soft "untested-above" warning from dario doctor.
- **template.version** (low) — baked cc-template-data.json is v2.1.234; npm latest is v2.1.235. Re-capture and re-bake the template if any request-shape field changed.
- **cch.seed** (info) — No cch seed for CC v2.1.235 in src/cch.ts (CCH_SEEDS). dario OMITS the cch token for it — correct while CC v2.1.235 sends none (2.1.199+). Only add a seed if scripts/check-wire-drift.mjs reports CC re-introduced cch; then run `node scripts/cch-calibrate.mjs` on a host with claude v2.1.235. dario#528.

### Fully autonomous — no maintainer action required

This PR validates, merges, and ships itself. Nothing here is a to-do — it is what already happens:

- ✅ **Patched** — `SUPPORTED_CC_RANGE.maxTested` (compat.range), the `package.json` version, and the `CHANGELOG` entry are written by the bot.
- ✅ **Wire-format compat is validated continuously** by `cc-drift-template-watch.yml` — a real CC capture on the self-hosted runner every 30 min. If the bundled template actually drifts against this CC it opens its own `bot/template-rebake-*` PR, independently of this one. (This is the automated equivalent of the old manual "run `dario doctor` against v2.1.235" step — no local run needed.)
- ✅ **Auto-merges** the moment the required CI checks pass (`build (18|20|22)`, `validate-package-json`, `analyze`, `actionlint`). `master` requires no review, so no human approval gates it.
- ✅ **Auto-releases** on merge: `cc-drift-auto-release.yml` tags `v5.5.21`, publishes `@askalf/dario@5.5.21` to npm (`--provenance`) + GHCR inline, and the box autodeploy timer picks it up within ~15 min.

**You only need to look if CI fails** — then auto-merge holds, this PR stays open with the failure visible, and the bot branch is preserved. Otherwise it is already on its way to npm.

### About this auto-draft

Only `compat.range` items are auto-patched by this script. Template re-capture is auto-handled separately by `cc-drift-template-watch.yml`. The remaining categories (scope rotations, URL / clientId / tokenUrl changes) require judgment and stay manual — the bot opens the plain drift-issue for those as before.

---

_Generated by `scripts/auto-draft-drift-fix.mjs`. Closes the detection-latency arc: [#112](https://github.com/askalf/dario/pull/112) (CF bypass), [#113](https://github.com/askalf/dario/pull/113) (hourly cadence), [#114](https://github.com/askalf/dario/pull/114) (auto-draft PR)._
