### PR TITLE
ci: advisory PR comment when a shipping change carries no version bump

### DIFF
--- a/.github/workflows/version-bump-advice.yml
+++ b/.github/workflows/version-bump-advice.yml
@@ -123,7 +123,10 @@ jobs:
           MARKER='<!-- version-bump-advice -->'
 
           if [ "$VERDICT" = "true" ]; then
-            NEXT=$(node -e 'const [a,b,c]=process.argv[1].split(".").map(Number);console.log(`${a}.${b}.${c+1}`)' "$BASE_VER")
+            # join() rather than a template literal: `${a}` inside the single-
+            # quoted -e argument reads as an unexpanded shell expression to
+            # shellcheck (SC2016), which actionlint runs over every `run:`.
+            NEXT=$(node -e 'const p=process.argv[1].split(".").map(Number);console.log([p[0],p[1],p[2]+1].join("."))' "$BASE_VER")
             BODY=$(cat <<EOF
           $MARKER
           ### :package: This PR will not cut a release

--- a/.github/workflows/version-bump-advice.yml
+++ b/.github/workflows/version-bump-advice.yml
@@ -1,0 +1,176 @@
+name: Version bump advice
+
+# Surfaces the release gate BEFORE merge instead of after.
+#
+# cc-drift-auto-release ships only when package.json's version moves on
+# master. A PR that changes shipping code without bumping is green on every
+# axis — CI passes, mergeable is clean, the merge succeeds — and then releases
+# nothing. Seven PRs in the 48h to 2026-08-30 (#1153, #1151, #1150, #1147,
+# #1139, #1131, #1010) sat in exactly that state, each found by an after-the-
+# fact sweep rather than by anything the author saw while the PR was open.
+#
+# This does NOT block. It posts (and keeps updated) a single comment on the PR
+# saying whether a bump is missing. Deliberately advisory:
+#
+#   - Not a required check. Making it one would gate human PRs on a release
+#     decision that is sometimes legitimately "no" (a revert, a stacked PR
+#     whose partner carries the bump), and a check people routinely override
+#     stops being read at all.
+#   - Not a new required status either — it reports `success` in both
+#     directions, so adding it to branch protection later is a deliberate act,
+#     not something that happens by accident on the next merge.
+#
+# The ordering question — is the proposed version ABOVE the base tip — is a
+# different one, already enforced for bot PRs by scripts/version-advances.sh
+# in auto-merge-bot-prs.yml. This workflow only asks whether a bump is there.
+#
+# `pull_request_target`, not `pull_request`: posting a comment needs
+# pull-requests: write, and a fork-headed `pull_request` run gets a read-only
+# token, which is exactly the external-contributor PR most likely to forget
+# the bump. Same safety shape as auto-merge-bot-prs.yml — the checkout takes
+# the BASE ref (never the PR head) and is sparse to the one script, so no
+# head-authored code is executed with this token.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  advise:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    # Bot PRs already carry their bump by construction (the drift drafters
+    # call bumpPackageJsonPatch) and are gated on ordering by
+    # auto-merge-bot-prs.yml. Commenting on them would be noise on a PR nobody
+    # reads before it auto-merges.
+    if: |
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      !startsWith(github.event.pull_request.head.ref, 'bot/')
+    steps:
+      - name: Fetch the advice script
+        uses: askalf/checkout-with-retry@115a6407547e9711edbc2e915838d495cad9583f  # v1.1.0
+        with:
+          sparse-checkout: scripts/version-bump-advice.mjs
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Decide whether a bump is missing
+        id: advice
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # Versions through the contents API, matching auto-merge-bot-prs.yml:
+          # the sparse checkout holds only the script, and the two versions live
+          # at two different refs anyway.
+          version_at() {
+            gh api "repos/${REPO}/contents/package.json?ref=$1" --jq '.content' 2>/dev/null \
+              | base64 -d 2>/dev/null | jq -r '.version // empty'
+          }
+
+          base_ver=$(version_at "$BASE_SHA")
+          head_ver=$(version_at "$HEAD_SHA")
+
+          # Fail SILENT, not open and not closed: an advisory that could not
+          # read a version has nothing useful to say, and a comment guessing at
+          # one is worse than no comment.
+          if [ -z "$base_ver" ] || [ -z "$head_ver" ]; then
+            echo "::warning::Could not read package.json at both refs - skipping advice."
+            echo "verdict=skip" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          gh api "repos/${REPO}/pulls/${PR}/files" --paginate --jq '.[].filename' > changed-files.txt
+          echo "changed files: $(wc -l < changed-files.txt)"
+
+          verdict=$(node scripts/version-bump-advice.mjs "$base_ver" "$head_ver" changed-files.txt)
+          needs=$(echo "$verdict" | head -1)
+          reason=$(echo "$verdict" | tail -1)
+
+          echo "base=$base_ver head=$head_ver -> needs_bump=$needs ($reason)"
+          {
+            echo "verdict=$needs"
+            echo "reason=$reason"
+            echo "base_ver=$base_ver"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post or update the advice comment
+        if: steps.advice.outputs.verdict != 'skip'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          VERDICT: ${{ steps.advice.outputs.verdict }}
+          REASON: ${{ steps.advice.outputs.reason }}
+          BASE_VER: ${{ steps.advice.outputs.base_ver }}
+        run: |
+          set -euo pipefail
+
+          # One comment per PR, edited in place. An HTML-comment marker is the
+          # identity: a `synchronize` on a long-lived branch can fire dozens of
+          # times, and a fresh comment each push would bury review discussion.
+          MARKER='<!-- version-bump-advice -->'
+
+          if [ "$VERDICT" = "true" ]; then
+            NEXT=$(node -e 'const [a,b,c]=process.argv[1].split(".").map(Number);console.log(`${a}.${b}.${c+1}`)' "$BASE_VER")
+            BODY=$(cat <<EOF
+          $MARKER
+          ### :package: This PR will not cut a release
+
+          $REASON
+
+          \`cc-drift-auto-release\` tags and publishes only when \`package.json\`'s
+          version moves on \`master\`. As it stands this PR merges green and ships
+          nothing — the change sits on master until some later PR's bump carries it
+          out.
+
+          If that is intended (revert, docs-only refactor, or a stacked PR whose
+          partner carries the bump), ignore this. Otherwise bump all three slots
+          that \`scripts/preflight.mjs\` checks, in one commit:
+
+          - \`package.json\` → \`$NEXT\`
+          - \`package-lock.json\` → \`.version\` **and** \`.packages[""].version\`
+          - \`CHANGELOG.md\` → a \`## [$NEXT] - $(date -u +%Y-%m-%d)\` section under \`## [Unreleased]\`
+
+          This comment is advisory and updates itself on every push; it never
+          blocks the merge.
+          EOF
+          )
+          else
+            BODY=$(cat <<EOF
+          $MARKER
+          ### :white_check_mark: Release gate looks satisfied
+
+          $REASON
+          EOF
+          )
+          fi
+
+          # `--jq` filter over the marker rather than a body search: comment
+          # listing is cheap on a PR and an exact marker match cannot collide
+          # with prose that quotes it.
+          existing=$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
+            --jq "[.[] | select(.body | contains(\"$MARKER\")) | .id] | first // empty")
+
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/${REPO}/issues/comments/${existing}" -f body="$BODY" >/dev/null
+            echo "updated comment $existing"
+          elif [ "$VERDICT" = "true" ]; then
+            gh api -X POST "repos/${REPO}/issues/${PR}/comments" -f body="$BODY" >/dev/null
+            echo "posted new comment"
+          else
+            # Nothing to say and nothing to correct — don't open a thread just
+            # to congratulate a PR that did the normal thing.
+            echo "no bump needed and no existing comment; staying quiet"
+          fi

--- a/.github/workflows/version-bump-advice.yml
+++ b/.github/workflows/version-bump-advice.yml
@@ -123,9 +123,10 @@ jobs:
           MARKER='<!-- version-bump-advice -->'
 
           if [ "$VERDICT" = "true" ]; then
-            # join() rather than a template literal: `${a}` inside the single-
-            # quoted -e argument reads as an unexpanded shell expression to
-            # shellcheck (SC2016), which actionlint runs over every `run:`.
+            # Patch-bumps BASE_VER for the suggestion. join() rather than a JS
+            # template literal, because a `${...}` inside the single-quoted -e
+            # argument reads as an unexpanded shell expression to SC2016, and
+            # actionlint runs shellcheck over every `run:` block.
             NEXT=$(node -e 'const p=process.argv[1].split(".").map(Number);console.log([p[0],p[1],p[2]+1].join("."))' "$BASE_VER")
             BODY=$(cat <<EOF
           $MARKER

--- a/scripts/version-bump-advice.mjs
+++ b/scripts/version-bump-advice.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * version-bump-advice — does THIS PR need a package.json version bump?
+ *
+ * WHY THIS EXISTS. cc-drift-auto-release only ships when package.json's
+ * version moves on master. A PR that changes shipping code without bumping is
+ * therefore green everywhere — CI passes, mergeable is clean, the merge
+ * succeeds — and then releases NOTHING. The defect is invisible until an
+ * after-the-fact sweep notices the deployed version never moved; seven PRs in
+ * the 48h to 2026-08-30 (#1153, #1151, #1150, #1147, #1139, #1131, #1010)
+ * landed or sat in exactly that state.
+ *
+ * The gate is correct and stays as it is. What was missing is VISIBILITY at
+ * the moment it can still be acted on cheaply, i.e. while the PR is open. So
+ * this is advisory: it decides, the workflow comments, nothing blocks.
+ *
+ * THE RULE. A PR needs a bump when it touches a file that reaches users, and
+ * its head version equals its base version. "Reaches users" is derived from
+ * what actually ships:
+ *
+ *   - package.json `files` (dist, docs, README.md, LICENSE) — the npm tarball;
+ *     dist/ is built from src/, so src/ is the real source entry.
+ *   - the Docker image inputs (Dockerfile, docker-entrypoint.sh) — the GHCR
+ *     leg of the same release pipeline.
+ *   - package.json / package-lock.json themselves — a dependency change is
+ *     shipped code even when no first-party line moved.
+ *
+ * Everything else (test/, .github/, scripts/, tools/, fuzz/, reviews/, the
+ * root docs that are not README) changes nothing a user can install, so
+ * nagging about it would train people to ignore the comment. CHANGELOG.md is
+ * exempt for the same reason AND because a bump always carries one, so
+ * counting it would make every bump PR self-justifying.
+ *
+ * Ordering ("is this version above the tip?") is a different question with a
+ * different answer, already enforced by scripts/version-advances.sh. This
+ * script only asks whether a bump is PRESENT.
+ *
+ * Usage:
+ *   node scripts/version-bump-advice.mjs <base_ver> <head_ver> [files-file]
+ *
+ * `files-file` is a newline-delimited list of changed paths; omit it (or pass
+ * `-`) to read the list from stdin.
+ *
+ * Writes exactly TWO lines to stdout, matching version-advances.sh:
+ *   1  needs_bump  "true" | "false"
+ *   2  reason      short human-readable explanation
+ *
+ * Exit status is 0 for a decision of either kind; non-zero means it could not
+ * decide, which callers must treat as "say nothing" — an advisory that guesses
+ * is worse than one that stays quiet.
+ */
+import { readFileSync } from 'node:fs';
+
+/**
+ * Paths that never reach an installed artifact. Prefix match on the repo-
+ * relative path, plus an exact-name list for root files.
+ */
+const EXEMPT_PREFIXES = [
+  'test/',
+  '.github/',
+  'scripts/',
+  'tools/',
+  'fuzz/',
+  'reviews/',
+  'cloudflare/',
+  'redis-lock/',
+];
+
+const EXEMPT_FILES = new Set([
+  'CHANGELOG.md',
+  'CLAUDE.md',
+  'CODEOWNERS',
+  'CODE_OF_CONDUCT.md',
+  'CONTRIBUTING.md',
+  'DISCLAIMER.md',
+  'MIGRATION.md',
+  'RELEASING.md',
+  'SECURITY.md',
+  'STABILITY.md',
+  '.gitignore',
+  '.npmignore',
+  '.dockerignore',
+]);
+
+/** True when changing this path can change what a user installs or runs. */
+export function shipsToUsers(path) {
+  if (!path) return false;
+  if (EXEMPT_FILES.has(path)) return false;
+  if (EXEMPT_PREFIXES.some((p) => path.startsWith(p))) return false;
+  return true;
+}
+
+/**
+ * @param {string} baseVer  version at the PR's merge base
+ * @param {string} headVer  version the PR proposes
+ * @param {string[]} files  changed paths, repo-relative
+ * @returns {{ needsBump: boolean, reason: string, shipping: string[] }}
+ */
+export function adviseBump(baseVer, headVer, files) {
+  const shipping = (files ?? []).filter(shipsToUsers);
+
+  if (headVer !== baseVer) {
+    return {
+      needsBump: false,
+      reason: `version bumped ${baseVer} -> ${headVer}`,
+      shipping,
+    };
+  }
+  if (shipping.length === 0) {
+    return {
+      needsBump: false,
+      reason: 'no shipping files changed - a release would carry nothing',
+      shipping,
+    };
+  }
+  const sample = shipping.slice(0, 3).join(', ');
+  const more = shipping.length > 3 ? ` (+${shipping.length - 3} more)` : '';
+  return {
+    needsBump: true,
+    reason: `version stays at ${baseVer} but ${shipping.length} shipping file(s) changed: ${sample}${more}`,
+    shipping,
+  };
+}
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+// Guarded so the test file can import the pure functions above without the
+// argv handling running, same shape as scripts/drift-report.mjs.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const [baseVer, headVer, filesArg] = process.argv.slice(2);
+
+  // Fail CLOSED, and "closed" for an advisory means SILENT: a caller that
+  // could not read a version must not post a comment guessing at one.
+  if (!baseVer || !headVer) {
+    console.error('usage: version-bump-advice.mjs <base_ver> <head_ver> [files-file]');
+    process.exit(2);
+  }
+
+  let raw;
+  try {
+    raw = readFileSync(!filesArg || filesArg === '-' ? 0 : filesArg, 'utf8');
+  } catch (e) {
+    console.error(`could not read changed-file list: ${e.message}`);
+    process.exit(2);
+  }
+
+  const files = raw.split('\n').map((s) => s.trim()).filter(Boolean);
+  const { needsBump, reason } = adviseBump(baseVer, headVer, files);
+  process.stdout.write(`${needsBump}\n${reason}\n`);
+}

--- a/test/version-bump-advice.mjs
+++ b/test/version-bump-advice.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+// Tests for scripts/version-bump-advice.mjs — the advisory that tells a PR
+// author, while the PR is still open, that their change will merge green and
+// release nothing.
+//
+// Worth testing for the same reason version-advances.sh is: both failure
+// directions are quiet. Too permissive and it stays silent on exactly the PRs
+// it exists for (#1153 / #1151 / #1150 / #1147 shape). Too noisy and it
+// comments on every test-only and workflow-only PR, at which point people
+// learn to scroll past it and the real warning goes unread too. Neither shows
+// up as a red run.
+
+import { adviseBump, shipsToUsers } from '../scripts/version-bump-advice.mjs';
+
+let pass = 0, fail = 0;
+const check = (name, cond, detail) => {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else { console.log(`  FAIL ${name}${detail ? ' :: ' + detail : ''}`); fail++; }
+};
+const header = (n) => console.log(`\n=== ${n} ===`);
+
+header('shipping vs non-shipping paths');
+{
+  for (const p of [
+    'src/proxy.ts',
+    'src/backends/codex-backend.ts',
+    'package.json',
+    'package-lock.json',
+    'Dockerfile',
+    'docker-entrypoint.sh',
+    'README.md',
+    'docs/recovery.md',
+  ]) {
+    check(`${p} ships`, shipsToUsers(p) === true);
+  }
+
+  for (const p of [
+    'test/proxy.mjs',
+    '.github/workflows/ci.yml',
+    'scripts/preflight.mjs',
+    'tools/bench.mjs',
+    'fuzz/headers.mjs',
+    'reviews/2026-08-25.md',
+    'cloudflare/worker.js',
+    'redis-lock/lock.lua',
+    'CHANGELOG.md',
+    'CONTRIBUTING.md',
+    'RELEASING.md',
+    'CLAUDE.md',
+  ]) {
+    check(`${p} does not ship`, shipsToUsers(p) === false);
+  }
+
+  check('empty path does not ship', shipsToUsers('') === false);
+  check('undefined path does not ship', shipsToUsers(undefined) === false);
+
+  // Prefix matching must not swallow a same-named root file: `scripts/` is
+  // exempt, `scripts.ts` at the root would not be.
+  check('a root file merely PREFIXED by an exempt dir still ships',
+    shipsToUsers('scripts.ts') === true);
+}
+
+header('the shape this exists for');
+{
+  // #1153 / #1151 / #1150: source change, version untouched.
+  const g = adviseBump('6.0.2', '6.0.2', ['src/proxy.ts', 'test/proxy.mjs']);
+  check('flags a src change with no bump', g.needsBump === true, g.reason);
+  check('names the stuck version', /stays at 6\.0\.2/.test(g.reason), g.reason);
+  check('names the offending file', /src\/proxy\.ts/.test(g.reason), g.reason);
+  check('counts only shipping files', g.shipping.length === 1, JSON.stringify(g.shipping));
+}
+
+header('bump present');
+{
+  const g = adviseBump('6.0.2', '6.0.3', ['src/proxy.ts', 'package.json', 'CHANGELOG.md']);
+  check('stays quiet when the version moved', g.needsBump === false, g.reason);
+  check('names both versions', /6\.0\.2 -> 6\.0\.3/.test(g.reason), g.reason);
+
+  // A minor/major bump is a bump; the ordering question belongs to
+  // version-advances.sh, not here.
+  const minor = adviseBump('6.0.2', '6.1.0', ['src/proxy.ts']);
+  check('accepts a minor bump', minor.needsBump === false, minor.reason);
+
+  // Even a version moving BACKWARDS is "bumped" as far as this advisory is
+  // concerned — wrong, but wrong in a way version-advances.sh already reports,
+  // and duplicating that judgement here would give two different comments for
+  // one defect.
+  const back = adviseBump('6.0.2', '6.0.1', ['src/proxy.ts']);
+  check('defers ordering to version-advances.sh', back.needsBump === false, back.reason);
+}
+
+header('nothing shipping changed');
+{
+  // A workflow-only or test-only PR releases nothing whether or not it bumps,
+  // so nagging would train people to ignore the comment.
+  const ci = adviseBump('6.0.2', '6.0.2', ['.github/workflows/ci.yml', 'test/all.test.mjs']);
+  check('quiet on a CI-only PR', ci.needsBump === false, ci.reason);
+  check('says why', /carry nothing/.test(ci.reason), ci.reason);
+
+  const changelogOnly = adviseBump('6.0.2', '6.0.2', ['CHANGELOG.md']);
+  check('quiet on a CHANGELOG-only PR', changelogOnly.needsBump === false, changelogOnly.reason);
+
+  const empty = adviseBump('6.0.2', '6.0.2', []);
+  check('quiet on an empty file list', empty.needsBump === false, empty.reason);
+
+  const missing = adviseBump('6.0.2', '6.0.2', undefined);
+  check('quiet on a missing file list', missing.needsBump === false, missing.reason);
+}
+
+header('the sample in the reason stays short');
+{
+  const many = adviseBump('6.0.2', '6.0.2', [
+    'src/a.ts', 'src/b.ts', 'src/c.ts', 'src/d.ts', 'src/e.ts',
+  ]);
+  check('flags it', many.needsBump === true, many.reason);
+  check('lists three then summarises', /\(\+2 more\)/.test(many.reason), many.reason);
+  check('reason stays one line', !many.reason.includes('\n'), many.reason);
+}
+
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## Why

`cc-drift-auto-release` ships only when `package.json`'s version moves on `master`. A PR that changes shipping code without bumping is green on every axis — CI passes, mergeable is clean, the merge succeeds — and then releases **nothing**. The defect is only visible to an after-the-fact sweep.

Seven PRs in the 48h to 2026-08-30 landed or sat in exactly that state: #1153, #1151, #1150, #1147, #1139, #1131, #1010. Source ticket: `01M19VPNCNZBJD07BR1TPG4JJV` (finding `00MTG1FYR7312BE175859533C2`), whose standing recommendation was "add a pre-merge check or comment bot that flags package.json version delta on PRs targeting main".

## What

- `scripts/version-bump-advice.mjs` — the decision rule. A PR needs a bump when it touches a file that reaches users **and** head version == base version. "Reaches users" is derived from what actually ships: `package.json` `files` (dist ← src, docs, README, LICENSE), the Docker image inputs, and package.json/lockfile themselves. `test/`, `.github/`, `scripts/`, `tools/`, `fuzz/`, `reviews/`, `cloudflare/`, `redis-lock/` and the non-README root docs are exempt — nagging about those would train people to scroll past the comment.
- `.github/workflows/version-bump-advice.yml` — posts and then **edits in place** a single marker-identified comment on the PR.
- `test/version-bump-advice.mjs` — 39 assertions over both directions.

## What it deliberately is not

- **Not blocking, and not a required check.** It reports `success` either way; adding it to branch protection later would be a deliberate act. A bump is sometimes legitimately absent (revert, stacked PR whose partner carries it), and a check people routinely override stops being read.
- **Not an ordering check.** "Is this version above the base tip?" is a different question, already enforced by `scripts/version-advances.sh` in `auto-merge-bot-prs.yml`. This only asks whether a bump is *present*, and explicitly defers the backwards-version case so one defect does not produce two comments.
- **Silent on bot PRs.** Drift drafters bump by construction (`bumpPackageJsonPatch`) and are already ordering-gated; commenting there is noise on a PR nobody reads before auto-merge.

## Safety

`pull_request_target` — posting needs `pull-requests: write`, and a fork-headed `pull_request` run gets a read-only token, which is exactly the external-contributor PR most likely to forget the bump. Same shape as `auto-merge-bot-prs.yml`: checkout takes the **base** ref, never the PR head, sparse to the one script, `persist-credentials: false`. No head-authored code executes with this token.

## Test plan

- `node test/version-bump-advice.mjs` → **39 pass, 0 fail** locally (no build, no node_modules — picked up automatically by `test/all.test.mjs`).
- Rendered the comment body locally with the step's heredoc under `VERDICT=true BASE_VER=6.0.2` — marker, `→ 6.0.3` next-version suggestion, and the dated CHANGELOG heading all interpolate correctly.
- This PR touches only `.github/`, `scripts/` and `test/`, so by its own rule it needs no version bump — and `preflight.mjs` stays happy.
- Live behaviour (comment posts / edits on push) is only exercisable once merged, since `pull_request_target` runs the base branch's copy of the workflow.