### PR TITLE
fix(ci): pin the OAuth credential in wire-drift too (v5.5.70)

### DIFF
--- a/.github/workflows/wire-drift-self-hosted.yml
+++ b/.github/workflows/wire-drift-self-hosted.yml
@@ -73,6 +73,35 @@ jobs:
           npm ci --no-audit --no-fund
           npm run build
 
+      - name: Pin OAuth credential to platform-dario canonical
+        # This job spawns `claude` on the box, and `claude` shares
+        # /root/.claude/.credentials.json with the platform dario container.
+        # Every OTHER self-hosted workflow that runs CC re-pins that path to the
+        # container's canonical store first; this one did not. Two files in one
+        # refresh-token family rotate each other to death via Anthropic's
+        # reuse detection — that is the 2026-06-23 fleet outage.
+        #
+        # The split is neither hypothetical nor a one-off: found again on
+        # 2026-08-25 (a REGULAR file at inode 290627 beside canonical 290583),
+        # alongside saved stubs from 2026-07-17, 07-18 and 08-02. Notably the
+        # clobbering file is an EMPTIED credential — accessToken "",
+        # refreshToken "", expiresAt 0, scopes intact — so something writes a
+        # blank credential on auth failure rather than CC refreshing over the
+        # link, which is what the runbook had assumed. Whatever the writer is,
+        # re-pinning before use is the cheap guard, and it is exactly what
+        # cc-billing-classifier-canary.yml and cc-drift-template-watch.yml
+        # already do.
+        run: |
+          CANON=/var/lib/askalf-dario/credentials.json
+          if [ -e "$CANON" ]; then
+            mkdir -p /root/.claude /root/.dario
+            ln -sfn "$CANON" /root/.claude/.credentials.json
+            ln -sfn "$CANON" /root/.dario/credentials.json
+            echo "pinned runner OAuth credential -> $CANON (inode $(stat -L -c %i "$CANON"))"
+          else
+            echo "::warning::canonical $CANON missing — platform dario down? proceeding as-is"
+          fi
+
       - name: Report claude version
         run: claude --version || echo "::warning::claude not on PATH — the wire-drift check will report a high-severity 'capture' finding"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.70] - 2026-08-25
+
+### Fixed
+
+- `wire-drift-self-hosted.yml` now pins the runner OAuth credential to the
+  container canonical before spawning `claude`, matching every other
+  self-hosted CC workflow. It was the one that did not, and a split credential
+  family is the 2026-06-23 fleet-outage root cause: two files carrying one
+  refresh-token family rotate each other to death via Anthropic's reuse
+  detection.
+
+  Found split again on 2026-08-25 — a regular file at inode 290627 beside
+  canonical 290583 — alongside saved stubs from 07-17, 07-18 and 08-02, so it
+  recurs. Notably the clobbering file is an EMPTIED credential (accessToken
+  `""`, refreshToken `""`, expiresAt `0`, scopes intact), which means the
+  writer blanks it on auth failure rather than CC refreshing over the symlink
+  as the runbook assumed. The writer is still unidentified; re-pinning before
+  use is the cheap guard regardless, and is what the canary and template-watch
+  already do.
+
 ## [5.5.69] - 2026-08-25
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.69",
+  "version": "5.5.70",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "5.5.69",
+      "version": "5.5.70",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.69",
+  "version": "5.5.70",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## The gap

`wire-drift-self-hosted.yml` spawns `claude` on the box, and `claude` shares `/root/.claude/.credentials.json` with the platform dario container.

**Every other self-hosted workflow that runs CC re-pins that path to the container's canonical store first.** This one didn't:

| workflow | runs CC | re-pins first |
|---|---|---|
| `cc-billing-classifier-canary.yml` | ✅ | ✅ |
| `cc-drift-template-watch.yml` | ✅ | ✅ |
| `compat-test-self-hosted.yml` | ✅ | isolated `HOME` (#1106) |
| `wire-drift-self-hosted.yml` | ✅ | ❌ **this PR** |

A split credential family is the **2026-06-23 fleet outage**: two files carrying one refresh-token family rotate each other to death via Anthropic's reuse detection.

## It recurs

Not hypothetical, not a one-off. Found split again today — a **regular file at inode 290627** beside canonical **290583** — and `/root/.claude/` holds saved stubs from **2026-07-17, 07-18 and 08-02**. So roughly monthly, with the daily canary re-link as the only thing closing it.

## A detail that contradicts the runbook

The recovery notes assume CC's atomic refresh replaces the symlink with a real credential file. **It doesn't.** The clobbering file is an *emptied* credential:

```
accessTokenLen: 0,  refreshTokenLen: 0,  expiresAt: 0,  scopes: [...intact]
```

All four saved stubs share that exact shape. So something writes a **blank** credential on auth failure. No workflow in this repo writes that path, so the writer is still unidentified — worth a follow-up, but re-pinning before use is the cheap guard either way.

## Verification

- Workflow YAML parses; the new step passes `bash -n` (extracted and checked directly).
- `npm run preflight` clean, `npm run lint:pkg` OK, **146 tests pass**.
- The **live** split was repaired on the box separately: backed up first, and the script refuses to clobber if the standalone file is the fresher credential — it confirmed canonical was fresher (expiresAt), then relinked. Both paths now resolve to inode 290583.
