### PR TITLE
fix(codex): fold the non-streaming Anthropic body from the stream, not the empty terminal event (v5.5.89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ checklist.
 
 ## [Unreleased]
 
+## [5.5.89] - 2026-08-30
+
+- **A non-streaming Anthropic reply from a ChatGPT subscription is no longer empty (dario#1143).** The collapse read its content off the terminal `response.completed` event, which is correct against the standard Responses API and wrong against this backend: the ChatGPT Codex backend sends `response.completed` with `output: []`, so the content — which only ever exists in the delta events — was dropped and the client received a perfectly well-formed message with `content: []`. A silent empty answer, indistinguishable from a model that chose to say nothing. Found by running the first live end-to-end test of the path against a real subscription: streaming returned the text, non-streaming returned nothing. The body is now FOLDED FROM THE STREAM by `createAnthropicMessageAssembler`, which is the discipline the chat path always had (`createResponsesTranslator.complete()` accumulates from deltas for exactly this reason) — so both the streamed and collapsed bodies now come from ONE translation instead of two that can disagree. The regression test pins the real shape: a terminal event carrying `output: []` must still yield the delta text.
+
+
 ## [5.5.88] - 2026-08-30
 
 - **A request that asks for an output cap no longer 400s against a ChatGPT subscription (dario#1142).** The Codex backend rejects the parameter outright — `400 {"detail":"Unsupported parameter: max_output_tokens"}` — and both request builders set it from the client's `max_tokens` / `max_completion_tokens`, so both wire shapes failed whenever a client asked for one. It hid for as long as it did because every smoke test happened to omit `max_tokens`; it then surfaced as a 100% failure the moment the Anthropic path went live, because the Messages API *requires* `max_tokens` and so always produced it. Verified against the live backend: the identical body 400s with the field and streams a normal reply without it. The strip lives in `forwardToCodex`, not in either translator, because it is a property of this backend rather than of either wire format — the same builders remain correct against an API-key Responses endpoint, which does support the parameter.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.88",
+  "version": "5.5.89",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "5.5.88",
+      "version": "5.5.89",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "5.5.88",
+  "version": "5.5.89",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/anthropic-responses-translate.ts
+++ b/src/anthropic-responses-translate.ts
@@ -1231,6 +1231,72 @@ export function parseResponsesSSEEvent(
  * Call `flush()` at end-of-stream to parse any trailing record that was
  * not blank-line terminated. Pure and offline-testable.
  */
+/**
+ * Fold the Anthropic stream this module produces back into ONE Message.
+ *
+ * Needed because the ChatGPT Codex backend's terminal `response.completed`
+ * carries `output: []` — the content only ever exists in the delta events, so
+ * `responsesToAnthropicResponse(terminal)` yields an empty message. (The
+ * standard Responses API does populate `output`, which is why this was not
+ * obvious.) The chat path has always avoided the trap by accumulating from
+ * deltas; this is the same discipline for the Anthropic shape, and it means
+ * the streaming and non-streaming bodies are assembled from ONE translation
+ * rather than two that can disagree. dario#1143.
+ */
+export function createAnthropicMessageAssembler(): {
+  push(events: readonly ResponsesAnthropicStreamEvent[]): void;
+  message(fallbackModel: string): AnthropicResponseWithThinking;
+} {
+  let msg: AnthropicResponseWithThinking | null = null;
+  const blocks: Array<Record<string, unknown>> = [];
+  const partialJson = new Map<number, string>();
+
+  return {
+    push(events) {
+      for (const e of events) {
+        if (e.type === 'message_start') {
+          msg = { ...e.message, content: [] } as AnthropicResponseWithThinking;
+        } else if (e.type === 'content_block_start') {
+          blocks[e.index] = { ...(e.content_block as Record<string, unknown>) };
+          if (e.content_block.type === 'tool_use') partialJson.set(e.index, '');
+        } else if (e.type === 'content_block_delta') {
+          const b = blocks[e.index] ?? (blocks[e.index] = {});
+          const d = e.delta;
+          if (d.type === 'text_delta') b.text = String(b.text ?? '') + d.text;
+          else if (d.type === 'thinking_delta') b.thinking = String(b.thinking ?? '') + d.thinking;
+          else if (d.type === 'input_json_delta') partialJson.set(e.index, (partialJson.get(e.index) ?? '') + d.partial_json);
+        } else if (e.type === 'message_delta') {
+          if (msg) {
+            msg.stop_reason = e.delta.stop_reason;
+            const u = msg.usage ?? { input_tokens: 0, output_tokens: 0 };
+            msg.usage = {
+              ...u,
+              output_tokens: e.usage.output_tokens,
+              input_tokens: e.usage.input_tokens ?? u.input_tokens,
+            };
+          }
+        }
+      }
+    },
+    message(fallbackModel) {
+      for (const [i, raw] of partialJson) {
+        const b = blocks[i];
+        if (!b || b.type !== 'tool_use') continue;
+        b.input = safeParseArguments(raw);
+      }
+      const content = blocks.filter(Boolean) as unknown as AnthropicResponseWithThinking['content'];
+      if (!msg) {
+        return {
+          id: 'msg_dario', type: 'message', role: 'assistant', model: fallbackModel,
+          content, stop_reason: 'end_turn', stop_sequence: null,
+          usage: { input_tokens: 0, output_tokens: 0 },
+        } as AnthropicResponseWithThinking;
+      }
+      return { ...msg, content };
+    },
+  };
+}
+
 export function createResponsesSSEParser(): {
   push(chunk: string): ResponsesStreamEvent[];
   flush(): ResponsesStreamEvent[];

--- a/src/codex-backend.ts
+++ b/src/codex-backend.ts
@@ -27,8 +27,8 @@ import {
   anthropicToResponsesRequest,
   createResponsesSSEParser,
   formatResponsesAnthropicSSE,
+  createAnthropicMessageAssembler,
   responsesStreamToAnthropicSSE,
-  responsesToAnthropicResponse,
   type AnthropicRequest,
   type ResponsesResponse,
   type ResponsesStreamEvent,
@@ -575,6 +575,10 @@ export async function forwardToCodex(
     const translator = isAnthropic ? null : createResponsesTranslator(model);
     const sseParser = isAnthropic ? createResponsesSSEParser() : null;
     const antTranslator = isAnthropic ? responsesStreamToAnthropicSSE({ requestModel: model }) : null;
+    // The non-streaming body is FOLDED FROM THE STREAM, not read off the
+    // terminal event: this backend sends response.completed with output: [],
+    // so the content exists only in the deltas (dario#1143).
+    const antAssembler = isAnthropic ? createAnthropicMessageAssembler() : null;
     let terminalResponse: ResponsesResponse | null = null;
     let anthropicFailed = false;
 
@@ -586,7 +590,9 @@ export async function forwardToCodex(
           if (r) terminalResponse = r;
           if (t === 'response.failed') anthropicFailed = true;
         }
-        for (const out of antTranslator!.push(ev)) {
+        const produced = antTranslator!.push(ev);
+        if (!clientWantsStream) antAssembler!.push(produced);
+        for (const out of produced) {
           if (clientWantsStream) res.write(formatResponsesAnthropicSSE(out));
         }
       }
@@ -662,7 +668,8 @@ export async function forwardToCodex(
           'Access-Control-Allow-Origin': corsOrigin,
           ...securityHeaders,
         });
-        res.end(JSON.stringify(responsesToAnthropicResponse(terminalResponse ?? {}, model)));
+        antAssembler!.push(antTranslator!.end());
+        res.end(JSON.stringify(antAssembler!.message(model)));
       }
     } else if (clientWantsStream) {
       res.end();

--- a/test/codex-backend.mjs
+++ b/test/codex-backend.mjs
@@ -672,5 +672,36 @@ header('max_output_tokens is never sent to the Codex backend (dario#1142)');
   check('the rest of the body still arrives', Array.isArray(sentA.body.input) && sentA.body.stream === true);
 }
 
+
+header('non-streaming Anthropic body is folded from the STREAM (dario#1143)');
+{
+  // The ChatGPT Codex backend really does send response.completed with
+  // output: [] (verified live against a real subscription). Reading content
+  // off the terminal event therefore yields an EMPTY message that still looks
+  // perfectly well-formed — a silent empty answer. The content only ever
+  // exists in the deltas, which is the discipline the chat path already had.
+  const EMPTY_TERMINAL = [
+    { type: 'response.created', response: { id: 'resp_e', model: 'gpt-5.6-sol' } },
+    { type: 'response.output_text.delta', delta: 'HI' },
+    { type: 'response.output_text.delta', delta: ' THERE' },
+    { type: 'response.completed', response: {
+        id: 'resp_e', model: 'gpt-5.6-sol', status: 'completed',
+        output: [],
+        usage: { input_tokens: 5, output_tokens: 2 },
+    } },
+  ];
+  const res = fakeRes();
+  await forwardToCodex({}, res, Buffer.from(JSON.stringify({
+    model: 'gpt-5.6-sol', max_tokens: 100, messages: [{ role: 'user', content: 'hi' }],
+  })), CREDS, '*', {}, 5000, false, 'anthropic', fakeUpstream(EMPTY_TERMINAL, {}));
+  check('HTTP 200', res.statusCode === 200);
+  const out = JSON.parse(res.body);
+  const text = (out.content || []).filter((b) => b.type === 'text').map((b) => b.text).join('');
+  check('content is assembled from the deltas, not the empty terminal output',
+    text === 'HI THERE', out.content);
+  check('usage still comes through', out.usage && out.usage.input_tokens === 5, out.usage);
+  check('stop_reason still set', typeof out.stop_reason === 'string', out.stop_reason);
+}
+
 console.log(`\n${'='.repeat(70)}\n  ${pass} passed, ${fail} failed\n${'='.repeat(70)}`);
 process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
Third and last defect from the live end-to-end run of the Anthropic path on the box. After v5.5.88 the proof went **17/18** — streaming returned text, the Claude path was untouched, and non-streaming returned a well-formed message with `content: []`.

## The bug

The collapse read content off the terminal `response.completed` event. Correct against the standard Responses API; wrong against **this** backend. Captured live:

```
response.completed keys: ["type","response","sequence_number"]
.response.output: []
translated content: []
```

The content only ever exists in the delta events. So a non-streaming client got a perfectly well-formed Anthropic message with empty content — **a silent empty answer**, indistinguishable from a model that chose to say nothing. That is the same failure shape as the two bugs before it, which is why it is worth fixing properly rather than special-casing.

## The fix

`createAnthropicMessageAssembler()` folds the Anthropic events this module already emits back into one `Message`, and the collapse uses it. So the streamed body and the collapsed body now come from **one** translation instead of two that can disagree.

This is the discipline the chat path always had — `createResponsesTranslator.complete()` accumulates from deltas for exactly this reason, which is why the OpenAI shape never showed the bug.

## Test

Pins the real backend shape rather than my earlier assumption: a terminal event carrying `output: []` must still yield the delta text, with usage and stop_reason intact.

`npm test` 153/153, `tsc` clean, README gate green. v5.5.89 bumped in-PR.