### PR TITLE
feat: refuse to bake or load through unclassified tool drops (v5.5.54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.54] - 2026-08-23
+
+- **Guard: a capture that drops unclassified tools can no longer bake or load silently** (#1062). The report's numbers did not reproduce — four real headless captures (win32 + linux, CC 2.1.236 and 2.1.241) each carried every tool the issue names, with `preservedToolReason` classifying 100% of the genuine absences — but the roster is provably remote-config-shaped (`WaitForMcpServers` appeared in one capture and vanished in the next, minutes apart), so the failure mode deserves a tripwire instead of a rewrite. New `unclassifiedToolDrops()` names any bundle tool a capture omits that no preservation set classifies; `capture-and-bake` now refuses to bake through one (exit 4, `--allow-tool-drops` + evidence to deliberately retire), `--check` mode warns, and `loadTemplate`'s live path logs it with a pointer to #1062 — turning every dario install with CC present into a rot detector for the day the roster shifts.
+
 ## [5.5.53] - 2026-08-23
 
 - **Fixed: genuine-CC path also inherits the trailing-empty-turn drop** (#1077 follow-up, stage 3 of 3). v5.5.52 hoisted the empty-block filter and the mid-conversation empty-user-turn drop above the `isGenuineCCClient` early return, but a trailing assistant turn the filter emptied (e.g. a lone `text: null` block) still left `content: []` at the end — which upstream reads as a prefill and refuses. A copy of the trailing drop (assistant turns only, per dario#1033/#37) now runs above the branch; the general-path original stays where it is, after the thinking strip it was written for. Predicted empirically by @LiveNathan ("the failure moves rather than disappears") before v5.5.52 shipped; their three-stage repro is now a verbatim regression test.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.53",
+  "version": "5.5.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "5.5.53",
+      "version": "5.5.54",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.53",
+  "version": "5.5.54",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/scripts/capture-and-bake.mjs
+++ b/scripts/capture-and-bake.mjs
@@ -35,6 +35,9 @@
  *       --allow-missing-variant)
  *   2 — --check mode only: wire-SHAPE drift vs current OUT (tools / system_prompt /
  *       beta / field order changed — needs a real re-bake; human-reviewed)
+ *   4 — bake mode only: the capture drops tools NO preservation set classifies
+ *       and --allow-tool-drops was not passed — refusing to shrink the bundle
+ *       silently (dario#1062).
  *   3 — --check mode only: LABEL-only drift — wire shape matches but the bundled
  *       `_version` lags the live CC version. computeDrift ignores `_version` (its
  *       job is within-version shape drift), so this slips past exit 2, yet
@@ -48,7 +51,7 @@ import { writeFileSync, readFileSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { captureLiveTemplateAsync, findInstalledCC, promptVariantsOf, TEMPLATE_BASE_MODEL, VARIANT_FAMILIES } from '../dist/live-fingerprint.js';
+import { captureLiveTemplateAsync, findInstalledCC, promptVariantsOf, TEMPLATE_BASE_MODEL, VARIANT_FAMILIES, unclassifiedToolDrops } from '../dist/live-fingerprint.js';
 import { scrubTemplate, findUserPathHits } from '../dist/scrub-template.js';
 import { PLATFORM_ONLY_TOOLS, INTERACTIVE_ONLY_TOOLS, CONFIG_SCOPED_TOOLS } from '../dist/cc-template.js';
 import { computeDrift, formatDriftReport, interpretDrift, formatDriftSummary, stripModelConditionalBetas, isOlderCCVersion, detectIssue881Residue, formatIssue881Warning } from './drift-report.mjs';
@@ -245,6 +248,31 @@ const preservedConfigScopedTools = (prev.tools || []).filter(
 if (preservedConfigScopedTools.length > 0) {
   log(`preserved ${preservedConfigScopedTools.length} config-scoped tool${preservedConfigScopedTools.length === 1 ? '' : 's'} from previous bundle (this capture's CC config omits them): ${preservedConfigScopedTools.map((t) => t.name).join(', ')}`);
   scrubbed.tools = [...scrubbed.tools, ...preservedConfigScopedTools].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+// Refuse to bake away tools nothing classifies. Every legitimate absence has
+// a set above (platform / interactive / config-scoped); a tool in the previous
+// bundle that is still missing AFTER those merges is either CC genuinely
+// retiring it or the preservation lists rotting (dario#1062's thesis — which
+// did not reproduce on 2.1.236 or 2.1.241, but the roster is remote-config-
+// shaped, so the day it happens must be loud). Baking through it silently
+// shrinks CC_NATIVE_NAMES_UNION and lands declaring clients in the unmapped
+// round-robin (v4.8.93). Retirement is a deliberate act: pass
+// --allow-tool-drops WITH capture evidence, and remove the names from the
+// preservation sets in the same change.
+const bakeToolDrops = unclassifiedToolDrops(scrubbed.tools, prev.tools || [], process.platform);
+if (bakeToolDrops.length > 0) {
+  const msg = `capture drops ${bakeToolDrops.length} tool(s) no preservation set classifies: ${bakeToolDrops.join(', ')}`;
+  if (CHECK_MODE) {
+    log(`WARNING: ${msg} — a re-bake would remove them from the bundle. See dario#1062.`);
+  } else if (process.argv.includes('--allow-tool-drops')) {
+    log(`warning: ${msg} — proceeding because --allow-tool-drops was passed. Pair this with capture evidence and prune the preservation sets.`);
+  } else {
+    log(`error: ${msg}`);
+    log('error: refusing to bake — this would silently shrink CC_NATIVE_NAMES_UNION (the v4.8.93 regression class).');
+    log('error: if CC genuinely retired these tools, re-run with --allow-tool-drops and record the evidence.');
+    process.exit(4);
+  }
 }
 
 // Re-derive tool_names AFTER every preservation merge. scrubTemplate() sets it

--- a/src/live-fingerprint.ts
+++ b/src/live-fingerprint.ts
@@ -343,6 +343,30 @@ export function preservedToolReason(name: string, platform: string): PreservedTo
 }
 
 /**
+ * Names the fallback bundle carries that `captureTools` lacks and NO
+ * preservation set classifies. Empty on every capture measured so far
+ * (win32 + linux, CC 2.1.236 and 2.1.241 — dario#1062's report did not
+ * reproduce), but the roster is remote-config-shaped: the config-scoped four
+ * flipped between the 8/11 and 8/15 bakes, and WaitForMcpServers appeared in
+ * one capture and vanished in the next, minutes apart, same binary. So the
+ * day this goes non-empty must be LOUD, not a silent shrink of
+ * CC_NATIVE_NAMES_UNION: capture-and-bake refuses to write the bundle, and
+ * the live path logs it. Note the win32 subtlety: a win32-only tool missing
+ * from a WIN32 capture is unclassified (it was expected there) — that is a
+ * real drop, not a platform artifact.
+ */
+export function unclassifiedToolDrops<T extends { name: string }>(
+  captureTools: T[],
+  fallbackTools: T[],
+  platform: string,
+): string[] {
+  const have = new Set(captureTools.map((t) => t.name));
+  return fallbackTools
+    .filter((t) => !have.has(t.name) && preservedToolReason(t.name, platform) === null)
+    .map((t) => t.name);
+}
+
+/**
  * Re-union `capture.tools` with any tool `fallback` carries that the capture is
  * required to keep (see preservedToolReason). Returns the merged tool array,
  * CC's alphabetical wire order restored, plus what was preserved and why.
@@ -447,6 +471,18 @@ function withPreservedTools(live: TemplateData, options?: { silent?: boolean }):
     return live; // bundle unreadable — the capture is still better than throwing
   }
   const { tools, preserved } = mergePreservedTools(live.tools, bundled.tools, process.platform);
+  // A tool the capture omitted that NO set classifies stays out of the merge
+  // (nothing here invents wire shape) — but silence is how that class of rot
+  // ships, so say it every load. A client declaring one of these will not
+  // identity-map and lands in the unmapped round-robin (the v4.8.93 mode).
+  const unclassified = unclassifiedToolDrops(live.tools, bundled.tools, process.platform);
+  if (unclassified.length > 0 && !options?.silent) {
+    console.warn(
+      `[dario] live template: this capture omitted ${unclassified.length} tool${unclassified.length === 1 ? '' : 's'} no preservation set classifies — ` +
+      `NOT restored, clients declaring them will not identity-map: ${unclassified.join(', ')}. ` +
+      'Please report this at dario#1062 with your `claude --version`.',
+    );
+  }
   if (preserved.length === 0) return live;
   if (!options?.silent) {
     const byReason = preserved.map((p) => `${p.name} (${p.reason})`).join(', ');

--- a/test/unclassified-tool-drops.mjs
+++ b/test/unclassified-tool-drops.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * unclassifiedToolDrops — the guard that keeps preservation-list rot LOUD.
+ *
+ * Background (dario#1062): a report claimed a headless capture drops 24 tools
+ * of which preservedToolReason classifies only 10. Measured against real
+ * captures (win32 + linux, CC 2.1.236 and 2.1.241, four runs) that did NOT
+ * reproduce — every absent tool was classified. But the roster is
+ * remote-config-shaped: the config-scoped four flipped between the 8/11 and
+ * 8/15 bakes, and WaitForMcpServers appeared in one capture and vanished in
+ * the next minutes apart. So instead of rewriting the merge on an unverified
+ * premise, this helper names any capture drop NO set classifies, the bake
+ * refuses to write through one (exit 4, --allow-tool-drops to override), and
+ * the live path warns. This file pins the helper's semantics.
+ */
+import { unclassifiedToolDrops, mergePreservedTools } from '../dist/live-fingerprint.js';
+
+let pass = 0, fail = 0;
+function check(label, cond) {
+  if (cond) { console.log(`  ✅ ${label}`); pass++; }
+  else { console.log(`  ❌ ${label}`); fail++; }
+}
+const T = (...names) => names.map((name) => ({ name }));
+
+console.log('\n=== classified absences are not drops ===');
+{
+  // Everything the three sets cover, absent at once — the real linux shape.
+  const bundle = T('Bash', 'Read', 'AskUserQuestion', 'EnterPlanMode', 'ExitPlanMode',
+    'TaskCreate', 'TaskGet', 'TaskList', 'TaskUpdate', 'PowerShell', 'Glob', 'Grep');
+  const capture = T('Bash', 'Read');
+  check('linux: interactive + config-scoped + win32-only all classified',
+    unclassifiedToolDrops(capture, bundle, 'linux').length === 0);
+}
+
+console.log('\n=== an unclassified absence is named ===');
+{
+  const bundle = T('Bash', 'WebSearch', 'WebFetch', 'AskUserQuestion');
+  const capture = T('Bash');
+  const drops = unclassifiedToolDrops(capture, bundle, 'linux');
+  check('WebSearch and WebFetch are reported', drops.length === 2 && drops.includes('WebSearch') && drops.includes('WebFetch'));
+  check('the classified absence (AskUserQuestion) is not', !drops.includes('AskUserQuestion'));
+}
+
+console.log('\n=== platform subtlety: a win32 tool missing ON win32 is a real drop ===');
+{
+  // On linux, Glob missing is expected (win32-only). On win32 itself, the
+  // capture was supposed to carry it — its absence is unclassified, i.e. loud.
+  const bundle = T('Bash', 'Glob');
+  const capture = T('Bash');
+  check('linux: Glob absence is classified', unclassifiedToolDrops(capture, bundle, 'linux').length === 0);
+  check('win32: Glob absence is a drop', unclassifiedToolDrops(capture, bundle, 'win32').join(',') === 'Glob');
+}
+
+console.log('\n=== the merge and the guard agree ===');
+{
+  // mergePreservedTools restores only classified tools; whatever it cannot
+  // restore is exactly what unclassifiedToolDrops names. The two must
+  // partition the absent set — a name in neither is a hole in the guard.
+  const bundle = T('Bash', 'AskUserQuestion', 'TaskCreate', 'WebSearch', 'Monitor');
+  const capture = T('Bash');
+  const { tools } = mergePreservedTools(capture, bundle, 'linux');
+  const merged = new Set(tools.map((t) => t.name));
+  const drops = new Set(unclassifiedToolDrops(capture, bundle, 'linux'));
+  const unaccounted = bundle.filter((t) => !merged.has(t.name) && !drops.has(t.name));
+  check('every absent bundle tool is either restored or reported', unaccounted.length === 0);
+  check('restored: AskUserQuestion + TaskCreate', merged.has('AskUserQuestion') && merged.has('TaskCreate'));
+  check('reported: WebSearch + Monitor', drops.has('WebSearch') && drops.has('Monitor'));
+}
+
+console.log('\n=== an identical capture is silent ===');
+{
+  const bundle = T('Bash', 'Read', 'Write');
+  check('no absence, no drops', unclassifiedToolDrops(bundle, bundle, 'linux').length === 0);
+}
+
+console.log(`\n  ${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Addresses #1062 — with measurements first, code second.

## We measured instead of taking the report's numbers

Four real headless captures via dario's own `captureLiveTemplateAsync`:

| run | CC | platform | captured | absent vs bundle | unclassified |
|---|---|---|---|---|---|
| 1 | 2.1.241 | win32 | 28 (+`WaitForMcpServers`) | 7 | **0** |
| 2 | 2.1.241 | win32 | 27 | 7 | **0** |
| 3 | 2.1.241 | linux | 24 | 10 | **0** |
| 4 | **2.1.236** (the report's version, scratch-installed) | linux | 24 | 10 | **0** |

Every capture carried all 14 tools the issue says get dropped. `preservedToolReason` classified 100% of the genuine absences on both versions and both platforms. The report's 12-tool figure does not match what the binary sends.

## What the measurement DID prove

The roster is remote-config-shaped: `WaitForMcpServers` appeared in capture 1 and vanished in capture 2, minutes apart, same binary — on top of the documented 8/11→8/15 config-scoped flip. So the issue's *structural* concern deserves a tripwire, not a merge rewrite on an unverified premise.

## The guard

- **`unclassifiedToolDrops()`** names any bundle tool a capture omits that no preservation set classifies. Win32 subtlety pinned: a win32-only tool missing from a *win32* capture IS a drop.
- **`capture-and-bake` refuses to bake through one** (new exit 4). The dangerous path was drift-watch → auto-rebake → silently shrunken bundle shipped by auto-merge; now retirement is deliberate (`--allow-tool-drops` + evidence, prune the sets in the same change). `--check` mode names the would-be drops.
- **`loadTemplate` warns on the live path** with a pointer to #1062 — every install with CC present becomes a rot detector for the day the roster genuinely shifts.

Tests pin the semantics, including that `mergePreservedTools` and the guard **partition** the absent set — a name in neither is a hole. 142/142.

In-PR bump to **v5.5.54** + CHANGELOG per the release gate.