### PR TITLE
fix(proxy): an empty final user turn must reach the #1092 rewind, not become a prefill 400 (v5.5.81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.81] - 2026-08-28
+
+### Fixed
+
+- **An empty final user turn now reaches the #1092 rewind instead of becoming
+  a prefill 400** (#1117, second report). CC's stream-interruption retry
+  appends a user turn with `content: []` as the final message — seen live
+  after a `Monitor` wait ended with "stream ended". `sanitizeMessages` runs
+  before the template build, and its message-level drop removed that turn
+  while the #1033 tail-restore skipped it ("only restore a tail that had
+  content"), so `buildCCRequest` saw a request already ending on the
+  assistant's real reply and upstream answered "This model does not support
+  assistant message prefill". The #1092 tests called `buildCCRequest`
+  directly and could not see the order. The restore now keeps an empty
+  trailing user turn in place: the genuine-CC path rewinds the pair as
+  designed, and the general path lets upstream name the malformed turn
+  honestly — the #1033 decision, unchanged. Pinned by a chained
+  `sanitizeMessages` → `buildCCRequest` test that fails 3/5 on the previous
+  build.
+
 ## [5.5.80] - 2026-08-28
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.80",
+  "version": "5.5.81",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "5.5.80",
+      "version": "5.5.81",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.80",
+  "version": "5.5.81",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -768,17 +768,24 @@ export function sanitizeMessages(body: Record<string, unknown>, preserveTags?: S
   // so keeping it is *more* wire-faithful, not less; for a non-CC client a
   // lone tag as the final turn is the actual prompt, and forwarding it beats
   // a hard 400. Every other position still scrubs exactly as before.
+  //
+  // This holds even when the tail was ALREADY empty before the scrub
+  // (dario#1117, second report). CC's stream-interruption retry appends a
+  // user turn with `content: []` as the final message — the shape the
+  // genuine-CC rewind in buildCCRequest (dario#1092) exists to recover. The
+  // message-level drop above ran first and removed that turn, and an
+  // "only restore a tail that had content" condition here let it go, so the
+  // template saw a request already ending on the assistant's real reply and
+  // upstream answered with the prefill rejection. Restoring an empty tail is
+  // never worse than dropping it: on the genuine-CC path #1092 rewinds the
+  // pair, and on the general path the upstream names the malformed turn
+  // accurately ("content must contain at least one block") — the #1033
+  // decision — instead of dario converting it into a misleading prefill 400.
   const tailWasDropped = tail !== undefined && kept[kept.length - 1] !== tail;
-  const tailHadContent = Array.isArray(tailContentBeforeScrub)
-    ? tailContentBeforeScrub.length > 0
-    : typeof tailContentBeforeScrub === 'string'
-      ? tailContentBeforeScrub !== ''
-      : tailContentBeforeScrub != null;
   if (
     tail !== undefined &&
     tailWasDropped &&
     tail.role === 'user' &&
-    tailHadContent &&
     kept.length > 0 &&
     kept[kept.length - 1]!.role === 'assistant'
   ) {

--- a/test/empty-text-blocks.mjs
+++ b/test/empty-text-blocks.mjs
@@ -10,6 +10,7 @@
 // cannot fix the session-killer on its own: the block itself must never
 // reach the wire. These tests pin the rebuild-side filter.
 import { buildCCRequest, applyCcPromptCaching, CC_CACHE_CONTROL } from '../dist/cc-template.js';
+import { sanitizeMessages } from '../dist/proxy.js';
 
 let pass = 0, fail = 0;
 function check(label, cond) {
@@ -277,6 +278,38 @@ console.log('\n=== a MID-conversation assistant turn emptied by a null-text bloc
   check('emptied mid-conversation assistant turn is dropped',
     body.messages.every((m) => Array.isArray(m.content) && m.content.length > 0));
   check('no empty text block survives', emptyTextBlocks(body).length === 0);
+}
+
+console.log('\n=== the #1092 rewind must survive the proxy-level scrub that runs first (dario#1117) ===');
+{
+  // The request hits sanitizeMessages (proxy.ts) BEFORE buildCCRequest. Its
+  // message-level drop removes a final content:[] user turn, and the #1033
+  // tail-restore used to skip a tail that had no content — so the template
+  // never saw the retry artifact #1092 rewinds, the request reached upstream
+  // ending on the assistant's real reply, and Anthropic answered "This model
+  // does not support assistant message prefill". The #1092 tests above call
+  // buildCCRequest directly and could not see this. Pin the real order.
+  const clientBody = {
+    model: 'claude-opus-5', max_tokens: 32,
+    system: structuredClone(GENUINE_SYSTEM),
+    messages: [
+      { role: 'user', content: [{ type: 'text', text: 'watch the job' }] },
+      { role: 'assistant', content: [{ type: 'tool_use', id: 't1', name: 'Monitor', input: { command: 'tail -f job.log' } }] },
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't1', content: 'stream ended' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'The stream ended before the data arrived.' }] },
+      { role: 'user', content: [] },                                   // CC's retry artifact
+    ],
+  };
+  sanitizeMessages(clientBody);
+  const afterScrub = clientBody.messages[clientBody.messages.length - 1];
+  check('#1117: the scrub leaves the empty final user turn in place for the template', afterScrub.role === 'user');
+  const { body, genuineCC } = buildCCRequest(clientBody, TAG, CC_CACHE_CONTROL, ID);
+  check('#1117: recognized as genuine CC', genuineCC === true);
+  const last = body.messages[body.messages.length - 1];
+  check('#1117: the request does not end on an assistant turn (no prefill)', last.role === 'user');
+  check('#1117: it rewinds to the last real user turn — the Monitor tool_result',
+    Array.isArray(last.content) && last.content.some((b) => b.type === 'tool_result' && b.tool_use_id === 't1'));
+  check('#1117: no empty turn survives', body.messages.every((m) => Array.isArray(m.content) && m.content.length > 0));
 }
 
 console.log(`\n  ${pass} passed, ${fail} failed`);


### PR DESCRIPTION
Fixes #1117 — the **second** report (Monitor "stream ended" → `400 This model does not support assistant message prefill`). The first report was fixed in #1118.

## Root cause — found in code, reproduced in-process

CC's stream-interruption retry appends a user turn with `content: []` as the final message. That is exactly the shape the #1092 rewind (#1093) recovers on the genuine-CC path — but the request reaches `buildCCRequest` **after** `sanitizeMessages` (`proxy.ts`, the call just after the body parse), and there:

1. the message-level drop (#744) removes the empty final user turn;
2. the #1033 tail-restore skips it — `tailHadContent` was false, so "only restore a tail that had content" let it go.

`buildCCRequest` therefore saw a request already ending on the assistant's real reply, the #1092 rewind had nothing to rewind, and upstream answered with the prefill rejection. The #1092 tests call `buildCCRequest` directly and could not see the order.

Timeline: the drop + guard landed in #1034 (08-20); the rewind in #1093 (08-25) was written for a turn the pipeline never delivered to it. Not a regression from #1118.

## Fix

Remove the `tailHadContent` condition from the #1033 guard: an empty trailing user turn is restored too. Restoring an empty tail is never worse than dropping it —

- genuine CC: `buildCCRequest` rewinds the pair as designed (#1092);
- general path: upstream names the malformed turn honestly ("content must contain at least one block") — the #1033 decision, unchanged — instead of dario converting it into a misleading prefill 400.

## Verification

New chained test in `test/empty-text-blocks.mjs` — `sanitizeMessages` → `buildCCRequest` on the Monitor shape (tool_use → tool_result "stream ended" → assistant reply → `content: []`):

| | |
|---|---|
| master | **3/5 fail** — scrub drops the tail, request ends on the assistant turn, no rewind |
| this fix | 5/5 — tail kept, genuine CC recognised, request rewinds to the Monitor `tool_result`, no empty turn survives |

Existing suites unchanged: `sanitize-messages` 59/59, `empty-text-blocks` 39/39, 146/146 overall.

## Release

Bumps to **v5.5.81**, stacked on #1129 (v5.5.80) so the two CHANGELOG entries don't collide — merge #1129 first and this becomes a one-commit diff. Both fixes stand on their own: #1129 skips the scrub for genuine CC, this one fixes the guard for every other client.
