### PR TITLE
ci(compat): fail closed when maxTested claims a CC the runner cannot back

### DIFF
--- a/.github/workflows/compat-test-self-hosted.yml
+++ b/.github/workflows/compat-test-self-hosted.yml
@@ -160,6 +160,30 @@ jobs:
               process.exit(1);
             }
             console.log('[compat] captured live template from CC ' + t._version);
+
+            // maxTested gate (dario#1014, second cause).
+            //
+            // The capture above fixes a STALE template. It does not fix the
+            // other lag: cc-drift-watch.yml drafts a maxTested bump from the
+            // npm registry's @latest, while this job runs against whatever CC
+            // is installed on the runner. When npm is ahead of the box, a PR
+            // claims support for a version nothing ever exercised — and compat
+            // goes green anyway. That shipped twice (#1012 -> v2.1.235,
+            // #1022 -> v2.1.236), both times caught only by a human reading
+            // the log.
+            //
+            // A green compat that validated an OLDER CC than the PR claims is
+            // worse than a red one: it is an affirmative 'we tested this'
+            // on a version that was never loaded. Fail closed instead.
+            const installed = t._version;
+            const claimed = m.SUPPORTED_CC_RANGE.maxTested;
+            if (m.compareVersions(installed, claimed) < 0) {
+              console.error('::error::compat cannot validate maxTested=' + claimed +
+                ' — the runner captured CC ' + installed + '. Upgrade CC on the runner' +
+                ' (npm i -g @anthropic-ai/claude-code@' + claimed + ') and re-run, or lower maxTested.');
+              process.exit(1);
+            }
+            console.log('[compat] maxTested gate ok: claimed ' + claimed + ' <= installed ' + installed);
           "
 
           # Background-start the proxy, capture PID for the always-run


### PR DESCRIPTION
Closes the **second** cause in #1014. #1016 fixed the stale-template lag; this fixes the version lag that survived it.

## The gap

`cc-drift-watch.yml` drafts a `maxTested` bump from the **npm registry's** `@latest`. `compat` runs against whatever CC is installed on the **self-hosted runner**. Nothing syncs them. When npm is ahead of the box, the PR claims support for a version nothing ever loaded — and compat goes green anyway.

This has now shipped twice:

| PR | claimed | compat actually validated |
|---|---|---|
| #1012 | v2.1.235 | v2.1.234 |
| #1022 | v2.1.236 | v2.1.235 |

Both were caught only because a human read the log line. That is not a control.

`#1016` was necessary but not sufficient — it guarantees the template is *fresh*, not that it is the *right version*. Worth being precise about that: on #1022 the capture step worked exactly as designed and still let an unvalidatable claim through, because freshness and correctness are different properties.

## The fix

After the forced capture, compare the captured CC version against `SUPPORTED_CC_RANGE.maxTested` and exit 1 if the runner is behind:

```
::error::compat cannot validate maxTested=2.1.240 — the runner captured CC 2.1.236.
Upgrade CC on the runner (npm i -g @anthropic-ai/claude-code@2.1.240) and re-run,
or lower maxTested.
```

The error names the exact remediation, so the next occurrence is a one-line fix rather than an investigation.

**Why fail closed:** a green compat that validated an *older* CC than the PR claims is worse than a red one. It is an affirmative "we tested this" attached to a version that was never exercised — precisely the signal `maxTested` exists to carry, inverted.

Reuses the already-exported `compareVersions` rather than reimplementing semver comparison in shell.

## Verified

Both paths, end to end, against the real capture pipeline:

```
# match (runner 2.1.236, claim 2.1.236)
[compat] captured live template from CC 2.1.236
[compat] maxTested gate ok: claimed 2.1.236 <= installed 2.1.236
exit=0

# mismatch (runner 2.1.236, claim 2.1.240)
::error::compat cannot validate maxTested=2.1.240 — the runner captured CC 2.1.236 …
exit=1
```

Truth table also checked: equal → pass, runner newer → pass, runner older → fail.

Closes #1014