### PR TITLE
fix(proxy): the #1033 tail-restore must deep-clone, not reference (v5.5.74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ checklist.
 
 ## [Unreleased]
 
-## [5.5.74] - 2026-08-27
+## [5.5.75] - 2026-08-27
 
 - **CC drift patch** — `SUPPORTED_CC_RANGE.maxTested` bumped `2.1.246` → `2.1.247` for CC v2.1.247. Auto-drafted by `cc-drift-watch.yml`. Template re-capture, if needed, is auto-handled by `cc-drift-template-watch.yml`.
 ## [5.5.73] - 2026-08-26

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.74",
+  "version": "5.5.75",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "5.5.74",
+      "version": "5.5.75",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.74",
+  "version": "5.5.75",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -679,8 +679,24 @@ export function sanitizeMessages(body: Record<string, unknown>, preserveTags?: S
   // drop below would expose an assistant turn, we put the original content
   // back rather than ship a prefill (dario#1033) — see the guard after the
   // filter for the reasoning.
+  //
+  // MUST be a deep clone when content is an array (dario#1117). `tail` is one
+  // of `messages`, and the per-block mutation loop just below rewrites each
+  // block's `.text` IN PLACE — so a bare `tail.content` reference here points
+  // at the SAME block objects the loop is about to scrub. "Restoring" it
+  // later then restores nothing: the array's length survives (the guard's
+  // `tailHadContent` check is length-based and stays fooled), but every
+  // block's text is already the post-scrub value, and any `cache_control` on
+  // that block rides along untouched. The restored tail then carries an empty
+  // text block WITH a live `cache_control` — a shape dario's own drop-filter
+  // exists to remove, and one Anthropic rejects outright with "cache_control
+  // cannot be set for empty text blocks", or (depending on what else sits in
+  // that position) a role-ordering 400 instead. Reproduced live against a
+  // background-subagent completion turn: dario#1117.
   const tail = messages.length > 0 ? messages[messages.length - 1] : undefined;
-  const tailContentBeforeScrub = tail ? tail.content : undefined;
+  const tailContentBeforeScrub = tail
+    ? (Array.isArray(tail.content) ? structuredClone(tail.content) : tail.content)
+    : undefined;
   for (const msg of messages) {
     if (typeof msg.content === 'string') {
       msg.content = sanitizeContent(msg.content, patterns);

--- a/test/sanitize-messages.mjs
+++ b/test/sanitize-messages.mjs
@@ -391,5 +391,107 @@ header('dario#1033 - the scrub must not leave a trailing assistant turn (prefill
   }
 }
 
+// -------------------------------------------------------------
+header('dario#1117 — the #1033 tail-restore must restore REAL text, not a shallow reference');
+{
+  // Reproduced live: a background-subagent completion round-trip, isolated
+  // proxy + isolated credential, real Anthropic traffic. Request #5 in that
+  // session ended:
+  //   [role=user, {type:'text', text:'', cache_control:{type:'ephemeral'}}]
+  // and Anthropic 400'd with "cache_control cannot be set for empty text
+  // blocks". A different transcript instead saw the *other* reported shape
+  // (dario#1117's own report): "role 'system' must follow a 'user' message
+  // …" — a second observable symptom of the identical defect, depending on
+  // which turn happens to sit in the corrupted position.
+  //
+  // Root cause: `tailContentBeforeScrub` was `tail.content` — a bare
+  // reference, not a copy. `tail` is one of `messages`, and the per-block
+  // mutation loop rewrites every block's `.text` IN PLACE, including tail's.
+  // So by the time the #1033 guard "restores" `tailContentBeforeScrub`, it is
+  // restoring the SAME objects the loop just emptied — the array's length
+  // survives (fooling the length-based `tailHadContent` check) but the text
+  // is already gone, and any `cache_control` rides along untouched. The
+  // restored tail ends up EXACTLY as invalid as the state #1033 was written
+  // to prevent, just via a different route.
+  const lastRole = (b) => b.messages[b.messages.length - 1]?.role;
+
+  {
+    // The exact shape: a cache_control-bearing block whose entire text is an
+    // orchestration tag.
+    const body = { messages: [
+      { role: 'user', content: [{ type: 'text', text: 'run the audit sub-agent' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'Audit complete: 3 findings.' }] },
+      { role: 'user', content: [{ type: 'text', text: '<system-reminder>The Task tool has returned.</system-reminder>', cache_control: { type: 'ephemeral' } }] },
+    ]};
+    sanitizeMessages(body);
+    const tail = body.messages[body.messages.length - 1];
+    check('message survives (existing #1033 guarantee, unchanged)', body.messages.length === 3);
+    check('still ends on a user turn (existing #1033 guarantee, unchanged)', lastRole(body) === 'user');
+    // The assertion #1033's own tests never made — this is what actually
+    // ships to Anthropic.
+    check('restored block has REAL pre-scrub text, not empty',
+      tail.content[0].text === '<system-reminder>The Task tool has returned.</system-reminder>');
+    check('cache_control survives paired with non-empty text',
+      tail.content[0].cache_control?.type === 'ephemeral');
+  }
+
+  {
+    // Multiple blocks in the tail, only one carrying cache_control — the
+    // clone must be per-block-faithful, not just array-shaped.
+    const body = { messages: [
+      { role: 'user', content: [{ type: 'text', text: 'go' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'ok' }] },
+      { role: 'user', content: [
+        { type: 'text', text: '<system-reminder>a</system-reminder>' },
+        { type: 'text', text: '<task_metadata>b</task_metadata>', cache_control: { type: 'ephemeral' } },
+      ] },
+    ]};
+    sanitizeMessages(body);
+    const tail = body.messages[body.messages.length - 1];
+    check('multi-block: both blocks keep their real text',
+      tail.content[0].text === '<system-reminder>a</system-reminder>' &&
+      tail.content[1].text === '<task_metadata>b</task_metadata>');
+    check('multi-block: cache_control stays on the block that had it, not the other',
+      tail.content[1].cache_control?.type === 'ephemeral' && tail.content[0].cache_control === undefined);
+  }
+
+  {
+    // The string-content path never referenced a mutable object (sanitizeContent
+    // returns a NEW string), so it was never exposed to the shallow-copy bug —
+    // confirm the fix didn't disturb it.
+    const body = { messages: [
+      { role: 'user', content: 'do the thing' },
+      { role: 'assistant', content: 'Done.' },
+      { role: 'user', content: '<system-reminder>note</system-reminder>' },
+    ]};
+    sanitizeMessages(body);
+    check('string content: unaffected by the array-specific fix',
+      body.messages[2].content === '<system-reminder>note</system-reminder>');
+  }
+
+  {
+    // A block carrying fields beyond type/text/cache_control must survive the
+    // clone whole — structuredClone must not narrow to known fields, and a
+    // non-text block that ALSO empties (this codebase's filter only drops
+    // {type:'text', text:''}; other block shapes with a stray empty `text`
+    // property are outside today's filter, so they stay in the array and the
+    // message must still fully empty to reach the restore path here).
+    const body = { messages: [
+      { role: 'user', content: [{ type: 'text', text: 'go' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'ok' }] },
+      { role: 'user', content: [
+        { type: 'text', text: '<system-reminder>done</system-reminder>', cache_control: { type: 'ephemeral', ttl: '5m' }, custom_id: 'block-9' },
+      ] },
+    ]};
+    sanitizeMessages(body);
+    const tail = body.messages[body.messages.length - 1];
+    check('restored block keeps text', tail.content[0].text === '<system-reminder>done</system-reminder>');
+    check('restored block keeps a NESTED cache_control field (ttl), not just type',
+      tail.content[0].cache_control?.ttl === '5m');
+    check('restored block keeps an arbitrary extra field (custom_id)',
+      tail.content[0].custom_id === 'block-9');
+  }
+}
+
 console.log(`\n${pass} pass, ${fail} fail`);
 process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Fixes #1117.

## Reproduced live, twice — 400 on master, clean on this fix

Isolated proxy, isolated credential, a genuine background-subagent completion round-trip through real Anthropic traffic. Confirmed the exact failure on current master, then confirmed clean on this fix, identical scenario, same box:

| | |
|---|---|
| master | `claude exit=1` — `API Error: 400 messages.5.content.0.text: cache_control cannot be set for empty text blocks` |
| this fix | `claude exit=0` — "The subagent completed and returned exactly `ack`." |

## Root cause

`sanitizeMessages`' #1033 guard snapshots the tail message before scrubbing, so it can restore original content if the scrub would leave a request ending on an assistant turn (a prefill 400):

```ts
const tailContentBeforeScrub = tail ? tail.content : undefined;
```

`tail` is one of `messages`. The very next loop mutates every block's `.text` **in place**, tail included. Since `tailContentBeforeScrub` points at the *same* array and the *same* block objects, "restoring" it later restores nothing — it hands back the already-emptied blocks. The array's **length** survives unchanged (the guard's `tailHadContent` check is length-based, so it stays fooled), but the text is already gone, and any `cache_control` on that block rides along untouched.

A background-subagent completion turn whose entire text is an orchestration tag hits this exactly: the restored tail carries `{type:'text', text:'', cache_control:{type:'ephemeral'}}` — which Anthropic rejects. #1117's own report shows a *different* symptom from the identical defect ("role 'system' must follow a 'user' message…") — which error surfaces depends on what else sits in the corrupted position.

## Fix

```ts
const tailContentBeforeScrub = tail
  ? (Array.isArray(tail.content) ? structuredClone(tail.content) : tail.content)
  : undefined;
```

String content is untouched — `sanitizeContent` returns a new string rather than mutating in place, so it was never exposed to this. Node floor is `>=18`, so `structuredClone` needs no new dependency.

## Why the existing #1033 tests never caught it

They assert the message **survives** and the **role** is right. Neither checks that the restored **text** is non-empty. I proved this in-process before touching anything live — ran the exact #1033 fixture through the *unfixed* code and printed the restored block:

```
restored block text: ""
restored block cache_control: {"type":"ephemeral"}
```

Zero API cost, confirmed before any live traffic.

## Verification

- **9 new assertions** (`test/sanitize-messages.mjs`): the exact failing shape; a multi-block tail where only *one* block carries `cache_control` (proves the clone is per-block-faithful, not just array-shaped); the string path confirmed unaffected; an arbitrary extra field *and* a nested `cache_control` field both confirmed to survive the clone whole (proves `structuredClone` isn't narrowing to known fields).
- **Live, both directions** — see table above. Same repro script, same box, isolated `HOME` + isolated test credential throughout (never the shared credential).
- **146 tests pass** (9 new), `npm run preflight` clean, `npm run lint:pkg` OK.
