### PR TITLE
docs: README for v6 — the banner still said v5 while npm shipped 6.0.5 (release: 6.0.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+## [6.0.6] - 2026-08-31
+
+- **README rewritten for v6.** The banner still announced v5.0 and the hero line still said the subscription, singular — accurate through v5, wrong since v6 made either plan serve either wire shape. Also adds the routing-table row v6 is actually built on (Anthropic Messages + a slug your ChatGPT account lists -> Codex backend), which was missing even though the capability shipped in v5.5.87. Docs only, but README.md is in package.json `files`, so it reaches the npm package page only on a release — hence the bump.
+
 ## [6.0.5] - 2026-08-30
 
 - **An effort suffix on a failover-chain alias target no longer skips the fallback.** A target such as `--model-alias=backup=claude:opus:high` is valid on the normal request path — the proxy strips the provider prefix, then `parseEffortSuffix` takes `:high` off before resolving `opus`. The failover classifier did the prefix pass but not the effort pass, so it tried to resolve `opus:high` against the catalog, matched nothing, and silently skipped a chain entry the request path would have served. The effort-parsing helpers move to their own `src/effort.ts` so both paths share one implementation instead of the classifier re-deriving a subset of it.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # `dario`
 
-### Your Claude Pro/Max subscription works in exactly one place: Claude Code.<br/>dario makes it work **everywhere** — at subscription pricing, not per-token API bills.
+### Your Claude and ChatGPT subscriptions each work in exactly one place.<br/>dario makes them work **everywhere** — at subscription pricing, not per-token API bills.
 
 <p>
   <a href="https://www.npmjs.com/package/@askalf/dario"><img src="https://img.shields.io/npm/v/@askalf/dario?color=6f42c1&label=npm&logo=npm" alt="npm version"></a>
@@ -16,7 +16,7 @@
   <a href="https://x.com/ask_alf"><img src="https://img.shields.io/badge/follow-@ask__alf-1da1f2?style=flat-square" alt="Follow on X"></a>
 </p>
 
-<p><strong>One local endpoint. Every AI tool you own. The subscription you already pay for.</strong></p>
+<p><strong>One local endpoint. Every AI tool you own. The subscriptions you already pay for.</strong></p>
 
 <sub><code>npm i -g @askalf/dario</code> · <strong>0</strong> runtime deps · <a href="https://www.npmjs.com/package/@askalf/dario">SLSA-attested</a> every release · nothing phones home · ~29k lines you can read in a weekend · independent, unofficial, third-party (<a href="DISCLAIMER.md">DISCLAIMER.md</a>)</sub>
 
@@ -26,14 +26,17 @@
 
 ---
 
-> ## 🎉 dario `v5.0` — one request path, one credential model
+> ## 🎉 dario `v6.0` — any client shape, any subscription, and failover between them
 >
-> v5 is a **breaking simplification**: two removals, zero feature pile-on.
+> Through v5, dario was a Claude proxy that had recently learned to reach a ChatGPT subscription on one path. v6 finishes that: **either subscription can serve either wire shape, and either one can cover for the other.**
 >
-> - **🏊 Pool-as-primitive.** Every dario is now a *pool*. A plain `dario login` is a pool of one; add a second Claude seat and the same `localhost:3456` load-balances across them by live headroom — no mode switch, no config flag.
-> - **🧹 Shim mode removed.** The deprecated shim transport is gone. Proxy mode rebuilds every request to Claude Code's wire shape and is strictly better for every client.
+> - **🔀 Both wire shapes, both plans.** Your ChatGPT plan now answers `/v1/messages`, not just `/v1/chat/completions` — so Claude Code, the Anthropic SDKs and agent runtimes can be served by it without knowing. Your Claude plan already answered both.
+> - **🪂 Failover between subscriptions.** `--pool-fallback=gpt-5.6-sol,claude-sonnet-5` is a *chain*: a drained Claude pool is served by ChatGPT, and a rate-limited ChatGPT is handed back to Claude. Two consumer plans, no API keys, and neither one going down takes you with it. → [Failover](#failover-between-subscriptions)
+> - **🧪 Shadow compare.** `x-dario-compare: <model>` answers you normally *and* runs the same prompt past the other family, writing both to `~/.dario/compare/`. Which model is better at **your** work, measured on your own traffic. → [Shadow compare](#shadow-compare)
+> - **➕ `dario add altman` / `dario add amodei`.** Attach a plan by whose it is.
+> - **🩺 `dario doctor` reports failover readiness** — including *armed but INERT*, the state that is green on every other check and cannot actually do anything.
 >
-> **Upgrading from v4?** Solo `dario login` + `dario proxy` users: nothing to do. Full notes → **[MIGRATION.md](MIGRATION.md)** · [CHANGELOG](CHANGELOG.md#500---2026-07-11)
+> **Upgrading from v5?** Nothing to do — every v6 feature is opt-in and a single-value `--pool-fallback` behaves exactly as it did. [CHANGELOG](CHANGELOG.md#600---2026-08-30)
 
 ---
 
@@ -119,6 +122,7 @@ You point every tool at one URL. dario reads each request, decides which backend
 | Client speaks | Model | Routes to | What happens |
 |---|---|---|---|
 | Anthropic Messages | `claude-*` / `opus` / `sonnet` / `haiku` | Claude backend | OAuth swap + CC template → `api.anthropic.com` |
+| Anthropic Messages | a slug your ChatGPT account lists | Codex backend | Messages→Responses translation, subscription auth |
 | Anthropic Messages | `gpt-*`, `llama-*`, … | OpenAI-compat backend | Anthropic→OpenAI translation, forwarded |
 | OpenAI Chat | `gpt-*` / `o1-*` / `o3-*` | OpenAI-compat backend | Auth swap, body forwarded byte-for-byte |
 | OpenAI Chat | a slug your ChatGPT account lists | Codex backend | chat/completions→Responses translation, subscription auth |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "6.0.5",
+      "version": "6.0.6",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
The banner still announced **v5.0** while npm shipped **6.0.5**, and the hero line still said *"your Claude Pro/Max subscription"*, singular. Both were accurate through v5; both have been wrong since v6 made either subscription serve either wire shape.

## What changed

**The banner** → v6.0, leading with what actually changed: both wire shapes on both plans, failover between subscriptions, shadow compare, `dario add altman/amodei`, and `doctor`'s failover readiness (including *armed but INERT*). Links into the body sections that already exist.

**The hero + subtitle** → plural. "Your Claude and ChatGPT subscriptions each work in exactly one place."

**The routing table** → adds the row v6 is built on:

| Client speaks | Model | Routes to |
|---|---|---|
| Anthropic Messages | a slug your ChatGPT account lists | Codex backend |

That capability shipped in **v5.5.87** and was never in the table — so the single row explaining how Claude Code gets served by a ChatGPT plan was missing from the section whose whole job is explaining routing.

The v6 body sections (*Failover between subscriptions*, *Shadow compare*, the rewritten Codex section) already landed with the feature work. This is the framing above them catching up.

## Why a version bump for a docs change

`README.md` is in `package.json` `files` — it ships in the npm tarball and renders on the package page. Without a release, npm keeps serving the **v5** README to everyone who lands there.

## Also done alongside (not in this diff)

The repo **About** was rewritten and topics re-cut for discovery:

- **Description** now leads with both subscriptions + failover instead of Claude-only.
- **Topics**: added `chatgpt`, `codex`, `claude-code`, `ai-gateway` — the highest-volume terms that are now genuinely accurate. Dropped `anthropic-api` (dupe of `anthropic`), `claude-pro` (dupe of `claude-max`), `proxy` (enormous result set, near-zero intent match) and `oauth` (generic infra term). Every tool-integration tag was kept deliberately — `aider`/`cline`/`cursor`/`ollama`/`openrouter` are long-tail but high-intent, and `litellm` doubles as the comparison search.

## Verification

162 files / 0 fail · preflight clean · README line-count gate ok · all four in-page anchors resolve.

## One bug found, deliberately not fixed here

`scripts/version-bump-advice.mjs` silently no-ops when run locally on Windows: its main-module guard is `import.meta.url === \`file://${process.argv[1]}\``, which never matches a Windows path (`file:///C:/...` vs `C:\...`). It works correctly in CI on ubuntu, so this is local-testing only — but it is the same defect `src/cli.ts` documents having already fixed once for npm-global installs. Left out of a docs PR rather than widening scope; worth its own one-liner.
