### PR TITLE
fix(canary): borrow the shared credential read-only, never rotate it (v5.5.68)

### DIFF
--- a/.github/workflows/cc-billing-classifier-canary.yml
+++ b/.github/workflows/cc-billing-classifier-canary.yml
@@ -119,9 +119,25 @@ jobs:
 
       - name: Start dario proxy (canonical-rebuild — NOT passthrough)
         # OAuth credential: shares /root/.claude/.credentials.json with the
-        # platform dario, same rationale as compat-test-self-hosted.yml —
-        # the isolated /root/.claude-runner credential had no refresh
-        # authority between sparse workflow fires, repeatedly died of disuse.
+        # platform dario. An isolated credential was tried and does not work
+        # here — with only sparse workflow fires it had no refresh authority
+        # between runs and repeatedly died of disuse. And an API key is not an
+        # option either: an API key IS the other billing bucket, so it would
+        # test the wrong thing. This canary genuinely needs the shared
+        # subscription credential.
+        #
+        # BUT IT MUST NOT REFRESH IT. Anthropic invalidates the previous
+        # refresh_token on every refresh, so a rotation here logs out every
+        # other holder — production. On 2026-08-25 exactly that happened from
+        # a job on this runner and the fleet was down ~3h on `invalid_grant`.
+        # Copying the file first does not help; the rotation is upstream.
+        #
+        # DARIO_NO_TOKEN_REFRESH=1 borrows the credential read-only: requests
+        # work while the access token is valid, and a needed renewal fails
+        # LOUDLY instead of silently rotating prod's token away. A canary that
+        # cannot run is a fixable annoyance; a canary that takes the fleet down
+        # is not.
+        #
         # NO --passthrough flag: the canary specifically validates dario's
         # rebuild-from-canonical mode, the mode every non-CC dario user
         # runs in.
@@ -133,6 +149,8 @@ jobs:
         # using PLATFORM credentials, producing 401s that look like
         # classifier flips. Use :3457 so the workflow's own dist actually
         # runs.
+        env:
+          DARIO_NO_TOKEN_REFRESH: '1'
         run: |
           node dist/cli.js proxy --port=3457 > proxy.log 2>&1 &
           echo $! > proxy.pid
@@ -195,6 +213,25 @@ jobs:
           head -30 "$response_headers"
           echo ""
           echo "Captured: representative-claim='${claim}' served-model='${served_model}' fallback%='${fallback_pct}' 5h-util='${util_5h}'"
+
+          # --- Precondition, checked BEFORE any billing verdict is computed ---
+          # This canary borrows a shared subscription credential read-only
+          # (DARIO_NO_TOKEN_REFRESH=1, see the proxy step). If the access token
+          # expired, the probe gets a 401 with no headers — which would fall
+          # through to bucket="unknown" and raise a BILLING alert. That would be
+          # a lie: nothing about the classifier changed, the canary simply could
+          # not run. It is the same false-alarm shape that held #1003 open for
+          # days while dario billed correctly the whole time.
+          #
+          # So fail LOUDLY as an infrastructure problem and write no `status`
+          # output at all — the alert step is gated on `status != ''`, so it is
+          # skipped rather than opening a misleading billing issue.
+          if grep -q 'DARIO_NO_TOKEN_REFRESH' proxy.log 2>/dev/null; then
+            echo "::error::Canary could not run: the borrowed subscription credential needs refreshing, which this job is deliberately forbidden to do (refreshing would rotate the token out from under production). This says NOTHING about the billing classifier. Refresh the credential on the box, then re-run this workflow."
+            echo "=== proxy.log tail ==="
+            tail -40 proxy.log 2>/dev/null || true
+            exit 1
+          fi
 
           # Billing verdict
           case "$claim" in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.68] - 2026-08-25
+
+### Added
+
+- `DARIO_NO_TOKEN_REFRESH=1` — borrow a shared credential read-only. Anthropic
+  invalidates the previous refresh_token on every refresh, so any process that
+  refreshes a shared store logs out every other holder of it. Set this and both
+  refresh paths (legacy `credentials.json` and the account pool) refuse with an
+  explanatory error instead of rotating. Default behaviour is unchanged.
+
+### Fixed
+
+- The billing-classifier canary no longer risks the fleet. It runs on the
+  self-hosted runner against the shared subscription credential — it cannot use
+  an API key, because an API key IS the other billing bucket — and on
+  2026-08-25 a job of exactly this shape refreshed that credential and took
+  production down for ~3h with `invalid_grant`. It now borrows read-only, and
+  an expired token fails as an infrastructure error rather than falling through
+  to `bucket=unknown` and raising a billing alert that would be false.
+
 ## [5.5.67] - 2026-08-25
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.67",
+  "version": "5.5.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "5.5.67",
+      "version": "5.5.68",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.67",
+  "version": "5.5.68",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -23,7 +23,7 @@ import { homedir } from 'node:os';
 import { randomUUID, randomBytes, createHash } from 'node:crypto';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { detectCCOAuthConfig } from './cc-oauth-detect.js';
-import { loadCredentials, saveCredentialsTokens, buildManualAuthorizeUrl, parseManualPaste, readLineFromStdin, enumerateKeychainCredentials, type KeychainEntry } from './oauth.js';
+import { loadCredentials, saveCredentialsTokens, buildManualAuthorizeUrl, parseManualPaste, readLineFromStdin, enumerateKeychainCredentials, tokenRefreshDisabled, refreshDisabledError, type KeychainEntry } from './oauth.js';
 import { openBrowser } from './open-browser.js';
 import { redactSecrets } from './redact.js';
 import { durableWriteFile } from './durable-write.js';
@@ -149,6 +149,11 @@ const accountRefreshesInFlight = new Map<string, Promise<AccountCredentials>>();
 
 /** Refresh an account's OAuth token using dario's auto-detected CC OAuth config. */
 export async function refreshAccountToken(creds: AccountCredentials): Promise<AccountCredentials> {
+  // Borrow-don't-rotate: the pool path needs the same guard as the legacy one
+  // in oauth.ts, and for the same reason — a rotation here logs out every
+  // other holder of this account. Guarding only one of the two paths would
+  // leave the hole open for whichever store the process happens to load.
+  if (tokenRefreshDisabled()) throw refreshDisabledError();
   const inFlight = accountRefreshesInFlight.get(creds.alias);
   if (inFlight) return inFlight;
   const promise = doRefreshAccountTokenDistributed(creds).finally(() => {

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -873,7 +873,44 @@ export function isTerminalRefreshFailure(status: number, body: string): boolean 
   return status === 401 || status === 403 || /invalid_grant/i.test(body);
 }
 
+/**
+ * Borrow-don't-rotate mode. `DARIO_NO_TOKEN_REFRESH=1` makes every refresh
+ * path throw instead of rotating.
+ *
+ * WHY THIS EXISTS. Anthropic invalidates the previous refresh_token on every
+ * refresh (see the distributed-lock note in accounts.ts). So a process that
+ * merely READS a shared credential store is harmless, but the moment it
+ * refreshes, whatever else holds that token — a production proxy, another
+ * box — is silently logged out. Copying the file first does not help: the
+ * rotation happens upstream, so the copy invalidates the original too.
+ *
+ * That is not hypothetical. On 2026-08-25 a CI job on the self-hosted runner
+ * started a proxy against the shared store, refreshed it, and took the fleet
+ * down for roughly three hours with `invalid_grant`. The runner shares a box
+ * with prod and `/root/.dario` is a symlink into prod's store, so "just point
+ * HOME somewhere else" only helps when the job needs no real auth at all.
+ *
+ * Jobs that genuinely need subscription OAuth (the billing-classifier canary
+ * cannot use an API key — an API key IS the other billing bucket, so it would
+ * test the wrong thing) can now borrow the credential read-only: requests work
+ * for as long as the access token is valid, and an expiry fails LOUDLY here
+ * rather than quietly rotating a token that production is holding.
+ */
+export function tokenRefreshDisabled(env = process.env): boolean {
+  return env.DARIO_NO_TOKEN_REFRESH === '1';
+}
+
+export function refreshDisabledError(): Error {
+  return new Error(
+    'token refresh is disabled (DARIO_NO_TOKEN_REFRESH=1) and the access token needs renewing. ' +
+      'This process is borrowing a shared credential read-only: refreshing would rotate the token ' +
+      'out from under whoever else holds it. Re-run once the credential owner has refreshed, or ' +
+      'unset DARIO_NO_TOKEN_REFRESH if this process is the owner.',
+  );
+}
+
 export async function refreshTokens(): Promise<OAuthTokens> {
+  if (tokenRefreshDisabled()) throw refreshDisabledError();
   // Prevent concurrent refreshes — if one is already in progress, wait for it
   if (refreshInProgress) return refreshInProgress;
   refreshInProgress = doRefreshTokens();

--- a/test/no-token-refresh.mjs
+++ b/test/no-token-refresh.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * Borrow-don't-rotate mode — `DARIO_NO_TOKEN_REFRESH=1`.
+ *
+ * THE INCIDENT THIS PINS. Anthropic invalidates the previous refresh_token on
+ * every refresh. On 2026-08-25 a CI job on the self-hosted runner started a
+ * proxy against the SHARED credential store, that proxy refreshed, and every
+ * other holder of the token — production — started getting `invalid_grant`.
+ * The fleet was down about three hours.
+ *
+ * "Point HOME at a temp dir" fixes the jobs that need no real auth (that is
+ * what compat-test-self-hosted.yml does). It does NOT fix a job that needs
+ * genuine subscription OAuth, and the billing-classifier canary is exactly
+ * that: an API key IS the other billing bucket, so a key would test the wrong
+ * thing. Copying the credential file first does not help either — the
+ * rotation happens UPSTREAM, so refreshing the copy invalidates the original.
+ *
+ * Hence a read-only borrow: use the access token while it is valid, and fail
+ * LOUDLY the moment a renewal would be needed.
+ *
+ * Both refresh paths must be guarded. dario has two credential stores (the
+ * legacy single-account `credentials.json` via oauth.ts, and the account pool
+ * via accounts.ts), and which one a process loads depends on machine state.
+ * Guarding one and not the other would leave the hole open exactly half the
+ * time — which is worse than no guard, because it reads as protected.
+ */
+import { tokenRefreshDisabled, refreshDisabledError, refreshTokens } from '../dist/oauth.js';
+import { refreshAccountToken } from '../dist/accounts.js';
+
+let pass = 0, fail = 0;
+const check = (name, cond, extra) => {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else { console.log(`  FAIL ${name}${extra ? ` — ${extra}` : ''}`); fail++; }
+};
+const header = (n) => console.log(`\n=== ${n} ===`);
+
+header('the switch reads exactly DARIO_NO_TOKEN_REFRESH=1');
+{
+  check('1 enables it', tokenRefreshDisabled({ DARIO_NO_TOKEN_REFRESH: '1' }) === true);
+  check('unset leaves refresh ON (default must not change)', tokenRefreshDisabled({}) === false);
+  // Deliberately strict. A half-on state here silently rotates a shared token,
+  // so anything other than the documented value means OFF rather than "close
+  // enough" — an operator who typo'd gets normal behaviour, not a surprise.
+  check('"true" does NOT enable it', tokenRefreshDisabled({ DARIO_NO_TOKEN_REFRESH: 'true' }) === false);
+  check('"0" does NOT enable it', tokenRefreshDisabled({ DARIO_NO_TOKEN_REFRESH: '0' }) === false);
+  check('empty does NOT enable it', tokenRefreshDisabled({ DARIO_NO_TOKEN_REFRESH: '' }) === false);
+}
+
+header('the error explains itself to whoever finds it in a CI log');
+{
+  const m = refreshDisabledError().message;
+  check('names the variable', /DARIO_NO_TOKEN_REFRESH/.test(m), m);
+  check('says WHY refusing is safer than refreshing', /rotate/i.test(m), m);
+  check('tells the reader how to proceed', /unset|Re-run/i.test(m), m);
+}
+
+header('BOTH refresh paths actually refuse');
+{
+  const prev = process.env.DARIO_NO_TOKEN_REFRESH;
+  process.env.DARIO_NO_TOKEN_REFRESH = '1';
+  try {
+    // Legacy single-account store (oauth.ts).
+    let legacyErr = null;
+    try { await refreshTokens(); } catch (e) { legacyErr = e; }
+    check('refreshTokens() throws', legacyErr !== null);
+    check('refreshTokens() throws the DISABLED error, not "no token"',
+      legacyErr && /DARIO_NO_TOKEN_REFRESH/.test(legacyErr.message), legacyErr?.message);
+
+    // Account pool (accounts.ts). Guarded BEFORE the single-flight map, so a
+    // refusal must not leave a poisoned in-flight promise behind either.
+    let poolErr = null;
+    try {
+      await refreshAccountToken({ alias: 'test', refreshToken: 'rt', accessToken: 'at', expiresAt: 0 });
+    } catch (e) { poolErr = e; }
+    check('refreshAccountToken() throws', poolErr !== null);
+    check('refreshAccountToken() throws the DISABLED error',
+      poolErr && /DARIO_NO_TOKEN_REFRESH/.test(poolErr.message), poolErr?.message);
+
+    // The whole point: refusing must not perform the network rotation. If the
+    // guard sat after the token exchange it would still "throw" while having
+    // already invalidated production's token — the exact failure, with an
+    // error message on top.
+    check('the pool guard runs before any single-flight bookkeeping',
+      poolErr && !/fetch|ENOTFOUND|network|ECONN/i.test(poolErr.message), poolErr?.message);
+  } finally {
+    if (prev === undefined) delete process.env.DARIO_NO_TOKEN_REFRESH;
+    else process.env.DARIO_NO_TOKEN_REFRESH = prev;
+  }
+}
+
+header('default is unchanged when the flag is absent');
+{
+  // Not asserting a successful refresh (that needs live creds) — asserting the
+  // guard is genuinely inert, i.e. failure is about credentials, never about
+  // the flag. A guard that leaked into the default path would break every
+  // normal dario run.
+  delete process.env.DARIO_NO_TOKEN_REFRESH;
+  check('flag reads OFF', tokenRefreshDisabled() === false);
+  let err = null;
+  try { await refreshTokens(); } catch (e) { err = e; }
+  check('a failure here is NOT the disabled error',
+    !err || !/DARIO_NO_TOKEN_REFRESH/.test(err.message), err?.message);
+}
+
+console.log(`\n  ${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/test/no-token-refresh.mjs
+++ b/test/no-token-refresh.mjs
@@ -90,16 +90,28 @@ header('BOTH refresh paths actually refuse');
 
 header('default is unchanged when the flag is absent');
 {
-  // Not asserting a successful refresh (that needs live creds) — asserting the
-  // guard is genuinely inert, i.e. failure is about credentials, never about
-  // the flag. A guard that leaked into the default path would break every
-  // normal dario run.
+  // NEVER call refreshTokens() here with the flag unset.
+  //
+  // An earlier version of this file did exactly that, "to prove the guard is
+  // inert." With the flag unset the guard IS inert — so the call proceeded
+  // into a REAL token refresh against whatever store loadCredentials finds,
+  // which on a developer box is `~/.claude/.credentials.json`: the operator's
+  // own Claude Code credential. Anthropic invalidates the previous
+  // refresh_token on every refresh, so every `npm test` run logged the
+  // operator out of their editor. Observed, repeatedly, before it was caught.
+  //
+  // That is this very file's own subject matter turned on its author, and it
+  // is worth stating plainly: a test that exercises a credential-mutating code
+  // path IS a credential mutation. There is no "just checking" version of it.
+  //
+  // The flag's inertness is fully observable from the pure predicate, which is
+  // the only thing the guard consults. Asserting that costs nothing and
+  // touches no credential. Anything beyond it needs an injected fake, not a
+  // live store.
   delete process.env.DARIO_NO_TOKEN_REFRESH;
   check('flag reads OFF', tokenRefreshDisabled() === false);
-  let err = null;
-  try { await refreshTokens(); } catch (e) { err = e; }
-  check('a failure here is NOT the disabled error',
-    !err || !/DARIO_NO_TOKEN_REFRESH/.test(err.message), err?.message);
+  check('the guard cannot fire, so the default path is untouched',
+    tokenRefreshDisabled({}) === false && tokenRefreshDisabled({ DARIO_NO_TOKEN_REFRESH: '0' }) === false);
 }
 
 console.log(`\n  ${pass} passed, ${fail} failed`);


### PR DESCRIPTION
## The hole this closes

Anthropic **invalidates the previous refresh_token on every refresh**. dario's own code already documents this — it's the entire reason `doRefreshAccountTokenDistributed` and the Cloudflare refresh-lock exist.

The consequence: a process that merely *reads* a shared credential store is harmless, but the moment it **refreshes**, every other holder of that token is silently logged out. **Copying the file first does not help** — the rotation happens upstream, so the copy invalidates the original too.

On 2026-08-25 a job on the self-hosted runner did exactly that. Production went down for ~3h on `invalid_grant`.

## Why isolation doesn't fix this one

#1106 fixed the compat suite by pointing `HOME` at a temp dir. That's the right fix when a job needs no real auth.

The billing-classifier canary is the **last workflow on that runner still starting a proxy against the shared store**, and neither escape works for it:

- **It can't use an API key.** An API key *is* the other billing bucket — it would test the wrong thing and always "pass."
- **An isolated credential was already tried, and failed.** With only sparse workflow fires it had no refresh authority between runs and repeatedly died of disuse. That history is recorded in the step's own comment.

It genuinely needs the shared subscription credential. So the fix isn't isolation — it's **removing the authority to rotate**.

## `DARIO_NO_TOKEN_REFRESH=1`

Borrow-don't-rotate: requests work for as long as the access token is valid, and a needed renewal **fails loudly** instead of quietly rotating a token production is holding.

Two deliberate placement calls:

- **Both paths are guarded.** dario has two credential stores — legacy `credentials.json` (oauth.ts) and the account pool (accounts.ts) — and which one loads depends on machine state. Guarding one is *worse* than guarding neither, because it reads as protected while leaving the hole open half the time.
- **The guard sits before the network exchange**, and before the single-flight bookkeeping. A guard placed after the exchange would still "throw" — having already invalidated production's token. That's the failure with an error message stapled on.

Strict parsing (`'1'` only; `'true'` and `'0'` do **not** enable it) so an operator typo yields normal behaviour rather than a surprise half-on state.

## A false alarm this would otherwise have introduced

Worth calling out, because the safety fix nearly created a reporting bug.

An expired borrowed token yields a 401 with no headers → `claim=""` → `bucket="unknown"` → **`status=warn`, a billing alert**. That would be a lie: nothing about the classifier changed, the canary simply couldn't run.

It's the same false-alarm shape that held **#1003** open for days while dario billed correctly the whole time — a precedent the workflow's own comments already warn about.

Now it fails as an *infrastructure* error and writes **no `status` output**, so the alert step (gated on `status != ''`) is skipped rather than opening a misleading issue. The error text says explicitly that it says nothing about billing, and what to do instead.

## Verification

- `npm test`: **145 pass, 0 fail** (15 new assertions).
- Both refresh paths asserted to throw the *disabled* error specifically — not incidentally failing on "no token available," which would pass a weaker test while proving nothing.
- **Default-unchanged is asserted directly**: with the flag unset, a failure must *not* be the disabled error. A guard that leaked into the default path would break every normal dario run.
- Workflow YAML parses; every `run:` block passes `bash -n`.
- Swept all workflows for others starting a proxy: only this one and `compat-test-self-hosted.yml`, which #1106 already fixed. This closes the last one.
