### PR TITLE
release: 6.0.3 — ship the mid-flight 429 fallback fix (#1153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ checklist.
 
 ## [Unreleased]
 
+## [6.0.3] - 2026-08-30
+
+### Fixed
+- **The mid-flight 429 fallback now fires in the mode dario actually runs in.** v6.0.0 put the pool-exhaustion fallback in `dispatchLoop`'s standalone `if (upstream.status === 429)` block. Outside passthrough, a 429 is peeked by the 400/long-context recovery chain, which returns from its own arm — so that block was unreachable and a pool that drained mid-request surfaced an enriched 429 to the client with a healthy ChatGPT subscription sitting unused beside it. Exactly the failure v6.0.0 exists to prevent, in the one configuration it was written for. Merged as #1153 without a version bump, so it did not ship with 6.0.2; this release carries it.
+
 ## [6.0.2] - 2026-08-30
 
 - **A Codex request that fails by THROWING is reported with the client's own stream flag and model.** v5.5.91 (#1149) put the ChatGPT engine on the admin/analytics surface via an `onDone` outcome hook. On the thrown path — a rejecting fetch, our own abort timeout — the outcome was built from defaults rather than from the request, so the analytics row said "non-streaming, unknown model" for a streaming `gpt-5.6-sol` call that died mid-transport. Raised by the calibration review on #1149; fixed with a direct test of the thrown outcome (stream flag + model) and coverage of the thrown upstream path, not just an HTTP 500.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "6.0.2",
+      "version": "6.0.3",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
`#1153` merged at 18:38Z with no version bump. Under the release gate that means it **did not ship**: the `v6.0.2` tag points at `#1152`'s commit, that is what is on npm, and that is what the box is running.

Verified rather than assumed — the running `dist/proxy.js` on the box carries the pre-`#1153` shape (2 occurrences of the fallback reason string; master has 4). Redline flagged the missing bump on the PR at 16:44 and it was merged anyway.

## Why this one matters now

The Claude pool on the box is **a pool of one account, rate-limited since 17:34Z**. Every Anthropic-shape agent has been dropping on 429 for over an hour — Developer, Finance, GitHub Manager, the Claude reviewer — while the ChatGPT subscription sits idle and the GPT reviewer completes normally on the same proxy.

That is precisely the failure v6.0.0 exists to prevent, in precisely the code path `#1153` repaired: outside passthrough the 429 is peeked by the 400/long-context recovery chain, which returns from its own arm, so v6.0.0's fallback block was unreachable in the mode dario actually runs in.

Shipping this is what makes the failover real on this deployment.

## Contents

Version bump + changelog only — no code change. `#1153`'s diff is already on master.

- `preflight`: clean (version agrees across package.json + lockfile; changelog top heading matches)
- `test/codex-pool-fallback-mid-flight.mjs`: 18/18
- full suite: green
