### PR TITLE
ci(triage): scan PR titles only for keyword labels, not bodies

### DIFF
--- a/.github/workflows/content-labeler.yml
+++ b/.github/workflows/content-labeler.yml
@@ -8,10 +8,27 @@ name: Triage issues and PRs
 #     most needs someone to notice and merge it, so it can't be the case
 #     that skips assignment (dario#1001/#1005, 2026-08-18 — both sat
 #     without an owner until a human went looking).
-#  2. Keyword labels from title + body — the thing labeler.yml
-#     (path-based) cannot do, since an issue has no changed files and a
-#     PR's *description* of what it fixes doesn't necessarily overlap the
-#     paths it touches. Skips bot-authored items here specifically:
+#  2. Keyword labels — the thing labeler.yml (path-based) cannot do,
+#     since an issue has no changed files and a PR's *description* of what
+#     it fixes doesn't necessarily overlap the paths it touches.
+#
+#     SCANS TITLE ONLY ON PRs, title + body on issues. A keyword match
+#     cannot tell MENTIONING a thing from BEING about it, and a PR body is
+#     where that distinction breaks down: dario#1162 was a README-only
+#     release PR that picked up `bug`, `auth` AND `compatibility` because
+#     its body happened to say "one bug found, deliberately not fixed
+#     here", listed `oauth` among repo topics it had REMOVED, and named
+#     `aider`/`cline`/`cursor` in that same list. Every match was real
+#     text; every label was wrong.
+#
+#     A PR title does not have that problem — it is one conventional-commit
+#     line stating what the change IS ("fix(proxy): OAuth refresh crash"
+#     still earns `auth` + `bug`), so the signal survives and the
+#     false-positive surface goes away. Issue bodies keep full scanning:
+#     that is a user describing a problem in prose, where the body IS the
+#     signal and there is no path-based labeler to fall back on.
+#
+#     Skips bot-authored items here specifically:
 #     github-actions[bot] opens the cc-drift / sdk-drift /
 #     cc-watcher-liveness family and those already carry the precise
 #     label their own workflow assigned — a generic keyword pass
@@ -84,7 +101,14 @@ jobs:
               return;
             }
 
-            const text = `${target.title}\n${target.body ?? ''}`;
+            // See the file header: PRs are title-only on purpose. Body prose
+            // discussing an adjacent bug/tool/term is not a statement about
+            // what the PR does, and labeling it as one is worse than not
+            // labeling it at all — a `bug` filter that surfaces docs PRs stops
+            // being read. Issues keep title + body.
+            const text = isIssue
+              ? `${target.title}\n${target.body ?? ''}`
+              : target.title;
             const existing = new Set((target.labels ?? []).map((l) => l.name));
             const toAdd = RULES.filter((r) => r.pattern.test(text) && !existing.has(r.label)).map((r) => r.label);
 


### PR DESCRIPTION
A keyword labeler cannot tell **mentioning** a thing from **being about** it, and a PR body is exactly where that distinction collapses.

## What happened

#1162 was a README-only release PR. It picked up `bug`, `auth` **and** `compatibility`:

| Label | Triggered by | Actually about |
|---|---|---|
| `bug` | *"one **bug** found, deliberately not fixed here"* | a defect in a different script |
| `auth` | *"Dropped … `**oauth**` (generic infra term)"* | a repo **topic I removed** |
| `compatibility` | `**aider**`/`**cline**`/`**cursor**`, "**Windows**" | topic names + where that other bug reproduces |
| `documentation` | "docs", "readme" | ✅ genuinely correct |

Every match was real text. Every label but one was wrong. A `bug` filter that surfaces docs PRs stops being read — which costs more than the labels were worth.

## The change

**PRs scan the title only. Issues keep title + body.**

A PR title doesn't have this problem: it's one conventional-commit line stating what the change *is*. The signal the pass exists for survives intact.

The asymmetry is deliberate. An issue is a user describing a problem in prose — the body **is** the signal, and there's no path-based labeler to fall back on for issues.

## Verified by replaying the live `RULES` against #1162's real title and body

```
#1162   BEFORE (title+body): auth, bug, documentation, compatibility
#1162   AFTER  (title only): documentation

true positives still work:
  "fix(proxy): OAuth refresh crash on expired token" -> auth, bug
  "fix(cursor): Windows path handling broken"        -> bug, compatibility
  "docs: README for v6"                              -> documentation
  "feat: add shadow compare"                         -> (none)

why issues must keep the body:
  issue title only -> (none)
  issue title+body -> auth, compatibility
```

## Notes

- `labeler.yml` (path-based) is untouched and still labels PRs from changed files — it correctly gave #1162 only `documentation`.
- The assignment pass is untouched and still runs on PRs and issues, including bots.
- Still additive-only: never removes a label, never overrides a human.
- **No version bump** — `.github/` is non-shipping per `scripts/version-bump-advice.mjs`.

Cut from `master`, not stacked on #1162.
