### PR TITLE
test: derive FABLE_MARKER structurally instead of pinning a literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.57] - 2026-08-24
+
+- **Test: FABLE_MARKER is now derived structurally, not pinned** (#1087). The literal prose pin rotted twice in two days as Anthropic A/B-served two Fable shapes at the same CC version. `per-model-system-prompt.mjs` now asserts the real invariant - the Fable variant carries at least one top-level `# ` heading absent from base/opus-5/sonnet-5 - and derives its marker from that set, so the suite survives editorial flip-flops and fails only if Fable genuinely stops being distinct. `FABLE_IDENTITY` stays literal.
+
 ## [5.5.56] - 2026-08-24
 
 - **Template rebake** — re-captured `src/cc-template-data.json` after cc-drift-template-watch detected wire-fingerprint drift against a live CC capture. Bundled fallback template now matches the current CC wire shape.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.56",
+  "version": "5.5.57",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/test/per-model-system-prompt.mjs
+++ b/test/per-model-system-prompt.mjs
@@ -13,21 +13,31 @@ function check(name, cond, detail) {
 }
 function header(n) { console.log(`\n=== ${n} ===`); }
 
-// FABLE_MARKER must be true of the Fable variant and FALSE of every other body
-// (base, opus-5, sonnet-5) — the negative assertions below depend on it.
+// The Fable marker is DERIVED, not pinned (#1087). A literal pin rotted twice
+// in two days: CC 2.1.241 first condensed Fable's '# Communicating with the
+// user' section and added '# Delivering work' (repinned in #1081), then the
+// 2026-08-24 capture reverted Fable byte-for-byte to the pre-condensation
+// 9220-char shape (repinned again in #1085) - same _version both times, so
+// Anthropic is A/B-serving this variant at a fixed version and ANY literal
+// prose pin is one remote-config flip from rot.
 //
-// This pin has now rotted twice. CC 2.1.241 first condensed Fable's
-// '# Communicating with the user' section to one sentence and added
-// '# Delivering work' (repinned in #1081), then the 2026-08-24 capture reverted
-// Fable byte-for-byte to the pre-condensation 9220-char shape — same _version
-// 2.1.241 both times, so this is a remote-config flip-flop, not a version bump.
-// A marker taken from either shape's section headings or from text unique to one
-// shape breaks on the next flip.
+// The invariant the suite actually cares about is structural: the Fable
+// variant carries at least one top-level '# ' section heading that appears in
+// NONE of base / opus-5 / sonnet-5. That is what makes Fable distinct and
+// routable, it holds under both observed shapes, and it survives editorial
+// drift. If it ever fails, Fable has genuinely stopped being distinct - a real
+// regression, not rot. The request-level checks below then use one of those
+// derived Fable-only headings as their marker, so they inherit the same
+// robustness.
 //
-// So pin a behavioural prose clause that survives BOTH observed Fable shapes and
-// appears in none of the other three bodies. Avoid typographic apostrophes so
-// punctuation normalisation alone cannot break it.
-const FABLE_MARKER = 'End your turn only when the task is complete or you are blocked on input only the user can provide';
+// FABLE_IDENTITY stays a literal: it is an identity string, not editorial
+// prose, and has been byte-stable across every observed shape.
+const headings = (body) => new Set(body.match(/^# .+$/gm) ?? []);
+const fableOnlyHeadings = [...headings(CC_SYSTEM_PROMPT_FABLE)].filter((h) =>
+  !headings(CC_SYSTEM_PROMPT).has(h) &&
+  !headings(CC_SYSTEM_PROMPT_OPUS5).has(h) &&
+  !headings(CC_SYSTEM_PROMPT_SONNET5).has(h));
+const FABLE_MARKER = fableOnlyHeadings[0];
 const FABLE_IDENTITY = 'This iteration of Claude is Claude Fable 5';
 
 // ─────────────────────────────────────────────────────────────
@@ -35,6 +45,9 @@ header('template carries a distinct Fable variant');
 {
   check('variant differs from base', CC_SYSTEM_PROMPT_FABLE !== CC_SYSTEM_PROMPT);
   check('variant is larger than base', CC_SYSTEM_PROMPT_FABLE.length > CC_SYSTEM_PROMPT.length);
+  check('variant carries at least one Fable-only # heading (structural distinctness, #1087)',
+    fableOnlyHeadings.length >= 1,
+    `fable headings: ${[...headings(CC_SYSTEM_PROMPT_FABLE)].join(' | ')}`);
   check('variant has the Fable-only section', CC_SYSTEM_PROMPT_FABLE.includes(FABLE_MARKER));
   check('variant has the Fable identity block', CC_SYSTEM_PROMPT_FABLE.includes(FABLE_IDENTITY));
   check('base has NO Fable-only section', !CC_SYSTEM_PROMPT.includes(FABLE_MARKER));


### PR DESCRIPTION
Fixes #1087.

The literal FABLE_MARKER pin rotted twice in two days (#1081 condensed shape, #1085 byte-for-byte reversion — same `_version` 2.1.241 both times: a remote-config A/B, not a version bump). Any prose literal is one flip from rot.

This replaces the pin with the invariant the suite actually cares about: **the Fable variant carries at least one top-level `# ` heading that appears in none of base / opus-5 / sonnet-5**, with the request-level checks using a heading derived from that set. The suite now survives editorial flip-flops and fails only if Fable genuinely stops being distinct — a real regression, not rot. `FABLE_IDENTITY` stays literal (identity string, byte-stable across every observed shape).

- 142/142 locally against the v5.5.56 template; the new structural check reports the full Fable heading list on failure for fast re-diagnosis.
- Bumps 5.5.56 → 5.5.57 (release gate) + CHANGELOG.