### PR TITLE
feat: pricing drift watcher, and fix Haiku 4.5's rates (#1048)

### DIFF
--- a/.github/workflows/pricing-drift-watch.yml
+++ b/.github/workflows/pricing-drift-watch.yml
@@ -1,0 +1,150 @@
+name: Pricing drift watch
+
+# Diffs dario's PRICING table against Anthropic's published rates.
+#
+# WHY. PRICING encodes external facts with no natural expiry. An entry is
+# correct when written, has a passing test, and then goes silently wrong the
+# moment Anthropic changes a price. Twice already:
+#
+#   - Sonnet 5's increase to $3/$15 was cancelled and $2/$10 made permanent,
+#     while the dated cutover stayed in the table — from 2026-09-01 every
+#     Sonnet 5 record would have priced 50% high (#1047).
+#   - Haiku 4.5 carried Haiku 3.5's rates, ~20% low, for an unknown period —
+#     found by the first run of the checker this workflow drives (#1048).
+#
+# The repo already watches every other external fact this way (cc-drift-watch,
+# cc-drift-template-watch, sdk-drift-watch, npm-drift-watch). Pricing was the
+# one feeding a user-visible number with nothing watching it.
+#
+# CHEAP: one HTTPS GET of a ~43KB markdown page plus a build. No npm registry,
+# no CC download. Daily is plenty — prices move rarely, and the cost of
+# noticing a day late is a slightly stale cost estimate, not an outage.
+#
+# EXIT CODES (scripts/check-pricing-drift.mjs):
+#   0 aligned  -> close any open issue
+#   1 drift    -> open/refresh the issue
+#   2 could not determine -> WARN AND PASS, never treated as drift
+#
+# Exit 2 covers every way of not knowing: network failure, the page moving, a
+# renamed column, a parse too thin to trust. That distinction is the whole
+# design — a watcher that reports "aligned" because it could not read anything
+# is worse than no watcher, since the first sign of trouble is a wrong number
+# in front of a user.
+
+on:
+  schedule:
+    # 09:23 UTC daily. Off the hour and clear of the drift watchers, which
+    # cluster at :00/:15/:27/:41/:47.
+    - cron: '23 9 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pricing-drift-watch
+  cancel-in-progress: false
+
+jobs:
+  pricing-drift-check:
+    name: Check published pricing
+    # Never from a fork. 54 forks inherit this schedule, and a fork filing
+    # pricing issues into its own tracker helps nobody. See #1039.
+    if: github.repository == 'askalf/dario'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: askalf/checkout-with-retry@115a6407547e9711edbc2e915838d495cad9583f  # v1.1.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        with:
+          node-version: '22'
+
+      # The checker imports PRICING from dist/, so the build has to run. It is
+      # the only reason this job needs npm at all.
+      - name: Build
+        run: |
+          npm ci --no-audit --no-fund
+          npm run build
+
+      - name: Check pricing drift
+        id: check
+        run: |
+          # `|| status=$?`, NOT a bare call: this step runs under the runner's
+          # default `bash -e {0}`, so a non-zero exit would kill it before the
+          # status could be captured — and exit 1 is DRIFT, the case this exists
+          # to report. As an AND-OR list the failure is exempt from `set -e`.
+          status=0
+          node scripts/check-pricing-drift.mjs > pricing-drift.json 2>pricing-drift.err || status=$?
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          cat pricing-drift.json || true
+          cat pricing-drift.err >&2 || true
+          exit 0
+
+      - name: Open / refresh / close the pricing-drift issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          STATUS: ${{ steps.check.outputs.status }}
+        run: |
+          set -euo pipefail
+
+          # Recover the exit code even if the step's output was not set (the
+          # node process dying before writing $GITHUB_OUTPUT).
+          status="${STATUS:-2}"
+          echo "checker exit: $status"
+
+          gh label create pricing-drift --repo "$REPO" --color 1D76DB \
+            --description "dario's PRICING table diverges from Anthropic's published rates" \
+            --force >/dev/null 2>&1 || true
+
+          existing="$(gh issue list --repo "$REPO" --label pricing-drift --state open \
+            --json number --jq '.[0].number // empty')"
+
+          if [ "$status" = "2" ]; then
+            # Could not determine. Do NOT touch the issue in either direction:
+            # opening one would be a false alarm, and closing one would silently
+            # retract a real finding because the page happened to be unreachable.
+            echo "::warning::pricing drift could not be determined — see the report above. Neither opening nor closing an issue."
+            exit 0
+          fi
+
+          if [ "$status" = "0" ]; then
+            if [ -n "$existing" ]; then
+              gh issue comment "$existing" --repo "$REPO" \
+                --body "✅ Resolved — dario's PRICING table matches the published rates as of $(date -Iseconds)."
+              gh issue close "$existing" --repo "$REPO"
+              echo "closed #$existing"
+            else
+              echo "aligned; nothing open."
+            fi
+            exit 0
+          fi
+
+          # status == 1: drift.
+          {
+            echo "\`scripts/check-pricing-drift.mjs\` found dario's \`PRICING\` table out of sync with [Anthropic's published rates](https://platform.claude.com/docs/en/about-claude/pricing)."
+            echo
+            echo "Every row below feeds \`estimatedCost\` in \`/analytics\`, the TUI's cost column and \`dario doctor\`. A wrong rate here is not cosmetic — it is a number users quote."
+            echo
+            echo '```json'
+            cat pricing-drift.json
+            echo '```'
+            echo
+            echo "**Fix:** update \`PRICING\` in \`src/analytics.ts\` to match the \`published\` column, then re-run \`node scripts/check-pricing-drift.mjs\` (exit 0 = aligned). If a rate genuinely should differ from the published one, say why in a comment beside the entry — an unexplained divergence will be re-reported here every day."
+            echo
+            echo "_Auto-filed by \`pricing-drift-watch.yml\`._"
+          } > body.md
+
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$REPO" --body-file body.md
+            echo "refreshed #$existing"
+          else
+            gh issue create --repo "$REPO" --label pricing-drift \
+              --title "Pricing drift: dario's PRICING table diverges from published rates" \
+              --body-file body.md
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.38] - 2026-08-20
+
+- **Fixed: Haiku 4.5 was priced at Haiku 3.5's rates** — `$0.80/$4` with cache `0.08/1` instead of `$1/$5` with cache `0.1/1.25`, so every Haiku 4.5 cost in `/analytics`, the TUI and `dario doctor` read about 20% low. The whole row had been copied from the wrong model.
+- **Added a pricing drift watcher** (#1048). `scripts/check-pricing-drift.mjs` diffs dario's `PRICING` against Anthropic's published table daily and files an issue on any divergence; `PRICING` is now exported so it can. Pricing entries are external facts with no natural expiry — correct when written, silently wrong once Anthropic changes them, and nothing in the repo could notice. That had already happened twice: Sonnet 5's cancelled cutover (#1047) and the Haiku 4.5 row above, which this watcher found on its first run. Every way of *not knowing* — network failure, a moved page, a renamed column, an implausibly thin parse — exits 2 and is treated as a skipped run, never as "aligned".
+
 ## [5.5.37] - 2026-08-20
 
 - **Fixed: `/analytics` would have over-stated every Sonnet 5 cost by 50% from 2026-09-01.** Sonnet 5 shipped at $2/$10 described as introductory "through 2026-08-31, then $3/$15", and `analytics.ts` modeled that as a dated cutover (`intro: { …, until: '2026-08-31' }`). Anthropic has since cancelled the increase and made $2/$10 the standard price. Left alone, `pricingRateFor` would have flipped to $3/$15 on 2026-09-01 — silently, with nothing in the output to indicate the number had moved. Sonnet 5 is now a flat rate. The dated-`intro` mechanism is retained for a model that genuinely has one; no entry uses it today.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.37",
+  "version": "5.5.38",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/scripts/check-pricing-drift.mjs
+++ b/scripts/check-pricing-drift.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+/**
+ * Pricing drift watcher.
+ *
+ * Diffs dario's PRICING table (src/analytics.ts) against Anthropic's published
+ * model-pricing table and reports any rate that has moved.
+ *
+ * WHY THIS EXISTS (#1048). PRICING encodes external facts with no natural
+ * expiry. An entry is correct when written, has a passing test, and then goes
+ * silently wrong the moment Anthropic changes a price — no error, no failing
+ * test, nothing in the output to suggest the number moved. It has already
+ * happened twice:
+ *
+ *   - Sonnet 5's increase to $3/$15 was cancelled and $2/$10 made permanent,
+ *     but the dated cutover stayed in the table. From 2026-09-01 every Sonnet 5
+ *     record would have priced 50% high (#1047).
+ *   - Haiku 4.5 carried Haiku 3.5's rates ($0.80/$4 instead of $1/$5) — found
+ *     by writing this watcher.
+ *
+ * The repo already treats every other external fact this way: cc-drift-watch,
+ * cc-drift-template-watch, sdk-drift-watch, npm-drift-watch. Pricing was the
+ * one that fed a user-visible number and had nothing watching it.
+ *
+ * FAILURE MODE IS THE DESIGN POINT. A watcher that silently stops matching is
+ * worse than no watcher — it reports "aligned" forever and the first anyone
+ * hears is the next wrong invoice. So every way of NOT knowing exits 2, never
+ * 0: network failure, a missing table, a renamed column, or an implausibly
+ * small parse. Exit 2 is "could not determine", which the workflow treats as a
+ * skipped run rather than as clean.
+ *
+ * Exit codes: 0 = aligned, 1 = drift, 2 = could not determine.
+ * JSON report to stdout in all cases.
+ */
+
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+// Fetch the `.md` variant, not the human page: the HTML is ~1.1MB of app shell
+// with the table buried in it, while this serves ~43KB of text/markdown. The
+// human URL is reported in the issue so a reader has somewhere to click.
+const SOURCE = 'https://platform.claude.com/docs/en/about-claude/pricing.md';
+const HUMAN_SOURCE = 'https://platform.claude.com/docs/en/about-claude/pricing';
+
+/**
+ * Column header -> the PRICING field it feeds. Matched by NAME, never by
+ * position: a column reorder upstream would otherwise silently map cache-read
+ * prices onto cache-write fields and report "aligned".
+ */
+const COLUMNS = {
+  'base input tokens': 'input',
+  'output tokens': 'output',
+  'cache hits & refreshes': 'cacheRead',
+  '5m cache writes': 'cacheCreate',
+};
+
+/** Fewer rows than this means the table shape changed. Refuse rather than guess. */
+const MIN_PLAUSIBLE_ROWS = 8;
+
+/**
+ * "Claude Opus 4.8" -> "claude-opus-4-8". Strips the trailing markdown link
+ * some rows carry ("Claude Opus 4.1 ([retired, …](…))") before normalizing.
+ */
+export function modelIdFromDisplayName(cell) {
+  const name = String(cell)
+    .replace(/\(\[[^\]]*\]\([^)]*\)\)/g, '')  // ([text](url))
+    .replace(/\[[^\]]*\]\([^)]*\)/g, '')      // [text](url)
+    .replace(/\*+/g, '')
+    .trim();
+  if (!/^claude /i.test(name)) return null;
+  return name.toLowerCase().replace(/[\s.]+/g, '-').replace(/-+$/, '');
+}
+
+/** "$12.50 / MTok" -> 12.5. Returns null when the cell is not a price. */
+export function priceFromCell(cell) {
+  const m = /^\$\s*([0-9]+(?:\.[0-9]+)?)\s*\/\s*MTok$/i.exec(String(cell).trim());
+  return m ? Number(m[1]) : null;
+}
+
+/**
+ * Pure parse of the published markdown into { modelId: {input, output,
+ * cacheRead, cacheCreate} }. Throws on anything that would make a silent
+ * wrong answer possible — the caller turns that into exit 2.
+ */
+export function parsePricingTable(markdown) {
+  const lines = String(markdown).split('\n');
+
+  // The model table is the first one carrying every column we need. Scanning
+  // for it by header content rather than by position means an added section
+  // above it does not shift us onto the batch-pricing or fast-mode table,
+  // both of which are also "Model | … | $x / MTok" shaped.
+  let headerIdx = -1;
+  let colIndex = null;
+  for (let i = 0; i < lines.length; i++) {
+    if (!lines[i].includes('|')) continue;
+    const cells = lines[i].split('|').map((c) => c.trim().toLowerCase());
+    const found = {};
+    for (const [header, field] of Object.entries(COLUMNS)) {
+      const at = cells.indexOf(header);
+      if (at !== -1) found[field] = at;
+    }
+    if (Object.keys(found).length === Object.keys(COLUMNS).length) {
+      headerIdx = i;
+      colIndex = found;
+      break;
+    }
+  }
+  if (headerIdx === -1) {
+    throw new Error(
+      `could not find a pricing table carrying all of: ${Object.keys(COLUMNS).join(', ')} ` +
+      '— the published table shape has probably changed',
+    );
+  }
+
+  const rates = {};
+  for (let i = headerIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.includes('|')) {
+      if (Object.keys(rates).length > 0) break;  // table ended
+      continue;
+    }
+    if (/^\s*\|?[\s:|-]+\|?\s*$/.test(line)) continue;  // separator row
+    const cells = line.split('|').map((c) => c.trim());
+    const id = modelIdFromDisplayName(cells[1] ?? '');
+    if (!id) continue;
+    const rate = {};
+    let ok = true;
+    for (const [field, at] of Object.entries(colIndex)) {
+      const v = priceFromCell(cells[at] ?? '');
+      if (v === null) { ok = false; break; }
+      rate[field] = v;
+    }
+    if (ok) rates[id] = rate;
+  }
+
+  if (Object.keys(rates).length < MIN_PLAUSIBLE_ROWS) {
+    throw new Error(
+      `parsed only ${Object.keys(rates).length} model rows (expected >= ${MIN_PLAUSIBLE_ROWS}) ` +
+      '— refusing to report "aligned" from a parse this thin',
+    );
+  }
+  return rates;
+}
+
+/**
+ * Compare dario's table against the published one. Only models dario actually
+ * prices are checked; the published table listing models dario does not model
+ * is not drift. A model dario prices that has VANISHED upstream is reported —
+ * it usually means a rename, and a stale key silently falls through to the
+ * unknown-model fallback rate.
+ */
+export function diffPricing(ours, published) {
+  const drift = [];
+  for (const [id, mine] of Object.entries(ours)) {
+    const theirs = published[id];
+    if (!theirs) {
+      drift.push({ model: id, field: '*', ours: 'priced', published: 'absent',
+        note: 'not in the published table — renamed upstream, or retired' });
+      continue;
+    }
+    for (const field of ['input', 'output', 'cacheRead', 'cacheCreate']) {
+      if (typeof mine[field] !== 'number') continue;
+      if (mine[field] !== theirs[field]) {
+        drift.push({ model: id, field, ours: mine[field], published: theirs[field] });
+      }
+    }
+  }
+  return drift.sort((a, b) => a.model.localeCompare(b.model) || a.field.localeCompare(b.field));
+}
+
+/** Flatten a PricingEntry to the four comparable fields (drops any `intro`). */
+function comparable(entry) {
+  return {
+    input: entry.input, output: entry.output,
+    cacheRead: entry.cacheRead, cacheCreate: entry.cacheCreate,
+  };
+}
+
+async function main() {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const report = { checkedAt: new Date().toISOString(), source: HUMAN_SOURCE };
+
+  let PRICING;
+  try {
+    // pathToFileURL, not a bare path: a Windows absolute path ("C:\…") is not
+    // a valid ESM specifier and the loader rejects it as an unknown protocol.
+    ({ PRICING } = await import(pathToFileURL(resolve(join(here, '..', 'dist', 'analytics.js'))).href));
+    if (!PRICING || typeof PRICING !== 'object') throw new Error('PRICING is not an object');
+  } catch (err) {
+    console.log(JSON.stringify({ ...report, status: 'infra_error',
+      error: `could not load dist/analytics.js — run \`npm run build\` first: ${err.message}` }, null, 2));
+    process.exit(2);
+  }
+
+  let markdown;
+  try {
+    const res = await fetch(SOURCE, { signal: AbortSignal.timeout(20_000) });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    markdown = await res.text();
+    // If the .md route ever starts serving the app shell, say so rather than
+    // failing later with a confusing "table shape changed".
+    if (/^\s*<!DOCTYPE/i.test(markdown)) {
+      throw new Error('got HTML, not markdown — the .md route may have moved');
+    }
+  } catch (err) {
+    // Network failure is NOT drift. Exit 2 so a flaky fetch never churns the
+    // issue or, worse, reports "aligned" because nothing came back.
+    console.log(JSON.stringify({ ...report, status: 'infra_error',
+      error: `could not fetch published pricing: ${err.message}` }, null, 2));
+    process.exit(2);
+  }
+
+  let published;
+  try {
+    published = parsePricingTable(markdown);
+  } catch (err) {
+    console.log(JSON.stringify({ ...report, status: 'infra_error',
+      error: `could not parse published pricing: ${err.message}` }, null, 2));
+    process.exit(2);
+  }
+
+  const ours = Object.fromEntries(
+    Object.entries(PRICING).map(([id, e]) => [id, comparable(e)]),
+  );
+  const drift = diffPricing(ours, published);
+
+  console.log(JSON.stringify({
+    ...report,
+    modelsChecked: Object.keys(ours).length,
+    modelsPublished: Object.keys(published).length,
+    drift,
+    status: drift.length === 0 ? 'clean' : 'drift',
+  }, null, 2));
+  process.exit(drift.length === 0 ? 0 : 1);
+}
+
+function isMainModule() {
+  if (!process.argv[1]) return false;
+  try { return resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url)); }
+  catch { return false; }
+}
+
+if (isMainModule()) await main();

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -176,7 +176,17 @@ interface PricingEntry extends Rate {
   intro?: Rate & { until: string }; // 'YYYY-MM-DD'
 }
 
-const PRICING: Record<string, PricingEntry> = {
+/**
+ * Published per-1M-token rates, keyed by dario's model id.
+ *
+ * EXPORTED so scripts/check-pricing-drift.mjs can diff it against Anthropic's
+ * published table. These are external facts with no natural expiry: an entry
+ * that is correct today goes wrong the moment Anthropic changes it, and
+ * nothing in this repo would notice. That has happened twice — Sonnet 5's
+ * cancelled cutover (#1047) and Haiku 4.5 carrying Haiku 3.5's rates — which
+ * is why the watcher exists (#1048).
+ */
+export const PRICING: Record<string, PricingEntry> = {
   // Fable 5 — official pricing (published with the 2026-07-01 redeploy):
   // $10/$50 per 1M in/out, 5m cache-write $12.50, cache-read $1 (platform docs).
   // Was previously assumed at the opus-4-8 rate ($5/$25) — corrected here.
@@ -200,7 +210,10 @@ const PRICING: Record<string, PricingEntry> = {
   // future — a date nobody is watching is exactly what caused this.
   'claude-sonnet-5': { input: 2, output: 10, cacheRead: 0.2, cacheCreate: 2.5 },
   'claude-sonnet-4-6': { input: 3, output: 15, cacheRead: 0.3, cacheCreate: 3.75 },
-  'claude-haiku-4-5': { input: 0.8, output: 4, cacheRead: 0.08, cacheCreate: 1 },
+  // Haiku 4.5 is $1/$5. This carried $0.80/$4 — Haiku 3.5's row, copied
+  // wholesale including its cache rates — so every Haiku 4.5 cost read ~20%
+  // LOW. Found by check-pricing-drift.mjs on its very first run (#1048).
+  'claude-haiku-4-5': { input: 1, output: 5, cacheRead: 0.1, cacheCreate: 1.25 },
 };
 
 /**

--- a/test/pricing-drift.mjs
+++ b/test/pricing-drift.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+// Tests for scripts/check-pricing-drift.mjs — the parse + diff behind the
+// pricing drift watcher.
+//
+// This watcher's failure mode is SILENCE, the same class as health-verdict.sh.
+// If the published table gains a column, renames one, or moves, a naive parser
+// does not error — it finds nothing, reports "aligned", and dario keeps
+// charging whatever it last believed. The first anyone hears is a wrong number
+// in front of a user. So most of what follows asserts that the parser THROWS
+// rather than that it succeeds.
+//
+// The fixture is a trimmed copy of the real published table, including the
+// awkward parts: markdown links inside model cells, $0.50 and $12.50 cells,
+// and a retired model dario does not price.
+
+import { parsePricingTable, priceFromCell, modelIdFromDisplayName, diffPricing }
+  from '../scripts/check-pricing-drift.mjs';
+
+let pass = 0, fail = 0;
+const check = (name, cond, detail) => {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else { console.log(`  FAIL ${name}${detail ? ' :: ' + detail : ''}`); fail++; }
+};
+const header = (n) => console.log(`\n=== ${n} ===`);
+const throws = (fn, re) => {
+  try { fn(); return false; }
+  catch (e) { return re ? re.test(e.message) : true; }
+};
+
+const HEADER = '| Model | Base Input Tokens | 5m Cache Writes | 1h Cache Writes | Cache Hits & Refreshes | Output Tokens |';
+const SEP    = '| --- | --- | --- | --- | --- | --- |';
+const ROWS = [
+  '| Claude Fable 5 | $10 / MTok | $12.50 / MTok | $20 / MTok | $1 / MTok | $50 / MTok |',
+  '| Claude Opus 5 | $5 / MTok | $6.25 / MTok | $10 / MTok | $0.50 / MTok | $25 / MTok |',
+  '| Claude Opus 4.8 | $5 / MTok | $6.25 / MTok | $10 / MTok | $0.50 / MTok | $25 / MTok |',
+  '| Claude Opus 4.7 | $5 / MTok | $6.25 / MTok | $10 / MTok | $0.50 / MTok | $25 / MTok |',
+  '| Claude Opus 4.6 | $5 / MTok | $6.25 / MTok | $10 / MTok | $0.50 / MTok | $25 / MTok |',
+  '| Claude Opus 4.1 ([retired, except on Bedrock](https://example.com/x)) | $15 / MTok | $18.75 / MTok | $30 / MTok | $1.50 / MTok | $75 / MTok |',
+  '| Claude Sonnet 5 | $2 / MTok | $2.50 / MTok | $4 / MTok | $0.20 / MTok | $10 / MTok |',
+  '| Claude Sonnet 4.6 | $3 / MTok | $3.75 / MTok | $6 / MTok | $0.30 / MTok | $15 / MTok |',
+  '| Claude Haiku 4.5 | $1 / MTok | $1.25 / MTok | $2 / MTok | $0.10 / MTok | $5 / MTok |',
+  '| Claude Haiku 3.5 ([retired](https://example.com/y)) | $0.80 / MTok | $1 / MTok | $1.60 / MTok | $0.08 / MTok | $4 / MTok |',
+];
+const DOC = ['# Pricing', '', '## Model pricing', '', HEADER, SEP, ...ROWS, '', 'Some prose after.'].join('\n');
+
+header('cell parsing');
+{
+  check('$5 / MTok', priceFromCell('$5 / MTok') === 5);
+  check('$12.50 / MTok', priceFromCell('$12.50 / MTok') === 12.5);
+  check('$0.50 / MTok', priceFromCell('$0.50 / MTok') === 0.5);
+  check('$0.08 / MTok', priceFromCell('$0.08 / MTok') === 0.08);
+  check('non-price cell -> null', priceFromCell('Claude Opus 5') === null);
+  check('empty -> null', priceFromCell('') === null);
+  // A unit change would silently halve or double every number. Reject it.
+  check('a different unit is NOT parsed as a price', priceFromCell('$5 / KTok') === null);
+  check('a bare number is NOT parsed', priceFromCell('5') === null);
+}
+
+header('model name -> dario id');
+{
+  check('Claude Opus 4.8', modelIdFromDisplayName('Claude Opus 4.8') === 'claude-opus-4-8');
+  check('Claude Sonnet 5', modelIdFromDisplayName('Claude Sonnet 5') === 'claude-sonnet-5');
+  check('Claude Haiku 4.5', modelIdFromDisplayName('Claude Haiku 4.5') === 'claude-haiku-4-5');
+  check('strips a trailing markdown link',
+    modelIdFromDisplayName('Claude Opus 4.1 ([retired, except on Bedrock](https://example.com/x))') === 'claude-opus-4-1');
+  check('non-Claude row -> null', modelIdFromDisplayName('Total') === null);
+  check('separator junk -> null', modelIdFromDisplayName('---') === null);
+}
+
+header('happy path');
+{
+  const r = parsePricingTable(DOC);
+  check('parsed every model row', Object.keys(r).length === 10, Object.keys(r).join(','));
+  check('sonnet 5 rates', JSON.stringify(r['claude-sonnet-5']) ===
+    JSON.stringify({ input: 2, output: 10, cacheRead: 0.2, cacheCreate: 2.5 }));
+  check('haiku 4.5 rates (the row dario had wrong)', JSON.stringify(r['claude-haiku-4-5']) ===
+    JSON.stringify({ input: 1, output: 5, cacheRead: 0.1, cacheCreate: 1.25 }));
+  check('cacheCreate reads the 5m column, not the 1h one', r['claude-fable-5'].cacheCreate === 12.5);
+  check('cacheRead reads Cache Hits & Refreshes', r['claude-fable-5'].cacheRead === 1);
+  check('stops at the end of the table', r['some prose after.'] === undefined);
+}
+
+header('columns are matched by NAME, not position');
+{
+  // Upstream reordering columns must not silently map cache reads onto writes.
+  const swapped = DOC
+    .replace(HEADER, '| Model | Output Tokens | Base Input Tokens | 5m Cache Writes | 1h Cache Writes | Cache Hits & Refreshes |')
+    .replace('| Claude Sonnet 5 | $2 / MTok | $2.50 / MTok | $4 / MTok | $0.20 / MTok | $10 / MTok |',
+             '| Claude Sonnet 5 | $10 / MTok | $2 / MTok | $2.50 / MTok | $4 / MTok | $0.20 / MTok |');
+  const r = parsePricingTable(swapped);
+  check('reordered columns still read correctly',
+    r['claude-sonnet-5'].input === 2 && r['claude-sonnet-5'].output === 10 &&
+    r['claude-sonnet-5'].cacheCreate === 2.5 && r['claude-sonnet-5'].cacheRead === 0.2);
+}
+
+header('every way of NOT knowing throws — never a quiet "aligned"');
+{
+  check('a renamed column throws',
+    throws(() => parsePricingTable(DOC.replace('Cache Hits & Refreshes', 'Cache Reads')), /table shape/));
+  check('no table at all throws',
+    throws(() => parsePricingTable('# Pricing\n\nPricing has moved to another page.\n'), /table shape/));
+  check('HTML instead of markdown throws',
+    throws(() => parsePricingTable('<!DOCTYPE html><html><body>nope</body></html>'), /table shape/));
+  check('empty input throws', throws(() => parsePricingTable('')));
+  // A table that parses but yields almost nothing is a shape change too.
+  const thin = ['# P', '', HEADER, SEP,
+    '| Claude Opus 5 | $5 / MTok | $6.25 / MTok | $10 / MTok | $0.50 / MTok | $25 / MTok |'].join('\n');
+  check('an implausibly thin parse throws rather than reporting clean',
+    throws(() => parsePricingTable(thin), /only 1 model rows/));
+}
+
+header('picking the RIGHT table when several look alike');
+{
+  // The batch-pricing table is also "Model | $x / MTok" shaped and appears
+  // later on the same page. Header matching must not land on it.
+  const batch = ['| Model | Batch input | Batch output |', '| --- | --- | --- |',
+    '| Claude Sonnet 5 | $1 / MTok | $5 / MTok |'].join('\n');
+  const r = parsePricingTable([DOC, '', '### Batch processing', '', batch].join('\n'));
+  check('reads the model table, not the batch table', r['claude-sonnet-5'].input === 2);
+  check('batch rates did not overwrite', r['claude-sonnet-5'].output === 10);
+}
+
+header('diff');
+{
+  const published = parsePricingTable(DOC);
+  const clean = { 'claude-sonnet-5': { input: 2, output: 10, cacheRead: 0.2, cacheCreate: 2.5 } };
+  check('matching rates -> no drift', diffPricing(clean, published).length === 0);
+
+  // The two real bugs this watcher was built after.
+  const sonnetCutover = { 'claude-sonnet-5': { input: 3, output: 15, cacheRead: 0.3, cacheCreate: 3.75 } };
+  check('the Sonnet 5 cutover bug is caught', diffPricing(sonnetCutover, published).length === 4);
+
+  const haiku = { 'claude-haiku-4-5': { input: 0.8, output: 4, cacheRead: 0.08, cacheCreate: 1 } };
+  const d = diffPricing(haiku, published);
+  check('the Haiku 4.5 bug is caught on all four fields', d.length === 4);
+  check('and reports both sides', d.some((x) => x.field === 'input' && x.ours === 0.8 && x.published === 1));
+
+  // A model dario prices that vanished upstream usually means a rename, and a
+  // stale key silently falls through to the unknown-model fallback rate.
+  const gone = { 'claude-opus-9': { input: 1, output: 2, cacheRead: 0.1, cacheCreate: 1.25 } };
+  const g = diffPricing(gone, published);
+  check('a model missing upstream is drift', g.length === 1 && g[0].published === 'absent');
+
+  // The published table lists models dario does not model. That is not drift.
+  check('extra published models are not drift', diffPricing(clean, published).length === 0);
+}
+
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Closes #1048.

## Why

`PRICING` encodes external facts with no natural expiry. An entry is correct when written, has a passing test, and then goes silently wrong the moment Anthropic changes a price. No error, no failing test, nothing in the output to suggest the number moved — the first anyone hears is a wrong figure in front of a user.

It had already happened twice:

- **Sonnet 5** — the increase to $3/$15 was cancelled and $2/$10 made permanent, while the dated cutover stayed in the table. From 2026-09-01 every Sonnet 5 record would have priced 50% high (#1047).
- **Haiku 4.5** — carried Haiku 3.5's *entire row*. Fixed here.

The repo already watches every other external fact this way — `cc-drift-watch`, `cc-drift-template-watch`, `sdk-drift-watch`, `npm-drift-watch`. Pricing was the one feeding a user-visible number with nothing watching it.

## The watcher found a live bug on its first run

That is the strongest argument for it, so leading with it:

```json
{ "model": "claude-haiku-4-5", "field": "input",       "ours": 0.8,  "published": 1 }
{ "model": "claude-haiku-4-5", "field": "output",      "ours": 4,    "published": 5 }
{ "model": "claude-haiku-4-5", "field": "cacheRead",   "ours": 0.08, "published": 0.1 }
{ "model": "claude-haiku-4-5", "field": "cacheCreate", "ours": 1,    "published": 1.25 }
```

All four fields — Haiku **3.5**'s row, copied wholesale. Every Haiku 4.5 cost in `/analytics`, the TUI and `dario doctor` read about **20% low**, for an unknown period. After the fix the checker reports `"drift": [], "status": "clean"` against the live table.

## Failure mode is the design point

A watcher that quietly stops matching is worse than none: it reports "aligned" forever. So **every way of not knowing exits 2, never 0** — network failure, a missing table, a renamed column, HTML where markdown was expected, or a parse too thin to trust.

The workflow treats exit 2 as a skipped run and touches the issue in **neither** direction. Opening one would be a false alarm; closing one would silently retract a real finding because a page happened to be unreachable.

Two more things that could have produced a confident wrong answer:

- **Columns are matched by name, not position.** An upstream reorder would otherwise map cache-read prices onto cache-write fields and still report "aligned". Asserted with a fixture whose columns are deliberately shuffled.
- **The model table is located by its header content, not by ordinal.** The batch-pricing and fast-mode tables further down the same page are also `Model | $x / MTok` shaped, and a positional parser would happily read Sonnet 5's batch rate as its standard rate. Asserted.

It fetches the `.md` route (~43KB of `text/markdown`) rather than the human page (~1.1MB of app shell), and reports explicitly if it ever starts receiving HTML.

## Tests

34 assertions in `test/pricing-drift.mjs`, **most asserting the parser throws rather than succeeds**. Both real bugs are locked in as fixtures — the Sonnet 5 cutover and the Haiku 4.5 row — so a regression on either is a test failure rather than a discovery.

`npm test`: **140/140**. Live run against the published table: clean, exit 0.

## Notes for review

- `PRICING` is now exported. That is the only production-code change besides the Haiku rates.
- Daily at 09:23 UTC, off the hour and clear of the other watchers' `:00/:15/:27/:41/:47` cluster. Prices move rarely; noticing a day late costs a slightly stale estimate, not an outage.
- Fork-guarded per #1039.
- The workflow captures the checker's exit with `|| status=$?` rather than a bare call — under the runner's `bash -e` a bare call would kill the step on exit 1, which is the *drift* case this exists to report. (That is not hypothetical: `compat-test-self-hosted.yml` currently has the mirror-image of this bug — when its gate fails before the compat step runs, `exit "$COMPAT_EXIT_CODE"` dies with `numeric argument required` and the run reports a shell error instead of the real verdict. Visible on #1046 right now. Separate fix.)
