### PR TITLE
codex: streamed chat-shape response.failed emits an error frame, not finish_reason stop

### DIFF
--- a/src/codex-backend.ts
+++ b/src/codex-backend.ts
@@ -407,6 +407,12 @@ export function failedResponseMessage(resp: unknown): string {
   return msg || code || 'the Codex backend ended the response as failed';
 }
 
+/** The upstream error code on a failed Responses payload, or null when absent. */
+export function failedResponseCode(resp: unknown): string | null {
+  const e = (resp as { error?: { code?: unknown } } | null)?.error;
+  return e && typeof e.code === 'string' && e.code ? e.code : null;
+}
+
 interface ToolCallAccumulator {
   index: number;
   id: string;
@@ -531,6 +537,23 @@ export function createResponsesTranslator(model: string) {
             completion_tokens: u.output_tokens ?? 0,
             total_tokens: (u.input_tokens ?? 0) + (u.output_tokens ?? 0),
           };
+        }
+        if (failed) {
+          // A failed turn must NOT close like a finished one: a
+          // `finish_reason:"stop"` frame is, to every OpenAI SDK, a successful
+          // empty completion, so the failure disappears entirely. Emit the
+          // error frame instead — openai-node's ChatCompletionStream and
+          // openai-python both raise on a chunk carrying `error` — then
+          // `[DONE]` so the parser terminates rather than waiting.
+          return opened(
+            `data: ${JSON.stringify({
+              error: {
+                message: failedResponseMessage(e.response),
+                type: 'server_error',
+                code: failedResponseCode(e.response),
+              },
+            })}\n\ndata: [DONE]\n\n`,
+          );
         }
         return opened(`${frame({}, toolCalls.size > 0 ? 'tool_calls' : 'stop')}data: [DONE]\n\n`);
       }

--- a/test/codex-backend.mjs
+++ b/test/codex-backend.mjs
@@ -597,9 +597,28 @@ header('response.failed — chat path terminates the stream');
   const joined = out.join('');
   check('a failed stream still emits [DONE]', joined.endsWith('data: [DONE]\n\n'));
   const frames = parseFrames(out);
-  check('and a terminal frame carrying finish_reason',
-    frames.some((f) => f.choices[0].finish_reason !== null));
+  const errFrame = frames.find((f) => f.error);
+  check('an error frame is on the wire (openai-node/-python raise on it)', Boolean(errFrame));
+  check('carrying the upstream message', errFrame?.error?.message === 'upstream exploded');
+  check('typed server_error, with the upstream code',
+    errFrame?.error?.type === 'server_error' && errFrame?.error?.code === 'server_error');
+  // The point of the frame: a terminal `stop` is a SUCCESSFUL empty completion
+  // to every OpenAI SDK, so a failure closed that way disappears silently.
+  check('and NO finish_reason frame at all',
+    !frames.some((f) => f.choices?.[0]?.finish_reason));
+  check('the role opener is still sent first',
+    frames[0]?.choices?.[0]?.delta?.role === 'assistant');
   check('the translator reports the failure', t.didFail() === true);
+}
+
+header('response.completed keeps the chat success contract unchanged');
+{
+  const t = createResponsesTranslator('gpt-5.6-sol');
+  const frames = parseFrames(feed(t, sse(TEXT_STREAM)));
+  check('a successful stream still ends with finish_reason "stop"',
+    frames.at(-1)?.choices?.[0]?.finish_reason === 'stop');
+  check('and carries no error frame', !frames.some((f) => f.error));
+  check('and is not reported as failed', t.didFail() === false);
 }
 
 header('response.failed — non-streaming clients get an error, not a fake empty success');
@@ -632,6 +651,20 @@ header('response.failed — a STREAMING client still gets a terminated stream');
     CREDS, '*', {}, 5000, false, 'anthropic', fakeUpstream(FAILED_STREAM, {}));
   check('streaming stays 200 (the terminal event is on the wire)', resS.statusCode === 200);
   check('the anthropic stream is closed properly', resS.body.includes('event: message_stop'));
+}
+
+header('response.failed — a STREAMING chat client sees the error, not an empty success');
+{
+  const resS = fakeRes();
+  await forwardToCodex({}, resS, Buffer.from(JSON.stringify({ model: 'gpt-5.6-sol', stream: true, messages: [{ role: 'user', content: 'hi' }] })),
+    CREDS, '*', {}, 5000, false, 'openai', fakeUpstream(FAILED_STREAM, {}));
+  // Headers were flushed before the failure arrived, so the wire status stays
+  // 200; the error rides the stream. Analytics still records this as 502.
+  check('streaming stays 200', resS.statusCode === 200);
+  check('the error frame reaches the client',
+    resS.body.includes('"server_error"') && resS.body.includes('upstream exploded'));
+  check('no finish_reason "stop" frame', !resS.body.includes('"finish_reason":"stop"'));
+  check('the stream is terminated with [DONE]', resS.body.trimEnd().endsWith('data: [DONE]'));
 }
 
 header('a SUCCESSFUL response is still not treated as failed');


### PR DESCRIPTION
## Problem

A `/v1/chat/completions` request with `stream: true` to a codex slug, where upstream ends with `response.failed`, delivered this to the client:

```
data: {..."delta":{"role":"assistant","content":""},"finish_reason":null}
data: {..."delta":{},"finish_reason":"stop"}
data: [DONE]
```

To every OpenAI SDK that is a **successful, empty completion** — the failure disappears. `createResponsesTranslator` treated all three terminal Responses events identically; `didFail()` was consulted only for the non-streaming collapse.

## Fix

`src/codex-backend.ts` — on a terminal event that is a failure (`response.failed`, or a terminal response whose `status` is `failed` / that carries an `error`), the chat-shape translator now emits

```
data: {"error":{"message":"<upstream message>","type":"server_error","code":<upstream code or null>}}
data: [DONE]
```

with **no** `finish_reason:"stop"` frame. openai-node's `ChatCompletionStream` and openai-python both raise on a chunk carrying `error`, which is the correct client outcome. The role-opener frame is unchanged, so the stream is still well-formed. New exported helper `failedResponseCode()` alongside the existing `failedResponseMessage()`.

Success streams are untouched: `response.completed` / `.incomplete` still close with `finish_reason` `stop` / `tool_calls`. Analytics already reports 502 for this case — left as is.

## Tests (`test/codex-backend.mjs`)

- Rewrote *"response.failed — chat path terminates the stream"*, which asserted the buggy behaviour as correct: it now asserts the error frame is present with the upstream message/type/code, that **no** `finish_reason` frame is emitted at all, that the role opener still leads, and that `[DONE]` still terminates.
- New: `response.completed keeps the chat success contract unchanged` — regression guard on `finish_reason:"stop"`, no error frame, `didFail() === false`.
- New: end-to-end through `forwardToCodex` with `stream:true` + openai shape — error frame on the wire, no `"finish_reason":"stop"`, ends with `[DONE]`.

## Test plan

`npm ci && npm run build && npm test`

Source ticket: DEV-d1e82cad