### PR TITLE
fix: OAuth watcher pages for a spent window, and calls a live container dead (#1041)

### DIFF
--- a/.github/workflows/cc-oauth-health.yml
+++ b/.github/workflows/cc-oauth-health.yml
@@ -152,7 +152,6 @@ jobs:
           # genuine loopback caller with no cf-ray is exactly what dario requires
           # before it will spend a token on this, so this path — and only this
           # path — gets the serving verdict.
-          URL='http://127.0.0.1:3456/health?probe=1'
           # Fetched with node, NOT wget/curl, because the body on a NON-2xx is
           # the whole point: /health answers 503 with a populated body whenever
           # the pool cannot serve, and that body says why.

--- a/.github/workflows/cc-oauth-health.yml
+++ b/.github/workflows/cc-oauth-health.yml
@@ -153,7 +153,19 @@ jobs:
           # before it will spend a token on this, so this path — and only this
           # path — gets the serving verdict.
           URL='http://127.0.0.1:3456/health?probe=1'
-          body="$(docker exec askalf-dario sh -lc "wget -qO- '$URL' 2>/dev/null || curl -s --max-time 20 '$URL'" 2>/dev/null || true)"
+          # Fetched with node, NOT wget/curl, because the body on a NON-2xx is
+          # the whole point: /health answers 503 with a populated body whenever
+          # the pool cannot serve, and that body says why.
+          #
+          # The container has BusyBox wget (no --content-on-error, it discards
+          # the body on an HTTP error) and NO curl at all — so the previous
+          # `wget -qO- || curl -s` produced an EMPTY body on every 503, the
+          # verdict script defaulted oauth to "unreachable", and the alert
+          # reported "container down or not answering" about a container that
+          # was up, healthy and answering truthfully (dario#1041). node is the
+          # app's own runtime, so it is always present.
+          FETCH='const http=require("http");const r=http.get({host:"127.0.0.1",port:3456,path:"/health?probe=1",timeout:20000},s=>{let b="";s.on("data",d=>b+=d);s.on("end",()=>process.stdout.write(b))});r.on("timeout",()=>{r.destroy();process.exit(0)});r.on("error",()=>process.exit(0));'
+          body="$(printf '%s' "$FETCH" | docker exec -i askalf-dario node - 2>/dev/null || true)"
           # `|| true`: grep exits 1 on no match, and this step runs under
           # the runner's default `bash -e {0}` plus pipefail — without it,
           # the empty-body case kills the job RIGHT HERE and the
@@ -170,6 +182,7 @@ jobs:
           probe_reason="$(printf '%s\n' "$verdict" | sed -n '3p')"
           stalled="$(printf '%s\n' "$verdict" | sed -n '4p')"
           axis="$(printf '%s\n' "$verdict" | sed -n '5p')"
+          reason="$(printf '%s\n' "$verdict" | sed -n '6p')"
 
           echo "dario /health -> oauth=$oauth probe=${probe_ok:-<not measured>}${probe_reason:+ ($probe_reason)} stalledForMs=$stalled"
 
@@ -226,6 +239,10 @@ jobs:
             echo "| axis | reading |"
             echo "|---|---|"
             echo "| oauth | \`$oauth\` |"
+            # The reason is what separates "run \`dario login\`" from "wait for
+            # the window". Without it every non-healthy pool looked identical in
+            # this table and every reader went to the credential runbook.
+            echo "| reason | ${reason:+\`$reason\`}${reason:-—} |"
             echo "| serving probe | \`${probe_ok:-not measured}\`${probe_reason:+ — \`$probe_reason\`} |"
             echo "| queue stalled | \`${stalled:-0}\` ms |"
             echo
@@ -246,7 +263,14 @@ jobs:
             # or addresses. The verdict script never extracts that field, and
             # the table above carries every value we actually act on, so the
             # raw dump was redundant as well as leaky.
-            echo "- Reachable: $([ -n "$body" ] && echo yes || echo '**no** — container down or not answering')"
+            # "Reachable" means dario ANSWERED, not that it answered 200. It
+            # answers 503 with a populated body whenever the pool cannot serve,
+            # and that is a reachable container reporting accurately. Reading a
+            # non-2xx as "container down" sent readers to the credential
+            # runbook for a proxy that was up and healthy (dario#1041) — a
+            # miscue that only became possible once the fetch started keeping
+            # the body on an error status.
+            echo "- Reachable: $([ -n "$body" ] && echo 'yes — dario answered' || echo '**no** — container down or not answering')"
             echo "- Container: $container"
             echo "- Credential split check: $split"
             echo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.36] - 2026-08-20
+
+- **The OAuth watcher no longer pages for a spent usage window, and no longer calls a live container dead** (#1041) — two faults, both surfaced by 5.5.30. (1) `derivePoolStatus` began answering the router's question, so a pool whose accounts are all rate-limited now reports `oauth: broken`; the watcher paged on it, contradicting the rule it already follows for a throttled probe (dario reports those as `ok:true` "so a watchdog does not restart on a throttle"). `health-verdict.sh` now reads dario's `expiresIn` reason and suppresses the alert for a rate-limited pool only — expired tokens, auth-cooldown, and an unreachable container all still page. (2) The body was fetched with BusyBox `wget -qO-`, which discards the body on a non-2xx, with a `curl` fallback that does not exist in the container — so every legitimate 503 produced an empty body, `oauth` defaulted to `unreachable`, and the alert reported "container down or not answering" about a container that was up and answering truthfully. Fetched via node now, and the alert carries the reason so a reader can tell "run `dario login`" from "wait for the window".
+
 ## [5.5.35] - 2026-08-20
 
 - **Scheduled workflows no longer fire on forks** (#1039) — every workflow carrying a `cron` ran on all 54 forks on the same schedule. `cc-drift-auto-release` was the one that reached outward and was fixed in #1029; the remaining 15 were waste rather than exposure, but 54 forks running them hourly-to-daily is a lot of other people's CI minutes, and several decide what to do by reading *this* repo's published state. Thirteen are `workflow_dispatch`-only besides cron, so they take a plain `github.repository ==` guard at no cost to a fork. `codeql` and `scorecard` also run on push/PR, where a forker scanning their own copy is legitimate — those are scoped to the schedule only (`github.event_name != 'schedule' || …`) so fork CI is untouched.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.35",
+  "version": "5.5.36",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/scripts/health-verdict.sh
+++ b/scripts/health-verdict.sh
@@ -8,13 +8,16 @@
 # block cannot be exercised without firing the real workflow against a real
 # broken proxy, so it never is. test/health-verdict.mjs drives this directly.
 #
-# Reads the body on stdin. Writes exactly FIVE lines to stdout, in this order:
+# Reads the body on stdin. Writes exactly SIX lines to stdout, in this order:
 #
 #   1  oauth         the oauth field, or "unreachable" when absent/empty
 #   2  probe_ok      "true" | "false" | "" (empty = not measured)
 #   3  probe_reason  the probe's reason, or "" when there was no probe
 #   4  stalled       queue.stalledForMs as an integer, or "0" when absent
 #   5  axis          "" when healthy, else a short failure label
+#   6  reason        dario's `expiresIn` line for a non-healthy pool — "all
+#                    accounts rate-limited", "all tokens expired — run `dario
+#                    login`", "all accounts in auth-cooldown" — or "" when absent
 #
 # Fixed-position lines rather than KEY=VALUE + eval: the body is attacker-
 # adjacent enough (it is whatever the container returned) that evaluating
@@ -37,6 +40,11 @@ probe_obj="$(printf '%s' "$body" | grep -o '"probe":{[^}]*}' | head -1 || true)"
 probe_ok="$(printf '%s' "$probe_obj" | grep -o '"ok":[a-z]*' | head -1 | cut -d: -f2 || true)"
 probe_reason="$(printf '%s' "$probe_obj" | grep -o '"reason":"[^"]*"' | head -1 | cut -d'"' -f4 || true)"
 
+# dario 5.5.30+ names WHY a pool cannot serve, in `expiresIn`. That string is
+# the difference between "run `dario login`" and "wait for the window", so it
+# is carried out rather than collapsed into the oauth field.
+reason="$(printf '%s' "$body" | grep -o '"expiresIn":"[^"]*"' | head -1 | cut -d'"' -f4 || true)"
+
 queue_obj="$(printf '%s' "$body" | grep -o '"queue":{[^}]*}' | head -1 || true)"
 stalled="$(printf '%s' "$queue_obj" | grep -o '"stalledForMs":[0-9]*' | head -1 | cut -d: -f2 || true)"
 [ -z "$stalled" ] && stalled=0
@@ -44,7 +52,21 @@ stalled="$(printf '%s' "$queue_obj" | grep -o '"stalledForMs":[0-9]*' | head -1 
 # Remediation-first ordering: a dead credential also fails the probe, so report
 # the root axis and not the symptom it produces.
 axis=""
-if [ "$oauth" != "healthy" ]; then
+
+# A pool whose accounts are ALL rate-limited reports oauth=broken as of dario
+# 5.5.30, when derivePoolStatus started answering the router's question instead
+# of a narrower one. The credential is fine there — the usage window is spent,
+# and it refills on its own. Paging for that contradicts the rule this file
+# already follows one branch down, where dario deliberately reports a throttled
+# probe as ok:true "so a watchdog does not restart on a throttle". The same
+# throttle must not page through the oauth axis either. Still reported on line
+# 1 and line 6; simply not raised as an axis.
+throttled=0
+case "$reason" in
+  *"rate-limited"*) throttled=1 ;;
+esac
+
+if [ "$oauth" != "healthy" ] && [ "$throttled" = "0" ]; then
   axis="OAuth $oauth"
 elif [ "$probe_ok" = "false" ]; then
   # rate-limited / upstream-overloaded never reach here — dario reports those
@@ -54,4 +76,4 @@ elif [ "$stalled" -gt "$STALL_ALERT_MS" ] 2>/dev/null; then
   axis="queue wedged ($((stalled / 60000))m)"
 fi
 
-printf '%s\n%s\n%s\n%s\n%s\n' "$oauth" "$probe_ok" "$probe_reason" "$stalled" "$axis"
+printf '%s\n%s\n%s\n%s\n%s\n%s\n' "$oauth" "$probe_ok" "$probe_reason" "$stalled" "$axis" "$reason"

--- a/test/health-verdict.mjs
+++ b/test/health-verdict.mjs
@@ -26,7 +26,7 @@ const check = (name, cond, detail) => {
 };
 const header = (n) => console.log(`\n=== ${n} ===`);
 
-/** Run the verdict script over a body, return the five named fields. */
+/** Run the verdict script over a body, return the six named fields. */
 function verdict(body, env = {}) {
   const r = spawnSync('sh', [SCRIPT], {
     input: body,
@@ -37,8 +37,8 @@ function verdict(body, env = {}) {
     console.log(`  SKIP — no POSIX sh available: ${r.error.message}`);
     process.exit(0);
   }
-  const [oauth, probeOk, probeReason, stalled, axis] = (r.stdout ?? '').split('\n');
-  return { oauth, probeOk, probeReason, stalled, axis, status: r.status, stderr: r.stderr };
+  const [oauth, probeOk, probeReason, stalled, axis, reason] = (r.stdout ?? '').split('\n');
+  return { oauth, probeOk, probeReason, stalled, axis, reason, status: r.status, stderr: r.stderr };
 }
 
 const healthyQueue = '"queue":{"active":0,"queued":0,"maxConcurrent":10,"maxQueued":128,"stalledSince":null}';
@@ -173,6 +173,47 @@ header('the probe object is matched by scope, not by loose key');
   check('decoy keys outside the probe object are ignored', v.probeOk === 'true', v.probeOk);
   check('decoy reason ignored', v.probeReason === 'served', v.probeReason);
   check('no false alert', v.axis === '');
+}
+
+header('a spent usage window must NOT page (dario#1041)');
+{
+  // dario 5.5.30 made derivePoolStatus answer the router's question, so a pool
+  // whose accounts are all rate-limited now reports oauth=broken. The credential
+  // is fine; the window refills on its own. This file already refuses to page on
+  // a throttled PROBE for exactly that reason - "so a watchdog does not restart
+  // on a throttle" - and the oauth axis must not become a way around that rule.
+  //
+  // The body below is the real one the box returned on 2026-08-20 while the
+  // subscription was spent, which is what filed #1041.
+  const spent = verdict('{"status":"degraded","version":"5.5.32","oauth":"broken","expiresIn":"all accounts rate-limited","requests":109,"queue":{"active":0,"queued":0,"maxConcurrent":10,"maxQueued":128,"stalledSince":null}}');
+  check('oauth is still reported as broken', spent.oauth === 'broken');
+  check('reason is carried out', spent.reason === 'all accounts rate-limited');
+  check('but NO axis is raised - does not page', spent.axis === '');
+
+  // The other two reasons accountIneligibility() can produce are real failures
+  // and must still page.
+  const dead = verdict('{"status":"degraded","oauth":"broken","expiresIn":"all tokens expired - run `dario login`","queue":{"stalledSince":null}}');
+  check('expired tokens still page', dead.axis === 'OAuth broken');
+  check('expired reason carried out', /tokens expired/.test(dead.reason));
+
+  const cooldown = verdict('{"status":"degraded","oauth":"broken","expiresIn":"all accounts in auth-cooldown","queue":{"stalledSince":null}}');
+  check('auth-cooldown still pages', cooldown.axis === 'OAuth broken');
+
+  // Suppression keys on the REASON, never on the oauth value alone.
+  const unreachable = verdict('');
+  check('unreachable still pages', unreachable.oauth === 'unreachable' && unreachable.axis === 'OAuth unreachable');
+  check('unreachable carries no reason', unreachable.reason === '');
+
+  // A pre-5.5.30 container sends no expiresIn at all - must not be mistaken
+  // for a throttle.
+  const legacy = verdict('{"status":"degraded","oauth":"broken","queue":{"stalledSince":null}}');
+  check('body without expiresIn still pages', legacy.axis === 'OAuth broken');
+
+  // A HEALTHY pool sends expiresIn as a DURATION ("2h 0m"), not a reason. It
+  // must not match the throttle string, and must stay healthy regardless.
+  const healthy = verdict('{"status":"ok","oauth":"healthy","expiresIn":"2h 0m","queue":{"stalledSince":null}}');
+  check('healthy pool raises no axis', healthy.axis === '');
+  check('healthy expiresIn passed through untouched', healthy.reason === '2h 0m');
 }
 
 console.log(`\nhealth-verdict: ${pass} passed, ${fail} failed`);


### PR DESCRIPTION
Fixes #1041 — which is a **true positive that should not have paged**, plus a second fault that made it point at the wrong runbook.

## 1. It paged for a throttle

5.5.30 (#1038) made `derivePoolStatus` answer the router's question rather than a narrower one. A pool whose accounts are all rate-limited therefore now reports `oauth: broken`, and `health-verdict.sh` raises an axis whenever `oauth != healthy` — so a spent usage window became a `[CRITICAL]` alert.

That contradicts a rule this repo had already settled, written **one branch below in the same file**:

```sh
elif [ "$probe_ok" = "false" ]; then
  # rate-limited / upstream-overloaded never reach here — dario reports those
  # as ok:true precisely so a watchdog does not restart on a throttle.
```

The oauth axis became a way around it. The credential is fine in that state and the window refills unattended.

`health-verdict.sh` now reads dario's `expiresIn` reason and suppresses the axis for a rate-limited pool **only**. The three reasons `accountIneligibility()` produces are treated distinctly:

| reason | pages? |
|---|---|
| `all accounts rate-limited` | **no** — refills on its own |
| `all tokens expired — run \`dario login\`` | yes |
| `all accounts in auth-cooldown` | yes |
| unreachable / empty body | yes |

## 2. It called a live container dead

The body was fetched with `wget -qO- || curl -s`. The container has **BusyBox** wget — which discards the body on a non-2xx and has no `--content-on-error` — and has **no curl at all**, so the fallback could never run:

```
$ docker exec askalf-dario wget --content-on-error -qO- .../health
wget: unrecognized option: content-on-error        # BusyBox v1.37.0
$ docker exec askalf-dario sh -c 'curl ...'
sh: curl: not found
```

So every legitimate 503 produced an empty body, `oauth` defaulted to `unreachable`, and the alert said *"Reachable: **no** — container down or not answering"* about a proxy that was up, healthy and answering accurately. That sends a reader straight to `docs/recovery.md → OAuth credential dead` for something that is not a credential problem.

Now fetched with **node** — the app's own runtime, guaranteed present — which keeps the body on an error status. "Reachable" now means *dario answered*, and the alert table carries the reason.

## Verified end-to-end against production

The box's pool is spent right now, so this was testable against the real thing rather than a fixture:

```
live body -> patched verdict:  oauth=broken  axis=[]                reason="all accounts rate-limited"
live body -> master  verdict:  oauth=broken  axis=[OAuth broken]    <- pages
```

The node fetch was also run against the live container and returned the full 503 body, which the old fetch could not.

## Tests

11 new assertions in `test/health-verdict.mjs`, using the exact body production returned tonight. They cover the suppression, both reasons that must still page, unreachable, a pre-5.5.30 body with no `expiresIn` (must not be mistaken for a throttle), and — the one most likely to bite later — a **healthy** pool, whose `expiresIn` is a *duration* (`"2h 0m"`) rather than a reason, so the match must not be loose. 43 passing.

## Note on ownership

The first fault is mine: #1038 shipped this morning and changed what `/health` reports on a monitored surface. I flagged in that review that *"uptime monitors will newly alarm; those are true positives that were previously suppressed."* That was right about credentials and wrong about throttles — a spent window is not an outage, and this repo had already decided that.
