### PR TITLE
fix: apply the tool superset rule when LOADING a live template (#1035)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.27] - 2026-08-20
+
+- **Fixed: a live template capture silently degraded the tool set** (#1035) — the superset rule that keeps `AskUserQuestion` / `EnterPlanMode` / `ExitPlanMode` / `TaskCreate` / `TaskGet` / `TaskList` / `TaskUpdate` (and other-platform tools such as `PowerShell`) in the bundle was enforced only at bake time. `loadTemplate` applied none of it to a user's live capture, so every install with CC present degraded itself within the 24h cache TTL: declared tools went unadvertised, and history `tool_use` blocks for the dropped tools were renamed onto fallback slots with junk arguments — the v4.8.93 failure mode, reached through the live-cache path. The rule is now defined once in `live-fingerprint.ts` and applied at load as well as at bake, with `tool_names` re-derived after the merge.
+
 ## [5.5.25] - 2026-08-20
 
 - **Template label refresh** — `_version`, `_supportedMaxTested`, and the `user-agent` header bumped to `2.1.236` to track `@anthropic-ai/claude-code@latest`. The live wire shape is unchanged — cc-drift-template-watch ran `capture-and-bake --check` against live CC v2.1.236 and found zero shape drift vs the bundle — so this is a label refresh, not a re-capture (`_captured` stays at the last real capture). Auto-merged; clears the `sdk-drift` early-warning signal.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.25",
+  "version": "5.5.27",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -8,35 +8,23 @@
  * action required. See src/live-fingerprint.ts for the capture pipeline.
  */
 
-import { loadTemplate, promptVariantsOf, TemplateData, VARIANT_FAMILIES } from './live-fingerprint.js';
+import {
+  loadTemplate, promptVariantsOf, TemplateData, VARIANT_FAMILIES,
+  PLATFORM_ONLY_TOOLS, INTERACTIVE_ONLY_TOOLS, CONFIG_SCOPED_TOOLS,
+} from './live-fingerprint.js';
+
+// Re-exported so existing importers (scripts/capture-and-bake.mjs, the template
+// invariant tests) keep their import site. The definitions live in
+// live-fingerprint.ts because loadTemplate must apply the same superset rule to
+// a live capture that the bake applies to the bundle, and cc-template.ts is
+// downstream of that load (#1035).
+export { PLATFORM_ONLY_TOOLS, INTERACTIVE_ONLY_TOOLS, CONFIG_SCOPED_TOOLS };
 
 // Load template at module init — prefer live cache, fall back to bundled.
 const TEMPLATE: TemplateData = loadTemplate({ silent: true });
 
 /** The loaded template itself — source, version, capture age, all fields. Startup banners and drift checks read this directly. */
 export const CC_TEMPLATE: TemplateData = TEMPLATE;
-
-/**
- * Tools CC only ships on a specific platform. The bundled template is a
- * union capture (any platform the maintainer baked from), so we filter it
- * down to the running platform at module load. Real CC on the client side
- * only advertises the tools available to its host — forwarding a larger
- * set through dario would both leak a fingerprint (Anthropic sees tools
- * the client would never actually call) and risk tool_use round-trips
- * coming back for a tool the client has no handler for.
- *
- * PowerShell shipped in CC v2.1.116 on Windows; POSIX CC installs do not
- * advertise it. As of CC v2.1.162 the Glob/Grep tools are the same shape:
- * Windows CC advertises them, POSIX CC drops them and steers the agent to
- * shell `find`/`grep` instead (which PowerShell has no native equivalent
- * for). Registering them here filters them to win32 clients AND keeps a
- * POSIX auto-bake from dropping them out of the union — the v4.8.28
- * regression, where a Linux runner re-baked the bundle down to 28 tools.
- * Add new platform-scoped tools here as CC adds them.
- */
-export const PLATFORM_ONLY_TOOLS: Record<string, Set<string>> = {
-  win32: new Set(['PowerShell', 'Glob', 'Grep']),
-};
 
 /** Keep tool `t` unless its name is listed under a platform other than the current one. */
 export function filterToolsForPlatform<T extends { name: string }>(
@@ -50,59 +38,6 @@ export function filterToolsForPlatform<T extends { name: string }>(
     return true;
   });
 }
-
-/**
- * Tools CC only advertises in an INTERACTIVE session. The bake captures CC
- * headlessly (`claude --print -p hi`, see live-fingerprint.ts), and CC v2.1.187
- * dropped these plan-mode / clarification tools in `--print` mode — so a fresh
- * headless capture no longer carries them even though every real interactive CC
- * client still advertises them. Like PLATFORM_ONLY_TOOLS, the bundled template
- * must stay a SUPERSET: register them here so a headless auto-rebake preserves
- * them from the previous bundle instead of dropping them. Dropping them broke
- * buildCCRequest's advertise-respects-client contract (the v4.8.93 regression):
- * dario advertises only the intersection of the client's declared tools and this
- * template, so a missing AskUserQuestion meant dario could not advertise it even
- * when a full CC client declared it. Unlike PLATFORM_ONLY_TOOLS these are NOT
- * platform-filtered — they stay in CC_TOOL_DEFINITIONS on every host so a client
- * that declares them is always honored. Add new interactive-only tools here as
- * CC adds them.
- */
-export const INTERACTIVE_ONLY_TOOLS: Set<string> = new Set([
-  'AskUserQuestion',
-  'EnterPlanMode',
-  'ExitPlanMode',
-]);
-
-/**
- * Tools CC advertises only under some runtime configurations. Unlike
- * INTERACTIVE_ONLY_TOOLS (absent because the bake captures headlessly), these
- * come and go with CC's REMOTE config for the same capture mode: the 2026-08-11
- * bake on CC v2.1.232 captured all four headlessly, and the 2026-08-15 bake on
- * v2.1.233 captured none of them — while TaskOutput/TaskStop, the rest of the
- * task subsystem, stayed put. That is the v4.2.1 drift class (same binary,
- * different wire shape via remote configuration), and it is not a signal that
- * CC retired the tools.
- *
- * The bundle must stay a SUPERSET, so the bake preserves these from the previous
- * bundle exactly as it does the platform- and interactive-only sets. The cost of
- * the two directions is asymmetric, which is what settles it: a stale entry is
- * INERT, because buildCCRequest advertises only the intersection of the bundle
- * with what the client declared — no client declares it, nothing is advertised.
- * Dropping one is NOT inert: CC_NATIVE_NAMES_UNION is derived from this bundle,
- * so a client that does declare TaskCreate stops identity-mapping, falls into
- * the unmapped round-robin, and is renamed onto a fallback slot with junk args
- * (the v4.8.93 regression, caught here by issue-29-tool-translation.mjs).
- *
- * Add new config-scoped tools here as CC's remote config churns. Removing a name
- * is a deliberate act: it means CC genuinely retired the tool, and it should be
- * paired with the capture evidence that says so.
- */
-export const CONFIG_SCOPED_TOOLS: Set<string> = new Set([
-  'TaskCreate',
-  'TaskGet',
-  'TaskList',
-  'TaskUpdate',
-]);
 
 /** CC's exact tool definitions for the current platform — filtered from the bundled union. */
 export const CC_TOOL_DEFINITIONS = filterToolsForPlatform(TEMPLATE.tools, process.platform);

--- a/src/live-fingerprint.ts
+++ b/src/live-fingerprint.ts
@@ -264,6 +264,120 @@ export function promptVariantsOf(t: TemplateData): Record<string, string> {
  * Variants the live template already has win, so a future per-model live
  * capture supersedes the bake without another change here.
  */
+/**
+ * Tools CC only ships on a specific platform. A capture sees only the host it
+ * ran on, so both the bundle and any live capture must be re-unioned against
+ * the other platforms' names before use. Filtered back down to the running
+ * platform at request time by filterToolsForPlatform().
+ *
+ * PowerShell shipped in CC v2.1.116 on Windows; POSIX CC installs do not
+ * advertise it. As of CC v2.1.162 Glob/Grep are the same shape: Windows CC
+ * advertises them, POSIX CC drops them and steers the agent to shell
+ * `find`/`grep` instead. Registering them here filters them to win32 clients
+ * AND keeps a POSIX capture from dropping them out of the union — the v4.8.28
+ * regression, where a Linux runner re-baked the bundle down to 28 tools.
+ * Add new platform-scoped tools here as CC adds them.
+ */
+export const PLATFORM_ONLY_TOOLS: Record<string, Set<string>> = {
+  win32: new Set(['PowerShell', 'Glob', 'Grep']),
+};
+
+/**
+ * Tools CC only advertises in an INTERACTIVE session. Captures spawn CC
+ * headlessly (`claude --print -p hi`), and CC v2.1.187 dropped these plan-mode /
+ * clarification tools in `--print` mode — so a fresh headless capture no longer
+ * carries them even though every real interactive CC client still advertises
+ * them. Unlike PLATFORM_ONLY_TOOLS these are NOT platform-filtered: they stay in
+ * the tool set on every host so a client that declares them is always honored.
+ * Add new interactive-only tools here as CC adds them.
+ */
+export const INTERACTIVE_ONLY_TOOLS: Set<string> = new Set([
+  'AskUserQuestion',
+  'EnterPlanMode',
+  'ExitPlanMode',
+]);
+
+/**
+ * Tools CC advertises only under some runtime configurations. Unlike
+ * INTERACTIVE_ONLY_TOOLS (absent because the capture is headless), these come
+ * and go with CC's REMOTE config for the same capture mode: the 2026-08-11 bake
+ * on CC v2.1.232 captured all four headlessly, and the 2026-08-15 bake on
+ * v2.1.233 captured none of them — while TaskOutput/TaskStop, the rest of the
+ * task subsystem, stayed put. That is the v4.2.1 drift class (same binary,
+ * different wire shape via remote configuration), not a signal that CC retired
+ * the tools.
+ *
+ * Removing a name here is a deliberate act: it means CC genuinely retired the
+ * tool, and it should be paired with the capture evidence that says so.
+ */
+export const CONFIG_SCOPED_TOOLS: Set<string> = new Set([
+  'TaskCreate',
+  'TaskGet',
+  'TaskList',
+  'TaskUpdate',
+]);
+
+/** Why a given tool was preserved — used for logging at bake time. */
+export type PreservedToolReason = 'platform' | 'interactive' | 'config-scoped';
+
+/**
+ * Decide whether `name` must be preserved into a capture taken on `platform`,
+ * and say why. The single definition of the superset rule.
+ *
+ * The cost of the two directions is asymmetric, which is what settles it. A
+ * stale entry is INERT: buildCCRequest advertises the intersection of the tool
+ * set with what the CLIENT declared, so an entry no client declares is never
+ * sent. Dropping one is NOT inert — CC_NATIVE_NAMES_UNION is derived from the
+ * loaded template, so a client that does declare the tool stops identity-
+ * mapping, falls into the unmapped round-robin, and has its history tool_use
+ * blocks renamed onto a fallback slot with junk arguments (the v4.8.93
+ * regression).
+ */
+export function preservedToolReason(name: string, platform: string): PreservedToolReason | null {
+  for (const [plat, names] of Object.entries(PLATFORM_ONLY_TOOLS)) {
+    if (names.has(name) && plat !== platform) return 'platform';
+  }
+  if (INTERACTIVE_ONLY_TOOLS.has(name)) return 'interactive';
+  if (CONFIG_SCOPED_TOOLS.has(name)) return 'config-scoped';
+  return null;
+}
+
+/**
+ * Re-union `capture.tools` with any tool `fallback` carries that the capture is
+ * required to keep (see preservedToolReason). Returns the merged tool array,
+ * CC's alphabetical wire order restored, plus what was preserved and why.
+ *
+ * This is the rule the bake has always applied to the previous bundle. It must
+ * apply to a LIVE capture too: `loadTemplate` prefers a fresh live cache, the
+ * cache refreshes on a 24h TTL, and the capture is headless — so without this,
+ * every dario install with CC present degrades its own tool set within a day
+ * of running, and CI never sees it because CI has no live cache (#1035).
+ */
+export function mergePreservedTools<T extends { name: string }>(
+  captureTools: T[],
+  fallbackTools: T[],
+  platform: string,
+): { tools: T[]; preserved: Array<{ name: string; reason: PreservedToolReason }> } {
+  const have = new Set(captureTools.map((t) => t.name));
+  const preserved: Array<{ name: string; reason: PreservedToolReason }> = [];
+  const additions: T[] = [];
+  for (const tool of fallbackTools) {
+    if (have.has(tool.name)) continue;
+    const reason = preservedToolReason(tool.name, platform);
+    if (!reason) continue;
+    additions.push(tool);
+    preserved.push({ name: tool.name, reason });
+    have.add(tool.name);
+  }
+  if (additions.length === 0) return { tools: captureTools, preserved };
+  // CC sends tools alphabetically by name — sort after merge so preserved tools
+  // insert at their natural position rather than appending at the end.
+  return {
+    tools: [...captureTools, ...additions].sort((a, b) => a.name.localeCompare(b.name)),
+    preserved,
+  };
+}
+
 export function withBundledVariants(live: TemplateData): TemplateData {
   let bundled: TemplateData;
   try {
@@ -314,12 +428,39 @@ const LIVE_TTL_MS = 24 * 60 * 60 * 1000; // re-extract once a day
  * background via refreshLiveFingerprintAsync(); its results are written
  * to the cache file and picked up on the next dario startup.
  */
+/**
+ * Bring a live capture up to the superset the rest of the codebase assumes:
+ * merge back any preserved tool the bundle has and the capture lacks, then
+ * re-derive `tool_names`.
+ *
+ * `tool_names === tools.map(t => t.name)` is the contract everywhere —
+ * scrubTemplate() sets it from `tools`, and so does the capture path. The bake
+ * learned the hard way that a merge which mutates `tools` without re-deriving
+ * the list ships an artifact whose two tool lists disagree; do not repeat it
+ * here (#1035).
+ */
+function withPreservedTools(live: TemplateData, options?: { silent?: boolean }): TemplateData {
+  let bundled: TemplateData;
+  try {
+    bundled = loadBundledTemplate({ silent: true });
+  } catch {
+    return live; // bundle unreadable — the capture is still better than throwing
+  }
+  const { tools, preserved } = mergePreservedTools(live.tools, bundled.tools, process.platform);
+  if (preserved.length === 0) return live;
+  if (!options?.silent) {
+    const byReason = preserved.map((p) => `${p.name} (${p.reason})`).join(', ');
+    console.log(`[dario] live template: restored ${preserved.length} tool${preserved.length === 1 ? '' : 's'} the capture omitted: ${byReason}`);
+  }
+  return { ...live, tools, tool_names: tools.map((t) => t.name) };
+}
+
 export function loadTemplate(_options?: { silent?: boolean }): TemplateData {
   const cached = readLiveCache();
   if (cached) {
     const age = Date.now() - new Date(cached._captured).getTime();
     if (age < LIVE_TTL_MS) {
-      return withBundledVariants(cached);
+      return withPreservedTools(withBundledVariants(cached), _options);
     }
     // Stale cache: prefer whichever of the live cache and the bundled
     // snapshot was captured more recently — do NOT blindly keep the cache.
@@ -333,7 +474,7 @@ export function loadTemplate(_options?: { silent?: boolean }): TemplateData {
     const bundled = loadBundledTemplate(_options);
     const cachedAt = new Date(cached._captured).getTime();
     const bundledAt = new Date(bundled._captured).getTime();
-    return Number.isFinite(bundledAt) && bundledAt > cachedAt ? bundled : withBundledVariants(cached);
+    return Number.isFinite(bundledAt) && bundledAt > cachedAt ? bundled : withPreservedTools(withBundledVariants(cached), _options);
   }
   return loadBundledTemplate(_options);
 }

--- a/test/live-fingerprint.mjs
+++ b/test/live-fingerprint.mjs
@@ -328,6 +328,67 @@ header('loadTemplate — reads fresh live cache in preference to bundled');
 }
 
 // ======================================================================
+//  loadTemplate - superset rule applies to a LIVE capture too (#1035)
+// ======================================================================
+header('loadTemplate - restores preserved tools a headless live capture omitted');
+{
+  // A capture spawns CC headlessly, so it does not see the interactive tools
+  // (CC v2.1.187+ drops them under --print) and sees the Task* four only when
+  // CC's remote config happens to advertise them. The bake re-adds both sets
+  // from the previous bundle; loadTemplate did not, so every install with CC
+  // present degraded its own tool set within the 24h cache TTL - and CI never
+  // caught it because CI has no live cache.
+  mkdirSync(dirname(LIVE_CACHE), { recursive: true });
+  const degraded = {
+    _version: '99.99.99-degraded-capture',
+    _captured: new Date().toISOString(),
+    _source: 'live',
+    _schemaVersion: CURRENT_SCHEMA_VERSION,
+    agent_identity: 'FAKE LIVE IDENTITY',
+    system_prompt: 'FAKE LIVE SYSTEM PROMPT',
+    // Exactly what a headless capture yields: real tools, none of the
+    // interactive or config-scoped ones.
+    tools: [
+      { name: 'Bash', description: '', input_schema: {} },
+      { name: 'Read', description: '', input_schema: {} },
+    ],
+    tool_names: ['Bash', 'Read'],
+  };
+  writeFileSync(LIVE_CACHE, JSON.stringify(degraded));
+
+  const loaded = loadTemplate({ silent: true });
+  const names = loaded.tools.map((t) => t.name);
+
+  check('live cache still preferred', loaded._version === '99.99.99-degraded-capture');
+  check('captured tools kept', names.includes('Bash') && names.includes('Read'));
+
+  for (const t of ['AskUserQuestion', 'EnterPlanMode', 'ExitPlanMode']) {
+    check(`interactive-only tool restored: ${t}`, names.includes(t));
+  }
+  for (const t of ['TaskCreate', 'TaskGet', 'TaskList', 'TaskUpdate']) {
+    check(`config-scoped tool restored: ${t}`, names.includes(t));
+  }
+  if (process.platform !== 'win32') {
+    check('other-platform tool restored: PowerShell', names.includes('PowerShell'));
+  }
+
+  // tool_names === tools.map(name) is the contract everywhere; the bake shipped
+  // artifacts where a merge broke it, so assert it explicitly here.
+  check('tool_names re-derived after the merge',
+    JSON.stringify(loaded.tool_names) === JSON.stringify(names));
+
+  // CC sends tools alphabetically - preserved entries must insert at their
+  // natural position, not append at the end.
+  const sorted = [...names].sort((a, b) => a.localeCompare(b));
+  check('merged tool array kept in CC alphabetical order',
+    JSON.stringify(names) === JSON.stringify(sorted));
+
+  // The rule must not INVENT tools: a name in neither preserved set and absent
+  // from the capture stays absent.
+  check('non-preserved tools are not injected', !names.includes('WebSearch'));
+}
+
+// ======================================================================
 //  loadTemplate — rejects cache without _schemaVersion (pre-v3.17 shape)
 // ======================================================================
 header('loadTemplate — rejects cache with missing or mismatched _schemaVersion');


### PR DESCRIPTION
Fixes #1035.

## Summary

The superset rule that keeps `AskUserQuestion` / `EnterPlanMode` / `ExitPlanMode`, the `Task*` four, and other-platform tools like `PowerShell` in the tool set was enforced **only in `capture-and-bake.mjs`**. `loadTemplate` applied none of it to a user's **live** capture.

Captures are headless and refresh on a 24h TTL, and CC v2.1.187+ drops the interactive tools under `--print` — so every dario install with CC present degraded its own tool set within a day of running. CI never caught it because CI has no live cache.

## Evidence

A real cache on this machine (`_source: live`, CC v2.1.236 — the *same* `_version` as the bundle) carried 26 tools against the bundle's 34, missing all seven names above. With it present, against unmodified `origin/master`:

```
client declared : Read, Bash, TaskCreate, AskUserQuestion, ExitPlanMode
dario advertised: Bash, Read

history tool_use name on the wire: Grep
history tool_use input           : {"pattern":".","path":"."}
```

The second line is the serious one. `CC_NATIVE_NAMES_UNION` is derived from the loaded template, so a client that still declares `TaskCreate` stops identity-mapping, falls into the unmapped round-robin, and **has its own transcript rewritten to claim it called `Grep` with junk arguments** — the v4.8.93 failure mode, reached through the live-cache path instead of the bake.

After this change, same machine, same cache:

```
client declared : Read, Bash, TaskCreate, AskUserQuestion, ExitPlanMode
dario advertised: AskUserQuestion, Bash, ExitPlanMode, Read, TaskCreate

history tool_use name on the wire: TaskCreate
history tool_use input           : {"subagent_type":"Explore","prompt":"find X"}
```

## The change

`PLATFORM_ONLY_TOOLS`, `INTERACTIVE_ONLY_TOOLS` and `CONFIG_SCOPED_TOOLS`, plus one `mergePreservedTools()`, now live in `live-fingerprint.ts` as a **single definition**. `loadTemplate` is upstream of `cc-template.ts`, so the rule has to be expressible there; `cc-template.ts` re-exports all three so every existing import site (`capture-and-bake.mjs`, the invariant tests) is untouched.

`tool_names` is re-derived after the merge — the `tool_names === tools.map(name)` contract the bake already learned to maintain the hard way.

The merge is conservative by construction: it only ever adds a name the **bundle already carries** *and* the preserved sets name. It cannot invent a tool, and a stale entry is inert because advertise is an intersection with what the client declared. Asserted both ways in the tests.

## Tests

14 new assertions in `test/live-fingerprint.mjs`. They **fail on master** (7 failures) and pass here — verified by running this exact file against an unmodified `origin/master` build. They synthesize a degraded capture through `DARIO_LIVE_TEMPLATE_CACHE`, so CI exercises the path without needing CC installed.

`npm test`: **137 / 137**. The three suites that fail on master on any machine with a live cache — `template-config-scoped-tools`, `template-interactive-tools`, `tool-advertise-respects-client` — now pass with the real degraded cache in place.

## Deliberately not in this PR

`capture-and-bake.mjs` still has its own three merge loops rather than calling `mergePreservedTools()`. The *sets* are now single-sourced, so they cannot drift; only the loops are duplicated. I left them because the bake needs a live CC to run end-to-end and I could not exercise it here — switching it blind is the wrong risk to take quietly. Worth a follow-up.

## Release note

Bumps `5.5.25` → `5.5.27`, leaving `5.5.26` to #1034 / #1028. Whichever of these lands second will need `gh pr update-branch` and a re-bump.
