### PR TITLE
fix(compat): close the CC lag instead of reporting it (v5.5.72)

### DIFF
--- a/.github/workflows/compat-test-self-hosted.yml
+++ b/.github/workflows/compat-test-self-hosted.yml
@@ -91,6 +91,61 @@ jobs:
           npm ci --no-audit --no-fund
           npm run build
 
+      - name: Bring the runner's CC up to the maxTested claim
+        # Close the lag INSTEAD of reporting it.
+        #
+        # cc-drift-watch.yml drafts a `maxTested` bump from the npm registry's
+        # @latest, but the runner only moves to @latest once a day when
+        # cc-autoupdate.timer fires (~04:58Z). Any drift PR drafted before that
+        # tick claims a CC version the runner cannot load, so the gate below
+        # fails closed and the PR sits red until a human upgrades the box by
+        # hand. That is not a rare edge: it burned two operator approvals and
+        # dario#1113 in a single day, and each time the resolution was to run
+        # the very command this step now runs.
+        #
+        # DELIBERATE SHAPE:
+        #   * UPGRADE ONLY, never downgrade. A PR that LOWERS maxTested must not
+        #     drag this shared runner backwards -- cc-drift-template-watch and
+        #     the billing canary capture from the same binary, and pinning them
+        #     to an older CC to satisfy one PR would corrupt their baselines.
+        #   * The version is validated as strict X.Y.Z before it reaches npm.
+        #     It comes from the PR's own source, and this runner is credentialed.
+        #     (Fork PRs cannot reach here -- the job-level guard requires
+        #     head.repo.full_name == github.repository -- but defence in depth.)
+        #   * NOT fatal on failure. If npm cannot serve that version, say so and
+        #     continue: the maxTested gate in the next step is still the
+        #     authority and will fail closed with its existing message. This
+        #     step only ever removes a reason to fail; it must never invent one.
+        #   * The capture in the next step is `force: true`, so it re-reads the
+        #     template from whatever CC is installed after this runs -- which is
+        #     exactly the self-healing path dario#1014 built.
+        run: |
+          set -uo pipefail
+          claimed="$(node -e 'import("./dist/live-fingerprint.js").then(m=>process.stdout.write(String(m.SUPPORTED_CC_RANGE.maxTested||"")))' 2>/dev/null || true)"
+          installed="$(claude --version 2>/dev/null | awk '{print $1}' || true)"
+          echo "claimed maxTested=${claimed:-<unreadable>} installed CC=${installed:-<none>}"
+
+          if [ -z "$claimed" ] || [ -z "$installed" ]; then
+            echo "::notice::cannot compare versions — leaving the runner alone; the maxTested gate still decides"
+            exit 0
+          fi
+          case "$claimed" in
+            *[!0-9.]*|""|.*|*.) echo "::notice::maxTested is not a bare X.Y.Z ($claimed) — not touching npm"; exit 0 ;;
+          esac
+          if [ "$(printf '%s\n%s\n' "$claimed" "$installed" | sort -V | tail -1)" = "$installed" ]; then
+            echo "runner already at or ahead of the claim — nothing to do"
+            exit 0
+          fi
+
+          echo "upgrading CC $installed -> $claimed so the claim can actually be exercised"
+          if npm i -g "@anthropic-ai/claude-code@${claimed}" >/dev/null 2>&1; then
+            now="$(claude --version 2>/dev/null | awk '{print $1}' || true)"
+            echo "runner CC now: ${now:-<unreadable>}"
+            [ "$now" = "$claimed" ] || echo "::warning::upgrade ran but version reads ${now:-<unreadable>}; the gate below will decide"
+          else
+            echo "::warning::npm could not install @anthropic-ai/claude-code@${claimed} (unpublished or registry down) — the maxTested gate below will fail closed with the actionable message"
+          fi
+
       - name: Start dario proxy (passthrough mode)
         # Always start dario: the suite routes THROUGH the proxy so the
         # passthrough-verification + OpenAI-compat sections actually run (they

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.72] - 2026-08-26
+
+### Fixed
+
+- compat now brings the runner up to the version a PR claims, instead of
+  only reporting the gap. cc-drift-watch drafts a maxTested bump from the npm
+  registry, but the runner moves to @latest once a day (cc-autoupdate.timer,
+  ~04:58Z), so any drift PR drafted before that tick claimed a CC the runner
+  could not load and sat red until someone upgraded the box by hand. That cost
+  two operator approvals and dario#1113 in one day, and every resolution was
+  the same npm command this step now runs.
+
+  Upgrade-only: a PR lowering maxTested will never drag the shared runner
+  backwards, since the template watch and billing canary capture from the same
+  binary. The version is validated as a bare X.Y.Z before reaching npm. The
+  step is non-fatal by design -- the existing maxTested gate stays the
+  authority and still fails closed, so this can only remove a reason to fail,
+  never invent one.
+
 ## [5.5.71] - 2026-08-25
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.245` → `2.1.246` for CC v2.1.246. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.71",
+  "version": "5.5.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "5.5.71",
+      "version": "5.5.72",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.71",
+  "version": "5.5.72",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Pairs with #1114. That one made drift bots sync `package-lock.json`; this one closes the *other* half of the same problem — and together they make a drift PR self-sufficient instead of needing a human twice.

## The loop this closes

`cc-drift-watch.yml` drafts a `maxTested` bump from the npm registry's `@latest`. The runner only moves to `@latest` once a day, when `cc-autoupdate.timer` fires (~04:58Z).

So every drift PR drafted between a version publishing and that tick claims a CC the runner cannot load. The `maxTested` gate correctly fails closed, and the PR sits red until someone upgrades the box by hand.

**That isn't a rare edge.** In one day it burned two operator approvals ("upgrade CC on the runner to 2.1.245", "…to 2.1.243") and blocked #1113 — and every resolution was the same one-line `npm i -g`. The gate was doing its job; nothing closed the loop it opened.

The step runs after build and before the capture, so the existing `force: true` capture re-reads the template from whatever CC ends up installed. That's the self-healing path #1014 already built, now with the claimed version actually present.

## Deliberate shape

**Upgrade only, never downgrade.** A PR that *lowers* `maxTested` must not drag this shared runner backwards — `cc-drift-template-watch` and the billing canary capture from the same binary, and pinning them to an older CC to satisfy one PR would corrupt their baselines. Verified numeric, not lexical (`2.1.9` vs `2.1.10`).

**The version is validated as a bare `X.Y.Z` before it reaches npm.** It comes from the PR's own source and this runner holds credentials. Fork PRs can't reach here — the job guard requires `head.repo.full_name == github.repository` — but that's one layer, not a reason to skip the second.

**Non-fatal by design.** If npm can't serve that version, it warns and continues; **the `maxTested` gate stays the authority** and still fails closed with its existing actionable message. This step can only ever *remove* a reason to fail, never invent one. That property is why the gate is untouched.

## Verification

| check | result |
|---|---|
| YAML parses | ✅ |
| run block `bash -n` | ✅ |
| upgrade/skip across 5 version pairs incl. lexical trap | ✅ |
| shape guard blocks `latest`, shell metacharacters, empty, trailing dot, prerelease | ✅ |
| node reader returns `maxTested` from a real dist build | ✅ |
| `npm test` | **146 pass** |
| `npm run preflight` / `lint:pkg` | clean |

Also worth noting: this branch hit a real three-file version conflict on rebase (`package.json`, `package-lock.json`, `CHANGELOG.md`) and `scripts/resolve-release-conflicts.mjs` from #1108 resolved all three cleanly — including the lockfile handler added there, which is the exact file that would have been left with live markers before. Both changelog entries survived and both lockfile slots agree.
