### PR TITLE
fix(bots): sync package-lock.json version when a drift bot bumps package.json

### DIFF
--- a/.github/workflows/cc-drift-template-watch.yml
+++ b/.github/workflows/cc-drift-template-watch.yml
@@ -252,7 +252,7 @@ jobs:
           new_version=$(node scripts/rebake-release-prep.mjs)
           echo "new_version=$new_version" >> "$GITHUB_OUTPUT"
 
-          git add src/cc-template-data.json package.json CHANGELOG.md
+          git add src/cc-template-data.json package.json package-lock.json CHANGELOG.md
           git commit -m "auto-rebake: template drift detected $(date -u +%Y-%m-%dT%H:%MZ) (v$new_version)"
           git push origin "$branch"
 
@@ -392,9 +392,9 @@ jobs:
           git config user.email "actions@github.com"
           git config user.name "cc-drift-template-watch[bot]"
           git checkout -b "$branch"
-          # Stage ONLY the three files label-sync touches — never `git add -A`
+          # Stage ONLY the four files label-sync touches — never `git add -A`
           # (would sweep in drift-output.txt / label-target.txt CI artifacts).
-          git add src/cc-template-data.json package.json CHANGELOG.md
+          git add src/cc-template-data.json package.json package-lock.json CHANGELOG.md
           git commit -m "chore(template): label refresh _version -> v$target (clears sdk-drift) (v$new_version)"
           git push origin "$branch"
 

--- a/scripts/_drift-patch-helpers.mjs
+++ b/scripts/_drift-patch-helpers.mjs
@@ -189,3 +189,36 @@ export function promoteUnreleased(changelog, newVersion, date) {
   const dated = `## [Unreleased]\n\n## [${newVersion}] - ${date}`;
   return before + dated + after;
 }
+
+/**
+ * Mirror a version into `package-lock.json`'s two version slots (root
+ * `.version` and `.packages[""].version`), returning the updated JSON text.
+ *
+ * The lockfile carries the package version twice, and `scripts/preflight.mjs`
+ * (run by the required `validate-package-json` check) fails when either slot
+ * disagrees with package.json. Every bot that bumps package.json must bump the
+ * lockfile in the same commit or its own PR goes red on a defect it introduced
+ * — exactly what happened to the drift PR that produced this helper
+ * (`package-lock.json: version 5.5.70 ≠ package.json 5.5.71`).
+ *
+ * A plain version bump does NOT change the dependency graph, so re-resolving
+ * with `npm install --package-lock-only` is unnecessary: these two slots
+ * MIRROR package.json by definition. Writing the version into them is
+ * derivation, not a guess — the same reasoning renumber-release-version.mjs
+ * spells out for its own lockfile write.
+ *
+ * Slots that are absent are left alone rather than invented. Throws if the
+ * text isn't parseable JSON, so a corrupt lockfile fails loud instead of
+ * being silently skipped.
+ */
+export function syncLockfileVersion(lockJsonString, version) {
+  if (typeof version !== 'string' || !/^\d+(?:\.\d+)+$/.test(version)) {
+    throw new Error(`version must be dotted-numeric, got: ${JSON.stringify(version)}`);
+  }
+  const lock = JSON.parse(lockJsonString);
+  if (typeof lock.version === 'string') lock.version = version;
+  if (lock.packages && lock.packages[''] && typeof lock.packages[''].version === 'string') {
+    lock.packages[''].version = version;
+  }
+  return JSON.stringify(lock, null, 2) + '\n';
+}

--- a/scripts/auto-draft-drift-fix.mjs
+++ b/scripts/auto-draft-drift-fix.mjs
@@ -47,6 +47,7 @@ import { fileURLToPath } from 'node:url';
 import {
   isOlderThan,
   patchMaxTested,
+  syncLockfileVersion,
   appendUnreleased,
   bumpPackageJsonPatch,
   promoteUnreleased,
@@ -172,6 +173,23 @@ try {
 }
 const newDarioVersion = packageBumpResult.after;
 
+// Mirror the new version into package-lock.json's two version slots. The
+// required `validate-package-json` check runs scripts/preflight.mjs, which
+// fails when the lockfile disagrees with package.json — so skipping this step
+// leaves the bot's own PR red on a defect the bot itself introduced.
+const lockPath = join(repoRoot, 'package-lock.json');
+try {
+  const lockSource = readFileSync(lockPath, 'utf-8');
+  writeFileSync(lockPath, syncLockfileVersion(lockSource, newDarioVersion), 'utf-8');
+} catch (err) {
+  emit({
+    fixed: false,
+    changedFiles: [],
+    reason: `could not sync package-lock.json to v${newDarioVersion}: ${(err instanceof Error ? err.message : String(err))}`,
+  });
+  process.exit(1);
+}
+
 // Update CHANGELOG:
 //   1. Promote `## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD` with a
 //      fresh `## [Unreleased]` above (the convention documented in
@@ -211,7 +229,7 @@ emit({
   prTitle,
   prBody,
   newDarioVersion,
-  changedFiles: [targetFile, 'package.json', changelogPath === '' ? '' : 'CHANGELOG.md'].filter(Boolean),
+  changedFiles: [targetFile, 'package.json', 'package-lock.json', changelogPath === '' ? '' : 'CHANGELOG.md'].filter(Boolean),
   reason: `auto-patched maxTested ${before} → ${after}, bumped dario ${packageBumpResult.before} → ${newDarioVersion}`,
 });
 process.exit(0);
@@ -231,7 +249,7 @@ function buildPrBody(ccVersion, before, after, newDarioVersion, report) {
     `The drift watcher flagged CC v${ccVersion} as outside the current supported range. This PR:`,
     '',
     `1. Bumps \`SUPPORTED_CC_RANGE.maxTested\` from \`${before}\` → \`${after}\` in \`src/live-fingerprint.ts\``,
-    `2. Bumps \`package.json\` version → \`${newDarioVersion}\``,
+    `2. Bumps \`package.json\` + \`package-lock.json\` version slots → \`${newDarioVersion}\``,
     `3. Promotes \`## [Unreleased]\` in \`CHANGELOG.md\` to \`## [${newDarioVersion}] - ${new Date().toISOString().slice(0, 10)}\` and appends the drift-fix bullet`,
     '',
     '### Items in the drift report',

--- a/scripts/label-sync.mjs
+++ b/scripts/label-sync.mjs
@@ -31,12 +31,14 @@ import {
   bumpPackageJsonPatch,
   promoteUnreleased,
   appendUnreleased,
+  syncLockfileVersion,
 } from './_drift-patch-helpers.mjs';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 const OUT = join(repoRoot, 'src/cc-template-data.json');
 const pkgPath = join(repoRoot, 'package.json');
 const changelogPath = join(repoRoot, 'CHANGELOG.md');
+const lockPath = join(repoRoot, 'package-lock.json');
 
 const target = (process.argv[2] || '').trim();
 if (!target) {
@@ -66,6 +68,10 @@ console.error(
 const { content: bumpedPkg, before: pkgBefore, after: pkgAfter } =
   bumpPackageJsonPatch(readFileSync(pkgPath, 'utf-8'));
 writeFileSync(pkgPath, bumpedPkg, 'utf-8');
+
+// Keep the lockfile's two version slots in step — preflight.mjs, run by the
+// required `validate-package-json` check, fails the PR when they disagree.
+writeFileSync(lockPath, syncLockfileVersion(readFileSync(lockPath, 'utf-8'), pkgAfter), 'utf-8');
 
 const today = new Date().toISOString().slice(0, 10);
 const bullet =

--- a/scripts/rebake-release-prep.mjs
+++ b/scripts/rebake-release-prep.mjs
@@ -22,14 +22,24 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { bumpPackageJsonPatch, promoteUnreleased, appendUnreleased } from './_drift-patch-helpers.mjs';
+import {
+  bumpPackageJsonPatch,
+  promoteUnreleased,
+  appendUnreleased,
+  syncLockfileVersion,
+} from './_drift-patch-helpers.mjs';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 const pkgPath = join(repoRoot, 'package.json');
 const changelogPath = join(repoRoot, 'CHANGELOG.md');
+const lockPath = join(repoRoot, 'package-lock.json');
 
 const { content: bumpedPkg, before, after } = bumpPackageJsonPatch(readFileSync(pkgPath, 'utf-8'));
 writeFileSync(pkgPath, bumpedPkg, 'utf-8');
+
+// Keep the lockfile's two version slots in step — preflight.mjs, run by the
+// required `validate-package-json` check, fails the PR when they disagree.
+writeFileSync(lockPath, syncLockfileVersion(readFileSync(lockPath, 'utf-8'), after), 'utf-8');
 
 const today = new Date().toISOString().slice(0, 10);
 const bullet =

--- a/test/auto-draft-drift-fix.mjs
+++ b/test/auto-draft-drift-fix.mjs
@@ -13,6 +13,7 @@ import {
   bumpPatch,
   bumpPackageJsonPatch,
   promoteUnreleased,
+  syncLockfileVersion,
 } from '../scripts/_drift-patch-helpers.mjs';
 
 let pass = 0, fail = 0;
@@ -254,6 +255,57 @@ header('appendUnreleased — custom heading regex (for auto-drafter)');
   const unreleasedIdx = out.indexOf('## [Unreleased]');
   check('bullet lands after the dated heading', bulletIdx > datedIdx);
   check('bullet lands BELOW the fresh Unreleased', bulletIdx > unreleasedIdx);
+}
+
+header('syncLockfileVersion — mirrors both version slots');
+{
+  const lock = JSON.stringify({
+    name: '@askalf/dario',
+    version: '5.5.70',
+    lockfileVersion: 3,
+    packages: {
+      '': { name: '@askalf/dario', version: '5.5.70', license: 'MIT' },
+      'node_modules/tsx': { version: '4.19.0' },
+    },
+  }, null, 2) + '\n';
+  const out = syncLockfileVersion(lock, '5.5.71');
+  const parsed = JSON.parse(out);
+  check('root slot bumped', parsed.version === '5.5.71');
+  check('packages[""] slot bumped', parsed.packages[''].version === '5.5.71');
+  check('dependency versions untouched', parsed.packages['node_modules/tsx'].version === '4.19.0');
+  check('other fields preserved', parsed.lockfileVersion === 3 && parsed.name === '@askalf/dario');
+  check('ends with newline', out.endsWith('\n'));
+  check('canonical 2-space indent', out === JSON.stringify(parsed, null, 2) + '\n');
+}
+
+header('syncLockfileVersion — guards and absent slots');
+{
+  let threw;
+  try { syncLockfileVersion('{"version":"1.0.0"}', 'not-a-version'); threw = false; } catch { threw = true; }
+  check('non-numeric version rejected', threw === true);
+
+  try { syncLockfileVersion('{ not json', '1.0.1'); threw = false; } catch { threw = true; }
+  check('invalid JSON throws (fails loud, not silently skipped)', threw === true);
+
+  // A lockfile without the packages[""] self-entry keeps parsing; the missing
+  // slot is left alone rather than invented.
+  const out = syncLockfileVersion(JSON.stringify({ version: '1.0.0', packages: {} }, null, 2) + '\n', '1.0.1');
+  const parsed = JSON.parse(out);
+  check('root slot bumped without self-entry', parsed.version === '1.0.1');
+  check('absent slot not invented', parsed.packages[''] === undefined);
+}
+
+header('syncLockfileVersion — agrees with a package.json patch bump');
+{
+  // The invariant preflight.mjs asserts: after a bot bumps package.json, the
+  // lockfile's two slots must equal the new version.
+  const pkg = JSON.stringify({ name: '@askalf/dario', version: '5.5.70' }, null, 2) + '\n';
+  const { content, after } = bumpPackageJsonPatch(pkg);
+  const lock = JSON.stringify({ version: '5.5.70', packages: { '': { version: '5.5.70' } } }, null, 2) + '\n';
+  const synced = JSON.parse(syncLockfileVersion(lock, after));
+  const pkgVersion = JSON.parse(content).version;
+  check('lockfile root == package.json', synced.version === pkgVersion);
+  check('lockfile self-entry == package.json', synced.packages[''].version === pkgVersion);
 }
 
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Every drift bot that patch-bumps `package.json` left `package-lock.json`'s two version slots behind. `scripts/preflight.mjs` — run by the **required** `validate-package-json` check — asserts they agree, so each bot PR failed a required check on a defect the bot itself introduced:

```
✗ package-lock.json: version 5.5.70 ≠ package.json 5.5.71
preflight: 1 finding — fix before pushing.
```

Seen on #1113 (`bot/cc-drift-v2.1.246`). The same gap exists in all three bump sites:

| script | used by |
|---|---|
| `scripts/auto-draft-drift-fix.mjs` | `cc-drift-watch.yml` (`bot/cc-drift-*`) |
| `scripts/rebake-release-prep.mjs` | `cc-drift-template-watch.yml` auto-rebake (`bot/template-rebake-*`) |
| `scripts/label-sync.mjs` | `cc-drift-template-watch.yml` label-sync (`bot/template-label-*`) |

## Change

- **`scripts/_drift-patch-helpers.mjs`** — new pure `syncLockfileVersion(lockJsonString, version)`: mirrors a version into the lockfile's root `.version` and `.packages[""].version`, returns canonical JSON text. Absent slots are left alone; bad input throws rather than silently no-op'ing.
- All three bump sites now call it immediately after `bumpPackageJsonPatch`.
- **`.github/workflows/cc-drift-template-watch.yml`** — both commit steps now `git add … package-lock.json …`. (`cc-drift-watch.yml` needs no workflow change: it stages from the drafter's `changedFiles`, which now includes the lockfile.)
- **`test/auto-draft-drift-fix.mjs`** — 13 new assertions covering both slots, dependency versions untouched, canonical formatting, guard rejections, absent-slot handling, and agreement with a `bumpPackageJsonPatch` result.

### Why not `npm install --package-lock-only`?

A version bump does not change the dependency graph — those two slots *mirror* `package.json` by definition. Writing the version into them is derivation, not a guess. This is the same reasoning `scripts/renumber-release-version.mjs` already spells out for its own lockfile write, and it keeps the bots free of an `npm install` step on the self-hosted runner.

## Test plan

- `node test/auto-draft-drift-fix.mjs` → **66 pass, 0 fail** (was 53).
- End-to-end dry run of the actual failure: fed the drafter a synthetic report matching #1113 (`ccVersion 2.1.246`, `pinned.maxTested 2.1.245`) against a clean `master` worktree:
  - `changedFiles` now `["src/live-fingerprint.ts", "package.json", "package-lock.json", "CHANGELOG.md"]`
  - `package.json` 5.5.71, lockfile root 5.5.71, `packages[""]` 5.5.71
  - `node scripts/preflight.mjs` → `✓ version agrees across package.json + lockfile (5.5.71)` … **preflight: clean.** (This is the exact check that went red on #1113.)
  - Dry-run mutations reverted before commit; the diff contains no version bump.

## Not in scope

The other red check on #1113 is `compat`, failing closed with *"compat cannot validate maxTested=2.1.246 — the runner captured CC 2.1.245"*. That is the maxTested gate working correctly: the self-hosted runner's installed CC is behind what the watcher read from npm `@latest`. It is a host action (upgrade CC on the runner, then re-run), not a code defect, and is tracked separately on the source ticket.

Source ticket: `00MT9AZII863C51A37A0B49580`.
