### PR TITLE
chore(release): v5.5.82 — version bump so #1131 actually ships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.82] - 2026-08-28
+
+### Changed
+
+- **CI: the live-test job's own check-run is the gate; the hand-posted
+  `dario/live-test` commit status is gone** (#1131). The workflow posted a
+  duplicate status context alongside the check-run GitHub already creates,
+  so one job reported twice. Release-only bump so the workflow change in
+  #1131 ships.
+
 ## [5.5.81] - 2026-08-28
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.81",
+  "version": "5.5.82",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "5.5.81",
+      "version": "5.5.82",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.81",
+  "version": "5.5.82",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release-trigger bump for #1131. Targets **#1131's own head branch**, not `master`, so the bump lands inside #1131's diff.

## Why

`cc-drift-auto-release.yml` gates the whole release pipeline on `package.json` version: if the merge commit's version equals its parent's, the `gate` step finds an existing `v<version>` tag and short-circuits — nothing reaches npm/GHCR. #1131 is currently at v5.5.81, identical to `master`, so merging it as-is ships nothing.

This is the second occurrence of the pattern. #1125 merged 2026-08-28T11:20Z workflow-only with no bump and shipped nothing; it took a separate PR (#1128) to release it. Basing this bump on `master` instead would repeat the trap one version later — the new `v5.5.82` tag would exist before #1131 merged, and the gate would short-circuit again.

## Merge order (important)

1. Merge **this PR** into `ci/live-test-drop-duplicate-status`.
2. Then merge **#1131** into `master` — the merge commit carries v5.5.82 and the release fires.

## Changes

Pure release trigger — no source or workflow files touched.

- `package.json`: 5.5.81 → 5.5.82
- `package-lock.json`: root + self-entry version slots (both required by the `validate-package-json` check via `scripts/preflight.mjs`)
- `CHANGELOG.md`: `## [5.5.82] - 2026-08-28` section inserted under `## [Unreleased]`

## Test plan

`node scripts/preflight.mjs` locally: clean — version agrees across package.json + lockfile (5.5.82), CHANGELOG top heading matches. CI `validate-package-json` will re-assert the same invariants.

Source ticket: 01M14NV6GESR7KHCX7CTAAXV2V