### PR TITLE
ci: stop scheduled workflows firing on all 54 forks (#1039)

### DIFF
--- a/.github/workflows/auto-merge-sweep.yml
+++ b/.github/workflows/auto-merge-sweep.yml
@@ -47,6 +47,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # Never from a fork. This job is meaningless anywhere but this
+      # repository, and 54 forks inherit the schedule. See #1039.
+    if: github.repository == 'askalf/dario'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/cc-billing-classifier-canary.yml
+++ b/.github/workflows/cc-billing-classifier-canary.yml
@@ -68,6 +68,9 @@ jobs:
     permissions:
       contents: read
       issues: write
+      # Never from a fork. This job is meaningless anywhere but this
+      # repository, and 54 forks inherit the schedule. See #1039.
+    if: github.repository == 'askalf/dario'
     runs-on: [self-hosted, dario-drift]
     timeout-minutes: 5
     steps:

--- a/.github/workflows/cc-drift-template-watch.yml
+++ b/.github/workflows/cc-drift-template-watch.yml
@@ -62,6 +62,9 @@ jobs:
     # Runs only on the self-hosted runner labeled `dario-drift`. Github-hosted
     # runners don't have CC + OAuth, so this job effectively gates on whether
     # a maintainer has registered a runner with that label.
+      # Never from a fork. This job is meaningless anywhere but this
+      # repository, and 54 forks inherit the schedule. See #1039.
+    if: github.repository == 'askalf/dario'
     runs-on: [self-hosted, dario-drift]
     timeout-minutes: 8
     steps:

--- a/.github/workflows/cc-drift-watch.yml
+++ b/.github/workflows/cc-drift-watch.yml
@@ -39,6 +39,9 @@ jobs:
     # Gate job only probes npm + a cache sentinel — no GitHub API writes.
     permissions:
       contents: read
+      # Never from a fork. This job is meaningless anywhere but this
+      # repository, and 54 forks inherit the schedule. See #1039.
+    if: github.repository == 'askalf/dario'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.probe.outputs.version }}
@@ -107,7 +110,11 @@ jobs:
       issues: write
       pull-requests: write
     needs: version_check
-    if: needs.version_check.outputs.should_run == 'true'
+      # Never from a fork. This job is meaningless anywhere but this
+      # repository, and 54 forks inherit the schedule. See #1039.
+    if: >-
+      github.repository == 'askalf/dario'
+      && (needs.version_check.outputs.should_run == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: askalf/checkout-with-retry@115a6407547e9711edbc2e915838d495cad9583f  # v1.1.0

--- a/.github/workflows/cc-drift-watcher-liveness.yml
+++ b/.github/workflows/cc-drift-watcher-liveness.yml
@@ -43,6 +43,9 @@ jobs:
       # to an operator alert — the recovery path had never once fired
       # before #950 surfaced it.
       actions: write
+      # Never from a fork. This job is meaningless anywhere but this
+      # repository, and 54 forks inherit the schedule. See #1039.
+    if: github.repository == 'askalf/dario'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:

--- a/.github/workflows/cc-oauth-health.yml
+++ b/.github/workflows/cc-oauth-health.yml
@@ -71,6 +71,9 @@ jobs:
       # scripts/health-verdict.sh through the contents API with this token.
       contents: read
       issues: write
+      # Never from a fork. This job is meaningless anywhere but this
+      # repository, and 54 forks inherit the schedule. See #1039.
+    if: github.repository == 'askalf/dario'
     runs-on: [self-hosted, dario-drift]
     timeout-minutes: 4
     steps:

--- a/.github/workflows/cflite.yml
+++ b/.github/workflows/cflite.yml
@@ -20,6 +20,9 @@ permissions: read-all
 
 jobs:
   Fuzzing:
+      # Never from a fork. This job is meaningless anywhere but this
+      # repository, and 54 forks inherit the schedule. See #1039.
+    if: github.repository == 'askalf/dario'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,11 @@ jobs:
       actions: read
       contents: read
       security-events: write
+      # Never from a fork ON THE SCHEDULE. A forker's own push/PR runs are
+      # left alone deliberately -- running security scanning on your own
+      # copy is legitimate and must not be broken to save cron minutes.
+      # See #1039.
+    if: github.event_name != 'schedule' || github.repository == 'askalf/dario'
     runs-on: ubuntu-latest
     steps:
       - uses: askalf/checkout-with-retry@115a6407547e9711edbc2e915838d495cad9583f  # v1.1.0

--- a/.github/workflows/dario-doctor-watch.yml
+++ b/.github/workflows/dario-doctor-watch.yml
@@ -38,6 +38,9 @@ jobs:
     permissions:
       contents: read
       issues: write
+      # Never from a fork. This job is meaningless anywhere but this
+      # repository, and 54 forks inherit the schedule. See #1039.
+    if: github.repository == 'askalf/dario'
     runs-on: [self-hosted, dario-drift]
     # 8 min: the obedience probe's worst case is 3 serial attempts × 30s per
     # family (families in parallel) on top of doctor's local checks.

--- a/.github/workflows/npm-drift-watch.yml
+++ b/.github/workflows/npm-drift-watch.yml
@@ -27,6 +27,9 @@ jobs:
     permissions:
       contents: read
       issues: write
+      # Never from a fork. This job is meaningless anywhere but this
+      # repository, and 54 forks inherit the schedule. See #1039.
+    if: github.repository == 'askalf/dario'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,6 +17,11 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
+      # Never from a fork ON THE SCHEDULE. A forker's own push/PR runs are
+      # left alone deliberately -- running security scanning on your own
+      # copy is legitimate and must not be broken to save cron minutes.
+      # See #1039.
+    if: github.event_name != 'schedule' || github.repository == 'askalf/dario'
     runs-on: ubuntu-latest
     permissions:
       security-events: write # upload the SARIF to code scanning

--- a/.github/workflows/sdk-drift-watch.yml
+++ b/.github/workflows/sdk-drift-watch.yml
@@ -40,6 +40,9 @@ jobs:
     permissions:
       contents: read
       issues: write
+      # Never from a fork. This job is meaningless anywhere but this
+      # repository, and 54 forks inherit the schedule. See #1039.
+    if: github.repository == 'askalf/dario'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:

--- a/.github/workflows/self-healing-supervisor.yml
+++ b/.github/workflows/self-healing-supervisor.yml
@@ -50,6 +50,9 @@ jobs:
       contents: read
       actions: write
       issues: write
+      # Never from a fork. This job is meaningless anywhere but this
+      # repository, and 54 forks inherit the schedule. See #1039.
+    if: github.repository == 'askalf/dario'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,6 +24,9 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+      # Never from a fork. This job is meaningless anywhere but this
+      # repository, and 54 forks inherit the schedule. See #1039.
+    if: github.repository == 'askalf/dario'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0

--- a/.github/workflows/wire-drift-self-hosted.yml
+++ b/.github/workflows/wire-drift-self-hosted.yml
@@ -53,7 +53,11 @@ jobs:
       issues: write
       pull-requests: write
     # Fork-PR guard: only the source repo runs on the self-hosted runner.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      # Never from a fork. This job is meaningless anywhere but this
+      # repository, and 54 forks inherit the schedule. See #1039.
+    if: >-
+      github.repository == 'askalf/dario'
+      && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [self-hosted, dario-drift]
     timeout-minutes: 10
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.35] - 2026-08-20
+
+- **Scheduled workflows no longer fire on forks** (#1039) — every workflow carrying a `cron` ran on all 54 forks on the same schedule. `cc-drift-auto-release` was the one that reached outward and was fixed in #1029; the remaining 15 were waste rather than exposure, but 54 forks running them hourly-to-daily is a lot of other people's CI minutes, and several decide what to do by reading *this* repo's published state. Thirteen are `workflow_dispatch`-only besides cron, so they take a plain `github.repository ==` guard at no cost to a fork. `codeql` and `scorecard` also run on push/PR, where a forker scanning their own copy is legitimate — those are scoped to the schedule only (`github.event_name != 'schedule' || …`) so fork CI is untouched.
+
 ## [5.5.34] - 2026-08-20
 
 - **Fixed two defects in `drift-pr-heal.yml`, both found by its first production run.** (1) It renumbered *after* merging, but `resolve-release-conflicts.mjs` keeps the higher version — so a stale bot PR ended up holding master's version, and the renumberer then renamed **master's already-published CHANGELOG section**, relabelling the notes of a tagged release while the bot's own entry sat orphaned. Renumbering now happens *before* the merge, while `package.json` still holds the PR's own version. (2) Every PR in one batch computed its floor from `origin/master`, which does not move during a run, so the first run renumbered both #1027 and #1028 onto 5.5.32 — reproducing the exact collision the workflow exists to clear. A running high-water mark now carries across the batch; the concurrency group only ever guarded against two *runs* colliding, and `version-advances.sh` cannot catch it because it only compares against master.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.34",
+  "version": "5.5.35",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Closes #1039. Follow-on to @chaogebaba's #1029, which fixed the one workflow that reached outward.

## The split is narrower than #1039 proposed

I argued in the issue for "guard the trigger, not the workflow", on the grounds that a blanket `github.repository ==` would break a forker's own push/PR security scanning. That worry was right in principle and **mostly wrong in practice** — I hadn't checked the trigger data. Having checked it:

| | count | other triggers besides `cron` | guard applied |
|---|---|---|---|
| `workflow_dispatch`-only | **13** | none | blanket `github.repository ==` |
| also `push` / `pull_request` | **2** | `codeql`, `scorecard` | schedule-scoped |

Thirteen of fifteen have no push/PR CI to break, so the blanket guard costs a fork nothing. Only `codeql` and `scorecard` needed the narrower form:

```yaml
if: github.event_name != 'schedule' || github.repository == 'askalf/dario'
```

## Severity, stated plainly

The 15 here are **waste, not exposure**. A fork's `GITHUB_TOKEN` is scoped to the fork, so the issue-filing watchers file into the fork rather than here. But 54 forks × 15 jobs on hourly-to-daily crons is a lot of other people's CI minutes spent on our behalf, and several decide whether to act by reading *this* package's registry entry or this repo's state — wrong on a fork by construction.

`cc-drift-auto-release`, the one that actually tagged, released and attempted an `npm publish`, was #1029.

## One that looked already-guarded and wasn't

`wire-drift-self-hosted` carried:

```yaml
if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
```

That guards **PRs from forks**. On a fork, `github.repository` *is* the fork, so it's true for the fork's own PRs and does nothing to stop the workflow running there. It needed the repository guard too.

## Composition, not replacement

Two jobs had an existing job-level `if:` (`cc-drift-watch`'s `check`, and the above). Both are composed with the original wrapped in parentheses:

```yaml
if: >-
  github.repository == 'askalf/dario'
  && (needs.version_check.outputs.should_run == 'true')
```

Dropping those parens would let `&&` bind tighter than `||` and silently make a trigger path unreachable — the exact failure #1029 was careful to avoid, and the one thing here that could break this repo rather than a fork.

## Verification

**No behaviour change on this repository.** `github.repository` is `askalf/dario`, so every added conjunct is constant-true and all jobs evaluate exactly as before.

Verified by parsing every workflow file and asserting that each job of each cron-carrying workflow now has the guard: **18/18 jobs across 17 cron workflows, none missed** — including the two already covered (`cc-drift-auto-release` via #1029, `drift-pr-heal` by construction).

The risk that matters here is a wrong `if:` silently disabling something on *our* side, which fails quietly rather than loudly. `actionlint` is a required check and catches syntax; it does not catch semantics, so the parenthesisation above is the part worth a human eye.
