### PR TITLE
fix: hoist the empty-text-block filter above the genuine-CC early return (v5.5.52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.52] - 2026-08-23
+
+- **Fixed: empty-text-block filter now reaches genuine Claude Code clients** (#1077). #1067's filter sat below the `isGenuineCCClient` early return, so real CC sessions — the one path forwarding messages verbatim — still died with `messages: text content blocks must be non-empty` on every request once an empty block entered the transcript (the #1066 session-killer; presented as "sub-agents hang and never report"). The filter and the mid-conversation empty-turn drop are hoisted above the branch so every path, present and future, shares one implementation; the thinking strip stays path-local (genuine CC forwards signed thinking verbatim). Regression-tested with a genuine-CC body. Reported with a full root-cause analysis by @LiveNathan.
+
 ## [5.5.51] - 2026-08-23
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.240` → `2.1.241` for CC v2.1.241. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.49",
+  "version": "5.5.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "5.5.49",
+      "version": "5.5.52",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.51",
+  "version": "5.5.52",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -1689,6 +1689,43 @@ export function buildCCRequest(
   const clientTools = clientBody.tools as Array<Record<string, unknown>> | undefined;
   const stream = clientBody.stream ?? false;
 
+  // ── Drop empty text blocks from history (ALL paths) ──
+  // Upstream rejects empty text blocks OUTRIGHT — stamped or not — and treats
+  // whitespace-only text the same way ("messages: text content blocks must be
+  // non-empty"; with a breakpoint on it, "cache_control cannot be set for
+  // empty text blocks"). One such block entering the transcript mid-run
+  // therefore killed every subsequent request of the session (dario#1066).
+  // Filtering here fixes the REQUEST, which no breakpoint guard can: skipping
+  // the stamp still leaves the illegal block on the wire.
+  //
+  // Sits ABOVE the genuine-CC early return on purpose. #1067 placed this
+  // below it, where real Claude Code — the one client whose messages are
+  // forwarded verbatim — never reached it, and the #1066 session-killer
+  // survived on exactly the client it hurts most (dario#1077). An empty text
+  // block is not a wire shape the client is authority over; it is a
+  // guaranteed upstream 400. `messages` aliases clientBody.messages, so
+  // these mutations reach the genuine-CC body, which spreads clientBody.
+  for (const msg of messages) {
+    if (!Array.isArray(msg.content)) continue;
+    msg.content = (msg.content as Array<Record<string, unknown>>).filter(
+      (b) => !(b.type === 'text' && (typeof b.text !== 'string' || (b.text as string).trim() === '')),
+    );
+  }
+  // A USER turn left with no blocks is dropped — but only MID-conversation,
+  // where the API combines the now-adjacent same-role turns and where the
+  // #1066 session-killer lives (the empty turn sits in history, so every
+  // later request carries it). The FINAL turn is deliberately left in place
+  // per the dario#1033 decision below: popping it would expose the assistant
+  // turn behind it and convert an honest "content must contain at least one
+  // block" into a misleading prefill rejection. Hoisted with the filter
+  // (dario#1077): removing a block can empty a turn on any path.
+  for (let i = messages.length - 2; i >= 0; i--) {
+    const m = messages[i];
+    if (m.role === 'user' && Array.isArray(m.content) && (m.content as unknown[]).length === 0) {
+      messages.splice(i, 1);
+    }
+  }
+
   // ── Genuine Claude Code client → byte-faithful passthrough ──
   // A real CC request already IS the CC wire shape. Replacing its system
   // prompt with the template (prepending ~25KB per request shape) and
@@ -1705,9 +1742,11 @@ export function buildCCRequest(
   //     here, conversation in applyCcPromptCaching) so the 4-breakpoint
   //     budget stays deterministic.
   // Messages, thinking, effort, max_tokens, top-level key order: untouched —
-  // the client is the authority on its own wire shape. Outranks the
-  // tool-mode flags: those configure how NON-CC clients are dressed up as
-  // CC, which a genuine CC client doesn't need.
+  // the client is the authority on its own wire shape. One exception, the
+  // empty-text filter above (dario#1077): a guaranteed upstream 400 is a
+  // defect, not a wire-shape preference. Outranks the tool-mode flags: those
+  // configure how NON-CC clients are dressed up as CC, which a genuine CC
+  // client doesn't need.
   if (isGenuineCCClient(clientBody)) {
     const clientSystem = clientBody.system as Array<Record<string, unknown>>;
     const system = clientSystem.map((b, i) => {
@@ -1784,33 +1823,9 @@ export function buildCCRequest(
     }
   }
 
-  // ── Drop empty text blocks from history ──
-  // Upstream rejects empty text blocks OUTRIGHT — stamped or not — and treats
-  // whitespace-only text the same way ("messages: text content blocks must be
-  // non-empty"; with a breakpoint on it, "cache_control cannot be set for
-  // empty text blocks"). One such block entering the transcript mid-run
-  // therefore killed every subsequent request of the session (dario#1066).
-  // Filtering here fixes the REQUEST, which no breakpoint guard can: skipping
-  // the stamp still leaves the illegal block on the wire.
-  for (const msg of messages) {
-    if (!Array.isArray(msg.content)) continue;
-    msg.content = (msg.content as Array<Record<string, unknown>>).filter(
-      (b) => !(b.type === 'text' && (typeof b.text !== 'string' || (b.text as string).trim() === '')),
-    );
-  }
-  // A USER turn left with no blocks is dropped — but only MID-conversation,
-  // where the API combines the now-adjacent same-role turns and where the
-  // #1066 session-killer lives (the empty turn sits in history, so every
-  // later request carries it). The FINAL turn is deliberately left in place
-  // per the dario#1033 decision below: popping it would expose the assistant
-  // turn behind it and convert an honest "content must contain at least one
-  // block" into a misleading prefill rejection.
-  for (let i = messages.length - 2; i >= 0; i--) {
-    const m = messages[i];
-    if (m.role === 'user' && Array.isArray(m.content) && (m.content as unknown[]).length === 0) {
-      messages.splice(i, 1);
-    }
-  }
+  // (Empty text blocks and the mid-conversation empty-user-turn drop moved
+  // above the genuine-CC branch — dario#1077. Only the thinking strip stays
+  // path-local: genuine CC forwards its signed thinking verbatim.)
 
   // ── Drop trailing empty turns ──
   // An assistant turn that was thinking-only before the strip above becomes

--- a/test/empty-text-blocks.mjs
+++ b/test/empty-text-blocks.mjs
@@ -109,5 +109,50 @@ console.log('\n=== non-text blocks are untouched ===');
   check('trailing empty text sibling is filtered', emptyTextBlocks(body).length === 0);
 }
 
+console.log('\n=== genuine Claude Code clients get the same filter (dario#1077) ===');
+// #1067's coverage passed with the bug present: none of the bodies above are
+// recognized by isGenuineCCClient, so they all take the general path. A
+// genuine-CC body needs the billing header in system[0] and a CC opener in
+// system[1] — then the branch returns early, and before #1077 the filter
+// below the return never ran.
+const GENUINE_SYSTEM = [
+  { type: 'text', text: 'x-anthropic-billing-header: client-tag' },
+  { type: 'text', text: "You are Claude Code, Anthropic's official CLI for Claude.", cache_control: { type: 'ephemeral' } },
+];
+{
+  const { body, genuineCC } = buildCCRequest({
+    model: 'claude-opus-5', max_tokens: 32,
+    system: structuredClone(GENUINE_SYSTEM),
+    messages: [
+      { role: 'user', content: [{ type: 'text', text: 'q1' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'a1' }, { type: 'text', text: '   ' }] },
+      { role: 'user', content: [{ type: 'text', text: 'q2' }, { type: 'text', text: '' }] },
+    ],
+  }, TAG, CC_CACHE_CONTROL, ID);
+  check('fixture is recognized as genuine CC', genuineCC === true);
+  check('no empty text block survives the genuine-CC path', emptyTextBlocks(body).length === 0);
+  check('real blocks survive on both turns', body.messages[1].content.length === 1 && body.messages[2].content.length === 1);
+  applyCcPromptCaching(body, CC_CACHE_CONTROL);
+  check('still none after conversation stamping', emptyTextBlocks(body).length === 0);
+}
+{
+  // A mid-conversation user turn emptied by the filter must be dropped
+  // entirely on this path too — the #1066 session-killer shape.
+  const { body, genuineCC } = buildCCRequest({
+    model: 'claude-opus-5', max_tokens: 32,
+    system: structuredClone(GENUINE_SYSTEM),
+    messages: [
+      { role: 'user', content: [{ type: 'text', text: 'q1' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'a1' }] },
+      { role: 'user', content: [{ type: 'text', text: '' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'a2' }] },
+      { role: 'user', content: [{ type: 'text', text: 'q2' }] },
+    ],
+  }, TAG, CC_CACHE_CONTROL, ID);
+  check('fixture is recognized as genuine CC', genuineCC === true);
+  check('mid-conversation turn emptied by the filter is dropped', body.messages.length === 4);
+  check('every surviving turn still has content', body.messages.every((m) => Array.isArray(m.content) && m.content.length > 0));
+}
+
 console.log(`\n  ${pass} passed, ${fail} failed`);
 process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## What

Hoists #1067's empty-text-block filter — and the mid-conversation empty-user-turn drop — above the `isGenuineCCClient` early return in `buildCCRequest`, so genuine Claude Code clients get the same protection as everyone else. Addresses #1077.

## Why

Exactly as @LiveNathan's report lays out (verified by inspection): the filter sat below the branch's `return`, unreachable for real CC — the one client whose messages are forwarded verbatim. An empty text block entering the transcript mid-run still 400'd every subsequent request of the session (`messages: text content blocks must be non-empty`, #1066), presenting as "sub-agents hang and never report" while the work sat finished on disk. #1067's tests passed with the bug present because none of their bodies satisfy `isGenuineCCClient`, and non-CC verification shows a false pass.

## How

- One shared implementation above the branch (the reporter's preferred shape — also closes the gap for any future early return). `messages` aliases `clientBody.messages`, so the mutations reach the genuine-CC body, which spreads `clientBody` — the same mechanism the branch's existing `cache_control` strip already relies on.
- The mid-conversation empty-turn drop travels with the filter (removing a block can empty a turn on any path). The final-turn/#1033 behavior is unchanged.
- The **thinking strip stays path-local** — genuine CC forwards its signed thinking verbatim; hoisting it would corrupt the path this fix protects.
- The branch comment's "client is the authority on its own wire shape" now states its one exception: a guaranteed upstream 400 is a defect, not a wire-shape preference.

## Verification

- New regression tests build a body `isGenuineCCClient` actually recognizes (billing header in `system[0]`, CC opener in `system[1]`) with empty/whitespace blocks in history: **4 checks fail against the pre-fix source, 19/19 pass with the fix**.
- Full suite: **141/141**.
- The reporter confirmed on a live proxy that their locally-patched equivalent restores sub-agent notification delivery (#1077).

## Release

In-PR bump to **v5.5.52** + CHANGELOG entry, per the release gate.