### PR TITLE
fix(ci): npm-drift-watch selected issues by fuzzy text, closing unrelated ones

### DIFF
--- a/.github/workflows/npm-drift-watch.yml
+++ b/.github/workflows/npm-drift-watch.yml
@@ -63,8 +63,24 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          marker='<!-- dario-npm-drift -->'
-          existing=$(gh issue list -R "${{ github.repository }}" --state open --search "in:body $marker" --json number --jq '.[0].number // ""')
+          # Select by LABEL, not by body search. The old selector was
+          # `--search "in:body <!-- dario-npm-drift -->"`, but GitHub full-text
+          # search tokenizes that HTML comment into `dario`/`npm`/`drift` and
+          # matches those words ANYWHERE in a body — it never required the
+          # marker. It matched 10+ unrelated issues (sdk-drift, cc-drift, and
+          # a plain `ci` bug report) simply for discussing npm and drift.
+          #
+          # That broke this workflow in both directions:
+          #   - dedupe (here): an unrelated match made it believe a drift issue
+          #     was already open, so it silently skipped filing a real alert —
+          #     a blinded watchdog.
+          #   - auto-close (below): it closed those unrelated issues whenever
+          #     npm caught up. dario#1014 was closed that way ~1h after filing,
+          #     while the bug it described was still live.
+          #
+          # The create step already applies `--label npm-drift`, so the label
+          # is an exact, reliable selector and needs no new bookkeeping.
+          existing=$(gh issue list -R "${{ github.repository }}" --state open --label npm-drift --json number --jq '.[0].number // ""')
           if [ -n "$existing" ]; then
             echo "Existing open drift issue #$existing — leaving alone."
             exit 0
@@ -103,8 +119,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          marker='<!-- dario-npm-drift -->'
-          open_issues=$(gh issue list -R "${{ github.repository }}" --state open --search "in:body $marker" --json number --jq '.[].number')
+          # Label selector, not body search — see the comment on the dedupe
+          # step above for why the old `in:body` marker search closed
+          # unrelated issues (dario#1014 among them).
+          open_issues=$(gh issue list -R "${{ github.repository }}" --state open --label npm-drift --json number --jq '.[].number')
           for n in $open_issues; do
             gh issue close "$n" -R "${{ github.repository }}" --comment "Auto-closed: npm latest (${{ steps.check.outputs.npm }}) matches release ${{ steps.check.outputs.tag }} on [run #${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})."
           done


### PR DESCRIPTION
Found while investigating why #1014 was closed ~1 hour after filing, by a bot, while the bug it described was still live — and then recurred in #1022.

## The bug

Both the dedupe and auto-close steps selected issues this way:

```
gh issue list --state open --search "in:body <!-- dario-npm-drift -->"
```

The intent is an exact marker match. But GitHub full-text search **tokenizes** that HTML comment into `dario` / `npm` / `drift` and matches those words anywhere in a body. The marker was never actually required.

## Measured blast radius

| selector | matches |
|---|---|
| old (`in:body` marker) | **12+ issues, none labeled `npm-drift`** — `sdk-drift`, `cc-drift`, and one plain `ci` bug report |
| new (`--label npm-drift`) | exactly the genuine set |

Every issue the old selector would ever have acted on was the wrong one. 100% false positives, 0% true positives — there has never been a real npm-drift issue for it to match.

Sampling the damage: #1014, #987, #957, and #909 all carry an `Auto-closed: npm latest … matches release …` comment. None of them are npm-drift issues.

## It failed in both directions

- **auto-close** — closed unrelated issues whenever npm caught up to the latest release. That is how #1014 got closed while its second root cause was still unfixed.
- **dedupe** — the *worse* one. An unrelated match makes the workflow believe a drift issue is already open, so it `exit 0`s and never files a real alert. A watchdog that silently stops barking because an unrelated issue mentions "npm" and "drift" is worse than no watchdog, because the green run looks identical either way.

## The fix

Select by label. The create step already applies `--label npm-drift`, so this is an exact selector that needs no new bookkeeping and no marker discipline.

Comments at both call sites explain why the body search was wrong, so nobody reintroduces it thinking a marker is being matched literally.

## Note on #1014

It stays closed — it is now genuinely fixed by #1016 (stale template) and #1024 (version gate). But it was closed for the wrong reason, an hour after filing, by this bug rather than by any fix.