### PR TITLE
feat(proxy): forward a genuine Claude Code client's conversation untouched (v5.5.80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.80] - 2026-08-28
+
+### Changed
+
+- **A genuine Claude Code client's conversation is forwarded untouched.**
+  `sanitizeMessages` — the orchestration-tag scrub that makes other harnesses
+  (Aider, Cursor, OpenClaw, ...) look like CC — no longer runs on requests
+  from Claude Code itself. CC's own `<system-reminder>`, `<task-notification>`
+  and `<env>` blocks are the CC wire shape; stripping them made every request
+  through dario less faithful than the same request sent direct, and the empty
+  blocks and emptied turns the scrub left behind were the origin of #54, #744,
+  #1033, #1092 and #1117, each needing its own guard. Detection is the check
+  `buildCCRequest` already uses for its byte-faithful branch (billing header
+  in `system[0]`, CC opener in `system[1]`); the empty-content filters that
+  genuine CC still needs (#1092's retry artifact) live there and keep running.
+  Non-CC clients and `--preserve-orchestration-tags` are unchanged.
+
+
+
+- **Template label refresh** — `_version`, `_supportedMaxTested`, and the `user-agent` header bumped to `2.1.250` to track `@anthropic-ai/claude-code@latest`. The live wire shape is unchanged — cc-drift-template-watch ran `capture-and-bake --check` against live CC v2.1.250 and found zero shape drift vs the bundle — so this is a label refresh, not a re-capture (`_captured` stays at the last real capture). Auto-merged; clears the `sdk-drift` early-warning signal.
+
 ## [5.5.79] - 2026-08-28
 
 - **CI — pace the self-hosted compat suite** — `compat-test-self-hosted.yml` now sets `DARIO_COMPAT_PACE_MS: '5000'`. `test/compat.mjs` defaults to a 20s inter-call sleep to keep a subscription-backed passthrough inside the 5h rate window; this job runs the proxy against an API-key upstream, which has no such window. Run 33132511802 spent 215s in "Run compat tests", ~200s of it asleep, holding the only `dario-drift` runner. Cuts the hold to roughly a minute.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.79",
+  "version": "5.5.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "5.5.79",
+      "version": "5.5.80",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.79",
+  "version": "5.5.80",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -9,7 +9,7 @@ import { getAccessToken, getStatus, ignoreCcCredentials } from './oauth.js';
 import { buildHealthResponse, derivePoolStatus, probeRequested, shouldDiscloseHealthInternals, shouldRunServingProbe } from './health-response.js';
 import { getServingProbe } from './serving-probe.js';
 import { darioVersion } from './version.js';
-import { buildCCRequest, applyCcPromptCaching, parseEffortSuffix, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, overlayTemplateHeaderValues, forwardClientCCIdentityHeaders, isMcpToolName, CC_TEMPLATE, CC_CACHE_CONTROL, effectiveCacheControl, withForced1hBeta, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
+import { buildCCRequest, applyCcPromptCaching, isGenuineCCClient, parseEffortSuffix, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, overlayTemplateHeaderValues, forwardClientCCIdentityHeaders, isMcpToolName, CC_TEMPLATE, CC_CACHE_CONTROL, effectiveCacheControl, withForced1hBeta, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
 import { stampCch, hasCchSeed } from './cch.js';
 import { describeTemplate, detectDrift, checkCCCompat, probeInstalledCCVersion } from './live-fingerprint.js';
 import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCooldown, authCooldownMs, accountIneligibility, reconcilePoolAccounts, resolvePoolStrategy, utilFreshness, type PoolAccount } from './pool.js';
@@ -674,6 +674,22 @@ function orchestrationPatternsFor(preserveTags?: Set<string>): RegExp[] {
 export function sanitizeMessages(body: Record<string, unknown>, preserveTags?: Set<string>): void {
   const messages = body.messages as Array<{ role: string; content: unknown }> | undefined;
   if (!messages) return;
+  // A genuine Claude Code client is forwarded with its conversation untouched.
+  // The scrub exists to make OTHER harnesses (Aider, Cursor, OpenClaw, ...)
+  // look like CC by removing their orchestration wrappers; CC's own
+  // `<system-reminder>`, `<task-notification>`, `<env>` blocks ARE the CC
+  // wire shape, and stripping them made every request through dario less
+  // faithful than the same request sent direct. It was also the origin of a
+  // whole class of defects — the empty blocks and emptied turns the scrub
+  // leaves behind (dario#54, #744, #1033, #1092, #1117) each needed its own
+  // guard, and each guard patched the previous one's hole. The genuine-CC
+  // branch of buildCCRequest already declares "messages: untouched — the
+  // client is the authority on its own wire shape"; this makes that true from
+  // the first byte. The empty-content filters that genuine CC still needs
+  // (a real CC retry artifact, dario#1092) live in buildCCRequest and keep
+  // running. Detection is the same check the template uses: the billing
+  // header in system[0] and a CC opener in system[1].
+  if (isGenuineCCClient(body)) return;
   const patterns = orchestrationPatternsFor(preserveTags);
   // Snapshot the tail turn before scrubbing. If the scrub empties it and the
   // drop below would expose an assistant turn, we put the original content

--- a/test/sanitize-messages.mjs
+++ b/test/sanitize-messages.mjs
@@ -493,5 +493,45 @@ header('dario#1117 — the #1033 tail-restore must restore REAL text, not a shal
   }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+header('genuine Claude Code client: the conversation is forwarded untouched');
+{
+  // The scrub is for other harnesses dressed up as CC. CC's own orchestration
+  // tags are the CC wire shape, so a genuine CC request must leave exactly as
+  // it arrived — mid-conversation reminders, a tag-only tail with its cache
+  // breakpoint, all of it. Detection is buildCCRequest's own check.
+  const GENUINE_SYSTEM = [
+    { type: 'text', text: 'x-anthropic-billing-header: client-tag' },
+    { type: 'text', text: "You are Claude Code, Anthropic's official CLI for Claude.", cache_control: { type: 'ephemeral' } },
+  ];
+  const messages = () => [
+    { role: 'user', content: [{ type: 'text', text: '<system-reminder>\nA reminder.\n</system-reminder>' }, { type: 'text', text: 'real question' }] },
+    { role: 'assistant', content: [{ type: 'text', text: 'real answer' }] },
+    { role: 'user', content: [{ type: 'text', text: '<system-reminder><task-notification>stream ended</task-notification></system-reminder>', cache_control: { type: 'ephemeral' } }] },
+  ];
+  const genuine = { system: structuredClone(GENUINE_SYSTEM), messages: messages() };
+  const before = JSON.stringify(genuine.messages);
+  sanitizeMessages(genuine);
+  check('genuine CC: messages are byte-identical after sanitizeMessages', JSON.stringify(genuine.messages) === before);
+  check('genuine CC: the mid-conversation reminder block survives', genuine.messages[0].content.length === 2);
+  check('genuine CC: the tag-only tail keeps its cache_control', genuine.messages[2].content[0].cache_control?.type === 'ephemeral');
+
+  // Same conversation from a non-CC client: scrubbed exactly as before.
+  const other = { system: [{ type: 'text', text: 'You are a helpful assistant.' }], messages: messages() };
+  sanitizeMessages(other);
+  check('non-CC client: the mid-conversation reminder is still scrubbed', other.messages[0].content.length === 1 && other.messages[0].content[0].text === 'real question');
+  check('non-CC client: the tag-only tail is still restored, not dropped (#1033)', other.messages.length === 3 && other.messages[2].role === 'user');
+
+  // The billing header alone is not proof — system[1] must open like CC.
+  const half = { system: [{ type: 'text', text: 'x-anthropic-billing-header: client-tag' }, { type: 'text', text: 'You are a helpful assistant.' }], messages: messages() };
+  sanitizeMessages(half);
+  check('billing header without a CC opener is still scrubbed', half.messages[0].content.length === 1);
+
+  // The explicit opt-out still governs non-CC clients and is not weakened.
+  const preserved = { system: [{ type: 'text', text: 'You are a helpful assistant.' }], messages: messages() };
+  sanitizeMessages(preserved, new Set(['*']));
+  check('--preserve-orchestration-tags still preserves everything for non-CC clients', preserved.messages[0].content.length === 2);
+}
+
 console.log(`\n${pass} pass, ${fail} fail`);
 process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## What

`sanitizeMessages` — the orchestration-tag scrub — no longer runs on requests from a genuine Claude Code client. Their conversation is forwarded exactly as it arrived.

## Why

The scrub exists to make **other** harnesses (Aider, Cursor, OpenClaw, …) look like CC by removing their orchestration wrappers. CC's own `<system-reminder>`, `<task-notification>` and `<env>` blocks *are* the CC wire shape. Stripping them meant every request through dario was less faithful than the same request sent direct — and the empty blocks and emptied turns the scrub leaves behind were the origin of a whole class of defects: #54, #744, #1033, #1092, #1117. Each needed its own guard, and each guard patched the previous one's hole (see #1118, and the companion PR for #1117's second report).

The genuine-CC branch of `buildCCRequest` already declares "messages: untouched — the client is the authority on its own wire shape". This makes that true from the first byte.

## How

One early return at the top of `sanitizeMessages`, using the detection `buildCCRequest` already uses for its byte-faithful branch: billing header in `system[0]`, CC opener in `system[1]`. `proxy.ts` already imports from `cc-template.ts` (not the reverse), so no cycle.

What still runs for genuine CC, unchanged: the empty-text filter and the #1092 retry-artifact rewind in `buildCCRequest` — those handle CC's *own* malformed shapes, not scrub leftovers.

What is unchanged: non-CC clients (scrubbed exactly as before, #1033 tail-restore included) and `--preserve-orchestration-tags`.

## Tests

`test/sanitize-messages.mjs` +7: genuine CC → messages byte-identical (mid-conversation reminder survives, tag-only tail keeps its `cache_control`); the same conversation from a non-CC client → scrubbed and tail-restored as before; billing header without a CC opener → still scrubbed; explicit preserve set → still honoured. 66/66 in the file, 146/146 suite.

## Release

Bumps to **v5.5.80** (master took 5.5.79 in #1128 while this was open). The companion #1117 fix, #1130, is rebased on top of this branch as 5.5.81 and merges after it.
