### PR TITLE
release: 6.0.5 — effort suffix on a failover alias target (rescued from a PR-less branch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [6.0.5] - 2026-08-30
+
+- **An effort suffix on a failover-chain alias target no longer skips the fallback.** A target such as `--model-alias=backup=claude:opus:high` is valid on the normal request path — the proxy strips the provider prefix, then `parseEffortSuffix` takes `:high` off before resolving `opus`. The failover classifier did the prefix pass but not the effort pass, so it tried to resolve `opus:high` against the catalog, matched nothing, and silently skipped a chain entry the request path would have served. The effort-parsing helpers move to their own `src/effort.ts` so both paths share one implementation instead of the classifier re-deriving a subset of it.
+
 ## [6.0.4] - 2026-08-30
 
 - **A `claude:`/`anthropic:` prefix on a failover-chain alias target now resolves correctly.** An operator `--model-alias` whose target carries an explicit provider prefix (`--model-alias=backup=claude:opus`) reached `resolveClaudeServable`'s catalog-base check as the literal string `claude:opus` — which matches no base — so `pickClaudeFallback` returned null and the chain entry silently never failed over, even though the same alias resolves fine on the normal request path. The classifier now strips a recognized Claude prefix before the alias/catalog check, matching what the request path already does, while still refusing a prefix naming a different provider (`openai:claude-opus-5`) or one it doesn't recognize. Also: #1156 merged (204274a) with no version bump and did not release — this entry ships it, along with the fix below.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "6.0.4",
+      "version": "6.0.5",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/cc-template.ts
+++ b/src/cc-template.ts
@@ -12,6 +12,7 @@ import {
   loadTemplate, promptVariantsOf, TemplateData, VARIANT_FAMILIES,
   PLATFORM_ONLY_TOOLS, INTERACTIVE_ONLY_TOOLS, CONFIG_SCOPED_TOOLS,
 } from './live-fingerprint.js';
+import { VALID_EFFORT_VALUES, parseEffortSuffix, type EffortValue } from './effort.js';
 
 // Re-exported so existing importers (scripts/capture-and-bake.mjs, the template
 // invariant tests) keep their import site. The definitions live in
@@ -1274,31 +1275,15 @@ export function resolveMaxTokens(flag: number | 'client' | undefined, clientBody
   return flag;
 }
 
-/** Valid values for the `--effort` flag. Mirrors CC's effort set (`low|medium|high|xhigh|max`) plus CC's `ultracode` mode and dario's pseudo-value `'client'` for passthrough. `'ultracode'` is CC's xhigh-plus-dynamic-workflow-orchestration mode (CC 2.1.154); the Messages API accepts only low|medium|high|xhigh|max, so dario normalizes ultracode → 'xhigh' on the wire (see normalizeEffortForWire). `'client'` passes through the client's own `output_config.effort` (falling back to `'xhigh'`). dario#87, `'max'` added in dario#190, `'ultracode'` added 2026-05-28. */
-export type EffortValue = 'low' | 'medium' | 'high' | 'xhigh' | 'ultracode' | 'max' | 'client';
-export const VALID_EFFORT_VALUES: ReadonlyArray<EffortValue> = ['low', 'medium', 'high', 'xhigh', 'ultracode', 'max', 'client'];
-
-/**
- * dario#419 — strip an optional effort suffix off a model name, so OpenAI-compat
- * clients that can't set `output_config.effort` (e.g. Cursor) can choose effort
- * by model name: `opus-4-8:high` (colon) or Cursor-style `claude-opus-4-8-high`
- * (hyphen). Only the wire-valid effort levels are recognized as a suffix — any
- * other trailing token is left as part of the model name, and a bare model that
- * IS an effort word (e.g. just "high") is left alone. Returns the model with the
- * suffix removed plus the parsed effort (undefined when none). Exported for tests.
- */
-const SUFFIX_EFFORTS: ReadonlyArray<EffortValue> = ['ultracode', 'medium', 'xhigh', 'high', 'low', 'max'];
-export function parseEffortSuffix(model: string): { model: string; effort?: EffortValue } {
-  for (const e of SUFFIX_EFFORTS) {
-    for (const sep of [':', '-']) {
-      const tag = sep + e;
-      if (model.length > tag.length && model.endsWith(tag)) {
-        return { model: model.slice(0, -tag.length), effort: e };
-      }
-    }
-  }
-  return { model };
-}
+// The effort vocabulary and the model-name effort suffix live in effort.ts so
+// the pool-fallback classifier can parse the SAME suffix the request path
+// parses without importing this module — claude-model.ts stays decidable over
+// a base set alone, and hand-copying the suffix list there is what would let
+// `claude:opus:high` drift from `opus:high` (dario#1156 review). Re-exported
+// here because proxy.ts, cli.ts and test/effort-flag.mjs import them from
+// cc-template.
+export { VALID_EFFORT_VALUES, parseEffortSuffix };
+export type { EffortValue };
 
 /**
  * Normalize an effort value to a wire-valid `output_config.effort`. The

--- a/src/claude-model.ts
+++ b/src/claude-model.ts
@@ -38,13 +38,22 @@
  * cold catalog must still admit real ids, and must still refuse typos.
  */
 import { BAKED_BASE_MODELS, resolveAliasAgainst } from './model-catalog.js';
-import { parseEffortSuffix } from './effort.js';
+import { parseEffortSuffix, type EffortValue } from './effort.js';
 
 /** Provider prefixes that force the Claude path (mirrors proxy.ts's PROVIDER_PREFIXES). */
 const CLAUDE_PREFIXES = new Set(['claude', 'anthropic']);
 
 /** Maps a bare name to a canonical id, or returns it unchanged. */
 export type ModelResolver = (model: string) => string;
+
+/**
+ * What the pool would serve a chain entry as: the canonical id, plus the effort
+ * the entry ASKED FOR when it carried a suffix (`claude:opus:high`). Both
+ * halves travel together because the caller needs both — the id goes into the
+ * body, the effort into the outbound `output_config` — and dropping the second
+ * is how `claude:opus:high` reached Anthropic at the pool default (dario#1161).
+ */
+export type ClaudeTarget = { model: string; effort?: EffortValue };
 
 /**
  * Strip a Claude-side provider prefix, or refuse the name outright.
@@ -79,17 +88,17 @@ function servableTarget(target: string, bases: readonly string[]): string | null
 }
 
 /**
- * The canonical id the Claude pool would serve `model` as, or null when it
- * cannot serve it. `bases` is the catalog base set — `getCachedBases()` at a
- * call site, a fixture in a test. `resolve` is the alias pipeline; the default
- * knows only catalog family shorthands, so pass the proxy's full resolver
- * (operator aliases + pinned aliases) where one exists.
+ * The id the Claude pool would serve `model` as AND the effort the entry asked
+ * for, or null when the pool cannot serve it. `bases` is the catalog base set —
+ * `getCachedBases()` at a call site, a fixture in a test. `resolve` is the alias
+ * pipeline; the default knows only catalog family shorthands, so pass the
+ * proxy's full resolver (operator aliases + pinned aliases) where one exists.
  */
-export function resolveClaudeServable(
+export function resolveClaudeTarget(
   model: string,
   bases: readonly string[] = BAKED_BASE_MODELS,
   resolve?: ModelResolver,
-): string | null {
+): ClaudeTarget | null {
   const entry = stripClaudePrefix(model.trim().toLowerCase());
   if (entry === null) return null;
 
@@ -103,7 +112,7 @@ export function resolveClaudeServable(
     .trim().toLowerCase();
 
   const direct = servableTarget(target, bases);
-  if (direct) return direct;
+  if (direct) return { model: direct };
 
   // …and it may carry an effort suffix as well (`claude:opus:high`,
   // `claude-opus-4-8-high`), which the request path strips on the Claude side
@@ -113,18 +122,34 @@ export function resolveClaudeServable(
   // AFTER the name as written fails, so a real id that happens to end in an
   // effort word keeps priority over the suffix reading.
   //
-  // The effort itself is dropped: the caller swaps the returned canonical id
-  // into the body, and the fallback request carries the pool's default effort.
-  // Serving the request at the default beats refusing to fail over at all.
+  // The effort is RETURNED, not discarded: an operator who writes `:high` on a
+  // chain entry is choosing the effort the failover request runs at, and the
+  // request path honours exactly that spelling for a client-sent model. Serving
+  // the failover at the pool default instead would silently answer a `high`
+  // request at whatever `--effort` happens to be (dario#1161).
   const eff = parseEffortSuffix(target);
-  return eff.effort ? servableTarget(eff.model, bases) : null;
+  if (!eff.effort) return null;
+  const stripped = servableTarget(eff.model, bases);
+  return stripped ? { model: stripped, effort: eff.effort } : null;
 }
 
-/** Whether the Claude pool can serve `model`. See resolveClaudeServable. */
+/**
+ * The canonical id alone, for callers that only need to name the model. See
+ * resolveClaudeTarget for the effort half.
+ */
+export function resolveClaudeServable(
+  model: string,
+  bases: readonly string[] = BAKED_BASE_MODELS,
+  resolve?: ModelResolver,
+): string | null {
+  return resolveClaudeTarget(model, bases, resolve)?.model ?? null;
+}
+
+/** Whether the Claude pool can serve `model`. See resolveClaudeTarget. */
 export function isClaudeServableModel(
   model: string,
   bases: readonly string[] = BAKED_BASE_MODELS,
   resolve?: ModelResolver,
 ): boolean {
-  return resolveClaudeServable(model, bases, resolve) !== null;
+  return resolveClaudeTarget(model, bases, resolve) !== null;
 }

--- a/src/claude-model.ts
+++ b/src/claude-model.ts
@@ -21,7 +21,8 @@
  *      supplies that resolver so classification and forwarding cannot
  *      disagree. The prefix rule applies to the alias TARGET too, since an
  *      operator alias is written the way a request model is written — see
- *      stripClaudePrefix.
+ *      stripClaudePrefix. So does the effort suffix (`:high`, `-high`) — see
+ *      servableTarget.
  *   2. VALIDATE the resolved id against the catalog base set. A `claude-`
  *      prefix on its own proves nothing — `claude-sonnet-6` has the prefix and
  *      does not exist — so the id (sans `[1m]`) must be a base the pool can
@@ -37,6 +38,7 @@
  * cold catalog must still admit real ids, and must still refuse typos.
  */
 import { BAKED_BASE_MODELS, resolveAliasAgainst } from './model-catalog.js';
+import { parseEffortSuffix } from './effort.js';
 
 /** Provider prefixes that force the Claude path (mirrors proxy.ts's PROVIDER_PREFIXES). */
 const CLAUDE_PREFIXES = new Set(['claude', 'anthropic']);
@@ -61,6 +63,22 @@ function stripClaudePrefix(model: string): string | null {
 }
 
 /**
+ * One spelling of the target: strip its prefix, run the catalog pass, keep it
+ * only if the result is a base the pool can forward.
+ *
+ * A target that arrived prefixed still holds a shorthand (`claude:opus` →
+ * `opus`), so the catalog pass runs on it. Idempotent for a target already
+ * canonical: resolveAliasAgainst only answers for family shorthands.
+ */
+function servableTarget(target: string, bases: readonly string[]): string | null {
+  const stripped = stripClaudePrefix(target);
+  if (stripped === null) return null;
+  const resolved = resolveAliasAgainst(stripped, bases) ?? stripped;
+  const base = resolved.endsWith('[1m]') ? resolved.slice(0, -4) : resolved;
+  return bases.some((b) => b.toLowerCase() === base) ? resolved : null;
+}
+
+/**
  * The canonical id the Claude pool would serve `model` as, or null when it
  * cannot serve it. `bases` is the catalog base set — `getCachedBases()` at a
  * call site, a fixture in a test. `resolve` is the alias pipeline; the default
@@ -81,17 +99,25 @@ export function resolveClaudeServable(
   // parses that prefix AFTER alias resolution; without the same pass here the
   // target reached the base check as the literal `claude:opus`, matched
   // nothing, and a perfectly valid fallback was skipped.
-  const target = stripClaudePrefix(
-    (resolve ? resolve(entry) : (resolveAliasAgainst(entry, bases) ?? entry)).trim().toLowerCase(),
-  );
-  if (target === null) return null;
+  const target = (resolve ? resolve(entry) : (resolveAliasAgainst(entry, bases) ?? entry))
+    .trim().toLowerCase();
 
-  // A target that arrived prefixed still holds a shorthand (`claude:opus` →
-  // `opus`), so the catalog pass runs on it. Idempotent for a target already
-  // canonical: resolveAliasAgainst only answers for family shorthands.
-  const resolved = resolveAliasAgainst(target, bases) ?? target;
-  const base = resolved.endsWith('[1m]') ? resolved.slice(0, -4) : resolved;
-  return bases.some((b) => b.toLowerCase() === base) ? resolved : null;
+  const direct = servableTarget(target, bases);
+  if (direct) return direct;
+
+  // …and it may carry an effort suffix as well (`claude:opus:high`,
+  // `claude-opus-4-8-high`), which the request path strips on the Claude side
+  // exactly like this (dario#419, proxy.ts). Without the same pass the suffix
+  // survived into the base check, matched nothing, and the entry was silently
+  // unservable — the prefix fix in #1156 left this half unresolved. Tried only
+  // AFTER the name as written fails, so a real id that happens to end in an
+  // effort word keeps priority over the suffix reading.
+  //
+  // The effort itself is dropped: the caller swaps the returned canonical id
+  // into the body, and the fallback request carries the pool's default effort.
+  // Serving the request at the default beats refusing to fail over at all.
+  const eff = parseEffortSuffix(target);
+  return eff.effort ? servableTarget(eff.model, bases) : null;
 }
 
 /** Whether the Claude pool can serve `model`. See resolveClaudeServable. */

--- a/src/codex-backend.ts
+++ b/src/codex-backend.ts
@@ -33,7 +33,7 @@ import {
   type ResponsesResponse,
   type ResponsesStreamEvent,
 } from './anthropic-responses-translate.js';
-import { resolveClaudeServable, type ModelResolver } from './claude-model.js';
+import { resolveClaudeTarget, type ModelResolver, type ClaudeTarget } from './claude-model.js';
 import { BAKED_BASE_MODELS } from './model-catalog.js';
 
 export const CODEX_BACKEND_BASE_URL =
@@ -216,10 +216,30 @@ export function pickClaudeFallback(
   // Returns the RESOLVED canonical id, not the entry as written: the caller
   // swaps it into the body after the proxy's own alias pass has already run,
   // so an alias returned raw would reach Anthropic unresolved and 400.
+  return pickClaudeTarget(models, slugs, bases, resolve)?.model ?? null;
+}
+
+/**
+ * {@link pickClaudeFallback} with the effort the winning entry asked for.
+ *
+ * `claude:opus:high` names BOTH a model and an effort, and the request path
+ * honours exactly that spelling for a client-sent model. Selection kept only
+ * the model half, so a declined codex request configured that way reached the
+ * Claude pool at the pool default effort — the operator's `high` silently
+ * dropped (dario#1161). The caller applies `effort` when it rebuilds the
+ * Claude-bound request; `undefined` means the entry named no effort and the
+ * pool default stands.
+ */
+export function pickClaudeTarget(
+  models: readonly string[],
+  slugs: readonly string[],
+  bases: readonly string[] = BAKED_BASE_MODELS,
+  resolve?: ModelResolver,
+): ClaudeTarget | null {
   for (const m of models) {
     if (isCodexModel(m, slugs)) continue;
-    const resolved = resolveClaudeServable(m, bases, resolve);
-    if (resolved) return resolved;
+    const target = resolveClaudeTarget(m, bases, resolve);
+    if (target) return target;
   }
   return null;
 }

--- a/src/effort.ts
+++ b/src/effort.ts
@@ -1,0 +1,43 @@
+/**
+ * effort.ts — the effort vocabulary and the model-name effort suffix.
+ *
+ * These lived in cc-template.ts, which is where the request path uses them.
+ * They moved down here because the pool-fallback classifier (claude-model.ts)
+ * has to parse the SAME suffix the request path parses, and that module is
+ * deliberately pure — it decides what the Claude pool can serve out of a base
+ * set and nothing else. Importing cc-template.js there would drag the CC
+ * template load (live capture / bundled snapshot, read at module init) into a
+ * classifier whose whole value is being decidable without one, and a second
+ * hand-written copy of the suffix list would be the other way to get it: two
+ * definitions of "what counts as an effort suffix" that drift apart silently,
+ * which is exactly the bug this file was extracted to fix (dario#1156 review).
+ *
+ * cc-template.ts re-exports all three, so every existing import site
+ * (proxy.ts, cli.ts, test/effort-flag.mjs) is unchanged.
+ */
+
+/** Valid values for the `--effort` flag. Mirrors CC's effort set (`low|medium|high|xhigh|max`) plus CC's `ultracode` mode and dario's pseudo-value `'client'` for passthrough. `'ultracode'` is CC's xhigh-plus-dynamic-workflow-orchestration mode (CC 2.1.154); the Messages API accepts only low|medium|high|xhigh|max, so dario normalizes ultracode → 'xhigh' on the wire (see normalizeEffortForWire). `'client'` passes through the client's own `output_config.effort` (falling back to `'xhigh'`). dario#87, `'max'` added in dario#190, `'ultracode'` added 2026-05-28. */
+export type EffortValue = 'low' | 'medium' | 'high' | 'xhigh' | 'ultracode' | 'max' | 'client';
+export const VALID_EFFORT_VALUES: ReadonlyArray<EffortValue> = ['low', 'medium', 'high', 'xhigh', 'ultracode', 'max', 'client'];
+
+/**
+ * dario#419 — strip an optional effort suffix off a model name, so OpenAI-compat
+ * clients that can't set `output_config.effort` (e.g. Cursor) can choose effort
+ * by model name: `opus-4-8:high` (colon) or Cursor-style `claude-opus-4-8-high`
+ * (hyphen). Only the wire-valid effort levels are recognized as a suffix — any
+ * other trailing token is left as part of the model name, and a bare model that
+ * IS an effort word (e.g. just "high") is left alone. Returns the model with the
+ * suffix removed plus the parsed effort (undefined when none). Exported for tests.
+ */
+const SUFFIX_EFFORTS: ReadonlyArray<EffortValue> = ['ultracode', 'medium', 'xhigh', 'high', 'low', 'max'];
+export function parseEffortSuffix(model: string): { model: string; effort?: EffortValue } {
+  for (const e of SUFFIX_EFFORTS) {
+    for (const sep of [':', '-']) {
+      const tag = sep + e;
+      if (model.length > tag.length && model.endsWith(tag)) {
+        return { model: model.slice(0, -tag.length), effort: e };
+      }
+    }
+  }
+  return { model };
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -20,7 +20,7 @@ import { loadAllAccounts, loadAccount, saveAccount, refreshAccountToken, resyncL
 import { handleAdminRequest, type AdminAccountLive, type AdminAuditEvent } from './admin-api.js';
 import { createTokenBucket } from './rate-limit.js';
 import { getOpenAIBackend, isOpenAIModel, forwardToOpenAI, type BackendCredentials } from './openai-backend.js';
-import { forwardToCodex, getCodexModelSlugs, peekCodexModelSlugs, isCodexModel, pickCodexFallback, pickClaudeFallback, CODEX_BACKEND_BASE_URL } from './codex-backend.js';
+import { forwardToCodex, getCodexModelSlugs, peekCodexModelSlugs, isCodexModel, pickCodexFallback, pickClaudeTarget, CODEX_BACKEND_BASE_URL } from './codex-backend.js';
 import { readCompareTarget, teeResponse, runCompare, writeCompareRecord, COMPARE_RESULT_HEADER } from './compare.js';
 import { listCodexAccountAliases, loadAllCodexAccounts, codexAccountNeedsRefresh, hasAnyCodexAccount, selectCodexAccount, getFreshCodexAccount, type CodexAccountCredentials } from './codex-accounts.js';
 import { route as routeProvider } from './provider-adapter.js';
@@ -3094,11 +3094,13 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
             // operator --model-alias first, then pinned + catalog aliases — so
             // `backup` or `opus48` in the chain works the way it does on a
             // request, and the classifier validates the id that would actually
-            // be forwarded.
-            const claudeTarget = pickClaudeFallback(
+            // be forwarded. The entry's own effort suffix (`claude:opus:high`)
+            // comes back with it — see the swap below.
+            const claudeTarget = pickClaudeTarget(
               poolFallbackModels, codexModels, getCachedBases(),
               (m) => resolveClaudeAlias(applyModelAlias(m, modelAliases) ?? m),
             );
+            const claudeTargetModel = claudeTarget?.model ?? null;
             const canDefer = claudeTarget !== null && pool.size > 0 && !upstreamApiKey;
             const codexReq = requestCount;
             const served = await forwardToCodex(
@@ -3134,13 +3136,20 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
               },
             );
             if (served) return;
-            const swapped = buildPoolFallbackBody(body, claudeTarget!);
+            const swapped = buildPoolFallbackBody(body, claudeTargetModel!);
             if (!swapped) {
               res.writeHead(503, { 'Content-Type': 'application/json', ...SECURITY_HEADERS });
               res.end(JSON.stringify({ error: { type: 'upstream_unavailable', message: 'Codex backend unavailable and the request body could not be re-pointed at the Claude pool.' } }));
               return;
             }
-            console.log(`[dario] #${requestCount} codex unavailable -> claude pool as ${claudeTarget}`);
+            // An operator who writes `--pool-fallback=gpt-5.6-sol,claude:opus:high`
+            // is choosing the effort the failover runs at, exactly as a client
+            // naming `claude:opus:high` on the request is. Selection parsed the
+            // suffix and then dropped it, so the rebuilt Claude request carried
+            // the pool default instead (dario#1161). A chain entry with no
+            // suffix leaves whatever the request itself asked for.
+            if (claudeTarget?.effort) requestEffort = claudeTarget.effort;
+            console.log(`[dario] #${requestCount} codex unavailable -> claude pool as ${claudeTargetModel}${claudeTarget?.effort ? ` (effort: ${claudeTarget.effort})` : ''}`);
             // Copy so the type matches the ArrayBuffer-backed buffer this
             // handler threads through (Buffer.concat's), as the other in-place
             // body rewrites above already do.
@@ -3151,7 +3160,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
             // reads as a success, which is the exact bug class this release
             // spent its whole review budget hunting.
             parsedBody = null;
-            res.setHeader('x-dario-pool-fallback', claudeTarget!);
+            res.setHeader('x-dario-pool-fallback', claudeTargetModel!);
             // fall through to Claude's turn below
           }
           if (rawModel && openaiBackend && decision.provider === 'openai') {

--- a/test/codex-decline-carries-effort.mjs
+++ b/test/codex-decline-carries-effort.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+// dario#1161 review — the effort a chain entry declares must reach the
+// OUTBOUND Claude request, proved at the boundary rather than at the picker.
+//
+// The prior revision added picker-level assertions: pickClaudeTarget returns
+// { model: 'claude-opus-5', effort: 'high' } for a `claude:opus:high` entry.
+// The reviewer's objection was exact and correct — those never execute the one
+// line that makes the fix real:
+//
+//     if (claudeTarget?.effort) requestEffort = claudeTarget.effort;   (proxy.ts)
+//
+// Delete that assignment and every picker assertion still passes, while a
+// declined Codex request reaches Claude at the pool default effort. That is the
+// same shape as the three wiring bugs this release already shipped: a correct
+// piece behind a gate nobody proved was wired to it.
+//
+// So this drives the real handler. A codex-bound request is refused by the
+// subscription (429), falls back down the chain to `claude:opus:high`, and the
+// Anthropic-bound body is captured and inspected for BOTH halves:
+//
+//   body.model                 -> the canonical Opus id (suffix + prefix gone)
+//   body.output_config.effort  -> 'high'  (the entry's own effort, carried)
+//
+// Hermetic: HOME is a mkdtemp'd dir with one Claude and one codex account, the
+// ChatGPT backend is a local stub, and the Anthropic upstream is
+// ProxyOptions.fetchImpl. No network.
+
+import { createServer } from 'node:http';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let pass = 0, fail = 0;
+const check = (name, cond, detail) => {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else { console.log(`  FAIL ${name}${detail ? ' :: ' + detail : ''}`); fail++; }
+};
+const header = (n) => console.log(`\n=== ${n} ===`);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const PROXY_PORT = 38841;
+const CODEX_PORT = 38842;
+const BASE = `http://127.0.0.1:${PROXY_PORT}`;
+
+const LISTED_SLUG = 'gpt-5.6-sol';
+// The chain the reviewer named: codex first, then a Claude entry that carries
+// BOTH a provider prefix and a NON-DEFAULT effort suffix.
+const CHAIN = `${LISTED_SLUG},claude:opus:low`;
+const EXPECT_MODEL = 'claude-opus-5';
+// Deliberately NOT 'high': that is dario's own default, so asserting it would
+// pass even with the propagation line deleted — a test that proves nothing,
+// which is the exact objection this file exists to answer. 'low' can only
+// appear here if the chain entry's own suffix actually reached the request.
+const EXPECT_EFFORT = 'low';
+
+// --------------------------------------------------------------------------
+// Codex stub: lists the slug (so the request routes here as PRIMARY), then
+// refuses with a deferrable 429 so the reverse fallback has to fire.
+// --------------------------------------------------------------------------
+const codexSeen = { models: 0, responses: 0 };
+const codexStub = createServer((req, res) => {
+  if (req.url.startsWith('/models')) {
+    codexSeen.models++;
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ models: [{ slug: LISTED_SLUG, visibility: 'list' }] }));
+    return;
+  }
+  if (req.url.startsWith('/responses')) {
+    codexSeen.responses++;
+    res.writeHead(429, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: { message: 'rate limited (stub)' } }));
+    return;
+  }
+  res.writeHead(404).end();
+});
+await new Promise((r) => codexStub.listen(CODEX_PORT, '127.0.0.1', r));
+
+const tmpHome = await mkdtemp(join(tmpdir(), 'dario-effort-'));
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+process.env.DARIO_CODEX_BASE_URL = `http://127.0.0.1:${CODEX_PORT}`;
+
+await mkdir(join(tmpHome, '.dario', 'accounts'), { recursive: true });
+await writeFile(join(tmpHome, '.dario', 'accounts', 'main.json'), JSON.stringify({
+  alias: 'main',
+  accessToken: 'claude-access-token',
+  refreshToken: 'claude-refresh-token',
+  expiresAt: Date.now() + 6 * 3_600_000,
+  scopes: ['user:inference'],
+  deviceId: 'dev-1',
+  accountUuid: 'uuid-1',
+}));
+await mkdir(join(tmpHome, '.dario', 'codex-accounts'), { recursive: true });
+await writeFile(join(tmpHome, '.dario', 'codex-accounts', 'live.json'), JSON.stringify({
+  alias: 'live',
+  accessToken: 'codex-access-token',
+  refreshToken: 'codex-refresh-token',
+  expiresAt: Date.now() + 6 * 3_600_000,
+}));
+
+const { startProxy } = await import('../dist/proxy.js');
+
+// The Anthropic seam: capture the outbound body, answer 200 so the fallback
+// completes normally. The catalog read must advertise Opus, or the classifier
+// correctly refuses a model the pool cannot serve and the chain entry is
+// skipped for the RIGHT reason — which would hide the thing under test.
+const seen = { calls: 0, body: null };
+const fakeFetch = async (url, init) => {
+  const target = String(url);
+  if (target.includes('/v1/models')) {
+    return new Response(JSON.stringify({
+      data: [
+        { id: 'claude-opus-5', type: 'model' },
+        { id: 'claude-sonnet-5', type: 'model' },
+      ],
+    }), { status: 200, headers: { 'content-type': 'application/json' } });
+  }
+  seen.calls++;
+  // The outbound body arrives as a Uint8Array, not a string or a Buffer —
+  // String() on it yields comma-separated byte values, which parses as JSON
+  // right up to the first comma and then fails misleadingly.
+  const raw = init?.body;
+  try {
+    seen.body = JSON.parse(typeof raw === 'string' ? raw : Buffer.from(raw).toString('utf8'));
+  } catch { seen.body = null; }
+  return new Response(JSON.stringify({
+    id: 'msg_1',
+    type: 'message',
+    role: 'assistant',
+    model: EXPECT_MODEL,
+    content: [{ type: 'text', text: 'served by the claude pool' }],
+    stop_reason: 'end_turn',
+    usage: { input_tokens: 1, output_tokens: 1 },
+  }), { status: 200, headers: { 'content-type': 'application/json' } });
+};
+
+await startProxy({
+  port: PROXY_PORT,
+  host: '127.0.0.1',
+  passthrough: false,
+  verbose: false,
+  noLiveCapture: true,
+  poolFallbackModel: CHAIN,
+  fetchImpl: fakeFetch,
+});
+for (let i = 0; i < 50; i++) {
+  try { await fetch(`${BASE}/health`); break; } catch { await sleep(100); }
+}
+
+header('a declined Codex request carries the chain entry\'s effort to Claude');
+{
+  const res = await fetch(`${BASE}/v1/messages`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    // Codex-bound: the stub lists this slug, so codex is PRIMARY here and the
+    // 429 below is a genuine mid-flight decline, not a selection-time defer.
+    body: JSON.stringify({
+      model: LISTED_SLUG,
+      max_tokens: 16,
+      messages: [{ role: 'user', content: 'ping' }],
+    }),
+  });
+  const text = await res.text();
+
+  check('the subscription was asked first', codexSeen.responses === 1, `responses=${codexSeen.responses}`);
+  check('...and declined, so the request reached the Claude pool', seen.calls === 1, `calls=${seen.calls}`);
+  check('the client got a 200, not the codex 429', res.status === 200, `${res.status} ${text.slice(0, 160)}`);
+  check('the substituted model is announced',
+    res.headers.get('x-dario-pool-fallback') === EXPECT_MODEL,
+    String(res.headers.get('x-dario-pool-fallback')));
+
+  // THE POINT OF THIS FILE — both halves of the outbound body.
+  check('the OUTBOUND body carries the canonical Opus id (prefix and suffix resolved)',
+    seen.body?.model === EXPECT_MODEL, String(seen.body?.model));
+  check('the OUTBOUND body carries the entry\'s own effort, not the pool default',
+    seen.body?.output_config?.effort === EXPECT_EFFORT,
+    JSON.stringify(seen.body?.output_config));
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+codexStub.close();
+process.exit(fail === 0 ? 0 : 1);

--- a/test/pool-fallback-alias-prefix.mjs
+++ b/test/pool-fallback-alias-prefix.mjs
@@ -24,7 +24,7 @@
  */
 
 import { isClaudeServableModel, resolveClaudeServable } from '../dist/claude-model.js';
-import { pickClaudeFallback } from '../dist/codex-backend.js';
+import { pickClaudeFallback, pickClaudeTarget } from '../dist/codex-backend.js';
 import { resolveClaudeAlias, applyModelAlias } from '../dist/proxy.js';
 
 let pass = 0;
@@ -46,6 +46,9 @@ const SLUGS = ['gpt-5.6-sol', 'gpt-5.5'];
 // site — operator aliases first, then the pinned + catalog pass.
 const ALIASES = {
   backup: 'claude:opus',
+  // Effort-bearing targets — the dario#1161 review case.
+  boosted: 'claude:opus:high',
+  boostedhyphen: 'claude-opus-4-8-high',
   spare: 'anthropic:sonnet',
   fast: 'anthropic:haiku',
   elsewhere: 'openai:gpt-4o',
@@ -101,6 +104,30 @@ header('pre-existing behaviour is unchanged by the second prefix pass');
   check('an entry prefixed for the other provider is a definite no',
     resolveClaudeServable('openai:claude-opus-5', BASES, resolver) === null);
   check('empty selects nothing', pickClaudeFallback([], SLUGS, BASES, resolver) === null);
+}
+
+header('effort suffix on an alias target survives the fallback (dario#1161 review)');
+{
+  // The suffix is request SEMANTICS, not just syntax to strip for the catalog
+  // check. `--model-alias=backup=claude:opus:high` means "Opus at high effort"
+  // on the normal request path; a fallback that keeps the model and drops the
+  // `high` silently serves at the pool default, and the two paths disagree —
+  // the exact class this classifier exists to close.
+  const t = pickClaudeTarget(['gpt-5.6-sol', 'boosted'], SLUGS, BASES, resolver);
+  check('the effort-bearing alias is servable', t !== null);
+  check('...resolved to the canonical model', t?.model === 'claude-opus-5', String(t?.model));
+  check('...and the configured effort is CARRIED, not dropped', t?.effort === 'high', String(t?.effort));
+
+  const h = pickClaudeTarget(['gpt-5.6-sol', 'boostedhyphen'], SLUGS, BASES, resolver);
+  check('the hyphen spelling works too', h?.model === 'claude-opus-4-8', String(h?.model));
+  check('...carrying its effort', h?.effort === 'high', String(h?.effort));
+
+  const plain = pickClaudeTarget(['gpt-5.6-sol', 'backup'], SLUGS, BASES, resolver);
+  check('an alias with NO effort suffix carries none',
+    plain?.model === 'claude-opus-5' && plain?.effort === undefined, String(plain?.effort));
+
+  check('the model-only picker still returns a bare string (unchanged API)',
+    pickClaudeFallback(['gpt-5.6-sol', 'boosted'], SLUGS, BASES, resolver) === 'claude-opus-5');
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);


### PR DESCRIPTION
**This work was stranded.** `d4e84a6` was pushed to `fix-effort-suffix-alias-prefix` with **no pull request** — not reviewable, not mergeable, and its originating finding (Second Read's medium on #1156, `src/claude-model.ts:84-92`) stays open indefinitely. Spotted only because you noticed the branch had recent pushes.

## ⚠️ Why this isn't just that branch re-pushed

That branch was cut **before #1159 and #1160 merged**. Merging it as-is would have silently reverted both:

- #1160's `github-actions[bot]` comment-selector fix → back to the vulnerable marker-only match
- the entire **6.0.4** version bump and CHANGELOG entry → `package.json` back to 6.0.3

Cherry-picked the single commit onto current master instead, so this carries the intended change and none of the reverts. Verified the `github-actions[bot]` filter is still present on this branch.

## The fix

`--model-alias=backup=claude:opus:high` is valid on the normal request path: the proxy strips the provider prefix, then `parseEffortSuffix` removes `:high` before resolving `opus`. The failover classifier did the prefix pass but **not** the effort pass, so it resolved `opus:high` against the catalog, matched nothing, and silently skipped a chain entry the request path would have served — the same silent-skip class as #1156 and #1151.

Effort parsing moves to `src/effort.ts` so both paths share one implementation rather than the classifier re-deriving a subset.

## Version bump included

It touches `src/`, which ships. Today already produced **two** merged-but-never-released PRs (#1153, #1156) from exactly this omission, so the bump is in the same PR rather than left to a follow-up.

## Verification

tsc clean · **161 files, 0 fail** · preflight clean · README gate ok