### PR TITLE
fix(release): resolve lockfile conflicts, and preflight the artifacts (v5.5.67)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,15 @@ jobs:
       - name: README line-count claim still matches src/
         run: node scripts/check-readme-line-count.mjs
 
+      # Artifact-level defects a green `npm test` cannot catch: conflict
+      # markers left in a tracked file, a lockfile that stopped being valid
+      # JSON, versions drifting between package.json / lockfile / CHANGELOG,
+      # a release entry buried in the CHANGELOG's header comment. All four
+      # shipped for real during the 2026-08-25 release collision. Same cheap
+      # no-install class as the two above, so it lives in this job.
+      - name: preflight — release artifacts are internally consistent
+        run: node scripts/preflight.mjs
+
   build:
     needs: validate-package-json
     runs-on: ubuntu-latest

--- a/.github/workflows/drift-pr-heal.yml
+++ b/.github/workflows/drift-pr-heal.yml
@@ -176,7 +176,7 @@ jobs:
               continue
             fi
             if ! git diff --quiet -- package.json CHANGELOG.md; then
-              git add package.json CHANGELOG.md
+              git add package.json package-lock.json CHANGELOG.md
               git commit -q -m "chore: renumber release above ${effective_floor} (base moved under this PR)"
             fi
 
@@ -213,7 +213,7 @@ jobs:
                 refused=$((refused + 1))
                 continue
               fi
-              git add package.json CHANGELOG.md
+              git add package.json package-lock.json CHANGELOG.md
               # Belt and braces: if anything is still unmerged the commit would
               # fail and `set -e` would end the job, so verify before running it.
               if [ -n "$(git diff --name-only --diff-filter=U)" ]; then

--- a/.github/workflows/drift-pr-heal.yml
+++ b/.github/workflows/drift-pr-heal.yml
@@ -175,7 +175,13 @@ jobs:
               refused=$((refused + 1))
               continue
             fi
-            if ! git diff --quiet -- package.json CHANGELOG.md; then
+            # package-lock.json is in BOTH the test and the add: renumber now
+            # mirrors the new version into the lockfile's two version slots, so
+            # a renumber that changed only the lockfile must still commit.
+            # Testing just the other two would leave that write uncommitted and
+            # the lockfile would disagree with package.json — the exact drift
+            # `npm run preflight` fails on.
+            if ! git diff --quiet -- package.json package-lock.json CHANGELOG.md; then
               git add package.json package-lock.json CHANGELOG.md
               git commit -q -m "chore: renumber release above ${effective_floor} (base moved under this PR)"
             fi
@@ -183,7 +189,8 @@ jobs:
             # Conflicts are expected — that is the case being healed — so the
             # merge is allowed to fail and the resolver decides.
             if ! git merge "origin/$base" --no-edit >/dev/null 2>&1; then
-              # The resolver only ever touches package.json and CHANGELOG.md.
+              # The resolver only ever touches the three files that carry the
+              # version: package.json, package-lock.json and CHANGELOG.md.
               # A drift PR CAN also conflict in source — observed on #1038,
               # where #1037 had added utilFreshness to the same pool import
               # line this PR was adding accountIneligibility to. Resolving the
@@ -196,7 +203,7 @@ jobs:
               # how the separator lands, and the first draft of it refused
               # everything because `tr` left a trailing space.
               outside=$(git diff --name-only --diff-filter=U \
-                        | grep -vxE 'package\.json|CHANGELOG\.md' || true)
+                        | grep -vxE 'package\.json|package-lock\.json|CHANGELOG\.md' || true)
               if [ -n "$outside" ]; then
                 echo "  REFUSED — conflicts outside the version files:"
                 # read-loop rather than `sed 's/^/    /'`: shellcheck SC2001

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.67] - 2026-08-25
+
+### Fixed
+
+- Release-conflict resolver now handles `package-lock.json`. It carries the
+  same version twice (root `.version` and `.packages[""].version`), so a
+  release collision conflicts it exactly like `package.json` — but the
+  resolver had no handler for it and `drift-pr-heal` did not even `git add`
+  it. A healed PR could therefore carry a lockfile with live `<<<<<<<`
+  markers, i.e. invalid JSON. `npm test` passes anyway (a warm
+  `node_modules` means nothing parses the lockfile); `npm ci` is where it
+  dies, which is CI and deploy. A dependency-graph conflict still throws
+  rather than guessing — regenerating a lockfile is `npm install`'s job.
+
+### Added
+
+- `npm run preflight` (and a CI step) for artifact-level defects no unit test
+  can catch: conflict markers in tracked files, unparseable JSON, version
+  drift across `package.json` / both lockfile slots / the CHANGELOG heading,
+  and a release entry buried inside the CHANGELOG header comment. All four
+  shipped for real during the 2026-08-25 four-PR release collision.
+
 ## [5.5.66] - 2026-08-25
 
 - **Fixed: `dario doctor` reported `OAuth expired` while the proxy was serving** (#1105). dario#805 deliberately keeps a newer POOL token and refuses to overwrite the legacy `credentials.json`, so a stale legacy file is an expected steady state — every recovery that restores a pool account leaves one behind. The doctor row read only that legacy file, so it printed `OAuth expired` while live probes returned 200 on both Haiku and Sonnet, and `dario-doctor-watch` filed an issue for it on every run. The row now consults the account pool first: a live pool reports `ok` (while still naming the stale legacy file and citing #805, rather than hiding it), and only "nothing can serve" is reported as warn/fail. Extracted as the pure `oauthCheckRow()` alongside `checkIdentityDrift()`, with unit tests for every branch.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.66",
+  "version": "5.5.67",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "5.5.66",
+      "version": "5.5.67",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.66",
+  "version": "5.5.67",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {
@@ -34,6 +34,7 @@
     "compat": "node test/compat.mjs",
     "test:refresh-lock-race": "node test/integration/dual-instance-race.mjs",
     "lint:pkg": "node scripts/check-package-json.mjs",
+    "preflight": "node scripts/preflight.mjs",
     "drift:sdk": "node scripts/check-sdk-drift.mjs",
     "drift:wire": "node scripts/check-wire-drift.mjs",
     "check:overage": "node scripts/check-overage-live.mjs",

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * preflight — the artifact-level checks a green `npm test` cannot make.
+ *
+ * WHY THIS EXISTS. On 2026-08-25 four version-bumping PRs were in flight at
+ * once, so every merge invalidated the others on the same two files and each
+ * one had to be hand-resolved. Three separate defects came out of that hand
+ * work, and NONE of them could fail a unit test:
+ *
+ *   1. `package-lock.json` was committed with unresolved `<<<<<<<` markers —
+ *      invalid JSON. `npm test` passed anyway because `node_modules` was
+ *      already installed, so nothing ever parsed the lockfile. `npm ci` would
+ *      have died on it.
+ *   2. A CHANGELOG entry was inserted INSIDE the release-convention HTML
+ *      comment (a script anchored on the first `## [`, which is the
+ *      `## [X.Y.Z]` placeholder in that comment) — so the entry never
+ *      rendered and the real heading was corrupted.
+ *   3. Version fields drifted between package.json, the lockfile's two
+ *      version slots, and the CHANGELOG's top heading.
+ *
+ * Every one is a five-second mechanical check. That is what this is.
+ *
+ * Usage:  node scripts/preflight.mjs [--fix-hint]
+ * Exit 0 = clean, 1 = at least one finding (each printed with its file).
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+let findings = 0;
+const fail = (file, msg) => { console.error(`  ✗ ${file}: ${msg}`); findings++; };
+const ok = (msg) => console.log(`  ✓ ${msg}`);
+
+/** Tracked files, via git — never walks node_modules or untracked scratch. */
+function trackedFiles() {
+  try {
+    return execFileSync('git', ['ls-files'], { cwd: repoRoot, encoding: 'utf8' })
+      .split('\n').map((s) => s.trim()).filter(Boolean);
+  } catch { return []; }
+}
+
+// ── 1. No unresolved merge-conflict markers ─────────────────────────────────
+// Anchored at line start so prose that merely QUOTES a marker does not trip it
+// — CHANGELOG.md legitimately documents Cline's `<<<<<<< SEARCH` diff fence,
+// and a checker that cried wolf on its own changelog would be turned off.
+{
+  const marker = /^(<{7} |={7}$|>{7} )/m;
+  const skip = /\.(png|jpg|jpeg|gif|ico|pdf|woff2?|zip|gz|mid)$/i;
+  let hits = 0;
+  for (const f of trackedFiles()) {
+    if (skip.test(f)) continue;
+    const p = join(repoRoot, f);
+    if (!existsSync(p)) continue;
+    let text;
+    try { text = readFileSync(p, 'utf8'); } catch { continue; }
+    // A file may hold marker-shaped text on purpose — the resolver's own test
+    // fixtures ARE conflicts. Opting out is explicit and greppable rather than
+    // a path allowlist that silently grows.
+    if (text.includes('preflight:allow-conflict-markers')) continue;
+    if (marker.test(text)) {
+      const line = text.split('\n').findIndex((l) => /^(<{7} |={7}$|>{7} )/.test(l)) + 1;
+      fail(f, `unresolved merge-conflict marker at line ${line}`);
+      hits++;
+    }
+  }
+  if (hits === 0) ok('no merge-conflict markers in tracked files');
+}
+
+// ── 2. Every tracked .json parses ───────────────────────────────────────────
+// The lockfile check that `npm test` skips when node_modules is warm.
+{
+  let bad = 0;
+  for (const f of trackedFiles()) {
+    if (!f.endsWith('.json')) continue;
+    const p = join(repoRoot, f);
+    if (!existsSync(p)) continue;
+    try { JSON.parse(readFileSync(p, 'utf8')); }
+    catch (e) { fail(f, `invalid JSON — ${String(e.message).slice(0, 90)}`); bad++; }
+  }
+  if (bad === 0) ok('every tracked .json parses');
+}
+
+// ── 3. Version agreement: package.json ↔ lockfile (both slots) ──────────────
+let pkgVersion = null;
+{
+  try {
+    const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8'));
+    pkgVersion = pkg.version;
+    const lockPath = join(repoRoot, 'package-lock.json');
+    if (existsSync(lockPath)) {
+      const lock = JSON.parse(readFileSync(lockPath, 'utf8'));
+      const rootV = lock.version;
+      const selfV = lock.packages?.['']?.version;
+      if (rootV !== pkgVersion) fail('package-lock.json', `version ${rootV} ≠ package.json ${pkgVersion}`);
+      else if (selfV !== pkgVersion) fail('package-lock.json', `packages[""].version ${selfV} ≠ package.json ${pkgVersion}`);
+      else ok(`version agrees across package.json + lockfile (${pkgVersion})`);
+    }
+  } catch (e) {
+    fail('package.json', `could not compare versions — ${String(e.message).slice(0, 80)}`);
+  }
+}
+
+// ── 4. CHANGELOG's top release heading is real and matches the version ──────
+// Strips HTML comments FIRST. The release-convention comment contains a
+// literal `## [X.Y.Z] - YYYY-MM-DD` placeholder, and treating that as the top
+// heading is exactly how an entry ended up buried inside the comment.
+{
+  const p = join(repoRoot, 'CHANGELOG.md');
+  if (existsSync(p) && pkgVersion) {
+    const raw = readFileSync(p, 'utf8');
+    const stripped = raw.replace(/<!--[\s\S]*?-->/g, '');
+    const heads = [...stripped.matchAll(/^## \[([^\]]+)\]/gm)].map((m) => m[1]);
+    const firstRelease = heads.find((h) => h !== 'Unreleased');
+    if (!firstRelease) {
+      fail('CHANGELOG.md', 'no release heading found outside the template comment');
+    } else if (firstRelease !== pkgVersion) {
+      fail('CHANGELOG.md', `top release heading [${firstRelease}] ≠ package.json ${pkgVersion}`);
+    } else {
+      ok(`CHANGELOG top heading matches the version ([${firstRelease}])`);
+    }
+    // The defect itself: a REAL release entry sitting inside the HTML comment.
+    // Stripping comments (which the heading check above must do) is precisely
+    // what blinds you to it — the buried entry vanishes from the parse and the
+    // placeholder is still there, so every other check reads clean. So look
+    // inside the comments explicitly for a heading carrying a real version;
+    // `## [X.Y.Z]` and `## [Unreleased]` belong there, a semver never does.
+    for (const c of raw.match(/<!--[\s\S]*?-->/g) || []) {
+      const buried = [...c.matchAll(/^## \[(\d+\.\d+\.\d+)\]/gm)].map((m) => m[1]);
+      if (buried.length) {
+        fail('CHANGELOG.md', `release heading(s) [${buried.join('], [')}] are INSIDE an HTML comment — the entry will not render; an inserter anchored on the \`## [X.Y.Z]\` placeholder instead of the first real heading`);
+      }
+    }
+    // The placeholder must survive intact — if it is gone, something wrote
+    // over the comment.
+    if (!/## \[X\.Y\.Z\] - YYYY-MM-DD/.test(raw)) {
+      fail('CHANGELOG.md', 'the release-convention placeholder `## [X.Y.Z] - YYYY-MM-DD` is missing — an edit likely overwrote the header comment');
+    }
+    // Duplicate release headings mean two entries claimed one version.
+    const rel = heads.filter((h) => h !== 'Unreleased');
+    const dupes = rel.filter((h, i) => rel.indexOf(h) !== i);
+    if (dupes.length) fail('CHANGELOG.md', `duplicate release heading(s): ${[...new Set(dupes)].join(', ')}`);
+  }
+}
+
+console.log('');
+if (findings > 0) {
+  console.error(`preflight: ${findings} finding${findings === 1 ? '' : 's'} — fix before pushing.`);
+  process.exit(1);
+}
+console.log('preflight: clean.');

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -103,15 +103,33 @@ let pkgVersion = null;
 }
 
 // ── 4. CHANGELOG's top release heading is real and matches the version ──────
-// Strips HTML comments FIRST. The release-convention comment contains a
-// literal `## [X.Y.Z] - YYYY-MM-DD` placeholder, and treating that as the top
-// heading is exactly how an entry ended up buried inside the comment.
+// The release-convention comment contains a literal `## [X.Y.Z] - YYYY-MM-DD`
+// placeholder, so a scan that does not know where the comments are will treat
+// that placeholder as the top heading — which is exactly how a real entry
+// ended up buried inside the comment.
+//
+// Comment regions are located by INDEX rather than deleted from the text. The
+// obvious implementation — `raw.replace(/<!--[\s\S]*?-->/g, '')` — is unsafe
+// for a reason that is easy to miss, and CodeQL flags it directly
+// (js/incomplete-multi-character-sanitization): removing one `<!-- ... -->`
+// can leave a bare `<!--` behind from a nested or malformed comment, so the
+// "stripped" text still carries comment syntax and the next scan reads
+// commented-out text as live. That is this very check's own bug, one level up.
+//
+// Indexing sidesteps it: nothing is rewritten, so nothing can be reintroduced,
+// and a single pass classifies every heading as live or buried.
 {
   const p = join(repoRoot, 'CHANGELOG.md');
   if (existsSync(p) && pkgVersion) {
     const raw = readFileSync(p, 'utf8');
-    const stripped = raw.replace(/<!--[\s\S]*?-->/g, '');
-    const heads = [...stripped.matchAll(/^## \[([^\]]+)\]/gm)].map((m) => m[1]);
+    const comments = [...raw.matchAll(/<!--[\s\S]*?-->/g)].map((m) => [m.index, m.index + m[0].length]);
+    const inComment = (i) => comments.some(([a, b]) => i >= a && i < b);
+
+    const heads = [];
+    const buried = [];
+    for (const m of raw.matchAll(/^## \[([^\]]+)\]/gm)) {
+      (inComment(m.index) ? buried : heads).push(m[1]);
+    }
     const firstRelease = heads.find((h) => h !== 'Unreleased');
     if (!firstRelease) {
       fail('CHANGELOG.md', 'no release heading found outside the template comment');
@@ -126,11 +144,9 @@ let pkgVersion = null;
     // placeholder is still there, so every other check reads clean. So look
     // inside the comments explicitly for a heading carrying a real version;
     // `## [X.Y.Z]` and `## [Unreleased]` belong there, a semver never does.
-    for (const c of raw.match(/<!--[\s\S]*?-->/g) || []) {
-      const buried = [...c.matchAll(/^## \[(\d+\.\d+\.\d+)\]/gm)].map((m) => m[1]);
-      if (buried.length) {
-        fail('CHANGELOG.md', `release heading(s) [${buried.join('], [')}] are INSIDE an HTML comment — the entry will not render; an inserter anchored on the \`## [X.Y.Z]\` placeholder instead of the first real heading`);
-      }
+    const buriedReleases = buried.filter((h) => /^\d+\.\d+\.\d+$/.test(h));
+    if (buriedReleases.length) {
+      fail('CHANGELOG.md', `release heading(s) [${buriedReleases.join('], [')}] are INSIDE an HTML comment — the entry will not render; an inserter anchored on the \`## [X.Y.Z]\` placeholder instead of the first real heading`);
     }
     // The placeholder must survive intact — if it is gone, something wrote
     // over the comment.

--- a/scripts/renumber-release-version.mjs
+++ b/scripts/renumber-release-version.mjs
@@ -24,8 +24,11 @@
 // maintainer's head:
 //
 //   version > floor   -> leave everything alone (already advances)
-//   version <= floor  -> set version to bumpPatch(floor), and rename the
-//                        CHANGELOG heading that carried the old version
+//   version <= floor  -> set version to bumpPatch(floor), rename the
+//                        CHANGELOG heading that carried the old version, and
+//                        mirror the new version into package-lock.json's two
+//                        version slots (root and packages[""]) so the three
+//                        files never disagree
 //
 // REFUSES rather than guesses when the CHANGELOG does not carry exactly one
 // heading for the version being replaced. A renumbered package.json whose
@@ -33,13 +36,13 @@
 // ships a release whose notes name a different version.
 //
 // Usage:
-//   node scripts/renumber-release-version.mjs <floor-version> [--pkg P] [--changelog C]
+//   node scripts/renumber-release-version.mjs <floor-version> [--pkg P] [--changelog C] [--lock L]
 //
 // Exit 0 = files are correct for a release above <floor-version>. Prints
 //          "renumbered <before> -> <after>" or "unchanged <version>".
 // Exit 1 = refused; the working tree is left exactly as it was found.
 
-import { readFileSync, writeFileSync, realpathSync } from 'node:fs';
+import { readFileSync, writeFileSync, realpathSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { bumpPatch } from './_drift-patch-helpers.mjs';
@@ -93,7 +96,7 @@ export function isGreater(a, b) {
  * version-advances.sh applies, so the two cannot disagree about what "safe"
  * means.
  */
-export function renumber(pkgJsonString, changelogText, floor) {
+export function renumber(pkgJsonString, changelogText, floor, lockJsonString) {
   const pkg = JSON.parse(pkgJsonString);
   if (typeof pkg.version !== 'string') {
     return { ok: false, reason: 'package.json has no version field' };
@@ -133,7 +136,28 @@ export function renumber(pkgJsonString, changelogText, floor) {
   pkg.version = after;
   const newPkg = restoreEol(JSON.stringify(pkg, null, 2) + '\n', pkgEol);
 
-  return { ok: true, changed: true, before, after, pkg: newPkg, changelog: newChangelog, reason: `${before} -> ${after} (floor ${floor})` };
+  // package-lock.json carries the SAME version twice (root `.version` and
+  // `.packages[""].version`). Renumbering package.json without it leaves the
+  // two disagreeing — real drift, which `npm run preflight` now fails on, so a
+  // healed PR would go red on a defect the healer itself introduced.
+  //
+  // Unlike the CHANGELOG above, this needs no refusal. Those slots are not
+  // independent information: they MIRROR package.json's version by
+  // definition. Writing `after` into them is derivation, not a guess, so
+  // there is nothing here to get wrong by assuming. Slots that are absent are
+  // simply left alone rather than invented.
+  let newLock;
+  if (typeof lockJsonString === 'string' && lockJsonString.length > 0) {
+    const lockEol = detectEol(lockJsonString);
+    const lock = JSON.parse(lockJsonString);
+    if (typeof lock.version === 'string') lock.version = after;
+    if (lock.packages && lock.packages[''] && typeof lock.packages[''].version === 'string') {
+      lock.packages[''].version = after;
+    }
+    newLock = restoreEol(JSON.stringify(lock, null, 2) + '\n', lockEol);
+  }
+
+  return { ok: true, changed: true, before, after, pkg: newPkg, changelog: newChangelog, lock: newLock, reason: `${before} -> ${after} (floor ${floor})` };
 }
 
 export function main(argv) {
@@ -148,10 +172,14 @@ export function main(argv) {
   };
   const pkgPath = flag('--pkg', join(repoRoot, 'package.json'));
   const clPath = flag('--changelog', join(repoRoot, 'CHANGELOG.md'));
+  const lockPath = flag('--lock', join(repoRoot, 'package-lock.json'));
 
   let result;
   try {
-    result = renumber(readFileSync(pkgPath, 'utf-8'), readFileSync(clPath, 'utf-8'), floor);
+    // The lockfile is optional: a checkout without one still renumbers, it
+    // just has no third slot to keep in step.
+    const lockText = existsSync(lockPath) ? readFileSync(lockPath, 'utf-8') : undefined;
+    result = renumber(readFileSync(pkgPath, 'utf-8'), readFileSync(clPath, 'utf-8'), floor, lockText);
   } catch (err) {
     console.error(`[renumber] refused: ${err instanceof Error ? err.message : String(err)}`);
     return 1;
@@ -165,10 +193,12 @@ export function main(argv) {
     console.error(`[renumber] unchanged ${result.before} — ${result.reason}`);
     return 0;
   }
-  // Both writes or neither: a renumbered package.json beside a CHANGELOG still
-  // announcing the old version is the one outcome worse than not running.
+  // All writes or none: a renumbered package.json beside a CHANGELOG still
+  // announcing the old version -- or beside a lockfile still carrying it -- is
+  // the one outcome worse than not running.
   writeFileSync(pkgPath, result.pkg);
   writeFileSync(clPath, result.changelog);
+  if (result.lock !== undefined) writeFileSync(lockPath, result.lock);
   console.error(`[renumber] renumbered ${result.before} -> ${result.after}`);
   return 0;
 }

--- a/scripts/resolve-release-conflicts.mjs
+++ b/scripts/resolve-release-conflicts.mjs
@@ -235,7 +235,7 @@ export function resolveChangelog(text) {
 
 // ── CLI ────────────────────────────────────────────────────────────────────
 
-const HANDLERS = {
+export const HANDLERS = {
   'package.json': resolvePackageJson,
   'package-lock.json': resolvePackageLock,
   'CHANGELOG.md': resolveChangelog,

--- a/scripts/resolve-release-conflicts.mjs
+++ b/scripts/resolve-release-conflicts.mjs
@@ -97,7 +97,7 @@ function versionFromSide(side) {
   return m ? { version: m[1], line: lines[0] } : null;
 }
 
-export function resolvePackageJson(text) {
+function resolveVersionOnlyConflicts(text, label) {
   if (!hasConflicts(text)) return text;
   const eol = detectEol(text);
   const parts = splitConflicts(toLf(text));
@@ -108,7 +108,7 @@ export function resolvePackageJson(text) {
     const a = versionFromSide(p.ours);
     const b = versionFromSide(p.theirs);
     if (!a || !b) {
-      throw new Error('package.json conflict is not a lone "version" line on both sides');
+      throw new Error(label + ' conflict is not a lone "version" line on both sides');
     }
     // Keep the higher version, and keep the LINE from that side so its
     // indentation and trailing comma survive untouched.
@@ -116,6 +116,32 @@ export function resolvePackageJson(text) {
     out += '\n' + winner.line + '\n';
   }
   return restoreEol(out, eol);
+}
+
+export function resolvePackageJson(text) {
+  return resolveVersionOnlyConflicts(text, 'package.json');
+}
+
+/**
+ * package-lock.json carries the SAME version twice (root `.version` and
+ * `.packages[""].version`), each conflicting as its own lone-version hunk, so
+ * the package.json rule applies verbatim — just more than once.
+ *
+ * WHY THIS EXISTS (2026-08-25). The resolver handled package.json and
+ * CHANGELOG.md but not the lockfile, so a release-collision merge left
+ * `<<<<<<<` markers in it and the file stopped being valid JSON. Nothing
+ * downstream caught it: `npm test` passes with a warm node_modules because
+ * nothing parses the lockfile, and drift-pr-heal only `git add`ed the other
+ * two files — it would have "healed" a PR and left this broken. `npm ci` is
+ * where it finally dies, which is CI and deploy.
+ *
+ * Anything richer than a version line (a real dependency-graph conflict)
+ * still THROWS. Regenerating a lockfile is `npm install`'s job, not a
+ * line-merger's; guessing there would produce a plausible tree nobody
+ * verified.
+ */
+export function resolvePackageLock(text) {
+  return resolveVersionOnlyConflicts(text, 'package-lock.json');
 }
 
 // ── CHANGELOG.md ───────────────────────────────────────────────────────────
@@ -211,6 +237,7 @@ export function resolveChangelog(text) {
 
 const HANDLERS = {
   'package.json': resolvePackageJson,
+  'package-lock.json': resolvePackageLock,
   'CHANGELOG.md': resolveChangelog,
 };
 

--- a/test/renumber-release-version.mjs
+++ b/test/renumber-release-version.mjs
@@ -7,7 +7,10 @@
 // claiming a version that has since been published (#1027 bumped 5.5.24 ->
 // 5.5.25 with v5.5.25 already tagged).
 
+import { readFileSync } from 'node:fs';
+
 import { renumber, isGreater, parseVersion } from '../scripts/renumber-release-version.mjs';
+import { HANDLERS } from '../scripts/resolve-release-conflicts.mjs';
 
 let pass = 0, fail = 0;
 function check(name, cond, detail) {
@@ -135,6 +138,83 @@ header('ordering hazard: `before` must be the PR own version, not the base tip')
   check('pre-merge: lands above the base tip', isGreater(right.after, '5.5.31'));
   check('pre-merge: no released heading in the tree to damage',
     !right.changelog.includes('## [5.5.31]'));
+}
+
+
+// ── package-lock.json (2026-08-25) ─────────────────────────────────────────
+// The lockfile carries the version TWICE and renumber did not touch it, so a
+// healed PR ended up with package.json at the new version and the lockfile at
+// the old one. That is exactly the drift `npm run preflight` fails on, which
+// would have made drift-pr-heal produce PRs that go red on a defect the healer
+// itself introduced.
+header('renumber keeps package-lock.json in step');
+{
+  const lockAt = (v) => JSON.stringify({
+    name: '@askalf/dario', version: v, lockfileVersion: 3,
+    packages: { '': { name: '@askalf/dario', version: v, license: 'MIT' } },
+  }, null, 2) + '\n';
+
+  const r = renumber(pkgAt('5.5.10'), clAt('5.5.10'), '5.5.10', lockAt('5.5.10'));
+  check('renumbered', r.ok && r.changed && r.after === '5.5.11', r.reason);
+  const lock = r.lock ? JSON.parse(r.lock) : null;
+  check('lock is returned and valid JSON', lock !== null);
+  check('root .version follows package.json', lock && lock.version === '5.5.11');
+  check('packages[""].version follows too', lock && lock.packages[''].version === '5.5.11');
+  // The invariant preflight asserts: all three files agree.
+  check('all three agree', lock && JSON.parse(r.pkg).version === lock.version
+    && lock.version === lock.packages[''].version);
+  check('unrelated lock fields survive', lock && lock.lockfileVersion === 3 && lock.packages[''].license === 'MIT');
+}
+
+header('renumber without a lockfile still works');
+{
+  // A checkout with no lockfile has no third slot to keep in step; the caller
+  // simply gets no `lock` back rather than a refusal.
+  const r = renumber(pkgAt('5.5.10'), clAt('5.5.10'), '5.5.10');
+  check('still renumbers', r.ok && r.changed && r.after === '5.5.11');
+  check('no lock returned', r.lock === undefined);
+}
+
+header('a no-op renumber does not rewrite the lockfile');
+{
+  const lockAt = (v) => JSON.stringify({ version: v, packages: { '': { version: v } } }, null, 2) + '\n';
+  // Version already advances past the floor -> nothing changes anywhere.
+  const r = renumber(pkgAt('5.5.30'), clAt('5.5.30'), '5.5.27', lockAt('5.5.30'));
+  check('reports unchanged', r.ok && r.changed === false);
+  check('no lock write is proposed', r.lock === undefined);
+}
+
+// ── the workflow allowlist must track the resolver (2026-08-25) ────────────
+// This is the bug the fleet reviewer caught on #1108/#1109/#1110, and it is a
+// SHAPE, not a one-off: `drift-pr-heal.yml` decides whether a conflict is
+// "ours" with its own hardcoded file list, BEFORE calling the resolver. Teach
+// the resolver a new file and forget that list, and the new capability is
+// unreachable — the workflow refuses the merge and never invokes it.
+//
+// Nothing in CI runs drift-pr-heal.yml, so no check could catch the drift
+// between the two lists. Binding them here is what makes it catchable: the
+// test reads the ACTUAL grep pattern out of the workflow and asserts every
+// file the resolver handles survives it.
+header('drift-pr-heal accepts exactly what the resolver can resolve');
+{
+  const wf = readFileSync(new URL('../.github/workflows/drift-pr-heal.yml', import.meta.url), 'utf8');
+  const m = /grep -vxE '([^']+)'/.exec(wf);
+  check('found the allowlist pattern in the workflow', m !== null);
+  if (m) {
+    // -x means whole-line match, so mirror that anchoring exactly.
+    const allow = new RegExp(`^(?:${m[1]})$`);
+    for (const file of Object.keys(HANDLERS)) {
+      check(`${file}: resolver handles it AND the workflow lets it through`, allow.test(file),
+        `workflow pattern /${m[1]}/ would send ${file} to the REFUSED branch`);
+    }
+    // The guard must still refuse what the resolver cannot resolve — a source
+    // conflict (the #1038 shape) has to abort, not get committed half-merged.
+    for (const outside of ['src/pool.ts', 'README.md', 'test/all.test.mjs']) {
+      check(`${outside}: correctly treated as outside`, !allow.test(outside));
+    }
+    // A near-miss that -x exact-matching must not let through.
+    check('a lookalike path is not accepted', !allow.test('packages/package.json'));
+  }
 }
 
 console.log(`\n${pass} pass, ${fail} fail`);

--- a/test/resolve-release-conflicts.mjs
+++ b/test/resolve-release-conflicts.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 // Tests for scripts/resolve-release-conflicts.mjs.
+// preflight:allow-conflict-markers — the fixtures below ARE conflicts.
 //
 // The fixtures are REAL conflicts from 2026-08-12, when four PRs (#952, #955,
 // #960, #961) all had to be hand-resolved in a worktree within a few hours.
@@ -13,7 +14,7 @@
 //     nothing downstream notices.
 
 import {
-  resolvePackageJson, resolveChangelog, compareVersions, parseVersion, hasConflicts,
+  resolvePackageJson, resolvePackageLock, resolveChangelog, compareVersions, parseVersion, hasConflicts,
 } from '../scripts/resolve-release-conflicts.mjs';
 
 let pass = 0, fail = 0;
@@ -250,6 +251,94 @@ header('malformed input is refused, not guessed');
   let threw = false;
   try { resolveChangelog('<<<<<<< HEAD\nunterminated\n'); } catch { threw = true; }
   check('unterminated marker throws', threw);
+}
+
+
+// ── package-lock.json (2026-08-25) ─────────────────────────────────────────
+// The resolver covered package.json and CHANGELOG.md but NOT the lockfile, so
+// a release-collision merge left markers in it and it stopped being valid
+// JSON. Nothing downstream caught that: `npm test` passes with a warm
+// node_modules because nothing parses the lockfile, and drift-pr-heal only
+// `git add`ed the other two files — it would have healed the PR and left this
+// broken. `npm ci` is where it dies, which is CI and deploy.
+header('package-lock.json — the two version slots');
+{
+  // The real shape: root .version and .packages[""].version each conflict as
+  // their own lone-version hunk, so one file carries TWO hunks.
+  const broken = [
+    '{',
+    '  "name": "@askalf/dario",',
+    '<<<<<<< HEAD',
+    '  "version": "5.5.66",',
+    '=======',
+    '  "version": "5.5.65",',
+    '>>>>>>> origin/master',
+    '  "lockfileVersion": 3,',
+    '  "packages": {',
+    '    "": {',
+    '      "name": "@askalf/dario",',
+    '<<<<<<< HEAD',
+    '      "version": "5.5.66",',
+    '=======',
+    '      "version": "5.5.65",',
+    '>>>>>>> origin/master',
+    '      "license": "MIT"',
+    '    }',
+    '  }',
+    '}',
+    '',
+  ].join('\n');
+
+  check('fixture really is conflicted', hasConflicts(broken));
+  const fixed = resolvePackageLock(broken);
+  check('markers are gone', !hasConflicts(fixed));
+
+  // The whole point: the artifact must be parseable again. This is the
+  // assertion that would have caught the 2026-08-25 defect.
+  let parsed = null, parseErr = null;
+  try { parsed = JSON.parse(fixed); } catch (e) { parseErr = e.message; }
+  check('result is valid JSON', parsed !== null, parseErr);
+
+  // Same rule as package.json: keep the HIGHER version. Resolving downward
+  // publishes below an existing tag and the duplicate-tag guard then ships
+  // nothing, green.
+  check('root .version keeps the higher side', parsed && parsed.version === '5.5.66');
+  check('packages[""].version keeps the higher side', parsed && parsed.packages[''].version === '5.5.66');
+  // Both slots must agree — a lockfile whose two versions disagree is the
+  // drift preflight exists to catch.
+  check('both version slots agree', parsed && parsed.version === parsed.packages[''].version);
+  // Untouched content survives verbatim.
+  check('unrelated fields survive', parsed && parsed.lockfileVersion === 3 && parsed.packages[''].license === 'MIT');
+}
+
+header('package-lock.json — refuses what it must not guess');
+{
+  // A genuine dependency-graph conflict is NOT a version bump. Regenerating a
+  // lockfile is `npm install`'s job; a line-merger guessing here would emit a
+  // plausible tree nobody verified.
+  const depConflict = [
+    '{',
+    '  "packages": {',
+    '<<<<<<< HEAD',
+    '    "node_modules/left-pad": { "version": "1.3.0" },',
+    '=======',
+    '    "node_modules/right-pad": { "version": "2.0.0" },',
+    '>>>>>>> origin/master',
+    '    "": { "name": "x" }',
+    '  }',
+    '}',
+    '',
+  ].join('\n');
+  let threw = false, msg = '';
+  try { resolvePackageLock(depConflict); } catch (e) { threw = true; msg = e.message; }
+  check('a dependency conflict throws rather than guessing', threw, msg);
+  check('the error names the file', threw && /package-lock\.json/.test(msg), msg);
+}
+
+header('package-lock.json — no-op safety');
+{
+  const clean = '{\n  "version": "5.5.66"\n}\n';
+  check('a clean lockfile is returned untouched', resolvePackageLock(clean) === clean);
 }
 
 console.log(`\n${pass} pass, ${fail} fail`);


### PR DESCRIPTION
## Why

Four version-bumping PRs were in flight at once on 2026-08-25. Every merge invalidated the others on the same two files, each had to be hand-resolved, and **three separate defects came out of that hand work — none of which any unit test could have failed.**

This closes the two mechanical holes that let them through.

## 1. The resolver never handled `package-lock.json`

`scripts/resolve-release-conflicts.mjs` already existed and already encoded the rule (keep the higher version, never resolve downward — a version below a published tag makes the duplicate-tag guard fast-exit green having shipped nothing). It covered `package.json` and `CHANGELOG.md`.

It did not cover the lockfile. Neither did the healer: `drift-pr-heal.yml` ran `git add package.json CHANGELOG.md`.

Those two gaps **compound**. The healer resolves a PR, leaves the lockfile carrying live `<<<<<<<` markers, and reports success. That file is then invalid JSON — and nothing downstream notices:

- `npm test` passes, because a warm `node_modules` means nothing ever parses the lockfile.
- `npm ci` is where it dies. Which is CI, and deploy.

This is not hypothetical — it happened on #1107, and the reviewer caught it only because it hypothesized exactly this cached-`node_modules` mechanism.

The lockfile carries the same version **twice** (root `.version` and `.packages[""].version`), each conflicting as its own lone-version hunk, so the existing rule applies verbatim — just more than once. `resolvePackageJson` was refactored into a shared `resolveVersionOnlyConflicts(text, label)` and registered for both files.

A genuine dependency-graph conflict still **throws**. Regenerating a lockfile is `npm install`'s job; a line-merger emitting a plausible tree nobody verified is worse than a hand-resolution.

## 2. `npm run preflight`

Four assertions, each one a defect that actually shipped:

| check | the defect it catches |
|---|---|
| no conflict markers in tracked files | markers committed live |
| every tracked `.json` parses | the invalid lockfile above |
| version agrees: `package.json` ↔ **both** lockfile slots ↔ CHANGELOG heading | fields drifting apart mid-collision |
| no release entry inside the CHANGELOG header comment | see below |

That last one is the subtle one. The header comment contains a literal `## [X.Y.Z] - YYYY-MM-DD` placeholder, so an inserter anchoring on the *first* `## [` writes the entry **inside the comment**, where it never renders. And stripping comments before parsing headings — which the version check *must* do — is precisely what blinds you to it: the buried entry vanishes from the parse and the placeholder survives, so every other check reads clean. So it is looked for explicitly.

Two deliberate design calls:

- **Marker detection is line-anchored**, so prose that merely *quotes* a marker does not trip it — `CHANGELOG.md` legitimately documents Cline's `<<<<<<< SEARCH` diff fence, and a checker that cries wolf on its own changelog gets turned off.
- **A file whose content is marker-shaped on purpose opts out** with a greppable `preflight:allow-conflict-markers` sentinel. The resolver's own test fixtures *are* conflicts. A path allowlist would have silently grown instead.

Wired into the existing `validate-package-json` job rather than a new one, so it **adds no required status check** to branch protection — same cheap, no-install class as the two checks already there.

## Verification

Not "it passes" — each check was run against a **reconstruction of the defect it exists to catch**, confirmed to fail, then confirmed to pass once repaired:

- lockfile with conflict markers → caught (marker + invalid-JSON, both)
- lockfile version drifted from `package.json` → caught
- a release heading buried in the header comment → caught

The third reconstruction is worth calling out: my first two attempts at it did **not** trip the checker, because the placeholder sits mid-line inside backticks and my injection never produced a line-start heading. That exposed a real gap in the check, which is why the buried-heading assertion exists at all rather than just the placeholder-intact one.

`npm test`: **144 pass, 0 fail** (10 new lockfile assertions). `npm run lint:pkg` OK. `npm run preflight` clean — it validated this PR's own version bump.
