### PR TITLE
fix(ci): version-bump-advice must not count docs/recovery.md as shipping

### DIFF
--- a/scripts/version-bump-advice.mjs
+++ b/scripts/version-bump-advice.mjs
@@ -19,9 +19,13 @@
  * what actually ships:
  *
  *   - package.json `files` (dist, docs, README.md, LICENSE) — the npm tarball;
- *     dist/ is built from src/, so src/ is the real source entry.
+ *     dist/ is built from src/, so src/ is the real source entry. `files` also
+ *     carries NEGATIONS (`!docs/recovery.md`), which are exclusions from the
+ *     tarball and so must be exclusions here too.
  *   - the Docker image inputs (Dockerfile, docker-entrypoint.sh) — the GHCR
- *     leg of the same release pipeline.
+ *     leg of the same release pipeline. Note the image copies src/ and
+ *     package.json only; it carries no docs, so a doc excluded from the
+ *     tarball reaches a user by neither route.
  *   - package.json / package-lock.json themselves — a dependency change is
  *     shipped code even when no first-party line moved.
  *
@@ -80,6 +84,13 @@ const EXEMPT_FILES = new Set([
   '.gitignore',
   '.npmignore',
   '.dockerignore',
+  // Mirrors the `!docs/recovery.md` negation in package.json `files`: docs/
+  // ships, this one file explicitly does not. The list is static rather than
+  // read from the manifest because the workflow sparse-checks out only this
+  // script — package.json is not on disk when it runs. test/version-bump-
+  // advice.mjs pins the two together, so adding a negation to `files` without
+  // adding it here fails CI.
+  'docs/recovery.md',
 ]);
 
 /** True when changing this path can change what a user installs or runs. */
@@ -89,6 +100,13 @@ export function shipsToUsers(path) {
   if (EXEMPT_PREFIXES.some((p) => path.startsWith(p))) return false;
   return true;
 }
+
+/**
+ * The `files` negations this script claims to mirror, for the manifest-drift
+ * test. Exported rather than derived at runtime for the sparse-checkout reason
+ * above.
+ */
+export const MANIFEST_EXCLUSIONS = ['docs/recovery.md'];
 
 /**
  * @param {string} baseVer  version at the PR's merge base

--- a/test/version-bump-advice.mjs
+++ b/test/version-bump-advice.mjs
@@ -10,7 +10,8 @@
 // learn to scroll past it and the real warning goes unread too. Neither shows
 // up as a red run.
 
-import { adviseBump, shipsToUsers } from '../scripts/version-bump-advice.mjs';
+import { readFileSync } from 'node:fs';
+import { adviseBump, shipsToUsers, MANIFEST_EXCLUSIONS } from '../scripts/version-bump-advice.mjs';
 
 let pass = 0, fail = 0;
 const check = (name, cond, detail) => {
@@ -29,7 +30,7 @@ header('shipping vs non-shipping paths');
     'Dockerfile',
     'docker-entrypoint.sh',
     'README.md',
-    'docs/recovery.md',
+    'docs/usage.md',
   ]) {
     check(`${p} ships`, shipsToUsers(p) === true);
   }
@@ -58,6 +59,42 @@ header('shipping vs non-shipping paths');
   // exempt, `scripts.ts` at the root would not be.
   check('a root file merely PREFIXED by an exempt dir still ships',
     shipsToUsers('scripts.ts') === true);
+}
+
+header('the manifest is the authority on what ships');
+{
+  // docs/ ships EXCEPT the one path package.json negates. Getting this wrong
+  // is not a red run either: it nags a doc-only PR for a bump that would
+  // publish a byte-identical tarball, which is exactly the noise that teaches
+  // people to scroll past the comment.
+  check('docs/recovery.md does not ship - package.json negates it',
+    shipsToUsers('docs/recovery.md') === false);
+  check('the negation is scoped to that one file',
+    shipsToUsers('docs/recovery-plan.md') === true);
+
+  const doc = adviseBump('6.0.2', '6.0.2', ['docs/recovery.md']);
+  check('quiet on a recovery.md-only PR', doc.needsBump === false, doc.reason);
+  check('and it is not counted as shipping', doc.shipping.length === 0,
+    JSON.stringify(doc.shipping));
+
+  // The script hard-codes the exclusion list because the workflow sparse-
+  // checks out only the script, so package.json is not on disk when it runs.
+  // This pins the copy to the manifest: adding a `!path` negation to `files`
+  // without adding it to EXEMPT_FILES fails here rather than silently
+  // producing a wrong verdict months later.
+  const manifest = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+  const negated = (manifest.files ?? [])
+    .filter((f) => f.startsWith('!'))
+    .map((f) => f.slice(1));
+
+  check('package.json still carries the negations the script mirrors',
+    negated.length === MANIFEST_EXCLUSIONS.length &&
+    negated.every((p) => MANIFEST_EXCLUSIONS.includes(p)),
+    `manifest=${JSON.stringify(negated)} script=${JSON.stringify(MANIFEST_EXCLUSIONS)}`);
+
+  for (const p of negated) {
+    check(`${p} (negated in files) does not ship`, shipsToUsers(p) === false);
+  }
 }
 
 header('the shape this exists for');


### PR DESCRIPTION
Review fix for #1157 (medium). Targets `add-version-bump-check` so it lands with the feature rather than after it.

## The defect

`scripts/version-bump-advice.mjs` derived "reaches users" from `package.json` `files` — but only from the *positive* entries. `files` is:

```json
["dist", "docs", "!docs/recovery.md", "README.md", "LICENSE"]
```

The `!docs/recovery.md` negation was not mirrored, so the advisory classified that path as shipping. Reproduced on the branch head before the change:

```
shipsToUsers("docs/recovery.md") = true
adviseBump("6.0.2","6.0.2",["docs/recovery.md"]) -> needsBump: true
```

The Docker leg doesn't rescue it either: the Dockerfile copies `src`, `package.json` and `docker-entrypoint.sh`, no `docs/`. So a recovery.md-only PR reaches a user by neither route, and the comment would demand a bump that publishes a byte-identical tarball — precisely the noise the PR body says would train people to scroll past the comment.

## The fix

- `docs/recovery.md` added to `EXEMPT_FILES`, with a comment saying it mirrors the manifest negation.
- New export `MANIFEST_EXCLUSIONS` so the pin below has something to compare against.

Deliberately **not** read from `package.json` at runtime: the workflow's checkout is `sparse-checkout: scripts/version-bump-advice.mjs`, so the manifest is not on disk when the script executes. Deriving it there would mean either widening the sparse checkout or an extra contents-API call, for a list that changes about once a year.

## The drift guard

Hard-coding a copy of manifest data is only safe if something fails when the two diverge, so `test/version-bump-advice.mjs` now reads `package.json`, extracts every `!`-prefixed `files` entry, and asserts the set equals `MANIFEST_EXCLUSIONS` — then asserts each one is non-shipping. Adding a negation to `files` without updating the script is a red test, not a wrong verdict discovered months later.

Also corrected the stale assertion that asserted `docs/recovery.md` ships (replaced with `docs/usage.md`), and added a case proving the negation is file-scoped, not a prefix (`docs/recovery-plan.md` still ships).

## Test plan

`node test/version-bump-advice.mjs` → **45 pass, 0 fail** (was 39). No build, no node_modules; picked up by `test/all.test.mjs`.

This PR touches only `scripts/` and `test/`, so by its own rule it needs no version bump.

Source ticket: `01M1A2JCM22DN0582AA36YP9DA`