### PR TITLE
fix(failover): prefix-parse pool-fallback alias targets before Claude resolution

### DIFF
--- a/src/claude-model.ts
+++ b/src/claude-model.ts
@@ -19,7 +19,9 @@
  *      `--model-alias` values, pinned aliases (`opus48`) and catalog family
  *      shorthands (`opus`, `sonnet1m`) map to a canonical id. The caller
  *      supplies that resolver so classification and forwarding cannot
- *      disagree.
+ *      disagree. The prefix rule applies to the alias TARGET too, since an
+ *      operator alias is written the way a request model is written — see
+ *      stripClaudePrefix.
  *   2. VALIDATE the resolved id against the catalog base set. A `claude-`
  *      prefix on its own proves nothing — `claude-sonnet-6` has the prefix and
  *      does not exist — so the id (sans `[1m]`) must be a base the pool can
@@ -43,6 +45,22 @@ const CLAUDE_PREFIXES = new Set(['claude', 'anthropic']);
 export type ModelResolver = (model: string) => string;
 
 /**
+ * Strip a Claude-side provider prefix, or refuse the name outright.
+ *
+ * Null on any prefix that isn't `claude:`/`anthropic:` — a recognized
+ * non-Claude prefix is a definite NO, not a fall-through to the name test
+ * (`openai:claude-sonnet-5` is the operator pointing somewhere else on
+ * purpose), and an unrecognized one names a model this pool has no claim on.
+ * `model` is expected already trimmed + lowercased.
+ */
+function stripClaudePrefix(model: string): string | null {
+  const idx = model.indexOf(':');
+  if (idx <= 0) return model || null;
+  if (!CLAUDE_PREFIXES.has(model.slice(0, idx))) return null;
+  return model.slice(idx + 1) || null;
+}
+
+/**
  * The canonical id the Claude pool would serve `model` as, or null when it
  * cannot serve it. `bases` is the catalog base set — `getCachedBases()` at a
  * call site, a fixture in a test. `resolve` is the alias pipeline; the default
@@ -54,21 +72,24 @@ export function resolveClaudeServable(
   bases: readonly string[] = BAKED_BASE_MODELS,
   resolve?: ModelResolver,
 ): string | null {
-  let m = model.trim().toLowerCase();
-  if (!m) return null;
+  const entry = stripClaudePrefix(model.trim().toLowerCase());
+  if (entry === null) return null;
 
-  const idx = m.indexOf(':');
-  if (idx > 0) {
-    const prefix = m.slice(0, idx);
-    // A recognized non-Claude prefix is a definite NO, not a fall-through to
-    // the name test below — `openai:claude-sonnet-5` is the operator pointing
-    // somewhere else on purpose.
-    if (!CLAUDE_PREFIXES.has(prefix)) return null;
-    m = m.slice(idx + 1);
-    if (!m) return null;
-  }
+  // The alias TARGET may carry a prefix of its own — operator aliases are
+  // declared the way a request model is written, and `--model-alias=backup=
+  // claude:opus` is the natural way to say it (dario#1151). The request path
+  // parses that prefix AFTER alias resolution; without the same pass here the
+  // target reached the base check as the literal `claude:opus`, matched
+  // nothing, and a perfectly valid fallback was skipped.
+  const target = stripClaudePrefix(
+    (resolve ? resolve(entry) : (resolveAliasAgainst(entry, bases) ?? entry)).trim().toLowerCase(),
+  );
+  if (target === null) return null;
 
-  const resolved = (resolve ? resolve(m) : (resolveAliasAgainst(m, bases) ?? m)).trim().toLowerCase();
+  // A target that arrived prefixed still holds a shorthand (`claude:opus` →
+  // `opus`), so the catalog pass runs on it. Idempotent for a target already
+  // canonical: resolveAliasAgainst only answers for family shorthands.
+  const resolved = resolveAliasAgainst(target, bases) ?? target;
   const base = resolved.endsWith('[1m]') ? resolved.slice(0, -4) : resolved;
   return bases.some((b) => b.toLowerCase() === base) ? resolved : null;
 }

--- a/test/pool-fallback-alias-prefix.mjs
+++ b/test/pool-fallback-alias-prefix.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * test/pool-fallback-alias-prefix.mjs
+ *
+ * dario#1151 review finding (src/proxy.ts:3050) — pool-fallback chain entries
+ * whose OPERATOR ALIAS TARGET carries a `claude:` / `anthropic:` prefix.
+ *
+ * The request path resolves an operator `--model-alias` FIRST and parses the
+ * provider prefix AFTER, precisely so a target may carry one
+ * (`my-fast` → `openai:gpt-4o-mini`) and retarget the backend. Chain
+ * selection ran the same resolver but only prefix-parsed the entry AS
+ * WRITTEN — so `--model-alias=backup=claude:opus --pool-fallback=gpt-5.6-sol,backup`
+ * resolved `backup` to the literal `claude:opus`, matched no catalog base, and
+ * pickClaudeFallback returned null. A perfectly valid reverse-failover target
+ * was silently skipped and a rate-limited subscription stayed terminal.
+ *
+ * Covers resolveClaudeServable / isClaudeServableModel / pickClaudeFallback
+ * with prefixed alias targets, using the proxy's REAL resolver shape
+ * (`resolveClaudeAlias(applyModelAlias(m, aliases) ?? m)`) so classification
+ * and forwarding cannot disagree — plus the fail-closed cases the prefix pass
+ * must not weaken.
+ *
+ * Runs in-process. No proxy, no OAuth, no network.
+ */
+
+import { isClaudeServableModel, resolveClaudeServable } from '../dist/claude-model.js';
+import { pickClaudeFallback } from '../dist/codex-backend.js';
+import { resolveClaudeAlias, applyModelAlias } from '../dist/proxy.js';
+
+let pass = 0;
+let fail = 0;
+
+function check(label, cond) {
+  if (cond) { pass++; console.log(`  ✅ ${label}`); }
+  else { fail++; console.log(`  ❌ ${label}`); }
+}
+
+function header(name) {
+  console.log(`\n${'='.repeat(70)}\n  ${name}\n${'='.repeat(70)}`);
+}
+
+const BASES = ['claude-opus-5', 'claude-opus-4-8', 'claude-sonnet-5', 'claude-haiku-4-5'];
+const SLUGS = ['gpt-5.6-sol', 'gpt-5.5'];
+
+// Exactly the resolver proxy.ts hands pickClaudeFallback at the codex-decline
+// site — operator aliases first, then the pinned + catalog pass.
+const ALIASES = {
+  backup: 'claude:opus',
+  spare: 'anthropic:sonnet',
+  fast: 'anthropic:haiku',
+  elsewhere: 'openai:gpt-4o',
+  ghost: 'claude:sonnet-6',
+  unknown: 'ollama:llama3',
+};
+const resolver = (m) => resolveClaudeAlias(applyModelAlias(m, ALIASES) ?? m);
+
+header('dario#1151 — an alias target carrying a claude:/anthropic: prefix');
+{
+  check('THE BUG: backup → claude:opus is servable (was null — target never prefix-parsed)',
+    resolveClaudeServable('backup', BASES, resolver) === 'claude-opus-5');
+  check('...and the picker selects it, returning the canonical id',
+    pickClaudeFallback(['gpt-5.6-sol', 'backup'], SLUGS, BASES, resolver) === 'claude-opus-5');
+  check('anthropic: on the target works the same way',
+    resolveClaudeServable('spare', BASES, resolver) === 'claude-sonnet-5');
+  check('...through the picker too',
+    pickClaudeFallback(['gpt-5.6-sol', 'spare'], SLUGS, BASES, resolver) === 'claude-sonnet-5');
+  check('a third family confirms it is the prefix rule, not one lucky name',
+    pickClaudeFallback(['gpt-5.5', 'fast'], SLUGS, BASES, resolver) === 'claude-haiku-4-5');
+  check('isClaudeServableModel agrees with the resolver',
+    isClaudeServableModel('backup', BASES, resolver) === true);
+}
+
+header('the prefix pass must stay FAIL-CLOSED');
+{
+  check('an alias target on a non-Claude provider is still refused',
+    resolveClaudeServable('elsewhere', BASES, resolver) === null);
+  check('...and the picker skips it rather than 404ing Anthropic with gpt-4o',
+    pickClaudeFallback(['gpt-5.6-sol', 'elsewhere'], SLUGS, BASES, resolver) === null);
+  check('a prefix cannot make a nonexistent model servable',
+    resolveClaudeServable('ghost', BASES, resolver) === null);
+  check('an unrecognized prefix on the target is refused, not stripped',
+    resolveClaudeServable('unknown', BASES, resolver) === null);
+  check('an alias naming nothing real falls through to the base check',
+    resolveClaudeServable('nonesuch', BASES, resolver) === null);
+  check('a chain of only unservable entries selects nothing',
+    pickClaudeFallback(['elsewhere', 'ghost', 'unknown'], SLUGS, BASES, resolver) === null);
+}
+
+header('pre-existing behaviour is unchanged by the second prefix pass');
+{
+  check('a prefixed ENTRY (no alias involved) still resolves',
+    pickClaudeFallback(['gpt-5.6-sol', 'claude:opus'], SLUGS, BASES) === 'claude-opus-5');
+  check('a bare canonical id is untouched',
+    resolveClaudeServable('claude-sonnet-5', BASES, resolver) === 'claude-sonnet-5');
+  check('a catalog shorthand still resolves',
+    resolveClaudeServable('opus', BASES, resolver) === 'claude-opus-5');
+  check('a [1m] variant survives the extra pass',
+    resolveClaudeServable('claude-opus-5[1m]', BASES, resolver) === 'claude-opus-5[1m]');
+  check('a codex slug is still handed to the codex end',
+    pickClaudeFallback(['gpt-5.6-sol'], SLUGS, BASES, resolver) === null);
+  check('an entry prefixed for the other provider is a definite no',
+    resolveClaudeServable('openai:claude-opus-5', BASES, resolver) === null);
+  check('empty selects nothing', pickClaudeFallback([], SLUGS, BASES, resolver) === null);
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Fixes the `src/proxy.ts:3050` finding from the #1151 review.
Source ticket: `01M19Z4H0N0SSHVRAZ5B79W9ZA`.

## The bug

`proxy.ts:3050` hands `pickClaudeFallback` the proxy's real resolver:

```ts
(m) => resolveClaudeAlias(applyModelAlias(m, modelAliases) ?? m)
```

`resolveClaudeServable` prefix-parsed the chain entry **as written**, then ran
that resolver, then checked the result against the catalog base set — with no
second prefix pass. But an operator `--model-alias` target is written the way a
request model is written, and the request path is explicitly ordered
alias-first / prefix-second so a target *may* carry a prefix
(`my-fast` → `openai:gpt-4o-mini`, per `proxy.ts:2869-2882` and the
`applyModelAlias` doc comment).

So with `--model-alias=backup=claude:opus --pool-fallback=gpt-5.6-sol,backup`,
`backup` resolved to the literal string `claude:opus`, matched no base, and
`pickClaudeFallback` returned `null`. `canDefer` went false, the ChatGPT
subscription was never allowed to decline, and a rate-limited plan stayed
terminal for the request — with an idle Claude pool sitting beside it. Silent:
the operator's config is valid and there is no log line saying it was ignored.

## The fix

`src/claude-model.ts` — the prefix rule is now a `stripClaudePrefix` helper
applied to **both** the entry and the resolved alias target. A target arriving
prefixed still holds a shorthand (`claude:opus` → `opus`), so the catalog pass
runs on it afterward; that pass is idempotent for an already-canonical target
because `resolveAliasAgainst` only answers for family shorthands.

Fail-closed behaviour is unchanged in both directions: a non-Claude prefix on
the target (`openai:gpt-4o`) is a definite no rather than a fall-through, an
unrecognized prefix (`ollama:llama3`) is refused rather than stripped, and a
prefix still cannot make a nonexistent model servable (`claude:sonnet-6`).

## Test plan

New `test/pool-fallback-alias-prefix.mjs` (picked up automatically by
`test/all.test.mjs`'s directory scan), 19 checks in three groups:

- the bug — prefixed alias targets across three families, through
  `resolveClaudeServable`, `isClaudeServableModel` and `pickClaudeFallback`,
  using the exact resolver shape `proxy.ts:3050` builds;
- fail-closed — non-Claude target, unrecognized-prefix target, typo behind a
  prefix, all-unservable chain;
- no regression — prefixed entry with no alias, canonical id, shorthand, `[1m]`
  variant, codex slug, `openai:`-prefixed entry, empty chain.

Verified locally under the build wall by extracting the new pure function into
a standalone harness with the family-shorthand resolver stubbed: 13/13 pass,
including the three cases that returned `null` before this change. CI compiles
and runs the suite proper.