### PR TITLE
codex: flatten chat-shape named tool_choice before /responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ checklist.
 
 ## [Unreleased]
 
+- **Forced tool calls work again on the Codex backend.** A chat/completions named `tool_choice` — `{"type":"function","function":{"name":"f"}}`, which Cursor, Continue and Aider send whenever they force a tool — reached the Responses backend un-flattened and 400'd with `Missing required parameter: 'tool_choice.name'`. It is now translated to the flat Responses form `{"type":"function","name":"f"}`, matching what the Anthropic path already did. String choices (`auto`/`none`/`required`) and unrecognized objects pass through unchanged.
+
 ## [6.0.21] - 2026-09-04
 
 - **Template label refresh** — `_version`, `_supportedMaxTested`, and the `user-agent` header bumped to `2.1.261` to track `@anthropic-ai/claude-code@latest`. The live wire shape is unchanged — cc-drift-template-watch ran `capture-and-bake --check` against live CC v2.1.261 and found zero shape drift vs the bundle — so this is a label refresh, not a re-capture (`_captured` stays at the last real capture). Auto-merged; clears the `sdk-drift` early-warning signal.

--- a/src/codex-backend.ts
+++ b/src/codex-backend.ts
@@ -293,6 +293,29 @@ function messageContentToText(content: unknown): string {
 }
 
 /**
+ * Translate a chat/completions `tool_choice` into the Responses shape.
+ *
+ * The two APIs agree on the string forms ("auto"/"none"/"required") but not on
+ * the forced-tool form: chat/completions nests the name under `function`,
+ * Responses takes it FLAT. Forwarding the nested form verbatim makes the Codex
+ * backend answer 400 "Missing required parameter: 'tool_choice.name'", which is
+ * what every client that forces a tool (Cursor, Continue, Aider) sends. Mirrors
+ * translateToolChoice() on the Anthropic path.
+ *
+ * Anything else passes through untouched: an unknown object is the backend's to
+ * reject, not ours to guess at. Pure; exported for tests.
+ */
+export function toResponsesToolChoice(choice: unknown): unknown {
+  if (choice == null || typeof choice !== 'object') return choice;
+  const c = choice as { function?: { name?: unknown } };
+  const name = c.function?.name;
+  if (typeof name === 'string' && name.length > 0) {
+    return { type: 'function', name };
+  }
+  return choice;
+}
+
+/**
  * Translate an OpenAI chat/completions request body into a Responses request.
  *
  * - system messages collapse into `instructions` (Responses has no system role)
@@ -365,7 +388,7 @@ export function chatCompletionsToResponses(body: Record<string, unknown>): Recor
       parameters: t.function?.parameters ?? { type: 'object', properties: {} },
     }));
   }
-  if (body.tool_choice != null) out.tool_choice = body.tool_choice;
+  if (body.tool_choice != null) out.tool_choice = toResponsesToolChoice(body.tool_choice);
   if (body.temperature != null) out.temperature = body.temperature;
   if (body.top_p != null) out.top_p = body.top_p;
   if (body.max_tokens != null || body.max_completion_tokens != null) {

--- a/test/codex-backend.mjs
+++ b/test/codex-backend.mjs
@@ -14,6 +14,7 @@
 import {
   chatCompletionsToResponses,
   createResponsesTranslator,
+  toResponsesToolChoice,
   buildCodexHeaders,
   extractChatGPTAccountId,
   fetchCodexModels,
@@ -115,6 +116,31 @@ header('chatCompletionsToResponses');
   check('tool type stays function', out.tools[0].type === 'function');
   check('tool parameters preserved', out.tools[0].parameters.properties.city.type === 'string');
   check('tool_choice forwarded', out.tool_choice === 'auto');
+}
+{
+  // A forced tool: chat/completions nests the name under function{}, Responses
+  // takes it flat. Sending the nested form 400s with "Missing required
+  // parameter: 'tool_choice.name'" — the bug this covers.
+  const out = chatCompletionsToResponses({
+    model: 'm',
+    messages: [{ role: 'user', content: 'x' }],
+    tools: [{ type: 'function', function: { name: 'get_weather', parameters: { type: 'object', properties: {} } } }],
+    tool_choice: { type: 'function', function: { name: 'get_weather' } },
+  });
+  check('named tool_choice loses the function{} nesting',
+    out.tool_choice.type === 'function' && out.tool_choice.name === 'get_weather');
+  check('flattened tool_choice keeps no function key', out.tool_choice.function === undefined);
+
+  check('string tool_choice "auto" is untouched', toResponsesToolChoice('auto') === 'auto');
+  check('string tool_choice "none" is untouched', toResponsesToolChoice('none') === 'none');
+  check('string tool_choice "required" is untouched', toResponsesToolChoice('required') === 'required');
+
+  // Unknown shapes are the backend's to reject, not ours to guess at.
+  const unknown = { type: 'allowed_tools', mode: 'auto' };
+  check('unknown tool_choice object passes through by identity',
+    toResponsesToolChoice(unknown) === unknown);
+  const emptyName = { type: 'function', function: { name: '' } };
+  check('empty forced-tool name is not flattened', toResponsesToolChoice(emptyName) === emptyName);
 }
 {
   // Full tool round trip: assistant tool_call then a tool-role result.


### PR DESCRIPTION
## Problem

`chatCompletionsToResponses` forwarded `tool_choice` verbatim. A chat/completions named choice

```json
{"type":"function","function":{"name":"get_weather"}}
```

reaches the Codex Responses backend un-flattened, which answers:

```
400 {"error":{"message":"Missing required parameter: 'tool_choice.name'.","type":"invalid_request_error"}}
```

The Responses forced form is flat — `{"type":"function","name":"get_weather"}` — and returns 200 with a `function_call`. Cursor / Continue / Aider send the nested form whenever they force a tool, so this broke every forced-tool request through the Codex path. Verified live 2026-09-04.

## Fix

New pure exported helper `toResponsesToolChoice()` in `src/codex-backend.ts`, mirroring `translateToolChoice()` on the Anthropic path:

- object with `.function.name` (non-empty string) → `{type:'function', name}`
- strings (`"auto"`/`"none"`/`"required"`) → unchanged
- anything else (unknown object, null) → passed through untouched; an unknown shape is the backend's to reject, not ours to guess at

## Test plan

`test/codex-backend.mjs` — the existing 3 `tool_choice` checks only covered `"auto"`. Added coverage for the nested named choice flattening, `"auto"` staying a string, and an unknown object passing through by identity.

`npm ci && npm run build && npm test`

Source ticket: DEV-c132b3de