### PR TITLE
Classify billing failures separately from rate limits

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4054,7 +4054,11 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           res.writeHead(429, responseHeaders);
           res.end(enriched);
           return;
-        } else if (upstream.status === 400 || upstream.status === 402 || upstream.status === 403) {
+        } else if (
+          upstream.status === 400
+          || upstream.status === 402
+          || (upstream.status === 403 && rejection.class === 'billing')
+        ) {
           // Non-long-context 400 — forward upstream error directly.
           // The body is already consumed, so we write it straight out.
           const responseHeaders: Record<string, string> = {
@@ -4096,8 +4100,23 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           pool.rebindSticky(stickyKey, nextAccount.alias);
           continue dispatchLoop;
         }
-        // No peer available — fall through to normal forwarding so the
-        // client sees the upstream's 401/403. Don't swallow the error.
+        // No peer available — forward the saved generic-403 bytes when the
+        // classifier consumed them; otherwise normal forwarding remains safe.
+        if (upstream.status === 403 && peekedBody !== null) {
+          const responseHeaders: Record<string, string> = {
+            'Content-Type': upstream.headers.get('content-type') ?? 'application/json',
+            'Access-Control-Allow-Origin': corsOrigin,
+            ...SECURITY_HEADERS,
+          };
+          for (const [key, value] of upstream.headers.entries()) {
+            if (key === 'request-id') responseHeaders[key] = value;
+          }
+          responseHeaders['x-dario-upstream-rejection'] = classifyUpstreamRejection(403, peekedBody).marker;
+          requestCount++;
+          res.writeHead(403, responseHeaders);
+          res.end(peekedBody);
+          return;
+        }
       }
 
       // Enrich 429 errors with rate limit details from headers (Anthropic only returns "Error")

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -27,6 +27,7 @@ import { route as routeProvider } from './provider-adapter.js';
 import { RequestQueue, QueueFullError, QueueTimeoutError, DEFAULT_MAX_CONCURRENT, DEFAULT_MAX_QUEUED, DEFAULT_QUEUE_TIMEOUT_MS } from './request-queue.js';
 import { redactSecrets } from './redact.js';
 import { BAKED_BASE_MODELS, withLongContextVariants, buildOpenAIModelsList, getModelCatalog, getCachedBases, resolveAliasAgainst, prewarmModelCatalog, retryModelCatalogNow, isSuspendedModel, type CatalogDeps } from './model-catalog.js';
+import { classifyUpstreamRejection, diagnosticSnippet } from './upstream-rejection.js';
 
 const ANTHROPIC_API = 'https://api.anthropic.com';
 const DEFAULT_PORT = 3456;
@@ -3775,8 +3776,23 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
       // Note: `upstream.text()` consumes the body, so once we peek we MUST
       // handle the response here (can't fall through to the normal forwarder).
       peekedBody = null;
-      if ((upstream.status === 400 || upstream.status === 429) && !passthrough) {
+      if ([400, 402, 403, 429].includes(upstream.status) && !passthrough) {
         peekedBody = await upstream.text().catch(() => '');
+        const rejection = classifyUpstreamRejection(upstream.status, peekedBody);
+        if (rejection.class === 'billing') {
+          console.error(
+            `[dario] upstream billing/entitlement rejection status=${upstream.status} `
+            + `marker=${rejection.marker}; the subscription requires operator billing action `
+            + 'and will not recover on a quota timer',
+          );
+        }
+        if (process.env.DARIO_CAPTURE_UPSTREAM_REJECTIONS === '1') {
+          console.error(
+            `[dario] upstream rejection diagnostic status=${upstream.status} `
+            + `class=${rejection.class} marker=${rejection.marker} `
+            + `body=${JSON.stringify(diagnosticSnippet(redactSecrets(peekedBody)))}`,
+          );
+        }
         const isLongContextError = peekedBody.includes('long context')
           || peekedBody.includes('Extra usage is required')
           || peekedBody.includes('long_context');
@@ -4038,7 +4054,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           res.writeHead(429, responseHeaders);
           res.end(enriched);
           return;
-        } else if (upstream.status === 400) {
+        } else if (upstream.status === 400 || upstream.status === 402 || upstream.status === 403) {
           // Non-long-context 400 — forward upstream error directly.
           // The body is already consumed, so we write it straight out.
           const responseHeaders: Record<string, string> = {
@@ -4049,8 +4065,10 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           for (const [key, value] of upstream.headers.entries()) {
             if (key === 'request-id') responseHeaders[key] = value;
           }
+          const rejection = classifyUpstreamRejection(upstream.status, peekedBody);
+          responseHeaders['x-dario-upstream-rejection'] = rejection.marker;
           requestCount++;
-          res.writeHead(400, responseHeaders);
+          res.writeHead(upstream.status, responseHeaders);
           res.end(peekedBody);
           return;
         }

--- a/src/upstream-rejection.ts
+++ b/src/upstream-rejection.ts
@@ -1,0 +1,24 @@
+export type UpstreamRejectionClass = 'billing' | 'rate_limit' | 'other';
+
+export interface UpstreamRejection {
+  class: UpstreamRejectionClass;
+  marker: 'billing_required' | 'rate_limited' | 'upstream_rejected';
+}
+
+/** Classify subscription entitlement failures separately from temporary quota exhaustion. */
+export function classifyUpstreamRejection(status: number, body: string): UpstreamRejection {
+  const normalized = body.toLowerCase();
+  const billing = status === 402
+    || normalized.includes('payment_required')
+    || normalized.includes('credit balance')
+    || normalized.includes('plans & billing')
+    || (status === 403 && normalized.includes('oauth_not_allowed_for_organization'));
+  if (billing) return { class: 'billing', marker: 'billing_required' };
+  if (status === 429) return { class: 'rate_limit', marker: 'rate_limited' };
+  return { class: 'other', marker: 'upstream_rejected' };
+}
+
+/** Bounded diagnostic text; callers must apply their standard secret redactor first. */
+export function diagnosticSnippet(body: string, maxLength = 500): string {
+  return body.replace(/\s+/g, ' ').trim().slice(0, maxLength);
+}

--- a/test/auth-failover-403-proxy.mjs
+++ b/test/auth-failover-403-proxy.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// Proxy-path regression: classifying a non-passthrough 403 consumes its body,
+// but a generic 403 must still enter account-pool auth failover. The saved body
+// is only forwarded when the pool has no healthy peer.
+
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let pass = 0, fail = 0;
+const check = (name, cond, detail = '') => {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else { console.error(`  FAIL ${name}${detail ? ` :: ${detail}` : ''}`); fail++; }
+};
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const tmpHome = await mkdtemp(join(tmpdir(), 'dario-auth403-'));
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+const accountsDir = join(tmpHome, '.dario', 'accounts');
+await mkdir(accountsDir, { recursive: true });
+for (const [alias, token] of [['a-main', 'bad-token'], ['b-peer', 'good-token']]) {
+  await writeFile(join(accountsDir, `${alias}.json`), JSON.stringify({
+    alias, accessToken: token, refreshToken: `${token}-refresh`,
+    expiresAt: Date.now() + 6 * 3_600_000,
+    scopes: ['user:inference'], deviceId: `device-${alias}`, accountUuid: `uuid-${alias}`,
+  }));
+}
+
+const seenTokens = [];
+const fakeFetch = async (url, init = {}) => {
+  if (String(url).includes('/v1/models')) {
+    return new Response(JSON.stringify({ data: [{ id: 'claude-sonnet-5', type: 'model' }] }), {
+      status: 200, headers: { 'content-type': 'application/json' },
+    });
+  }
+  const token = new Headers(init.headers).get('authorization');
+  seenTokens.push(token);
+  if (token === 'Bearer bad-token') {
+    return new Response(JSON.stringify({ error: { type: 'permission_error', message: 'generic forbidden' } }), {
+      status: 403, headers: { 'content-type': 'application/json', 'request-id': 'req-denied' },
+    });
+  }
+  return new Response(JSON.stringify({
+    id: 'msg_peer', type: 'message', role: 'assistant', model: 'claude-sonnet-5',
+    content: [{ type: 'text', text: 'served by peer' }], stop_reason: 'end_turn',
+    usage: { input_tokens: 1, output_tokens: 2 },
+  }), { status: 200, headers: { 'content-type': 'application/json' } });
+};
+
+const { startProxy } = await import('../dist/proxy.js');
+const port = 38847;
+await startProxy({ port, host: '127.0.0.1', noLiveCapture: true, fetchImpl: fakeFetch });
+for (let i = 0; i < 50; i++) {
+  try { await fetch(`http://127.0.0.1:${port}/health`); break; } catch { await sleep(50); }
+}
+const response = await fetch(`http://127.0.0.1:${port}/v1/messages`, {
+  method: 'POST', headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ model: 'claude-sonnet-5', max_tokens: 16, messages: [{ role: 'user', content: 'ping' }] }),
+});
+const text = await response.text();
+check('first pool account receives the request', seenTokens[0] === 'Bearer bad-token', JSON.stringify(seenTokens));
+check('generic 403 retries with the healthy peer', seenTokens[1] === 'Bearer good-token', JSON.stringify(seenTokens));
+check('client receives peer success, not consumed 403', response.status === 200 && text.includes('served by peer'), `${response.status} ${text}`);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/test/upstream-rejection.mjs
+++ b/test/upstream-rejection.mjs
@@ -1,0 +1,21 @@
+import { strict as assert } from 'node:assert';
+import { classifyUpstreamRejection, diagnosticSnippet } from '../dist/upstream-rejection.js';
+
+const billingCases = [
+  [402, '{"error":{"type":"payment_required"}}'],
+  [403, '{"error":{"details":{"error_code":"oauth_not_allowed_for_organization"}}}'],
+  [400, '{"error":{"message":"Credit balance too low; visit Plans & Billing"}}'],
+];
+for (const [status, body] of billingCases) {
+  assert.deepEqual(classifyUpstreamRejection(status, body), {
+    class: 'billing', marker: 'billing_required',
+  });
+}
+assert.deepEqual(classifyUpstreamRejection(429, '{"error":{"type":"rate_limit_error"}}'), {
+  class: 'rate_limit', marker: 'rate_limited',
+});
+assert.deepEqual(classifyUpstreamRejection(403, '{"error":{"type":"permission_error"}}'), {
+  class: 'other', marker: 'upstream_rejected',
+});
+assert.equal(diagnosticSnippet('  one\n  two  ', 7), 'one two');
+console.log('upstream rejection classification: ok');


### PR DESCRIPTION
## Summary
- classify 402/payment/credit and observed 403 oauth_not_allowed_for_organization as billing_required
- add opt-in redacted bounded rejection capture via DARIO_CAPTURE_UPSTREAM_REJECTIONS=1
- preserve upstream status and add x-dario-upstream-rejection marker
- add synthetic classifier cases for 402, observed 403, 429, and credit-balance 400

Ticket: DEV-72bd8bbd

No live model-loop smoke was run; the intentional lapsed-seat fixture was not modified.