### PR TITLE
fix: rewind an empty final user turn on the genuine-CC path (#1092)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.59] - 2026-08-24
+
+- **Fixed: an empty final user turn no longer session-kills a genuine CC client** (#1092). CC's stream-interruption retry can append a `content: []` user turn as the final message; the three earlier empty-turn drops (#1077/#1078/#1079) all skip the final turn, so it reached the wire and 400'd (`messages.N: user messages must have non-empty content`), then stuck in history and killed every later request. On the genuine-CC path this is CC's own retry artifact, so the request is rewound to the interrupted response - the empty user turn and the assistant turn behind it are dropped, landing back on the last real user turn for a clean regeneration. The general path is unchanged: a third-party client's empty final user turn is still forwarded so upstream names it honestly (#1033). The rewind is bounded and distinct from the #37 runaway loop (fires only on a trailing empty user turn, pops at most one pair). The mid-conversation empty-turn drop now also covers assistant turns emptied by a null/non-string text block (the flavor the proxy-level string scrub leaves behind).
+
 ## [5.5.58] - 2026-08-24
 
 - **Template rebake** — re-captured `src/cc-template-data.json` after cc-drift-template-watch detected wire-fingerprint drift against a live CC capture. Bundled fallback template now matches the current CC wire shape.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.58",
+  "version": "5.5.59",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -1711,17 +1711,21 @@ export function buildCCRequest(
       (b) => !(b.type === 'text' && (typeof b.text !== 'string' || (b.text as string).trim() === '')),
     );
   }
-  // A USER turn left with no blocks is dropped — but only MID-conversation,
-  // where the API combines the now-adjacent same-role turns and where the
-  // #1066 session-killer lives (the empty turn sits in history, so every
-  // later request carries it). The FINAL turn is deliberately left in place
-  // per the dario#1033 decision below: popping it would expose the assistant
-  // turn behind it and convert an honest "content must contain at least one
-  // block" into a misleading prefill rejection. Hoisted with the filter
-  // (dario#1077): removing a block can empty a turn on any path.
+  // A turn left with no blocks is dropped — but only MID-conversation, where
+  // the API combines the now-adjacent same-role turns and where the #1066
+  // session-killer lives (the empty turn sits in history, so every later
+  // request carries it). BOTH roles: a user turn whose only block was empty,
+  // and an assistant turn the filter emptied (a null/non-string text block the
+  // proxy-level string scrub leaves behind, dario#1092) — either one mid-stream
+  // is "messages.N: … content must contain at least one block" upstream. The
+  // FINAL turn is deliberately left in place per the dario#1033 decision below:
+  // popping it would expose the assistant turn behind it and convert an honest
+  // "content must contain at least one block" into a misleading prefill
+  // rejection. Hoisted with the filter (dario#1077): removing a block can empty
+  // a turn on any path.
   for (let i = messages.length - 2; i >= 0; i--) {
     const m = messages[i];
-    if (m.role === 'user' && Array.isArray(m.content) && (m.content as unknown[]).length === 0) {
+    if (Array.isArray(m.content) && (m.content as unknown[]).length === 0) {
       messages.splice(i, 1);
     }
   }
@@ -1768,6 +1772,32 @@ export function buildCCRequest(
   // configure how NON-CC clients are dressed up as CC, which a genuine CC
   // client doesn't need.
   if (isGenuineCCClient(clientBody)) {
+    // ── dario#1092: recover an empty FINAL user turn (genuine CC only) ──
+    // CC's stream-interruption retry path can append a user turn with
+    // content:[] as the final message. #1033 leaves an empty final user turn in
+    // place on the GENERAL path so a malformed third-party client gets an honest
+    // upstream error rather than a mangled conversation. But on a genuine CC
+    // session that empty turn is CC's OWN retry artifact, and "let upstream name
+    // it" is the #1066 session-killer: it sticks in history and every later
+    // request dies with "messages.N: user messages must have non-empty content".
+    // The retry's intent is to regenerate the response whose stream was cut, so
+    // rewind to it — drop the empty user turn and the assistant turn it
+    // interrupted, landing the request back on the last real user turn for a
+    // clean regeneration.
+    //
+    // Bounded and distinct from the #37 runaway loop: that popped a NON-empty
+    // trailing assistant with no empty user after it; this fires ONLY on a
+    // trailing EMPTY user turn and pops at most the one pair. Mid-conversation
+    // empties are already gone above, so a trailing empty user is the only shape
+    // that can reach here, and the assistant behind it is real.
+    {
+      const last = messages.length > 0 ? messages[messages.length - 1] : undefined;
+      if (last && last.role === 'user' && Array.isArray(last.content) && last.content.length === 0) {
+        messages.pop();
+        const prev = messages[messages.length - 1];
+        if (prev && prev.role === 'assistant') messages.pop();
+      }
+    }
     const clientSystem = clientBody.system as Array<Record<string, unknown>>;
     const system = clientSystem.map((b, i) => {
       const copy = { ...b };

--- a/test/empty-text-blocks.mjs
+++ b/test/empty-text-blocks.mjs
@@ -192,9 +192,39 @@ console.log('\n=== genuine CC: stage 3 — trailing turn emptied by the filter (
   const last = body.messages[body.messages.length - 1];
   check('trailing emptied assistant turn is dropped', last.role === 'user' && body.messages.length === 1);
 }
+console.log('\n=== genuine CC: an empty FINAL user turn is rewound, not forwarded (dario#1092) ===');
 {
-  // The #1033 guarantee holds on this path: an empty FINAL user turn is
-  // forwarded (as content: []), never popped.
+  // CC's stream-interruption retry can append a user turn with content:[] as
+  // the final message. On the general path #1033 leaves it (honest upstream
+  // error for a malformed third-party client), but on a genuine CC session it
+  // is CC's own retry artifact: "let upstream name it" is the #1066
+  // session-killer ("messages.N: user messages must have non-empty content",
+  // then every later request dies). Rewind to the interrupted response instead:
+  // drop the empty user turn and the assistant turn behind it, landing back on
+  // the last real user turn for a clean regeneration.
+  const { body, genuineCC } = buildCCRequest({
+    model: 'claude-opus-5', max_tokens: 32,
+    system: structuredClone(GENUINE_SYSTEM),
+    messages: [
+      { role: 'user', content: [{ type: 'text', text: 'q1' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'a1' }] },
+      { role: 'user', content: [{ type: 'text', text: 'q2' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'a2' }] },
+      { role: 'user', content: [] },                                   // the retry artifact
+    ],
+  }, TAG, CC_CACHE_CONTROL, ID);
+  check('#1092: recognized as genuine CC', genuineCC === true);
+  const last = body.messages[body.messages.length - 1];
+  check('#1092: empty final user turn is gone', !(last.role === 'user' && Array.isArray(last.content) && last.content.length === 0));
+  check('#1092: request ends on the last real user turn (regeneration)',
+    last.role === 'user' && last.content.some((b) => b.text === 'q2'));
+  check('#1092: the interrupted assistant turn was dropped for regen', body.messages.length === 3);
+  check('#1092: no empty turn survives', body.messages.every((m) => Array.isArray(m.content) && m.content.length > 0));
+}
+{
+  // Same shape but the empty final turn arrived via an emptied block
+  // ([{text:''}]) rather than content:[] — identical after the filter, same
+  // rewind. This is the fixture the genuine-CC #1033 test used before #1092.
   const { body } = buildCCRequest({
     model: 'claude-opus-5', max_tokens: 32,
     system: structuredClone(GENUINE_SYSTEM),
@@ -204,9 +234,49 @@ console.log('\n=== genuine CC: stage 3 — trailing turn emptied by the filter (
       { role: 'user', content: [{ type: 'text', text: '' }] },
     ],
   }, TAG, CC_CACHE_CONTROL, ID);
+  check('#1092: emptied-block final user turn also rewinds to the real user turn',
+    body.messages.length === 1 && body.messages[0].role === 'user' && body.messages[0].content.some((b) => b.text === 'q'));
+}
+{
+  // The general path is UNCHANGED: a third-party client's empty final user turn
+  // is still forwarded as content:[] so upstream names it honestly (#1033). The
+  // rewind is scoped to genuine CC, where the empty turn is a known artifact.
+  const { body, genuineCC } = buildCCRequest({
+    model: 'claude-opus-5', max_tokens: 32,
+    system: 'a third-party harness system prompt',
+    messages: [
+      { role: 'user', content: [{ type: 'text', text: 'q' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'a' }] },
+      { role: 'user', content: [] },
+    ],
+  }, TAG, CC_CACHE_CONTROL, ID);
   const last = body.messages[body.messages.length - 1];
-  check('final emptied user turn kept on the genuine-CC path (dario#1033)',
+  check('general path is not genuine CC', genuineCC !== true);
+  check('#1033 preserved on the general path: empty final user turn is kept',
     last.role === 'user' && Array.isArray(last.content) && last.content.length === 0);
+}
+
+console.log('\n=== a MID-conversation assistant turn emptied by a null-text block is dropped (dario#1092) ===');
+{
+  // The proxy-level scrub only empties string text ('' / whitespace); a
+  // null/non-string text block reaches cc-template intact and the filter empties
+  // the turn here. Mid-stream that leaves content:[] on an ASSISTANT turn, which
+  // upstream rejects the same way an empty user turn is — so the mid-drop now
+  // covers both roles.
+  const { body } = buildCCRequest({
+    model: 'claude-opus-5', max_tokens: 32,
+    system: structuredClone(GENUINE_SYSTEM),
+    messages: [
+      { role: 'user', content: [{ type: 'text', text: 'q1' }] },
+      { role: 'assistant', content: [{ type: 'text', text: null }] },   // emptied by the filter, mid-stream
+      { role: 'user', content: [{ type: 'text', text: 'q2' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'a2' }] },
+      { role: 'user', content: [{ type: 'text', text: 'q3' }] },
+    ],
+  }, TAG, CC_CACHE_CONTROL, ID);
+  check('emptied mid-conversation assistant turn is dropped',
+    body.messages.every((m) => Array.isArray(m.content) && m.content.length > 0));
+  check('no empty text block survives', emptyTextBlocks(body).length === 0);
 }
 
 console.log(`\n  ${pass} passed, ${fail} failed`);


### PR DESCRIPTION
Fixes #1092.

## The bug

CC's stream-interruption retry can append a user turn with `content: []` as the final message. The three earlier empty-turn drops all deliberately skip the final turn:

- empty `text` blocks → filtered, all paths (#1078)
- empty **user** turn, *mid-conversation* → dropped (#1077)
- empty **assistant** turn, *trailing* → popped (#1079)

So an empty **final user** turn reaches the wire and 400s (`messages.N: user messages must have non-empty content`), then sticks in history and kills every later request — the #1066 session-killer re-entering through the one turn the filters won't touch. Reproduced deterministically (no live API needed): an empty final user turn survives `buildCCRequest` unchanged.

## The fix, and the #1033 tension it resolves

`#1033` deliberately leaves an empty final user turn in place so a **malformed third-party client** gets an honest upstream error instead of a mangled conversation. That reasoning is right for the general path and is **kept**. But on a **genuine CC** session the empty turn is CC's *own* retry artifact, and "let upstream name it" is exactly the session-killer — the honest 400 is still a 400, and it repeats forever.

The retry's intent is to regenerate the response whose stream was cut, so on the genuine-CC path the request is **rewound to it**: drop the empty user turn and the assistant turn behind it, landing back on the last real user turn for a clean regeneration.

- **Scoped to genuine CC** (billing header in `system[0]`, CC opener in `system[1]`). The general path keeps #1033 verbatim — asserted by a test.
- **Distinct from the #37 runaway loop**: #37 popped a *non-empty* trailing assistant with no empty user after it; this fires *only* on a trailing empty user turn and pops at most the one pair. Not a single-prompt runaway — each rewind corresponds to one real streaming failure and stops when streaming recovers.
- Also extends the mid-conversation empty-turn drop to **assistant** turns emptied by a null/non-string text block (the flavor the proxy-level string scrub, which is string-only, leaves behind).

## Tests

`test/empty-text-blocks.mjs` gains the #1092 rewind (both `content:[]` and emptied-block shapes), the general-path #1033 preservation, and the mid-assistant drop. 142/142 suite green. Verified by a deterministic 16-shape empty-content matrix through `sanitizeMessages` + `buildCCRequest`.

## Known gap, deliberately not guessed here

The same matrix shows an empty/null **text block nested inside a `tool_result` content array** still survives on both paths (requires a tool wrapper to emit a malformed text block — not the reported shape, and rare). Fixing it safely needs to know whether upstream accepts an emptied `tool_result` (`content: []` / `""`), which I can't confirm without a live capture. Flagging rather than shipping a transform that might itself 400. A captured body of that shape would let it be fixed correctly.

## Note on #1077

Fully resolved as shipped (5.5.52/53) — the reporter's three-stage repro passes verbatim in the matrix. Left open for the reporter to close per the earlier thread.