### PR TITLE
fix: never leave a request ending on an assistant turn (#1033)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.26] - 2026-08-20
+
+- **Fixed: sub-agent turns rejected with `400 assistant message prefill`** (#1033) — CC emits standalone `<system-reminder>` / `<task_metadata>` user turns, notably right after a Task (sub-agent) result folds back into the transcript. Both tags are scrubbed by the orchestration-tag pass, so the turn emptied, the drop-empty-messages filter removed it, and the request left ending on the *assistant* turn. Anthropic reads that as a prefill and rejects it: *"This model does not support assistant message prefill. The conversation must end with a user message."* `sanitizeMessages` now restores that turn's pre-scrub content instead of dropping it, and the template build's trailing-empty pop is restricted to assistant turns — popping an empty *user* turn exposed the assistant turn behind it and caused the same rejection.
+
 ## [5.5.25] - 2026-08-20
 
 - **Template label refresh** — `_version`, `_supportedMaxTested`, and the `user-agent` header bumped to `2.1.236` to track `@anthropic-ai/claude-code@latest`. The live wire shape is unchanged — cc-drift-template-watch ran `capture-and-bake --check` against live CC v2.1.236 and found zero shape drift vs the bundle — so this is a label refresh, not a re-capture (`_captured` stays at the last real capture). Auto-merged; clears the `sdk-drift` early-warning signal.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.25",
+  "version": "5.5.26",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -1845,10 +1845,19 @@ export function buildCCRequest(
   // appended its assistant reply locally, dario stripped it from the next
   // request, the model regenerated the same reply, dario stripped that, and
   // the loop never terminated (133 POSTs from a single user prompt).
+  //
+  // Restricted to ASSISTANT turns, which is the only shape this loop was
+  // written for (a thinking-only assistant turn emptied by the strip above).
+  // Popping an empty *user* turn is what the loop must not do: it exposes the
+  // assistant turn behind it and produces the very prefill rejection the loop
+  // exists to prevent (dario#1033). An empty user turn is a malformed client
+  // request either way — leaving it in place lets the upstream name it
+  // accurately ("messages.N: content must contain at least one block")
+  // instead of dario converting it into a misleading prefill error.
   while (messages.length > 0) {
     const last = messages[messages.length - 1];
     const contentEmpty = Array.isArray(last.content) && (last.content as unknown[]).length === 0;
-    if (contentEmpty) {
+    if (contentEmpty && last.role === 'assistant') {
       messages.pop();
       continue;
     }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -675,6 +675,12 @@ export function sanitizeMessages(body: Record<string, unknown>, preserveTags?: S
   const messages = body.messages as Array<{ role: string; content: unknown }> | undefined;
   if (!messages) return;
   const patterns = orchestrationPatternsFor(preserveTags);
+  // Snapshot the tail turn before scrubbing. If the scrub empties it and the
+  // drop below would expose an assistant turn, we put the original content
+  // back rather than ship a prefill (dario#1033) — see the guard after the
+  // filter for the reasoning.
+  const tail = messages.length > 0 ? messages[messages.length - 1] : undefined;
+  const tailContentBeforeScrub = tail ? tail.content : undefined;
   for (const msg of messages) {
     if (typeof msg.content === 'string') {
       msg.content = sanitizeContent(msg.content, patterns);
@@ -705,11 +711,50 @@ export function sanitizeMessages(body: Record<string, unknown>, preserveTags?: S
   // The message carried nothing for the model, so removing it is the same
   // decision the block filter already made, applied one level up. String
   // content scrubbed to '' is the same case in its other shape.
-  body.messages = messages.filter((m) => {
+  const kept = messages.filter((m) => {
     if (Array.isArray(m.content)) return m.content.length > 0;
     if (typeof m.content === 'string') return m.content !== '';
     return true;
   });
+
+  // Invariant: the scrub must never turn a request that ended on a USER turn
+  // into one that ends on an ASSISTANT turn. Anthropic reads a trailing
+  // assistant turn as a prefill ("continue from this text") and Opus 4.6 under
+  // adaptive thinking + the claude-code beta rejects it outright:
+  //   400 "This model does not support assistant message prefill.
+  //        The conversation must end with a user message."
+  //
+  // CC emits standalone `<system-reminder>` / `<task_metadata>` user turns —
+  // notably right after a Task (sub-agent) result is folded back into the
+  // parent transcript. Both tags are in ORCHESTRATION_TAG_NAMES, so that turn
+  // scrubs to empty, the filter above drops it, and a valid CC request leaves
+  // as a prefill (dario#1033).
+  //
+  // The fix restores the turn's PRE-SCRUB content instead of dropping it. The
+  // orchestration tag survives in this one position only, which is the right
+  // trade in both directions: for a CC client the tag is CC's own injection,
+  // so keeping it is *more* wire-faithful, not less; for a non-CC client a
+  // lone tag as the final turn is the actual prompt, and forwarding it beats
+  // a hard 400. Every other position still scrubs exactly as before.
+  const tailWasDropped = tail !== undefined && kept[kept.length - 1] !== tail;
+  const tailHadContent = Array.isArray(tailContentBeforeScrub)
+    ? tailContentBeforeScrub.length > 0
+    : typeof tailContentBeforeScrub === 'string'
+      ? tailContentBeforeScrub !== ''
+      : tailContentBeforeScrub != null;
+  if (
+    tail !== undefined &&
+    tailWasDropped &&
+    tail.role === 'user' &&
+    tailHadContent &&
+    kept.length > 0 &&
+    kept[kept.length - 1]!.role === 'assistant'
+  ) {
+    tail.content = tailContentBeforeScrub;
+    kept.push(tail);
+  }
+
+  body.messages = kept;
 }
 
 /**

--- a/test/hybrid-tools.mjs
+++ b/test/hybrid-tools.mjs
@@ -640,6 +640,35 @@ header('dario#36 — drop trailing assistant/empty turns (prefill rejection)');
 // ======================================================================
 //
 // ======================================================================
+header('dario#1033 - the trailing-empty pop must not expose an assistant turn');
+{
+  // The pop loop above exists for thinking-only ASSISTANT turns. Applied to an
+  // empty USER turn it does the opposite of its job: it removes the turn that
+  // was terminating the conversation and exposes the assistant turn behind it,
+  // producing exactly the prefill rejection the loop was written to avoid.
+  const body = {
+    model: 'claude-opus-4-6',
+    messages: [
+      { role: 'user', content: 'go' },
+      { role: 'assistant', content: [{ type: 'text', text: 'here you go' }] },
+      { role: 'user', content: [] },
+    ],
+  };
+  const built = buildCCRequest(
+    JSON.parse(JSON.stringify(body)),
+    'billing',
+    { type: 'ephemeral' },
+    { deviceId: 'd', accountUuid: 'a', sessionId: 's' },
+    {},
+  );
+  const m = built.body.messages;
+  check('empty trailing USER turn is not popped', m.length === 3);
+  check('request does not end on an assistant turn', m[m.length - 1].role !== 'assistant');
+}
+
+// ======================================================================
+//
+// ======================================================================
 header('dario#37 — trailing assistant with real content is preserved (runaway loop fix)');
 {
   // v3.10.1 popped any trailing assistant, including ones with real

--- a/test/sanitize-messages.mjs
+++ b/test/sanitize-messages.mjs
@@ -306,5 +306,90 @@ header('no-`<` fast path — output identical to the full regex loop');
     codeBody.messages[0].content === 'const x: Map<string, number> = new Map(); if (a < b) {}');
 }
 
+// -------------------------------------------------------------
+header('dario#1033 - the scrub must not leave a trailing assistant turn (prefill 400)');
+{
+  // CC emits standalone <system-reminder> / <task_metadata> user turns, notably
+  // right after a Task (sub-agent) result is folded back into the transcript.
+  // Both tags are scrubbed, so the turn empties, the drop-empty-messages filter
+  // removes it, and the request goes out ending on the ASSISTANT turn. Anthropic
+  // reads that as a prefill and Opus 4.6 under adaptive thinking + the
+  // claude-code beta rejects it:
+  //   400 "This model does not support assistant message prefill.
+  //        The conversation must end with a user message."
+  const lastRole = (b) => b.messages[b.messages.length - 1]?.role;
+
+  {
+    const body = { messages: [
+      { role: 'user', content: [{ type: 'text', text: 'run the audit sub-agent' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'Audit complete: 3 findings.' }] },
+      { role: 'user', content: [{ type: 'text', text: '<system-reminder>The Task tool has returned.</system-reminder>' }] },
+    ]};
+    sanitizeMessages(body);
+    check('array content: trailing user turn survives the scrub', body.messages.length === 3);
+    check('array content: request still ends on a user turn', lastRole(body) === 'user');
+  }
+
+  {
+    const body = { messages: [
+      { role: 'user', content: 'do the thing' },
+      { role: 'assistant', content: 'Done.' },
+      { role: 'user', content: '<system-reminder>note</system-reminder>' },
+    ]};
+    sanitizeMessages(body);
+    check('string content: trailing user turn survives the scrub', body.messages.length === 3);
+    check('string content: request still ends on a user turn', lastRole(body) === 'user');
+  }
+
+  {
+    // task_metadata is the other tag CC wraps sub-agent bookkeeping in.
+    const body = { messages: [
+      { role: 'user', content: [{ type: 'text', text: 'go' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'ok' }] },
+      { role: 'user', content: [{ type: 'text', text: '<task_metadata>subagent=explore</task_metadata>' }] },
+    ]};
+    sanitizeMessages(body);
+    check('task_metadata-only trailing turn survives', lastRole(body) === 'user');
+  }
+
+  {
+    // The guard is positional: an emptied user turn in the MIDDLE is still
+    // dropped exactly as before - only the tail is protected.
+    const body = { messages: [
+      { role: 'user', content: [{ type: 'text', text: '<system-reminder>mid</system-reminder>' }] },
+      { role: 'user', content: [{ type: 'text', text: 'the real prompt' }] },
+    ]};
+    sanitizeMessages(body);
+    check('interior emptied turn is still dropped', body.messages.length === 1);
+    check('interior drop keeps the real prompt', body.messages[0].content[0].text === 'the real prompt');
+  }
+
+  {
+    // Unaffected control: a trailing user turn carrying real text alongside the
+    // reminder scrubs normally and keeps only the real text.
+    const body = { messages: [
+      { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
+      { role: 'user', content: [{ type: 'text', text: '<system-reminder>x</system-reminder>keep going' }] },
+    ]};
+    sanitizeMessages(body);
+    check('control: reminder stripped from a turn with real text',
+      body.messages[2].content[0].text === 'keep going');
+    check('control: still ends on a user turn', lastRole(body) === 'user');
+  }
+
+  {
+    // A trailing ASSISTANT turn that empties is NOT resurrected - the guard
+    // only protects user turns, so #36's behaviour is untouched.
+    const body = { messages: [
+      { role: 'user', content: [{ type: 'text', text: 'go' }] },
+      { role: 'assistant', content: [{ type: 'text', text: '<thinking>hmm</thinking>' }] },
+    ]};
+    sanitizeMessages(body);
+    check('emptied trailing assistant turn is still dropped', body.messages.length === 1);
+    check('and the request ends on the user turn', lastRole(body) === 'user');
+  }
+}
+
 console.log(`\n${pass} pass, ${fail} fail`);
 process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Fixes #1033.

## The report

@miklisanton hits this the moment a sub-agent returns, on dario 5.5.18 / CC / Ubuntu 24:

```
API Error: 400 This model does not support assistant message prefill.
The conversation must end with a user message.
```

## What is actually happening

CC emits standalone `<system-reminder>` / `<task_metadata>` user turns — notably right after a Task (sub-agent) result is folded back into the parent transcript. Both tags are in `ORCHESTRATION_TAG_NAMES`, so:

1. the orchestration-tag scrub empties that turn,
2. `sanitizeMessages`' drop-empty-messages filter (added for #744) removes it,
3. the request leaves dario ending on the **assistant** turn.

Anthropic reads a trailing assistant turn as a prefill ("continue from this text"), and Opus 4.6 under adaptive thinking + the `claude-code` beta refuses it. Nothing about the user's own conversation is malformed — dario makes it malformed on the way out.

Reproduced against `origin/master` (`298a89d`), before the fix:

```
A. trailing user turn = system-reminder only (array content)
  roles: user -> assistant          ends-on: assistant   <-- PREFILL 400
B. trailing user turn = system-reminder only (string content)
  roles: user -> assistant          ends-on: assistant   <-- PREFILL 400
C. control - trailing user turn has real text
  roles: user -> assistant -> user  ends-on: user   ok
```

A second, independent path produces the same shape — the trailing-empty pop in `buildCCRequest`:

```
D. client sends trailing user turn with content: []
  roles: user -> assistant          ends-on: assistant   <-- PREFILL 400
```

After the fix all four end on a user turn.

## The fix

One invariant, enforced at both sites: **dario must never turn a request that ended on a user turn into one that ends on an assistant turn.**

- **`sanitizeMessages` (`src/proxy.ts`)** restores the tail turn's *pre-scrub* content instead of dropping it, when dropping would expose an assistant turn. The orchestration tag survives in that one position only, which is the right trade in both directions: for a CC client the tag is CC's own injection, so keeping it is *more* wire-faithful, not less; for a non-CC client a lone tag as the final turn is the actual prompt, and forwarding it beats a hard 400. Every other position scrubs exactly as before — the guard is positional, and an emptied turn in the middle is still dropped.

- **The trailing-empty pop (`src/cc-template.ts`)** is restricted to **assistant** turns, which is the only shape it was written for (a thinking-only assistant turn emptied by the thinking strip above it). Popping an empty *user* turn exposed the assistant turn behind it and produced the very rejection the loop exists to prevent. An empty user turn is a malformed client request either way — leaving it in place lets the upstream name it accurately (`messages.N: content must contain at least one block`) instead of dario converting it into a misleading prefill error.

## What this must not regress, and doesn't

- #36 — a trailing **thinking-only assistant** turn is still dropped (covered by the existing `hybrid-tools.mjs` case, still green).
- #37 — a trailing assistant turn that still carries text / `tool_use` is still **not** popped. That was the v3.10.1 runaway loop (133 POSTs from one prompt); the guard here only ever *adds* a user turn back, never removes an assistant one.
- #744 / #54 — interior emptied turns and empty text blocks are dropped exactly as before, asserted explicitly.

## Tests

13 new cases — 11 in `test/sanitize-messages.mjs`, 2 in `test/hybrid-tools.mjs` — covering array and string content, `task_metadata` as well as `system-reminder`, the positional guard, and both no-regress controls.

`npm test`: **134 / 137 pass.** The 3 failures (`template-config-scoped-tools`, `template-interactive-tools`, `tool-advertise-respects-client`) are **pre-existing on clean `origin/master`** and are not caused by this change — they reproduce identically on an unmodified checkout, and all three pass when run against a clean `HOME`. They are an artifact of a local `~/.dario/cc-template.live.json`, which is a separate bug I am filing on its own.

## Release note

Bumps `5.5.25` → `5.5.26`. Heads-up: **#1028 also claims 5.5.26**, so whichever of the two lands second needs `gh pr update-branch` and a re-bump. Separately, **#1027 looks stale** — it bumps `5.5.24` → `5.5.25`, but master is already at 5.5.25 and `v5.5.25` is tagged and on npm.
