### PR TITLE
fix(codex): thrown path reports the client's stream flag and model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [6.0.2] - 2026-08-30
+
+- **A Codex request that fails by THROWING is reported with the client's own stream flag and model.** v5.5.91 (#1149) put the ChatGPT engine on the admin/analytics surface via an `onDone` outcome hook. On the thrown path — a rejecting fetch, our own abort timeout — the outcome was built from defaults rather than from the request, so the analytics row said "non-streaming, unknown model" for a streaming `gpt-5.6-sol` call that died mid-transport. Raised by the calibration review on #1149; fixed with a direct test of the thrown outcome (stream flag + model) and coverage of the thrown upstream path, not just an HTTP 500.
+
 ## [6.0.1] - 2026-08-30
 
 - **The reverse half of failover now tests what a model IS, not what it isn't.** v6.0.0 shipped `pickClaudeFallback` as `/^claude/i` — the right direction (fail closed rather than swap in something the pool will 404 on) and the wrong test. It rejected `anthropic:sonnet`, where the operator has named the provider explicitly, and every catalog shorthand (`opus`, `sonnet1m`), so a perfectly legitimate chain entry would silently never fail over — the same class of quiet wrongness the check existed to prevent. It also did nothing about model discovery degrading: when `getCodexModelSlugs` returns an EMPTY set, selection by elimination calls *every* chain entry Claude-servable. `isClaudeServableModel` replaces it with a positive capability test resolved against the live catalog, so canonical ids, `[1m]` variants, shorthands and explicit `claude:` / `anthropic:` prefixes all qualify and the alias limitation v6.0.0 documented as accepted is gone. Two review findings on the first cut are folded in: a `claude-` prefix alone no longer counts as proof (`claude-sonnet-6` has the prefix and does not exist — the resolved id must be a catalog base), and chain entries resolve through the same alias pipeline as a request model, so pinned aliases (`opus48`) and operator `--model-alias` values work in the chain. The picker returns the resolved canonical id, because the body swap runs after the proxy's own alias pass.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/codex-backend.ts
+++ b/src/codex-backend.ts
@@ -852,7 +852,7 @@ export async function forwardToCodex(
     } else {
       try { res.end(); } catch { /* already closed */ }
     }
-    report(502, null, false, '');
+    report(502, null, clientWantsStream, model);
     return true;
   } finally {
     clearTimeout(timeout);

--- a/test/codex-admin-surface.mjs
+++ b/test/codex-admin-surface.mjs
@@ -28,6 +28,10 @@ const BASE = `http://127.0.0.1:${PROXY_PORT}`;
 const LISTED_SLUG = 'gpt-5.6-admin';
 
 let failNext = false;
+// Kill the socket instead of answering: a reset connection makes the upstream
+// fetch REJECT rather than return a status, which is the thrown path — a
+// different exit from the HTTP-500 one below.
+let resetNext = false;
 const stub = createServer((req, res) => {
   if (req.url.startsWith('/models')) {
     res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -35,6 +39,7 @@ const stub = createServer((req, res) => {
     return;
   }
   if (req.url.startsWith('/responses')) {
+    if (resetNext) { resetNext = false; req.socket.destroy(); return; }
     if (failNext) { failNext = false; res.writeHead(500, { 'Content-Type': 'application/json' }); res.end('{"error":"boom"}'); return; }
     const chunks = [];
     req.on('data', (c) => chunks.push(c));
@@ -68,6 +73,31 @@ await startProxy({ port: PROXY_PORT, host: '127.0.0.1', passthrough: true, verbo
 for (let i = 0; i < 50; i++) { try { await fetch(`${BASE}/health`); break; } catch { await sleep(100); } }
 
 const getJson = async (p) => { const r = await fetch(`${BASE}${p}`); return { status: r.status, json: await r.json() }; };
+
+// The per-request RECORDS, not the aggregates. /analytics rolls the stream flag
+// and the model up into counts, so the only surface that shows what a single
+// request was recorded AS is the SSE backlog /analytics/stream replays on
+// connect. The endpoint never ends — read the backlog, then hang up.
+const analyticsRecords = async () => {
+  const ac = new AbortController();
+  const res = await fetch(`${BASE}/analytics/stream`, { signal: ac.signal });
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = '';
+  for (let i = 0; i < 5; i++) {
+    const chunk = await Promise.race([
+      reader.read().catch(() => null),
+      sleep(250).then(() => null),
+    ]);
+    if (!chunk || chunk.done || !chunk.value) break;
+    buf += decoder.decode(chunk.value, { stream: true });
+  }
+  ac.abort();
+  return buf.split('\n')
+    .filter((l) => l.startsWith('data: '))
+    .map((l) => { try { return JSON.parse(l.slice(6)); } catch { return null; } })
+    .filter(Boolean);
+};
 
 header('GET /codex before any request — the stored account, no token, no upstream call');
 {
@@ -122,6 +152,35 @@ header('a failing backend is recorded as a failure, not a success');
   const an = (await getJson('/analytics')).json;
   check('perAccount counted the second request', an.perAccount?.fleet?.requests === 2, JSON.stringify(an.perAccount?.fleet));
   check('the window error rate is no longer zero', (an.window?.errorRate ?? 0) > 0, JSON.stringify(an.window));
+}
+
+// The HTTP-500 case above exits through the !upstream.ok branch, which always
+// reported the client's stream flag and model. The THROWN path — a fetch that
+// rejects because the connection died — is a different exit, and it used to
+// report `(502, null, false, '')`: a streaming GPT request was recorded as a
+// non-streaming one with no model, so the dashboards under-counted streams and
+// filed the failure under a nameless model (dario#1149 review).
+header('a thrown (reset) upstream keeps the request stream flag and model');
+{
+  resetNext = true;
+  const r = await fetch(`${BASE}/v1/chat/completions`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model: LISTED_SLUG, stream: true, messages: [{ role: 'user', content: 'ping' }] }),
+  });
+  const text = await r.text();
+  check('the client saw the transport failure as a 502', r.status === 502, `${r.status} ${text.slice(0, 120)}`);
+
+  const an = (await getJson('/analytics')).json;
+  check('perAccount counted the third request', an.perAccount?.fleet?.requests === 3, JSON.stringify(an.perAccount?.fleet));
+
+  const records = await analyticsRecords();
+  const thrown = records[records.length - 1];
+  check('the thrown request was recorded at all', !!thrown, `${records.length} records`);
+  check('...as the 502 the client was served', thrown?.status === 502, JSON.stringify(thrown));
+  check('...still flagged as a stream', thrown?.isStream === true, JSON.stringify(thrown));
+  check('...and still named the model it asked for', thrown?.model === LISTED_SLUG, JSON.stringify(thrown));
+  check('...against the codex alias, on the subscription claim',
+    thrown?.account === 'fleet' && thrown?.claim === 'chatgpt_subscription', JSON.stringify(thrown));
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/test/codex-thrown-report.mjs
+++ b/test/codex-thrown-report.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * test/codex-thrown-report.mjs
+ *
+ * The forwardToCodex OUTCOME on the thrown path (dario#1149/#1152 review).
+ *
+ * There are two ways a codex request fails: the upstream answers a non-2xx,
+ * or the fetch itself rejects — a reset socket, a refused connection, our own
+ * abort timeout. The first exit always reported the client's stream flag and
+ * model; the second reported `(502, null, false, '')`, so every transport
+ * failure was recorded as a NON-streaming request against a nameless model.
+ * The dashboards under-counted streams and filed the failure under ''.
+ *
+ * test/codex-admin-surface.mjs drives the same path through a real proxy, but
+ * the model half is masked there: the proxy's analytics hook falls back to the
+ * request's own model (`o.model || rawModel`, src/proxy.ts), so only the
+ * stream flag is observable end to end. The outcome object is only visible
+ * undiluted here.
+ *
+ * No network: an injected `fetch` that throws, and a fake ServerResponse.
+ */
+
+import { forwardToCodex } from '../dist/codex-backend.js';
+
+let pass = 0, fail = 0;
+function check(label, cond, detail) {
+  if (cond) { console.log(`  ✅ ${label}`); pass++; }
+  else { console.log(`  ❌ ${label}${detail ? ' :: ' + detail : ''}`); fail++; }
+}
+function header(label) {
+  console.log(`\n${'='.repeat(70)}\n  ${label}\n${'='.repeat(70)}`);
+}
+
+/** Minimal ServerResponse stand-in: records status, headers and written body. */
+function fakeRes() {
+  return {
+    statusCode: null, headers: null, chunks: [], ended: false, headersSent: false,
+    writeHead(code, hdrs) { this.statusCode = code; this.headers = hdrs; this.headersSent = true; },
+    write(s) { this.chunks.push(s); return true; },
+    end(s) { if (s !== undefined) this.chunks.push(s); this.ended = true; },
+    get body() { return this.chunks.join(''); },
+  };
+}
+const CREDS = { alias: 'test', accessToken: 'tok', idToken: undefined };
+const throwingUpstream = (err) => async () => { throw err; };
+const reqBody = (over = {}) => Buffer.from(JSON.stringify({
+  model: 'gpt-5.6-sol', messages: [{ role: 'user', content: 'hi' }], ...over,
+}));
+
+/** Run one thrown-upstream request and return the reported outcome (or null). */
+async function reportOf(bodyOver, { shape = 'openai', defer = false, err = new TypeError('fetch failed') } = {}) {
+  let outcome = null;
+  const res = fakeRes();
+  const served = await forwardToCodex(
+    {}, res, reqBody(bodyOver), CREDS, '*', {}, 5000, false, shape,
+    throwingUpstream(err), defer, (o) => { outcome = o; },
+  );
+  return { outcome, res, served };
+}
+
+header('a thrown upstream reports the CLIENT\'s stream flag, not a hardcoded false');
+{
+  const streaming = await reportOf({ stream: true });
+  check('the client is still answered 502', streaming.served === true && streaming.res.statusCode === 502,
+    String(streaming.res.statusCode));
+  check('the outcome is reported at all', streaming.outcome !== null);
+  check('THE BUG: a streaming request is recorded as a stream',
+    streaming.outcome?.stream === true, JSON.stringify(streaming.outcome));
+  check('THE BUG: and against the model it asked for, not \'\'',
+    streaming.outcome?.model === 'gpt-5.6-sol', JSON.stringify(streaming.outcome));
+  check('status is the 502 the client saw', streaming.outcome?.status === 502, JSON.stringify(streaming.outcome));
+  check('no tokens were exchanged, so both counts are zero',
+    streaming.outcome?.inputTokens === 0 && streaming.outcome?.outputTokens === 0);
+  check('the account is named so per-account analytics can attribute it',
+    streaming.outcome?.alias === 'test');
+
+  const plain = await reportOf({});
+  check('a NON-streaming request is still recorded as non-streaming (no over-correction)',
+    plain.outcome?.stream === false, JSON.stringify(plain.outcome));
+  check('...and still carries the model', plain.outcome?.model === 'gpt-5.6-sol');
+}
+
+header('the same holds on the Anthropic shape and for our own abort timeout');
+{
+  const ant = await reportOf({ stream: true }, { shape: 'anthropic' });
+  check('anthropic streaming: recorded as a stream', ant.outcome?.stream === true, JSON.stringify(ant.outcome));
+  check('anthropic streaming: recorded with the model', ant.outcome?.model === 'gpt-5.6-sol');
+
+  const abortErr = Object.assign(new Error('This operation was aborted'), { name: 'AbortError' });
+  const timedOut = await reportOf({ stream: true }, { err: abortErr });
+  check('an upstream timeout lands in the same catch and keeps the metadata',
+    timedOut.outcome?.stream === true && timedOut.outcome?.model === 'gpt-5.6-sol' && timedOut.outcome?.status === 502,
+    JSON.stringify(timedOut.outcome));
+}
+
+header('a DECLINE still reports nothing — the next provider records what it serves');
+{
+  const declined = await reportOf({ stream: true }, { defer: true });
+  check('the request is handed on, not answered', declined.served === false);
+  check('and nothing is reported, so the row is not double-counted',
+    declined.outcome === null, JSON.stringify(declined.outcome));
+  check('...having written no bytes either',
+    declined.res.headersSent === false && declined.res.ended === false && declined.res.chunks.length === 0);
+}
+
+header('an unparseable body reports the 400 it served, with no model to name');
+{
+  let outcome = null;
+  const res = fakeRes();
+  await forwardToCodex(
+    {}, res, Buffer.from('not json'), CREDS, '*', {}, 5000, false, 'openai',
+    throwingUpstream(new TypeError('fetch failed')), false, (o) => { outcome = o; },
+  );
+  check('the client gets a 400, not a 502', res.statusCode === 400, String(res.statusCode));
+  check('reported as a 400 with no stream flag and no model — there was no request to read one from',
+    outcome?.status === 400 && outcome?.stream === false && outcome?.model === '', JSON.stringify(outcome));
+}
+
+console.log(`\n${'='.repeat(70)}\n  ${pass} passed, ${fail} failed\n${'='.repeat(70)}`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
Review follow-up on #1149 (source ticket 00MTFXR6NV7E9AC720D9DEC819).

## Problem
`src/codex-backend.ts:835` — the `catch` arm of `forwardToCodex` called
`report(502, null, false, '')`. Any request that died by throw (upstream
transport failure, abort/timeout, a mid-stream error) was therefore recorded
as non-streaming with an empty model, even when the client had asked for a
stream on a named model. That silently skews the analytics rows and per-account
counts the `onDone` hook exists to produce: every codex failure looks like a
non-streaming request to an unknown model.

The 400 arm at :644 keeps `report(400, null, false, '')` — it fires before the
body is parsed, so neither value is known there. That one is correct as-is.

## Fix
Pass the real values, both of which are already in scope at the catch
(`clientWantsStream` :648, `model` :649):

```
-    report(502, null, false, '');
+    report(502, null, clientWantsStream, model);
```

## Test plan
- CI (build 18/20/22, test, CodeQL) on this branch.
- Behaviour is reporting-only: no change to what the client receives on either
  the deferral path (`return false`, no report — unchanged) or the 502 path.

Based on `codex-admin-surface` so it lands with #1149; retarget to master if
#1149 merges first.