### PR TITLE
fix: genuine-CC path inherits the trailing-empty-turn drop (v5.5.53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.53] - 2026-08-23
+
+- **Fixed: genuine-CC path also inherits the trailing-empty-turn drop** (#1077 follow-up, stage 3 of 3). v5.5.52 hoisted the empty-block filter and the mid-conversation empty-user-turn drop above the `isGenuineCCClient` early return, but a trailing assistant turn the filter emptied (e.g. a lone `text: null` block) still left `content: []` at the end — which upstream reads as a prefill and refuses. A copy of the trailing drop (assistant turns only, per dario#1033/#37) now runs above the branch; the general-path original stays where it is, after the thinking strip it was written for. Predicted empirically by @LiveNathan ("the failure moves rather than disappears") before v5.5.52 shipped; their three-stage repro is now a verbatim regression test.
+
 ## [5.5.52] - 2026-08-23
 
 - **Fixed: empty-text-block filter now reaches genuine Claude Code clients** (#1077). #1067's filter sat below the `isGenuineCCClient` early return, so real CC sessions — the one path forwarding messages verbatim — still died with `messages: text content blocks must be non-empty` on every request once an empty block entered the transcript (the #1066 session-killer; presented as "sub-agents hang and never report"). The filter and the mid-conversation empty-turn drop are hoisted above the branch so every path, present and future, shares one implementation; the thinking strip stays path-local (genuine CC forwards signed thinking verbatim). Regression-tested with a genuine-CC body. Reported with a full root-cause analysis by @LiveNathan.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.52",
+  "version": "5.5.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "5.5.52",
+      "version": "5.5.53",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.52",
+  "version": "5.5.53",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -1725,6 +1725,26 @@ export function buildCCRequest(
       messages.splice(i, 1);
     }
   }
+  // A TRAILING assistant turn the filter emptied is dropped too — content: []
+  // at the end reads as a prefill upstream, which Opus under adaptive thinking
+  // + the claude-code beta refuses outright. This is a copy of the trailing
+  // drop further down (which must ALSO stay there, running after the general
+  // path's thinking strip — the shape it was written for); the copy exists so
+  // the genuine-CC early return inherits it (dario#1077 follow-up: stage 3 of
+  // 3, the "failure moves rather than disappears" case). Same constraints as
+  // the original: assistant turns ONLY — popping an empty final user turn
+  // would convert an honest "content must contain at least one block" into a
+  // misleading prefill rejection (dario#1033), and popping a NON-empty
+  // trailing assistant is the OpenClaw runaway loop (#37). Idempotent, so
+  // running it twice on the general path changes nothing.
+  while (messages.length > 0) {
+    const last = messages[messages.length - 1];
+    if (last.role === 'assistant' && Array.isArray(last.content) && (last.content as unknown[]).length === 0) {
+      messages.pop();
+      continue;
+    }
+    break;
+  }
 
   // ── Genuine Claude Code client → byte-faithful passthrough ──
   // A real CC request already IS the CC wire shape. Replacing its system

--- a/test/empty-text-blocks.mjs
+++ b/test/empty-text-blocks.mjs
@@ -154,5 +154,60 @@ const GENUINE_SYSTEM = [
   check('every surviving turn still has content', body.messages.every((m) => Array.isArray(m.content) && m.content.length > 0));
 }
 
+console.log('\n=== genuine CC: stage 3 — trailing turn emptied by the filter (dario#1077 follow-up) ===');
+{
+  // The reporter's full three-stage repro, verbatim: expected shape after all
+  // three stages is user[1] assistant[1] assistant[1] user[1].
+  const { body, genuineCC } = buildCCRequest({
+    model: 'claude-opus-5', max_tokens: 32,
+    system: structuredClone(GENUINE_SYSTEM),
+    messages: [
+      { role: 'user', content: [{ type: 'text', text: 'start' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'ok' }] },
+      { role: 'user', content: [{ type: 'text', text: '' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'mid' }] },
+      { role: 'user', content: [{ type: 'text', text: '   ' }, { type: 'text', text: 'real' }] },
+    ],
+  }, TAG, CC_CACHE_CONTROL, ID);
+  check('repro: recognized as genuine CC', genuineCC === true);
+  const shape = body.messages.map((m) => m.role + '[' + m.content.length + ']').join(' ');
+  check('repro: exact expected shape user[1] assistant[1] assistant[1] user[1]',
+    shape === 'user[1] assistant[1] assistant[1] user[1]');
+  check('repro: no empty text block on the wire', emptyTextBlocks(body).length === 0);
+}
+{
+  // Stage 1 emptying a TRAILING assistant turn must not leave content: [] at
+  // the end — upstream reads that as a prefill and refuses. Null-text is the
+  // flavor that reaches cc-template in the live pipeline (the proxy-level
+  // scrub only handles string text).
+  const { body, genuineCC } = buildCCRequest({
+    model: 'claude-opus-5', max_tokens: 32,
+    system: structuredClone(GENUINE_SYSTEM),
+    messages: [
+      { role: 'user', content: [{ type: 'text', text: 'q' }] },
+      { role: 'assistant', content: [{ type: 'text', text: null }] },
+    ],
+  }, TAG, CC_CACHE_CONTROL, ID);
+  check('trailing: recognized as genuine CC', genuineCC === true);
+  const last = body.messages[body.messages.length - 1];
+  check('trailing emptied assistant turn is dropped', last.role === 'user' && body.messages.length === 1);
+}
+{
+  // The #1033 guarantee holds on this path: an empty FINAL user turn is
+  // forwarded (as content: []), never popped.
+  const { body } = buildCCRequest({
+    model: 'claude-opus-5', max_tokens: 32,
+    system: structuredClone(GENUINE_SYSTEM),
+    messages: [
+      { role: 'user', content: [{ type: 'text', text: 'q' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'a' }] },
+      { role: 'user', content: [{ type: 'text', text: '' }] },
+    ],
+  }, TAG, CC_CACHE_CONTROL, ID);
+  const last = body.messages[body.messages.length - 1];
+  check('final emptied user turn kept on the genuine-CC path (dario#1033)',
+    last.role === 'user' && Array.isArray(last.content) && last.content.length === 0);
+}
+
 console.log(`\n  ${pass} passed, ${fail} failed`);
 process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Stage 3 of #1077, which @LiveNathan called before v5.5.52 shipped (their follow-up crossed with the merge by 13 minutes): stage-1 filtering can empty a **trailing assistant** turn, and `content: []` at the end reads as a prefill upstream — the failure moves rather than disappears. Verified on the shipped v5.5.52 build: a trailing assistant turn holding a lone `text: null` block leaves `assistant[0]` on the wire.

## How

A copy of the trailing-empty-turn drop now runs above the `isGenuineCCClient` branch, next to stages 1–2. Constraints preserved exactly: **assistant turns only** — an empty final user turn is still forwarded (dario#1033's honest-error decision, covered by a new test), and a non-empty trailing assistant is never popped (the OpenClaw runaway, #37). The general-path original stays below, where it must run after the thinking strip; the loop is idempotent so the general path running both copies changes nothing.

## Verification

- @LiveNathan's three-stage repro, verbatim, asserting the exact expected shape `user[1] assistant[1] assistant[1] user[1]` — green.
- Trailing null-text assistant: fails 1/1 against v5.5.52's source, passes with this PR.
- #1033 final-user guarantee asserted on the genuine-CC path.
- Full suite 141/141.

## Release

In-PR bump to **v5.5.53** + CHANGELOG.

Addresses #1077