### PR TITLE
feat(watch): alert when the box is not running what was released (v5.5.69)

### DIFF
--- a/.github/workflows/deployed-version-watch.yml
+++ b/.github/workflows/deployed-version-watch.yml
@@ -1,0 +1,159 @@
+name: Deployed version watch (self-hosted)
+
+# Is what's RUNNING what we last RELEASED?
+#
+# THE GAP. cc-drift-auto-release.yml's idempotency gate already proves the
+# artifacts exist — the git tag, the npm version, the ghcr image. Nothing
+# checked the last leg: that the box actually pulled the image and is running
+# it. Publishing is not deploying, and that leg has failed silently before
+# (dario's refresh-lock `lockId` code sat released-but-not-live on the CF
+# Worker while every status surface read green, because each was reporting on
+# a different link in the chain and no single link is the deployment).
+#
+# WHY THE HEALTH WATCHER CANNOT COVER THIS. cc-oauth-health.yml probes the
+# running container and asks "are you serving?". A container running a stale
+# version answers yes — truthfully. Healthy and current are different
+# questions and only one of them was being asked.
+#
+# DIVISION OF LABOUR. If the container is down or its version is unreadable,
+# this workflow stays SILENT: cc-oauth-health.yml owns container-down and
+# already files that alert with the right diagnostics. Two watchers filing
+# separate issues for one outage just doubles the noise on the worst day.
+#
+# The verdict itself lives in scripts/deploy-verdict.mjs and is unit-tested
+# (test/deploy-verdict.mjs), because this logic only runs for real when a
+# deploy is stuck — i.e. exactly when nobody is watching. A watcher's failure
+# mode is not a crash, it is quietly reporting "aligned" forever.
+
+on:
+  schedule:
+    # Hourly, offset off the :00 rush. A stuck deploy is not urgent to the
+    # minute — it is urgent that it is noticed at all rather than sitting for
+    # days.
+    - cron: '27 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dario-deployed-version
+  cancel-in-progress: false
+
+jobs:
+  check:
+    permissions:
+      contents: read
+      issues: write
+    # Never from a fork: meaningless anywhere but this repository, and the
+    # forks inherit the schedule (see #1039).
+    if: github.repository == 'askalf/dario'
+    runs-on: [self-hosted, dario-drift]
+    timeout-minutes: 5
+    steps:
+      - uses: askalf/checkout-with-retry@115a6407547e9711edbc2e915838d495cad9583f  # v1.1.0
+
+      - name: Compare deployed version against the latest release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          # A release legitimately takes time to reach the box (multi-arch
+          # build, ghcr push, pull). Alerting the instant a tag appears would
+          # page on every single release, so this is what makes it a
+          # deploy-STUCK detector rather than a deploy-in-progress detector.
+          GRACE_MINUTES: '90'
+        run: |
+          set -uo pipefail
+
+          # The container's own package.json is the ground truth for what is
+          # RUNNING. Not the image tag: `:latest` is a moving label that says
+          # nothing about which build is actually resident.
+          deployed="$(docker exec askalf-dario node -e 'console.log(require("/app/package.json").version)' 2>/dev/null | tr -d '\r\n[:space:]' || true)"
+
+          released="$(gh release view --repo "$REPO" --json tagName --jq .tagName 2>/dev/null || true)"
+          published="$(gh release view --repo "$REPO" --json publishedAt --jq .publishedAt 2>/dev/null || true)"
+
+          age_ms=0
+          if [ -n "$published" ]; then
+            then_s="$(date -u -d "$published" +%s 2>/dev/null || echo 0)"
+            now_s="$(date -u +%s)"
+            if [ "$then_s" -gt 0 ]; then age_ms=$(( (now_s - then_s) * 1000 )); fi
+          fi
+
+          echo "deployed=${deployed:-<unreadable>} released=${released:-<unreadable>} release_age_min=$(( age_ms / 60000 ))"
+
+          verdict="$(DEPLOYED="$deployed" RELEASED="$released" AGE_MS="$age_ms" GRACE_MIN="$GRACE_MINUTES" \
+            node -e '
+              import("./scripts/deploy-verdict.mjs").then(({ deployVerdict }) => {
+                const r = deployVerdict({
+                  deployed: process.env.DEPLOYED,
+                  released: process.env.RELEASED,
+                  releaseAgeMs: Number(process.env.AGE_MS),
+                  graceMs: Number(process.env.GRACE_MIN) * 60000,
+                });
+                console.log(r.state);
+                console.log(r.alert ? "1" : "0");
+                console.log(r.summary);
+              }).catch((e) => { console.log("error"); console.log("0"); console.log(String(e && e.message)); });
+            ')"
+
+          state="$(printf '%s\n' "$verdict" | sed -n '1p')"
+          alert="$(printf '%s\n' "$verdict" | sed -n '2p')"
+          summary="$(printf '%s\n' "$verdict" | sed -n '3p')"
+          echo "verdict: $state — $summary"
+
+          gh label create dario-deploy-stuck --repo "$REPO" --color D93F0B \
+            --description "Released but not deployed on the box" --force >/dev/null 2>&1 || true
+          existing="$(gh issue list --repo "$REPO" --label dario-deploy-stuck --state open \
+            --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+
+          if [ "$alert" != "1" ]; then
+            if [ -n "$existing" ]; then
+              gh issue close "$existing" --repo "$REPO" \
+                --comment "✅ Recovered — $summary ($(date -Iseconds))."
+              echo "closed #$existing (recovered)"
+            else
+              echo "OK — $state, no alert."
+            fi
+            exit 0
+          fi
+
+          if [ -n "$existing" ]; then
+            echo "$state — alert #$existing already open, leaving it."
+            exit 0
+          fi
+
+          image="$(docker inspect --format '{{.Config.Image}}' askalf-dario 2>/dev/null || echo '?')"
+          created="$(docker inspect --format '{{.Created}}' askalf-dario 2>/dev/null || echo '?')"
+
+          tmp="$(mktemp)"
+          {
+            echo "**The box is not running what was released.** $summary"
+            echo
+            echo "The release pipeline's own gate only proves the tag, the npm version and the ghcr image exist. It does not prove the box pulled them — and \`cc-oauth-health.yml\` cannot catch this either, because a container running a stale version still answers \"serving\" truthfully."
+            echo
+            echo "| field | value |"
+            echo "|---|---|"
+            echo "| state | \`$state\` |"
+            echo "| deployed | \`${deployed:-<unreadable>}\` |"
+            echo "| latest release | \`${released:-<unreadable>}\` |"
+            echo "| release age | $(( age_ms / 60000 )) min |"
+            echo "| image | \`$image\` |"
+            echo "| container created | \`$created\` |"
+            echo
+            echo "**Recover:** pull and recreate on the box —"
+            echo '```sh'
+            echo "docker pull $image"
+            echo "docker compose -f /opt/askalf/compose.selfhosted.yml up -d askalf-dario"
+            echo '```'
+            echo
+            echo "Then confirm the ARTIFACT, not the exit code: \`docker exec askalf-dario node -e 'console.log(require(\"/app/package.json\").version)'\`"
+            echo
+            echo "If the image itself is missing from ghcr, the release run's docker leg failed — re-run \`cc-drift-auto-release.yml\`; its idempotency gate skips the legs that already succeeded."
+            echo
+            echo "_Auto-filed by \`deployed-version-watch.yml\` on the self-hosted runner._"
+          } > "$tmp"
+
+          gh issue create --repo "$REPO" --label dario-deploy-stuck \
+            --title "🟠 dario released $released but box runs ${deployed:-?} — deploy stuck" --body-file "$tmp"
+          echo "filed deploy-stuck alert"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.69] - 2026-08-25
+
+### Added
+
+- `deployed-version-watch.yml` — alerts when the box is not running what was
+  released. The release pipeline already proves the tag, the npm version and
+  the ghcr image exist; nothing proved the box pulled them. `cc-oauth-health`
+  cannot cover it either — a container on a stale version still answers
+  "serving", truthfully. Healthy and current are different questions.
+  A 90-minute grace window keeps it a deploy-STUCK detector rather than a
+  deploy-in-progress one, and it stays silent when the container is
+  unreadable so it never double-files against the health watcher.
+
 ## [5.5.68] - 2026-08-25
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.68",
+  "version": "5.5.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "5.5.68",
+      "version": "5.5.69",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.68",
+  "version": "5.5.69",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/scripts/deploy-verdict.mjs
+++ b/scripts/deploy-verdict.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * Is what's RUNNING what we last RELEASED?
+ *
+ * THE GAP THIS FILLS. The release pipeline's idempotency gate already proves
+ * the artifacts exist: the git tag, the npm version, the ghcr image. What
+ * nothing checked is the last leg — that the box actually pulled the image and
+ * is running it. Publishing is not deploying.
+ *
+ * That leg has failed before and stayed failed silently: dario's refresh-lock
+ * `lockId` code sat released-but-not-live on the Cloudflare Worker. Every
+ * status surface read green the whole time, because each was reporting on a
+ * different link in the chain and no one link is the deployment.
+ *
+ * And the existing health watcher cannot see it BY DESIGN. It probes the
+ * running container and asks "are you serving?" — a container running a stale
+ * version answers yes, truthfully. Healthy and current are different
+ * questions, and only one of them was being asked.
+ *
+ * WHY A GRACE PERIOD. A release legitimately takes time to reach the box:
+ * multi-arch build, ghcr push, then the pull. Alerting the instant a tag
+ * appears would page on every single release. The grace window is what makes
+ * this a deploy-stuck detector rather than a deploy-in-progress detector.
+ *
+ * Pure and dependency-free so it is unit-testable (test/deploy-verdict.mjs).
+ * A watcher whose parsing silently stops matching reports "aligned" forever —
+ * that has to be provable without cutting a real release to find out.
+ */
+
+/** Parse "v5.5.66" / "5.5.66" -> [5,5,66]; null when not X.Y.Z. */
+export function parseVersion(v) {
+  const m = /^v?(\d+)\.(\d+)\.(\d+)$/.exec(String(v ?? '').trim());
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+
+export function compareVersions(a, b) {
+  const pa = parseVersion(a), pb = parseVersion(b);
+  if (!pa || !pb) return null;
+  for (let i = 0; i < 3; i++) if (pa[i] !== pb[i]) return pa[i] < pb[i] ? -1 : 1;
+  return 0;
+}
+
+/**
+ * @param {object} o
+ * @param {string|null} o.deployed        version the container reports, null/'' if unreadable
+ * @param {string|null} o.released        latest release tag
+ * @param {number}      o.releaseAgeMs    how long ago that release was cut
+ * @param {number}      o.graceMs         how long a deploy is allowed to take
+ * @returns {{state:string, alert:boolean, summary:string}}
+ *
+ * States:
+ *   aligned      deployed === released
+ *   deploying    behind, but the release is still inside the grace window
+ *   stuck        behind, and the grace window has passed        -> ALERT
+ *   ahead        deployed > released                            -> ALERT
+ *   unreadable   could not read the container's version         -> no alert
+ */
+export function deployVerdict({ deployed, released, releaseAgeMs, graceMs }) {
+  const dep = (deployed ?? '').trim();
+  const rel = (released ?? '').trim();
+
+  // Deliberately NOT an alert. The health watcher owns "container down" and
+  // already alerts on it with the right diagnostics; a second workflow filing
+  // its own issue for the same event just doubles the noise on the worst day.
+  // Silence here is not a blind spot — it is the other watcher's job.
+  if (!dep || !parseVersion(dep)) {
+    return { state: 'unreadable', alert: false, summary: `could not read the deployed version (got ${JSON.stringify(deployed ?? null)}) — the health watcher owns container-down alerting` };
+  }
+  if (!rel || !parseVersion(rel)) {
+    return { state: 'unreadable', alert: false, summary: `could not read the latest release (got ${JSON.stringify(released ?? null)})` };
+  }
+
+  const cmp = compareVersions(dep, rel);
+  if (cmp === 0) return { state: 'aligned', alert: false, summary: `deployed ${dep} === released ${rel}` };
+
+  if (cmp > 0) {
+    // The box is running something never released. Usually a hand-built image
+    // or an aborted rollback — either way the running code is not the code in
+    // the tag, which is the invariant this watcher exists to hold.
+    return { state: 'ahead', alert: true, summary: `deployed ${dep} is NEWER than the latest release ${rel} — the box is running code that was never released` };
+  }
+
+  const mins = Math.round(releaseAgeMs / 60000);
+  if (releaseAgeMs < graceMs) {
+    return { state: 'deploying', alert: false, summary: `deployed ${dep} behind released ${rel}, but that release is only ${mins}m old — inside the ${Math.round(graceMs / 60000)}m deploy window` };
+  }
+  return { state: 'stuck', alert: true, summary: `deployed ${dep} is BEHIND released ${rel}, and that release is ${mins}m old — past the ${Math.round(graceMs / 60000)}m deploy window` };
+}

--- a/test/deploy-verdict.mjs
+++ b/test/deploy-verdict.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for the released-vs-deployed verdict.
+ *
+ * This logic is only ever exercised for real when a deploy is stuck — i.e.
+ * exactly when nobody is watching and the answer matters most. So it is pinned
+ * here rather than discovered in production. The failure mode of a watcher is
+ * not a crash; it is quietly reporting "aligned" forever.
+ */
+import { deployVerdict, parseVersion, compareVersions } from '../scripts/deploy-verdict.mjs';
+
+let pass = 0, fail = 0;
+const check = (name, cond, extra) => {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else { console.log(`  FAIL ${name}${extra ? ` — ${extra}` : ''}`); fail++; }
+};
+const header = (n) => console.log(`\n=== ${n} ===`);
+
+const MIN = 60_000;
+const GRACE = 90 * MIN;
+const v = (o) => deployVerdict({ graceMs: GRACE, ...o });
+
+header('version parsing tolerates the tag/package split');
+{
+  // Releases are tagged `v5.5.66`; the container reports `5.5.66`. Comparing
+  // them raw would make every aligned deploy look mismatched.
+  check('a v-prefixed tag parses', JSON.stringify(parseVersion('v5.5.66')) === '[5,5,66]');
+  check('a bare version parses', JSON.stringify(parseVersion('5.5.66')) === '[5,5,66]');
+  check('they compare equal', compareVersions('5.5.66', 'v5.5.66') === 0);
+  check('junk is null, not 0', parseVersion('latest') === null);
+  check('numeric compare, not lexical (5.5.9 < 5.5.66)', compareVersions('5.5.9', '5.5.66') === -1);
+}
+
+header('aligned');
+{
+  const r = v({ deployed: '5.5.66', released: 'v5.5.66', releaseAgeMs: 5 * MIN });
+  check('state', r.state === 'aligned', r.state);
+  check('does not alert', r.alert === false);
+}
+
+header('a deploy in flight must NOT page');
+{
+  // The common case: a release was just cut and the box has not pulled yet.
+  // Alerting here would page on literally every release.
+  const r = v({ deployed: '5.5.65', released: 'v5.5.66', releaseAgeMs: 4 * MIN });
+  check('state is deploying', r.state === 'deploying', r.state);
+  check('does not alert', r.alert === false);
+  check('summary says why it is being patient', /window/.test(r.summary), r.summary);
+}
+
+header('a deploy that never landed MUST page');
+{
+  const r = v({ deployed: '5.5.65', released: 'v5.5.66', releaseAgeMs: 5 * 60 * MIN });
+  check('state is stuck', r.state === 'stuck', r.state);
+  check('alerts', r.alert === true);
+  check('summary names both versions', /5\.5\.65/.test(r.summary) && /5\.5\.66/.test(r.summary), r.summary);
+}
+
+header('the grace boundary is exact');
+{
+  check('one ms inside the window is still deploying',
+    v({ deployed: '5.5.65', released: 'v5.5.66', releaseAgeMs: GRACE - 1 }).state === 'deploying');
+  check('exactly at the window is stuck (not off-by-one into silence)',
+    v({ deployed: '5.5.65', released: 'v5.5.66', releaseAgeMs: GRACE }).state === 'stuck');
+}
+
+header('running something that was never released');
+{
+  // A hand-built image or an aborted rollback. The tag no longer describes
+  // what is running, which is the whole invariant.
+  const r = v({ deployed: '5.6.0', released: 'v5.5.66', releaseAgeMs: 10 * 60 * MIN });
+  check('state is ahead', r.state === 'ahead', r.state);
+  check('alerts regardless of grace', r.alert === true);
+  check('a fresh release does not excuse it',
+    v({ deployed: '5.6.0', released: 'v5.5.66', releaseAgeMs: 1 * MIN }).alert === true);
+}
+
+header('unreadable input never alerts — the health watcher owns container-down');
+{
+  // Two watchers filing separate issues for one outage doubles the noise on
+  // the worst possible day. Silence here is a division of labour, not a gap.
+  for (const bad of [null, '', '   ', 'latest', 'unknown']) {
+    const r = v({ deployed: bad, released: 'v5.5.66', releaseAgeMs: 10 * 60 * MIN });
+    check(`deployed=${JSON.stringify(bad)} -> unreadable, no alert`, r.state === 'unreadable' && r.alert === false, r.state);
+  }
+  const r = v({ deployed: '5.5.66', released: null, releaseAgeMs: 10 * 60 * MIN });
+  check('unreadable release -> no alert', r.state === 'unreadable' && r.alert === false, r.state);
+}
+
+header('every verdict explains itself');
+{
+  // These strings land in a GH issue that someone reads at 3am.
+  for (const c of [
+    { deployed: '5.5.66', released: 'v5.5.66', releaseAgeMs: MIN },
+    { deployed: '5.5.65', released: 'v5.5.66', releaseAgeMs: MIN },
+    { deployed: '5.5.65', released: 'v5.5.66', releaseAgeMs: 500 * MIN },
+    { deployed: '5.6.0', released: 'v5.5.66', releaseAgeMs: MIN },
+    { deployed: '', released: 'v5.5.66', releaseAgeMs: MIN },
+  ]) {
+    const r = v(c);
+    check(`${r.state}: summary is non-empty`, typeof r.summary === 'string' && r.summary.length > 10, r.summary);
+  }
+}
+
+console.log(`\n  ${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
> Stacked on #1108 and #1109. Reviewable now; merge after those.

## The gap

`cc-drift-auto-release.yml`'s idempotency gate already proves the **artifacts** exist — the git tag, the npm version, the ghcr image.

Nothing proved the last leg: **that the box actually pulled them and is running them.** Publishing is not deploying.

That leg has failed silently before — dario's refresh-lock `lockId` code sat released-but-not-live on the Cloudflare Worker while every status surface read green. Each surface was reporting on a different link in the chain, and no single link *is* the deployment.

## Why the health watcher can't cover it

`cc-oauth-health.yml` is a genuinely good watcher — its axis 2 makes a real `max_tokens:1` request, which is why it caught today's outage in minutes (#1103, opened 11:35Z, auto-closed on recovery at 14:40Z).

But it probes the running container and asks *"are you serving?"* — and **a container running a stale version answers yes, truthfully.** Healthy and current are different questions, and only one of them was being asked.

## Design calls

- **90-minute grace window.** A release legitimately takes time to reach the box (multi-arch build → ghcr push → pull). Alerting the instant a tag appears would page on *every* release. The window is what makes this a deploy-**stuck** detector rather than a deploy-in-progress one.
- **Silent when the container is unreadable.** `cc-oauth-health.yml` owns container-down and files that alert with the right diagnostics. Two watchers filing separate issues for one outage doubles the noise on the worst possible day. Silence here is division of labour, not a blind spot.
- **`ahead` alerts regardless of grace.** Running something never released (hand-built image, aborted rollback) means the tag no longer describes what's running — that's the invariant.
- **The container's own `package.json` is the source of truth**, not the image tag. `:latest` is a moving label that says nothing about which build is resident.

## Verification

Verdict logic is a pure, unit-tested module rather than inline shell, because it only runs for real when a deploy is stuck — i.e. exactly when nobody is watching. **A watcher's failure mode isn't a crash; it's quietly reporting "aligned" forever.**

Driven through **the exact node invocation the workflow uses**, against the box's real state:

| scenario | result |
|---|---|
| real box: deployed `5.5.66`, released `v5.5.66` | `aligned`, no alert |
| behind, release 23m old | `deploying`, no alert |
| behind, release 300m old | `stuck`, **alert** |
| ahead of the latest release | `ahead`, **alert** |
| container unreadable | `unreadable`, no alert |

The aligned case also exercises the tag/package version split (`v5.5.66` vs `5.5.66`) — compared naively, that would make every correctly-deployed box look broken.

`npm test`: **146 pass, 0 fail** (29 new). `npm run preflight` clean.
