### PR TITLE
chore(cc-drift): v5.5.37 — maxTested → v2.1.238

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.37] - 2026-08-20
+
+- **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.237` → `2.1.238` for CC v2.1.238. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.
 ## [5.5.36] - 2026-08-20
 
 - **The OAuth watcher no longer pages for a spent usage window, and no longer calls a live container dead** (#1041) — two faults, both surfaced by 5.5.30. (1) `derivePoolStatus` began answering the router's question, so a pool whose accounts are all rate-limited now reports `oauth: broken`; the watcher paged on it, contradicting the rule it already follows for a throttled probe (dario reports those as `ok:true` "so a watchdog does not restart on a throttle"). `health-verdict.sh` now reads dario's `expiresIn` reason and suppresses the alert for a rate-limited pool only — expired tokens, auth-cooldown, and an unreachable container all still page. (2) The body was fetched with BusyBox `wget -qO-`, which discards the body on a non-2xx, with a `curl` fallback that does not exist in the container — so every legitimate 503 produced an empty body, `oauth` defaulted to `unreachable`, and the alert reported "container down or not answering" about a container that was up and answering truthfully. Fetched via node now, and the alert carries the reason so a reader can tell "run `dario login`" from "wait for the window".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ checklist.
 
 ## [Unreleased]
 
-## [5.5.37] - 2026-08-20
+## [5.5.38] - 2026-08-20
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.237` → `2.1.238` for CC v2.1.238. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.
 ## [5.5.36] - 2026-08-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ checklist.
 
 ## [Unreleased]
 
-## [5.5.38] - 2026-08-20
+## [5.5.39] - 2026-08-20
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.237` → `2.1.238` for CC v2.1.238. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ checklist.
 
 ## [Unreleased]
 
-## [5.5.39] - 2026-08-20
+## [5.5.40] - 2026-08-20
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.237` → `2.1.238` for CC v2.1.238. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.36",
+  "version": "5.5.37",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.39",
+  "version": "5.5.40",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.38",
+  "version": "5.5.39",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.37",
+  "version": "5.5.38",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/live-fingerprint.ts
+++ b/src/live-fingerprint.ts
@@ -1286,7 +1286,7 @@ export function detectDrift(t: TemplateData, installedOverride?: string | null):
  */
 export const SUPPORTED_CC_RANGE = {
   min: '1.0.0',
-  maxTested: '2.1.237',
+  maxTested: '2.1.238',
 } as const;
 
 /**


### PR DESCRIPTION
## Auto-drafted by cc-drift-watch.yml

The drift watcher flagged CC v2.1.238 as outside the current supported range. This PR:

1. Bumps `SUPPORTED_CC_RANGE.maxTested` from `2.1.237` → `2.1.238` in `src/live-fingerprint.ts`
2. Bumps `package.json` version → `5.5.37`
3. Promotes `## [Unreleased]` in `CHANGELOG.md` to `## [5.5.37] - 2026-08-20` and appends the drift-fix bullet

### Items in the drift report

- **compat.range** (medium) — CC v2.1.238 is beyond SUPPORTED_CC_RANGE.maxTested (v2.1.237). Run the e2e suite against the new CC and bump maxTested in src/live-fingerprint.ts — users on the new CC currently get a soft "untested-above" warning from dario doctor.
- **template.version** (low) — baked cc-template-data.json is v2.1.237; npm latest is v2.1.238. Re-capture and re-bake the template if any request-shape field changed.
- **cch.seed** (info) — No cch seed for CC v2.1.238 in src/cch.ts (CCH_SEEDS). dario OMITS the cch token for it — correct while CC v2.1.238 sends none (2.1.199+). Only add a seed if scripts/check-wire-drift.mjs reports CC re-introduced cch; then run `node scripts/cch-calibrate.mjs` on a host with claude v2.1.238. dario#528.

### Fully autonomous — no maintainer action required

This PR validates, merges, and ships itself. Nothing here is a to-do — it is what already happens:

- ✅ **Patched** — `SUPPORTED_CC_RANGE.maxTested` (compat.range), the `package.json` version, and the `CHANGELOG` entry are written by the bot.
- ✅ **Wire-format compat is validated continuously** by `cc-drift-template-watch.yml` — a real CC capture on the self-hosted runner every 30 min. If the bundled template actually drifts against this CC it opens its own `bot/template-rebake-*` PR, independently of this one. (This is the automated equivalent of the old manual "run `dario doctor` against v2.1.238" step — no local run needed.)
- ✅ **Auto-merges** once the required CI checks pass (`build (18|20|22)`, `validate-package-json`, `analyze`, `actionlint`) **and the PR has an approving review** — the ruleset on `master` requires one, and dismisses it on any later push. Until then this PR sits open regardless of how green it is.
- ✅ **Auto-releases** on merge: `cc-drift-auto-release.yml` tags `v5.5.37`, publishes `@askalf/dario@5.5.37` to npm (`--provenance`) + GHCR inline, and the box autodeploy timer picks it up within ~15 min.

**You only need to look if CI fails** — then auto-merge holds, this PR stays open with the failure visible, and the bot branch is preserved. Otherwise it is already on its way to npm.

### About this auto-draft

Only `compat.range` items are auto-patched by this script. Template re-capture is auto-handled separately by `cc-drift-template-watch.yml`. The remaining categories (scope rotations, URL / clientId / tokenUrl changes) require judgment and stay manual — the bot opens the plain drift-issue for those as before.

---

_Generated by `scripts/auto-draft-drift-fix.mjs`. Closes the detection-latency arc: [#112](https://github.com/askalf/dario/pull/112) (CF bypass), [#113](https://github.com/askalf/dario/pull/113) (hourly cadence), [#114](https://github.com/askalf/dario/pull/114) (auto-draft PR)._
