### PR TITLE
ci: arm bot auto-merge with the drift-bot PAT; reap merged bot branches

### DIFF
--- a/.github/workflows/auto-merge-bot-prs.yml
+++ b/.github/workflows/auto-merge-bot-prs.yml
@@ -159,7 +159,18 @@ jobs:
             )
           )
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Arm with the drift-bot PAT, GITHUB_TOKEN only as a fallback. The
+          # identity that arms native auto-merge is the identity GitHub
+          # records as the merger, and a GITHUB_TOKEN merge is loop-protected:
+          # it fires no push event (so cc-drift-auto-release waits for its
+          # hourly schedule instead of releasing on the spot) and it does NOT
+          # run the repo's delete-branch-on-merge — #1180 (bot/template-rebake-
+          # 20260901-215856) merged as github-actions and its branch stayed
+          # behind for three days, while every PAT-armed sibling had its
+          # branch deleted one second after merge. Same PAT-or-token contract
+          # as cc-drift-template-watch.yml. The sweep workflow reaps whatever
+          # this still misses.
+          GH_TOKEN: ${{ secrets.DARIO_DRIFT_BOT_PAT || secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
           AUTHOR: ${{ github.event.pull_request.user.login }}
           BRANCH: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/auto-merge-sweep.yml
+++ b/.github/workflows/auto-merge-sweep.yml
@@ -18,7 +18,8 @@ name: Auto-merge sweep (webhook-loss fallback)
 # workflow in the release path that lacked it. `gh pr merge --auto` on a PR
 # that is already armed is a no-op, so a healthy hour costs one API listing.
 #
-# SCOPE: drift-bot branches only (`bot/cc-drift-`, `bot/template-label-`).
+# SCOPE: drift-bot branches only (`bot/cc-drift-`, `bot/template-label-`,
+# `bot/template-rebake-` — the same three prefixes the event path arms).
 # Dependabot is deliberately excluded. Its major-version exclusion comes from
 # dependabot/fetch-metadata, which needs the PR event payload and cannot run
 # on a schedule; title-parsing is not an acceptable substitute (a grouped
@@ -65,7 +66,11 @@ jobs:
 
       - name: Arm auto-merge on any unarmed drift-bot PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT first, GITHUB_TOKEN as fallback — the arming identity becomes
+          # the merge identity, and a GITHUB_TOKEN merge neither fires the
+          # push event nor deletes the head branch (#1180). See the sibling
+          # workflow's Enable auto-merge step.
+          GH_TOKEN: ${{ secrets.DARIO_DRIFT_BOT_PAT || secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -84,7 +89,7 @@ jobs:
                    | select(.isDraft == false)
                    | select(.autoMergeRequest == null)
                    | select(.headRepositoryOwner.login == "'"${REPO%%/*}"'")
-                   | select(.headRefName | startswith("bot/cc-drift-") or startswith("bot/template-label-"))]')
+                   | select(.headRefName | startswith("bot/cc-drift-") or startswith("bot/template-label-") or startswith("bot/template-rebake-"))]')
 
           count=$(printf '%s' "$candidates" | jq 'length')
           echo "Unarmed drift-bot PRs: $count"
@@ -146,4 +151,48 @@ jobs:
           # a warning, and never a failed run.
           if [ "$armed" -gt 0 ]; then
             echo "::notice::Sweep armed $armed drift-bot PR(s) the pull_request_target trigger did not. Expected after a webhook-delivery incident."
+          fi
+
+      - name: Reap bot branches whose PR already merged
+        # delete-branch-on-merge is repo-wide, but GitHub skips it when the
+        # merger is GITHUB_TOKEN (#1180 sat for three days). Belt to the PAT
+        # braces above: any bot/* branch whose only PRs are MERGED, none OPEN,
+        # and whose tip is exactly the merged PR's head, is dead and goes.
+        # Never a branch with an open PR, never one nothing merged, never one
+        # that moved after its merge — those are someone's work.
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          branches=$(gh api "repos/${REPO}/branches?per_page=100" --paginate             --jq '.[] | select(.name | startswith("bot/")) | .name + " " + .commit.sha')
+
+          reaped=0
+          kept=0
+          while read -r name sha; do
+            [ -n "$name" ] || continue
+            prs=$(gh pr list --repo "$REPO" --head "$name" --state all --limit 20               --json number,state,headRefOid)
+            open=$(printf '%s' "$prs" | jq '[.[] | select(.state == "OPEN")] | length')
+            merged=$(printf '%s' "$prs" | jq -r '[.[] | select(.state == "MERGED" and .headRefOid == "'"$sha"'")] | .[0].number // empty')
+
+            if [ "$open" != "0" ]; then
+              echo "  $name KEEP — open PR"
+              kept=$((kept + 1))
+            elif [ -z "$merged" ]; then
+              echo "  $name KEEP — no merged PR at this tip"
+              kept=$((kept + 1))
+            elif gh api -X DELETE "repos/${REPO}/git/refs/heads/${name}" >/dev/null; then
+              echo "  $name REAPED — merged as #$merged, branch left behind"
+              reaped=$((reaped + 1))
+            else
+              echo "  $name could not delete — will retry next tick"
+              kept=$((kept + 1))
+            fi
+          done <<< "$branches"
+
+          echo "reaped=$reaped kept=$kept"
+          if [ "$reaped" -gt 0 ]; then
+            echo "::notice::Reaped $reaped merged bot branch(es) delete-branch-on-merge left behind."
           fi

--- a/.github/workflows/auto-merge-sweep.yml
+++ b/.github/workflows/auto-merge-sweep.yml
@@ -173,7 +173,11 @@ jobs:
           kept=0
           while read -r name sha; do
             [ -n "$name" ] || continue
-            prs=$(gh pr list --repo "$REPO" --head "$name" --state all --limit 20               --json number,state,headRefOid)
+            if ! prs=$(gh pr list --repo "$REPO" --head "$name" --state all --limit 20 --json number,state,headRefOid); then
+              echo "  $name KEEP — could not list its PRs; next tick"
+              kept=$((kept + 1))
+              continue
+            fi
             open=$(printf '%s' "$prs" | jq '[.[] | select(.state == "OPEN")] | length')
             merged=$(printf '%s' "$prs" | jq -r '[.[] | select(.state == "MERGED" and .headRefOid == "'"$sha"'")] | .[0].number // empty')
 
@@ -183,12 +187,25 @@ jobs:
             elif [ -z "$merged" ]; then
               echo "  $name KEEP — no merged PR at this tip"
               kept=$((kept + 1))
-            elif gh api -X DELETE "repos/${REPO}/git/refs/heads/${name}" >/dev/null; then
-              echo "  $name REAPED — merged as #$merged, branch left behind"
-              reaped=$((reaped + 1))
             else
-              echo "  $name could not delete — will retry next tick"
-              kept=$((kept + 1))
+              # Re-check right before the delete. The listing above is a
+              # snapshot; a bot could push to this name or open a PR on it
+              # while the loop walked earlier branches. DELETE takes no
+              # expected SHA, so the closest thing to compare-and-delete is a
+              # fresh read of both facts the decision rests on. Any drift, or
+              # any read failure, keeps the branch — next tick sees it again.
+              live_sha=$(gh api "repos/${REPO}/git/ref/heads/${name}" --jq '.object.sha' 2>/dev/null || echo unreadable)
+              live_open=$(gh pr list --repo "$REPO" --head "$name" --state open --limit 1 --json number --jq 'length' 2>/dev/null || echo unreadable)
+              if [ "$live_sha" != "$sha" ] || [ "$live_open" != "0" ]; then
+                echo "  $name KEEP — moved or gained an open PR during the sweep"
+                kept=$((kept + 1))
+              elif gh api -X DELETE "repos/${REPO}/git/refs/heads/${name}" >/dev/null; then
+                echo "  $name REAPED — merged as #$merged, branch left behind"
+                reaped=$((reaped + 1))
+              else
+                echo "  $name could not delete — will retry next tick"
+                kept=$((kept + 1))
+              fi
             fi
           done <<< "$branches"
 


### PR DESCRIPTION
## Why

#1180 (`bot/template-rebake-20260901-215856`) merged on 9/1 as `github-actions` and the branch was still there on 9/4. Every other bot PR in the last week (#1173 through #1198) was armed with the drift-bot PAT, merged as `askalf`, and had its branch deleted one second later. The repo has delete-branch-on-merge enabled; GitHub just does not run it for a GITHUB_TOKEN merge, the same loop-protection that suppresses the `push` event `cc-drift-auto-release.yml` already documents.

`auto-merge-bot-prs.yml` was the only armer for the rebake PR (the template watch deliberately does not arm rebakes), and it armed with GITHUB_TOKEN.

## What

- **auto-merge-bot-prs.yml**: arm with `DARIO_DRIFT_BOT_PAT || GITHUB_TOKEN`, the contract `cc-drift-template-watch.yml` already uses. Side benefit: PAT merges fire `push`, so auto-release runs on the spot instead of waiting for the :15 schedule.
- **auto-merge-sweep.yml**:
  - same PAT-first arming
  - `bot/template-rebake-` added to the prefix filter (event path has armed it since #1096; the webhook-loss fallback never did)
  - new step after the sweep: reap any `bot/*` branch whose PR is MERGED at exactly that tip and has no OPEN PR. Never touches a branch with an open PR, one nothing merged, or one that moved after merge.

The stray branch itself was deleted by hand today.

## Verified

- jq filters exercised against the real #1180 data via `gh --jq`: selects #1180 by MERGED + headRefOid, open count 0.
- Both files parse as YAML. actionlint runs in CI.
