### PR TITLE
Test serving verdict through production doctor path

### DIFF
--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -13,18 +13,16 @@ import {
   type RunChecksOptions,
 } from './doctor-core.js';
 import { applyServingVerdict } from './doctor-serving.js';
-import { getServingProbe } from './serving-probe.js';
+import { getServingProbe, type ProbeResult } from './serving-probe.js';
 
-/**
- * Collect doctor rows and, when --probe is requested, make the live serving
- * result authoritative over structural OAuth/pool/identity conclusions.
- */
-export async function runChecks(opts: RunChecksOptions = {}): Promise<Check[]> {
-  const checks = await collectChecks(opts);
-  if (!opts.probe) return checks;
+interface DoctorDependencies {
+  collect: (opts: RunChecksOptions) => Promise<Check[]>;
+  probe: () => Promise<ProbeResult>;
+}
 
+async function productionProbe(): Promise<ProbeResult> {
   const upstreamApiKey = (process.env.ANTHROPIC_UPSTREAM_API_KEY ?? '').trim();
-  const probe = await getServingProbe({
+  return getServingProbe({
     ...(upstreamApiKey
       ? { upstreamApiKey }
       : {
@@ -34,7 +32,26 @@ export async function runChecks(opts: RunChecksOptions = {}): Promise<Check[]> {
           },
         }),
   });
+}
+
+/**
+ * Collect doctor rows and, when --probe is requested, make the live serving
+ * result authoritative over structural OAuth/pool/identity conclusions.
+ */
+export async function runDoctorChecks(
+  opts: RunChecksOptions = {},
+  dependencies: DoctorDependencies = { collect: collectChecks, probe: productionProbe },
+): Promise<Check[]> {
+  const checks = await dependencies.collect(opts);
+  if (!opts.probe) return checks;
+
+  const probe = await dependencies.probe();
   return applyServingVerdict(checks, probe);
+}
+
+/** Production entry point shared by the CLI and MCP callers. */
+export async function runChecks(opts: RunChecksOptions = {}): Promise<Check[]> {
+  return runDoctorChecks(opts);
 }
 
 export { applyServingVerdict } from './doctor-serving.js';

--- a/test/doctor-serving.mjs
+++ b/test/doctor-serving.mjs
@@ -1,5 +1,6 @@
 import { strict as assert } from 'node:assert';
 import { applyServingVerdict } from '../dist/doctor-serving.js';
+import { runDoctorChecks } from '../dist/doctor.js';
 
 const structural = [
   { status: 'ok', label: 'OAuth', detail: 'healthy (expires in 5h)' },
@@ -7,7 +8,7 @@ const structural = [
   { status: 'info', label: 'Pool routing', detail: 'next: login (1/1 healthy)' },
   { status: 'ok', label: 'Identity', detail: '1/1 pool account match' },
 ];
-const billing = applyServingVerdict(structural, {
+const billingProbe = {
   ok: false,
   reason: 'billing-required',
   detail: 'The subscription needs operator attention. Restarting or logging in again will not help.',
@@ -15,7 +16,8 @@ const billing = applyServingVerdict(structural, {
   latencyMs: 1,
   model: 'synthetic',
   status: 403,
-});
+};
+const billing = applyServingVerdict(structural, billingProbe);
 assert.equal(billing[0].status, 'fail');
 assert.match(billing[0].detail, /billing-required/);
 for (const label of ['OAuth', 'Pool', 'Pool routing', 'Identity']) {
@@ -28,4 +30,34 @@ const healthy = applyServingVerdict(structural, {
 });
 assert.equal(healthy[0].status, 'ok');
 assert.match(healthy[0].detail, /served/);
+
+let probeCalls = 0;
+const commandRows = await runDoctorChecks(
+  { probe: true },
+  {
+    collect: async () => structural,
+    probe: async () => {
+      probeCalls += 1;
+      return billingProbe;
+    },
+  },
+);
+assert.equal(probeCalls, 1, 'doctor --probe obtains the live serving verdict');
+assert.equal(commandRows[0].label, 'Serving');
+assert.equal(commandRows[0].status, 'fail');
+assert.equal(commandRows.find((check) => check.label === 'OAuth').status, 'fail');
+
+let skippedProbeCalls = 0;
+const structuralOnlyRows = await runDoctorChecks(
+  {},
+  {
+    collect: async () => structural,
+    probe: async () => {
+      skippedProbeCalls += 1;
+      return billingProbe;
+    },
+  },
+);
+assert.equal(skippedProbeCalls, 0, 'doctor without --probe remains structural-only');
+assert.deepEqual(structuralOnlyRows, structural);
 console.log('doctor serving conclusion: ok');


### PR DESCRIPTION
## Summary
- preserve the production `runChecks` entry point while exposing its command boundary for dependency-controlled coverage
- verify `--probe` obtains and overlays a failed serving verdict onto green structural rows
- verify the non-probe path remains structural-only

## Verification
- `git diff --check`
- CI compiles and runs dist-based tests (local builds prohibited by fleet build wall)

Ticket: 01M1HJMNNNEAC6RMWY3WYW57GQ
