### PR TITLE
ci: the auto-release job must never fire from a fork

### DIFF
--- a/.github/workflows/cc-drift-auto-release.yml
+++ b/.github/workflows/cc-drift-auto-release.yml
@@ -106,7 +106,21 @@ jobs:
     # For pull_request: require `merged == true` (rules out close-
     # without-merge). For schedule / workflow_dispatch: always proceed;
     # the gate step short-circuits when there's nothing to ship.
-    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
+    # Never from a fork. Everything below is triggered by nothing more than
+    # package.json.version moving on master, on an hourly cron -- and it tags,
+    # cuts a GitHub Release, runs `npm publish --access public --provenance`
+    # and pushes to GHCR. A fork inherits the workflow and the schedule but
+    # none of the authority, and its package.json is whatever it last merged,
+    # so the duplicate-tag gate finds no matching tag in the fork and the job
+    # proceeds. The publish itself should fail -- npm's trusted publisher is
+    # bound to this repository, and the OIDC subject from a fork will not
+    # match -- but the tag and the GitHub Release are created before that, and
+    # `npm view` against @askalf/dario is what the gate reads, so a fork also
+    # decides whether to "release" by looking at this package's registry
+    # entry rather than its own.
+    if: >-
+      github.repository == 'askalf/dario'
+      && (github.event_name != 'pull_request' || github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     # Serializes overlapping triggers so a pull_request:closed and a
     # schedule tick that fire within seconds of each other don't both


### PR DESCRIPTION
`cc-drift-auto-release` runs on an hourly cron and carries no repository guard, so every fork runs it on the same schedule. There are 54.

The gate asks whether a tag matching `package.json.version` already exists. A fork's tags are whatever it inherited when it diverged, so on any fork whose master has since moved the answer is no, and the job proceeds into the release path: tag, GitHub Release, `npm publish --access public --provenance`, GHCR push.

The publish step should fail on its own — npm's trusted publisher is bound to this repository, and the OIDC subject presented from a fork will not match. Two things sit in front of it though:

- the tag and the GitHub Release are created before the publish runs, so a fork produces those even when the publish is rejected;
- the duplicate-tag gate reads `npm view @askalf/dario`, so a fork is deciding whether to release by consulting *this* package's registry entry rather than anything about itself.

I found this on my own fork, where the job had been firing hourly for several days. Nothing shipped from it — but only because an unrelated breakage was killing every run before it reached the gate, not because anything was stopping it. When I fixed that breakage the runs started getting further, which is how it surfaced.

One line of condition, plus a comment saying why it is there so it does not get tidied away later. No behaviour change on this repository.

Worth saying explicitly since I cannot verify it from outside: if npm's trusted publisher is *not* in fact bound narrowly, or if any fork has an `NPM_TOKEN` secret of its own configured, the exposure is larger than the tag and the Release. The guard covers both cases either way.