### PR TITLE
fix: compat reports its verdict, and the pricing watcher covers intro windows

### DIFF
--- a/.github/workflows/compat-test-self-hosted.yml
+++ b/.github/workflows/compat-test-self-hosted.yml
@@ -322,4 +322,20 @@ jobs:
         run: |
           # The job's pass/fail is the compat suite's exit code, regardless
           # of whether the comment step succeeded.
-          exit "$COMPAT_EXIT_CODE"
+          #
+          # DEFAULTED, because `exit_code` is empty whenever the compat step
+          # never ran — and it does not run when an EARLIER step fails, which
+          # includes the maxTested gate refusing to validate a claim the runner
+          # cannot back. In that case `exit ""` dies with
+          #
+          #   line 3: exit: : numeric argument required
+          #
+          # and the run surfaces a shell error (exit 2) instead of the real
+          # verdict. Seen on #1046: the gate correctly refused a
+          # maxTested=2.1.238 claim on a runner holding 2.1.237, and what a
+          # reader saw was the shell message, not "compat cannot validate".
+          #
+          # Failing closed on 1 is the right default — reaching this step with
+          # no recorded exit code means something upstream already failed, and
+          # the only wrong answer here is a green run.
+          exit "${COMPAT_EXIT_CODE:-1}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.39] - 2026-08-20
+
+- **Fixed: the compat job reported a shell error instead of its verdict.** `exit "$COMPAT_EXIT_CODE"` is empty whenever the compat step never ran — which is the case when an earlier step fails, including the `maxTested` gate refusing a claim the runner cannot back. The run then died with `exit: : numeric argument required` and surfaced that instead of "compat cannot validate maxTested=…". Visible on #1046. Defaults to 1 now: reaching that step with no recorded exit code means something upstream already failed, and the only wrong answer is a green run.
+- **The pricing watcher now covers promotional windows** (#1048 follow-up). It checks an `intro` block's `until` DATE rather than comparing its rate to the published standard — a promotional price differs from the standard by definition, so a rate comparison would report drift forever and the issue would be learned-ignored. A lapsed or unparseable `until` is reported instead, which is exactly the Sonnet 5 shape (#1047): the bug was never in the standard rate, it was a dated block that outlived its promotion. `MIN_PLAUSIBLE_ROWS` renamed `MIN_PUBLISHED_ROWS` — it is a sanity floor on the published table, deliberately not tied to how many models dario prices.
+
 ## [5.5.38] - 2026-08-20
 
 - **Fixed: Haiku 4.5 was priced at Haiku 3.5's rates** — `$0.80/$4` with cache `0.08/1` instead of `$1/$5` with cache `0.1/1.25`, so every Haiku 4.5 cost in `/analytics`, the TUI and `dario doctor` read about 20% low. The whole row had been copied from the wrong model.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.38",
+  "version": "5.5.39",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/scripts/check-pricing-drift.mjs
+++ b/scripts/check-pricing-drift.mjs
@@ -53,8 +53,17 @@ const COLUMNS = {
   '5m cache writes': 'cacheCreate',
 };
 
-/** Fewer rows than this means the table shape changed. Refuse rather than guess. */
-const MIN_PLAUSIBLE_ROWS = 8;
+/**
+ * A sanity floor on the PUBLISHED table, not a statement about dario. If a
+ * parse yields fewer rows than this, the shape changed and a "clean" verdict
+ * would be worthless — refuse rather than guess.
+ *
+ * Deliberately NOT derived from how many models dario prices: those two
+ * numbers happen to be close today, and tying them together would silently
+ * turn this into "did we parse at least as many as we price", which is a
+ * different and much weaker check.
+ */
+const MIN_PUBLISHED_ROWS = 8;
 
 /**
  * "Claude Opus 4.8" -> "claude-opus-4-8". Strips the trailing markdown link
@@ -132,9 +141,9 @@ export function parsePricingTable(markdown) {
     if (ok) rates[id] = rate;
   }
 
-  if (Object.keys(rates).length < MIN_PLAUSIBLE_ROWS) {
+  if (Object.keys(rates).length < MIN_PUBLISHED_ROWS) {
     throw new Error(
-      `parsed only ${Object.keys(rates).length} model rows (expected >= ${MIN_PLAUSIBLE_ROWS}) ` +
+      `parsed only ${Object.keys(rates).length} model rows (expected >= ${MIN_PUBLISHED_ROWS}) ` +
       '— refusing to report "aligned" from a parse this thin',
     );
   }
@@ -167,12 +176,54 @@ export function diffPricing(ours, published) {
   return drift.sort((a, b) => a.model.localeCompare(b.model) || a.field.localeCompare(b.field));
 }
 
-/** Flatten a PricingEntry to the four comparable fields (drops any `intro`). */
-function comparable(entry) {
+/** The four rate fields, from an entry or from an `intro` block. */
+function comparable(rate) {
   return {
-    input: entry.input, output: entry.output,
-    cacheRead: entry.cacheRead, cacheCreate: entry.cacheCreate,
+    input: rate.input, output: rate.output,
+    cacheRead: rate.cacheRead, cacheCreate: rate.cacheCreate,
   };
+}
+
+/**
+ * Promotional windows that have LAPSED.
+ *
+ * This is the Sonnet 5 shape (#1047), and the reason it went unnoticed: the bug
+ * was never in the standard rate, it was a dated `intro` block that outlived the
+ * promotion it described.
+ *
+ * Comparing an intro RATE against the published standard would be worse than
+ * useless — a promotional price differs from the standard price by definition,
+ * so every entry carrying one would report drift forever and the issue would be
+ * learned-ignored inside a week. That is how watchers die.
+ *
+ * What is genuinely checkable is the DATE. An `until` in the past means the
+ * entry is either stale (the promotion ended and nobody removed the block) or
+ * wrong (the promotion was made permanent and the block should have become the
+ * standard rate — exactly what happened to Sonnet 5). Both need a human, and
+ * both are invisible today.
+ *
+ * No entry carries an `intro` right now, so this is dormant by design: it exists
+ * so the next promotional window is covered on arrival rather than after the
+ * next incident.
+ */
+export function staleIntroWindows(pricing, nowMs) {
+  const stale = [];
+  for (const [id, entry] of Object.entries(pricing)) {
+    if (!entry.intro || typeof entry.intro.until !== 'string') continue;
+    const endsAt = Date.parse(`${entry.intro.until}T23:59:59.999Z`);
+    if (!Number.isFinite(endsAt)) {
+      stale.push({ model: id, field: 'intro.until', ours: entry.intro.until,
+        published: 'unparseable',
+        note: 'intro window carries an invalid `until` date, so it can never expire correctly' });
+      continue;
+    }
+    if (endsAt < nowMs) {
+      stale.push({ model: id, field: 'intro.until', ours: entry.intro.until,
+        published: 'lapsed',
+        note: 'promotional window has passed — remove the intro block, or promote its rate to standard if the promotion was made permanent' });
+    }
+  }
+  return stale;
 }
 
 async function main() {
@@ -221,7 +272,9 @@ async function main() {
   const ours = Object.fromEntries(
     Object.entries(PRICING).map(([id, e]) => [id, comparable(e)]),
   );
-  const drift = diffPricing(ours, published);
+  // A rate that no longer matches, and a promotional window that has lapsed,
+  // are both "PRICING no longer describes reality" — one report, one exit code.
+  const drift = [...diffPricing(ours, published), ...staleIntroWindows(PRICING, Date.now())];
 
   console.log(JSON.stringify({
     ...report,

--- a/test/pricing-drift.mjs
+++ b/test/pricing-drift.mjs
@@ -13,7 +13,7 @@
 // awkward parts: markdown links inside model cells, $0.50 and $12.50 cells,
 // and a retired model dario does not price.
 
-import { parsePricingTable, priceFromCell, modelIdFromDisplayName, diffPricing }
+import { parsePricingTable, priceFromCell, modelIdFromDisplayName, diffPricing, staleIntroWindows }
   from '../scripts/check-pricing-drift.mjs';
 
 let pass = 0, fail = 0;
@@ -143,6 +143,40 @@ header('diff');
 
   // The published table lists models dario does not model. That is not drift.
   check('extra published models are not drift', diffPricing(clean, published).length === 0);
+}
+
+header('lapsed promotional windows (the #1047 shape)');
+{
+  // Checking an intro RATE against the published standard would be permanent
+  // noise - a promotional price differs from the standard by definition, so
+  // every entry carrying one would report drift forever and the issue would be
+  // learned-ignored. What is checkable is the DATE.
+  const NOW = Date.parse('2026-08-20T00:00:00Z');
+  const withIntro = (until) => ({
+    m: { input: 1, output: 2, cacheRead: 0.1, cacheCreate: 1.25,
+         intro: { input: 1, output: 2, cacheRead: 0.1, cacheCreate: 1.25, until } },
+  });
+
+  check('no intro block -> nothing to report',
+    staleIntroWindows({ m: { input: 1, output: 2, cacheRead: 0.1, cacheCreate: 1.25 } }, NOW).length === 0);
+  check('a promotion still running is NOT drift',
+    staleIntroWindows(withIntro('2026-12-31'), NOW).length === 0);
+  check('boundary: the last day of the window is still running',
+    staleIntroWindows(withIntro('2026-08-20'), NOW).length === 0);
+
+  const lapsed = staleIntroWindows(withIntro('2026-08-19'), NOW);
+  check('a lapsed window is drift', lapsed.length === 1);
+  check('and is labelled lapsed', lapsed[0].published === 'lapsed');
+  check('and says what to do about it', /remove the intro block|promote its rate/.test(lapsed[0].note));
+
+  // The exact Sonnet 5 bug: an intro whose `until` had been cancelled, still in
+  // the table, evaluated the day the cutover would have fired.
+  const sonnet5 = staleIntroWindows(withIntro('2026-08-31'), Date.parse('2026-09-01T00:00:00Z'));
+  check('the Sonnet 5 shape is caught', sonnet5.length === 1 && sonnet5[0].published === 'lapsed');
+
+  // An unparseable date can never expire, so it would sit forever unnoticed.
+  const bad = staleIntroWindows(withIntro('soon'), NOW);
+  check('an unparseable until is reported', bad.length === 1 && bad[0].published === 'unparseable');
 }
 
 console.log(`\n${pass} pass, ${fail} fail`);


### PR DESCRIPTION
Two defects raised in review earlier today and deliberately left for a follow-up. This is the follow-up.

## 1. The compat job reported a shell error instead of its verdict

```yaml
exit "$COMPAT_EXIT_CODE"
```

`exit_code` is empty whenever the compat step never ran — and it does not run when an **earlier** step fails, which includes the `maxTested` gate refusing to validate a claim the runner cannot back. That is a legitimate, expected outcome, not a crash.

So the run died with:

```
line 3: exit: : numeric argument required
##[error]Process completed with exit code 2.
```

and surfaced *that* instead of `compat cannot validate maxTested=2.1.238`. **Visible on #1046 right now**: the gate did exactly its job, and a reader is shown a shell error rather than the reason.

Defaults to `1`. Reaching that step with no recorded exit code means something upstream already failed; the only wrong answer there is a green run.

## 2. The pricing watcher did not cover promotional windows

My own review of #1049 flagged that `comparable()` drops `intro`, so a model on a promotion would have its **standard** rate watched while the rate it actually bills at went unchecked.

**My first attempt at fixing it was wrong**, and wrong in the way this repo keeps re-learning: it compared the intro *rate* against the published standard. A promotional price differs from the standard by definition, so every entry carrying one would have reported drift **forever**, and the issue would have been learned-ignored inside a week. A watcher nobody reads is worse than no watcher — which is the exact argument I made in the review that prompted this.

What is genuinely checkable is the **date**:

```js
staleIntroWindows(pricing, nowMs)   // `until` in the past, or unparseable
```

That is precisely the Sonnet 5 shape (#1047). The bug there was never in the standard rate — it was a dated block that outlived the promotion it described. Dormant by design (no entry carries an `intro` today), so the next promotional window is covered on arrival rather than after the next incident.

Verified against the real case:

```
no intro block                                     -> 0 findings
promotion still running (until 2026-12-31)         -> 0 findings
last day of the window (until 2026-08-20, now 20th)-> 0 findings
lapsed (until 2026-08-19)                          -> lapsed
the Sonnet 5 shape (until 2026-08-31, now Sep 1)   -> lapsed
unparseable (until "soon")                         -> unparseable
```

Also renamed `MIN_PLAUSIBLE_ROWS` → `MIN_PUBLISHED_ROWS`. It is a sanity floor on the *published* table and happens to equal dario's model count today; tying the two together would silently turn it into "did we parse at least as many as we price", which is weaker and means something different.

## Tooling gap closed

Both of today's CI-only misses (`SC2001` on `drift-pr-heal.yml`, `SC2034` on `cc-oauth-health.yml`) got through because **`bash -n` checks syntax, not style**, and neither shellcheck nor actionlint was installed on the dev box.

`actionlint 1.7.1` — the same version this repo's CI pins — is now installed locally, and this PR was linted with it before pushing. Whole repo: clean.

Worth recording *why* shellcheck alone is not sufficient here. Extracting `run:` blocks and shellchecking them raw produces false positives, because shellcheck cannot know that `${{ github.repository }}` is an Actions expression rather than a shell expansion:

```
SC2296 (error): Parameter expansions can't start with {. Double check syntax.
```

actionlint substitutes those first and then delegates to shellcheck, which is why CI is clean on blocks that raw shellcheck rejects. The lesson is to run actionlint locally, not shellcheck.

## Tests

8 new assertions on `staleIntroWindows` — 42 in that file, **140/140** overall. `actionlint` clean across the repo.
