### PR TITLE
fix(codex): never send max_output_tokens to the ChatGPT backend — it 400s the request (v5.5.88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.88] - 2026-08-30
+
+- **A request that asks for an output cap no longer 400s against a ChatGPT subscription (dario#1142).** The Codex backend rejects the parameter outright — `400 {"detail":"Unsupported parameter: max_output_tokens"}` — and both request builders set it from the client's `max_tokens` / `max_completion_tokens`, so both wire shapes failed whenever a client asked for one. It hid for as long as it did because every smoke test happened to omit `max_tokens`; it then surfaced as a 100% failure the moment the Anthropic path went live, because the Messages API *requires* `max_tokens` and so always produced it. Verified against the live backend: the identical body 400s with the field and streams a normal reply without it. The strip lives in `forwardToCodex`, not in either translator, because it is a property of this backend rather than of either wire format — the same builders remain correct against an API-key Responses endpoint, which does support the parameter.
+
+
 ## [5.5.87] - 2026-08-29
 
 - **A ChatGPT subscription now serves Anthropic-shape `/v1/messages` too, so a Claude-shaped harness can run on a ChatGPT plan (dario#1141).** The codex engine was OpenAI-path only: `codexAdapter` refused anything that wasn't `/v1/chat/completions`, because the Messages/Responses translation did not exist in the tree. Any Anthropic-SDK client naming a subscription slug therefore fell through to Claude and came back `404 not_found_error: model: gpt-5.6-sol` — which is exactly how askalf's own fleet found it: an agent configured on `gpt-5.6-sol` was dispatched for the first time and its Anthropic-SDK call 404'd. `src/anthropic-responses-translate.ts` supplies the missing half (Messages → Responses requests, Responses → Messages responses, and the Responses event stream → Anthropic SSE), and `forwardToCodex` takes a `shape` so both client wire formats share one transport: same headers, timeout, upstream POST, read loop and error paths, with only the two translation ends swapped. `stream: true` is forced upstream for both shapes — the backend is always streamed and collapsed here — and an Anthropic-shape client gets Anthropic-shape errors (`{type:'error',error:{type,message}}`), because an SDK reads its own error shape.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.87",
+  "version": "5.5.88",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "5.5.87",
+      "version": "5.5.88",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.87",
+  "version": "5.5.88",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/codex-backend.ts
+++ b/src/codex-backend.ts
@@ -536,6 +536,17 @@ export async function forwardToCodex(
   const upstreamBody = isAnthropic
     ? { ...anthropicToResponsesRequest(parsed as unknown as AnthropicRequest, model), stream: true }
     : chatCompletionsToResponses(parsed);
+  // The ChatGPT Codex backend REJECTS an output cap outright:
+  //   400 {"detail":"Unsupported parameter: max_output_tokens"}
+  // Both builders set it from the client's max_tokens / max_completion_tokens,
+  // so BOTH shapes 400 whenever a client asks for one. It stayed hidden because
+  // every smoke test so far happened to omit max_tokens; it then showed up as a
+  // 100% failure on the Anthropic path, where the Messages API REQUIRES
+  // max_tokens and so always produced it. Stripped here rather than in either
+  // translator because it is a property of THIS backend, not of either wire
+  // format — the same builders are correct against an API-key Responses
+  // endpoint, which does support the parameter.
+  delete (upstreamBody as Record<string, unknown>).max_output_tokens;
   const target = `${CODEX_BACKEND_BASE_URL.replace(/\/$/, '')}/responses`;
 
   const abort = new AbortController();

--- a/test/codex-backend.mjs
+++ b/test/codex-backend.mjs
@@ -642,5 +642,35 @@ header('a SUCCESSFUL response is still not treated as failed');
   check('and still a message', JSON.parse(res.body).type === 'message');
 }
 
+
+header('max_output_tokens is never sent to the Codex backend (dario#1142)');
+{
+  // Live 400 from the backend: {"detail":"Unsupported parameter: max_output_tokens"}.
+  // Anthropic REQUIRES max_tokens, so without this strip the Anthropic path
+  // fails 100%; the chat path fails whenever a client sends an output cap.
+  const sentA = {};
+  await forwardToCodex({}, fakeRes(), Buffer.from(JSON.stringify({
+    model: 'gpt-5.6-sol', max_tokens: 200, messages: [{ role: 'user', content: 'hi' }],
+  })), CREDS, '*', {}, 5000, false, 'anthropic', fakeUpstream(TEXT_STREAM, sentA));
+  check('anthropic: client max_tokens does not become max_output_tokens upstream',
+    !('max_output_tokens' in sentA.body), Object.keys(sentA.body));
+
+  const sentO = {};
+  await forwardToCodex({}, fakeRes(), Buffer.from(JSON.stringify({
+    model: 'gpt-5.6-sol', max_tokens: 200, messages: [{ role: 'user', content: 'hi' }],
+  })), CREDS, '*', {}, 5000, false, 'openai', fakeUpstream(TEXT_STREAM, sentO));
+  check('chat: client max_tokens does not become max_output_tokens upstream',
+    !('max_output_tokens' in sentO.body), Object.keys(sentO.body));
+
+  const sentC = {};
+  await forwardToCodex({}, fakeRes(), Buffer.from(JSON.stringify({
+    model: 'gpt-5.6-sol', max_completion_tokens: 512, messages: [{ role: 'user', content: 'hi' }],
+  })), CREDS, '*', {}, 5000, false, 'openai', fakeUpstream(TEXT_STREAM, sentC));
+  check('chat: max_completion_tokens is stripped too',
+    !('max_output_tokens' in sentC.body), Object.keys(sentC.body));
+
+  check('the rest of the body still arrives', Array.isArray(sentA.body.input) && sentA.body.stream === true);
+}
+
 console.log(`\n${'='.repeat(70)}\n  ${pass} passed, ${fail} failed\n${'='.repeat(70)}`);
 process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
Found by running the **first live end-to-end test of the Anthropic path** on the box after v5.5.87 deployed. Every `/v1/messages` request to a gpt slug came back 400.

## The bug

The Codex backend rejects the parameter outright:

```
400 {"detail":"Unsupported parameter: max_output_tokens"}
```

Both builders set it from the client's `max_tokens` / `max_completion_tokens`, so **both wire shapes** fail whenever a client asks for an output cap. Reproduced directly against the live backend — the *chat*-derived body 400s identically, so this is a pre-existing bug on that path too, not something the Anthropic work introduced.

It hid for as long as it did because every smoke test so far happened to omit `max_tokens`. It then became a **100% failure** the moment v5.5.87 went live, because the Messages API *requires* `max_tokens` and so always produced it.

## Verified live

Same body, same account, one field different:

| | |
|---|---|
| with `max_output_tokens` | `400 Unsupported parameter` |
| without | `200`, streams `response.output_text.delta` normally |

## The fix

Stripped in `forwardToCodex`, not in either translator — it is a property of *this backend*, not of either wire format. The same builders stay correct against an API-key Responses endpoint, which does support the parameter.

Tests assert it never reaches the upstream body for either shape, and for `max_completion_tokens` too. `npm test` 153/153, `tsc` clean. v5.5.88 bumped in-PR.