### PR TITLE
fix: Sonnet 5's $2/$10 is permanent — drop the cancelled cutover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.37] - 2026-08-20
+
+- **Fixed: `/analytics` would have over-stated every Sonnet 5 cost by 50% from 2026-09-01.** Sonnet 5 shipped at $2/$10 described as introductory "through 2026-08-31, then $3/$15", and `analytics.ts` modeled that as a dated cutover (`intro: { …, until: '2026-08-31' }`). Anthropic has since cancelled the increase and made $2/$10 the standard price. Left alone, `pricingRateFor` would have flipped to $3/$15 on 2026-09-01 — silently, with nothing in the output to indicate the number had moved. Sonnet 5 is now a flat rate. The dated-`intro` mechanism is retained for a model that genuinely has one; no entry uses it today.
+
 ## [5.5.36] - 2026-08-20
 
 - **The OAuth watcher no longer pages for a spent usage window, and no longer calls a live container dead** (#1041) — two faults, both surfaced by 5.5.30. (1) `derivePoolStatus` began answering the router's question, so a pool whose accounts are all rate-limited now reports `oauth: broken`; the watcher paged on it, contradicting the rule it already follows for a throttled probe (dario reports those as `ok:true` "so a watchdog does not restart on a throttle"). `health-verdict.sh` now reads dario's `expiresIn` reason and suppresses the alert for a rate-limited pool only — expired tokens, auth-cooldown, and an unreachable container all still page. (2) The body was fetched with BusyBox `wget -qO-`, which discards the body on a non-2xx, with a `curl` fallback that does not exist in the container — so every legitimate 503 produced an empty body, `oauth` defaulted to `unreachable`, and the alert reported "container down or not answering" about a container that was up and answering truthfully. Fetched via node now, and the alert carries the reason so a reader can tell "run `dario login`" from "wait for the window".

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.36",
+  "version": "5.5.37",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -189,13 +189,16 @@ const PRICING: Record<string, PricingEntry> = {
   'claude-opus-4-7': { input: 5, output: 25, cacheRead: 0.5, cacheCreate: 6.25 },
   // Opus 4.6 is $5/$25 (same as 4.7/4.8), not the old $15/$75 Opus-4.1 rate.
   'claude-opus-4-6': { input: 5, output: 25, cacheRead: 0.5, cacheCreate: 6.25 },
-  // Sonnet 5 standard $3/$15; launch intro $2/$10 through 2026-08-31, then
-  // standard. Cache rates follow Anthropic's usual 0.1x-read / 1.25x-write of
-  // input. Date-modeled below (was a flat display estimate before).
-  'claude-sonnet-5': {
-    input: 3, output: 15, cacheRead: 0.3, cacheCreate: 3.75,
-    intro: { input: 2, output: 10, cacheRead: 0.2, cacheCreate: 2.5, until: '2026-08-31' },
-  },
+  // Sonnet 5 is $2/$10 — PERMANENTLY. This shipped as "introductory pricing
+  // through 2026-08-31, then $3/$15", and was modeled here as a dated cutover.
+  // Anthropic has since cancelled that increase and made $2/$10 the standard
+  // price, so the cutover must NOT stay: on 2026-09-01 it would have silently
+  // started pricing every Sonnet 5 record 50% high, with no error and nothing
+  // in the output to suggest the number had moved.
+  //
+  // Left as a flat rate rather than an `intro` whose `until` sits far in the
+  // future — a date nobody is watching is exactly what caused this.
+  'claude-sonnet-5': { input: 2, output: 10, cacheRead: 0.2, cacheCreate: 2.5 },
   'claude-sonnet-4-6': { input: 3, output: 15, cacheRead: 0.3, cacheCreate: 3.75 },
   'claude-haiku-4-5': { input: 0.8, output: 4, cacheRead: 0.08, cacheCreate: 1 },
 };
@@ -220,7 +223,8 @@ export function pricingRateFor(model: string, atMs: number): Rate {
 
 function estimateCost(record: RequestRecord): number {
   // Price each record at the rate effective at ITS OWN timestamp, so a window
-  // that spans a pricing cutover (e.g. Sonnet 5's intro ending 2026-08-31)
+  // that spans a pricing cutover (no model currently has one — Sonnet 5's
+  // scheduled increase was cancelled and its $2/$10 made permanent)
   // estimates each side correctly rather than repricing history at today's rate.
   const p = pricingRateFor(record.model, record.timestamp);
   return (

--- a/test/pricing-intro-window.mjs
+++ b/test/pricing-intro-window.mjs
@@ -1,9 +1,19 @@
 #!/usr/bin/env node
-// Tests for date-modeled intro pricing (analytics.ts pricingRateFor).
-// Sonnet 5 launched with an intro rate ($2/$10) that reverts to standard
-// ($3/$15) after 2026-08-31 UTC. Each request is priced at the rate effective
-// at its OWN timestamp, so a window spanning the cutover estimates both sides
-// correctly. Pure function, no I/O.
+// Tests for date-modeled pricing (analytics.ts pricingRateFor).
+//
+// Sonnet 5 launched at $2/$10 described as introductory "through 2026-08-31,
+// then $3/$15", and that cutover was modeled here. Anthropic has since
+// CANCELLED the increase and made $2/$10 the standard price, so Sonnet 5 is a
+// flat rate at every timestamp and the assertions below say so.
+//
+// The dated-intro MECHANISM is retained in pricingRateFor for the next model
+// that genuinely has one, but no entry currently uses it — so that branch is
+// unexercised today. If you add an `intro` window to PRICING, add coverage of
+// its boundary here; the previous version of this file is the template.
+//
+// Each request is priced at the rate effective at its OWN timestamp, so a
+// window spanning any future cutover still estimates both sides correctly.
+// Pure function, no I/O.
 
 import { pricingRateFor } from '../dist/analytics.js';
 
@@ -16,7 +26,9 @@ function header(n) { console.log(`\n=== ${n} ===`); }
 const at = (iso) => Date.parse(iso);
 const eq = (r, o) => r.input === o.input && r.output === o.output && r.cacheRead === o.cacheRead && r.cacheCreate === o.cacheCreate;
 
-const INTRO = { input: 2, output: 10, cacheRead: 0.2, cacheCreate: 2.5 };
+// Sonnet 5's permanent rate. Named INTRO historically; it is simply the price.
+const SONNET5 = { input: 2, output: 10, cacheRead: 0.2, cacheCreate: 2.5 };
+const INTRO = SONNET5;
 const STANDARD = { input: 3, output: 15, cacheRead: 0.3, cacheCreate: 3.75 };
 
 // ─────────────────────────────────────────────────────────────
@@ -27,18 +39,22 @@ header('Sonnet 5 — intro rate inside the window');
 }
 
 // ─────────────────────────────────────────────────────────────
-header('Sonnet 5 — cutover boundary is inclusive of 2026-08-31 UTC');
+header('Sonnet 5 — $2/$10 is PERMANENT; the 2026-09-01 increase was cancelled');
 {
-  check('last instant of 2026-08-31 -> intro', eq(pricingRateFor('claude-sonnet-5', at('2026-08-31T23:59:59.999Z')), INTRO));
-  check('first instant of 2026-09-01 -> standard', eq(pricingRateFor('claude-sonnet-5', at('2026-09-01T00:00:00.000Z')), STANDARD));
-  check('well after (2026-12-01) -> standard', eq(pricingRateFor('claude-sonnet-5', at('2026-12-01T00:00:00Z')), STANDARD));
+  // The old cutover instant is the regression guard: before the fix this
+  // flipped to $3/$15 here, silently over-stating every Sonnet 5 record by 50%
+  // from 2026-09-01 with nothing in the output to show the number had moved.
+  check('last instant of 2026-08-31 -> $2/$10', eq(pricingRateFor('claude-sonnet-5', at('2026-08-31T23:59:59.999Z')), SONNET5));
+  check('first instant of 2026-09-01 -> STILL $2/$10', eq(pricingRateFor('claude-sonnet-5', at('2026-09-01T00:00:00.000Z')), SONNET5));
+  check('well after (2026-12-01) -> STILL $2/$10', eq(pricingRateFor('claude-sonnet-5', at('2026-12-01T00:00:00Z')), SONNET5));
+  check('far future (2028-01-01) -> STILL $2/$10', eq(pricingRateFor('claude-sonnet-5', at('2028-01-01T00:00:00Z')), SONNET5));
 }
 
 // ─────────────────────────────────────────────────────────────
 header('[1m] context variant follows the same window');
 {
   check('sonnet-5[1m] mid-window -> intro', eq(pricingRateFor('claude-sonnet-5[1m]', at('2026-07-15T00:00:00Z')), INTRO));
-  check('sonnet-5[1m] after cutover -> standard', eq(pricingRateFor('claude-sonnet-5[1m]', at('2026-10-01T00:00:00Z')), STANDARD));
+  check('sonnet-5[1m] after the old cutover -> STILL $2/$10', eq(pricingRateFor('claude-sonnet-5[1m]', at('2026-10-01T00:00:00Z')), SONNET5));
 }
 
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
A dated bug with an eleven-day fuse.

## What breaks on 2026-09-01

Sonnet 5 launched at $2/$10, described as introductory pricing *"through 2026-08-31"*, after which it would rise to $3/$15. `analytics.ts` modeled that faithfully:

```js
'claude-sonnet-5': {
  input: 3, output: 15, cacheRead: 0.3, cacheCreate: 3.75,
  intro: { input: 2, output: 10, cacheRead: 0.2, cacheCreate: 2.5, until: '2026-08-31' },
},
```

**Anthropic has cancelled that increase and made $2/$10 the standard price.** The 2026-09-01 rise will not happen.

Left alone, `pricingRateFor` flips to $3/$15 on 2026-09-01 and every Sonnet 5 figure in `/analytics`, the TUI and doctor's cost lines reads 50% high — silently. No error, no warning, nothing in the output to suggest the number moved. Demonstrated against `master` vs this branch on identical records:

```
record dated        master     fixed
2026-08-20            $2         $2
2026-09-01            $3         $2     <- the bug
2027-01-01            $3         $2
```

A cost estimate that is quietly wrong is worse than one that is obviously missing, because it still gets quoted.

## The change

Sonnet 5 becomes a flat entry. The dated-`intro` mechanism **stays** in `pricingRateFor` — it is correct, and the next model to launch on a promotion will need it — but no entry carries one today, so that branch is now unexercised. The test says so explicitly rather than leaving a future reader to find out.

I deliberately did *not* keep an `intro` with a far-future `until`. A date nobody is watching is precisely what caused this.

## Tests

`test/pricing-intro-window.mjs` is rewritten around the new reality. The old cutover instant is now the **regression guard** rather than the assertion:

```js
check('first instant of 2026-09-01 -> STILL $2/$10', …)
check('far future (2028-01-01) -> STILL $2/$10', …)
```

18/18 there, **139/139** overall. Everything else in that file — Opus 5/4.8/4.7/4.6 rates, Fable 5's $10/$50, the `[1m]` tag stripping, the unknown-model fallback — is untouched and still passing.

## How this was found

I asserted the cutover as current fact in a public answer on #1018, having taken it from a *cached* price table instead of checking the live source. The maintainer caught it and asked me to re-verify every claim in that comment.

Six turned out to be wrong or overstated, and this is the one that would have actually mispriced something rather than merely misinformed a reader. The #1018 comment is being corrected separately.

Worth noting the shape of the failure for next time: the pricing entry was *correct when written* and had a test proving it. Both quietly became wrong when an external fact changed, and nothing in the repo could notice. Anything keyed to a future date deserves that same suspicion.
