### PR TITLE
codex: a dead refresh token must not become a silent per-request refresh storm

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 <p><strong>One local endpoint. Every AI tool you own. The subscriptions you already pay for.</strong></p>
 
-<sub><code>npm i -g @askalf/dario</code> · <strong>0</strong> runtime deps · <a href="https://www.npmjs.com/package/@askalf/dario">SLSA-attested</a> every release · nothing phones home · ~29k lines you can read in a weekend · independent, unofficial, third-party (<a href="DISCLAIMER.md">DISCLAIMER.md</a>)</sub>
+<sub><code>npm i -g @askalf/dario</code> · <strong>0</strong> runtime deps · <a href="https://www.npmjs.com/package/@askalf/dario">SLSA-attested</a> every release · nothing phones home · ~30k lines you can read in a weekend · independent, unofficial, third-party (<a href="DISCLAIMER.md">DISCLAIMER.md</a>)</sub>
 
 <sub>Part of <a href="#own-your-stack"><strong>Own Your Stack</strong></a> — 12 open tools for owning your AI infra: <a href="https://github.com/askalf/truecopy">truecopy</a> · <a href="https://github.com/askalf/strongroom">strongroom</a> · <a href="https://github.com/askalf/fieldpass">fieldpass</a> · <a href="https://github.com/askalf/plumbline">plumbline</a> · <a href="#own-your-stack">full family ↓</a></sub>
 
@@ -307,7 +307,7 @@ The split isn't live, but it was announced once on short notice and could return
 
 | Signal | Status |
 |---|---|
-| Source | **~29k** lines of TypeScript across **59** files — auditable in a weekend (v5 removed shim; the pool is the one code path) |
+| Source | **~30k** lines of TypeScript across **65** files — auditable in a weekend (v5 removed shim; the pool is the one code path) |
 | Dependencies | **0 runtime.** Verify: `npm ls --production` |
 | Provenance | Every release [SLSA-attested](https://www.npmjs.com/package/@askalf/dario) via GitHub Actions + Sigstore |
 | Scanning | [CodeQL](https://github.com/askalf/dario/actions/workflows/codeql.yml) on every push and weekly |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1158,7 +1158,7 @@ async function codex() {
       process.exit(1);
     }
 
-    const { authorizeUrl, codeVerifier } = await startAddCodexAccount(alias);
+    const { authorizeUrl, codeVerifier, state } = await startAddCodexAccount(alias);
     console.log('');
     console.log('  Open this URL and log in with your ChatGPT Plus/Pro account.');
     console.log('  The browser will land on a localhost page that does not load —');
@@ -1167,9 +1167,19 @@ async function codex() {
     console.log(`  ${authorizeUrl}`);
     console.log('');
     const pasted = await readLineFromStdin('  Redirect URL (or code): ');
-    const { code } = parseCodexManualPaste(pasted);
+    const { code, state: pastedState } = parseCodexManualPaste(pasted);
     if (!code) {
       console.error('[dario] No code found in what you pasted.');
+      process.exit(1);
+    }
+    // The state parameter is what ties this paste to the URL printed above.
+    // It was parsed and then discarded, which made the CSRF guard the OAuth
+    // flow carries decorative: a redirect from some other authorize request
+    // would have been accepted and stored. A paste with no state at all (a
+    // bare code — accepted shape #3) can't be checked and is left alone.
+    if (pastedState !== null && pastedState !== state) {
+      console.error('[dario] The pasted redirect does not match this login attempt (state mismatch).');
+      console.error('        Start over with `dario codex add ' + alias + '` and paste the URL from THAT browser tab.');
       process.exit(1);
     }
     try {

--- a/src/codex-accounts.ts
+++ b/src/codex-accounts.ts
@@ -18,6 +18,7 @@ import {
   buildCodexAuthorizeUrl,
   exchangeCodexAuthorizationCode,
   refreshCodexAccessToken,
+  CodexRefreshError,
   type CodexTokens,
 } from './codex-oauth.js';
 import { durableWriteFile } from './durable-write.js';
@@ -121,6 +122,7 @@ export async function removeCodexAccount(alias: string): Promise<boolean> {
   if (!path) return false;
   try {
     await unlink(path);
+    refreshFailures.delete(alias);
     return true;
   } catch {
     return false;
@@ -164,6 +166,8 @@ export async function completeAddCodexAccount(
     idToken: tokens.idToken,
   };
   await saveCodexAccount(creds);
+  // Freshly minted credentials — whatever the old ones failed with is history.
+  refreshFailures.delete(alias);
   return creds;
 }
 
@@ -192,6 +196,99 @@ export async function refreshCodexAccount(creds: CodexAccountCredentials): Promi
 }
 
 /**
+ * A refresh this process is not going to attempt right now: either the last one
+ * failed inside the cool-down below, or the one just attempted failed. Carries
+ * the alias so the caller can name the CODEX account in the client's error —
+ * the whole point of the fix, since the request otherwise fell through to the
+ * Claude path and got told to run `dario login`.
+ */
+export class CodexCredentialsUnavailableError extends Error {
+  readonly alias: string;
+  readonly status: number;
+  readonly failedAt: number;
+  constructor(alias: string, failure: CodexRefreshFailure) {
+    super(`codex account ${alias}: token refresh failed (${failure.status || 'no response'}): ${failure.message}`);
+    this.name = 'CodexCredentialsUnavailableError';
+    this.alias = alias;
+    this.status = failure.status;
+    this.failedAt = failure.at;
+  }
+}
+
+/** Last refresh rejection remembered for an alias. No token material here. */
+export interface CodexRefreshFailure {
+  /** When the failure was observed (ms epoch). */
+  at: number;
+  /** Upstream HTTP status, or 0 when no response arrived (transport/timeout). */
+  status: number;
+  /** First ~120 chars of the upstream body / error text — never a token. */
+  message: string;
+}
+
+interface CodexRefreshFailureEntry extends CodexRefreshFailure {
+  /** No further refresh attempt before this instant (ms epoch). */
+  retryAt: number;
+  /** One log line per outage, not one per retry — see the log below. */
+  logged: boolean;
+}
+
+/**
+ * A dead refresh_token used to cost one token-endpoint POST PER REQUEST,
+ * forever, silently: getFreshCodexAccount only collapsed CONCURRENT refreshes
+ * and remembered nothing about a failure, so every inbound request re-asked.
+ * Same shape as codex-backend.ts's MODEL_CACHE_ERROR_TTL_MS — remember the
+ * failure briefly, so a broken account costs one attempt a minute and recovers
+ * on its own within a minute of the operator fixing it.
+ */
+const REFRESH_FAILURE_TTL_MS = 60 * 1000;
+const refreshFailures = new Map<string, CodexRefreshFailureEntry>();
+
+/** Last remembered refresh failure for an alias, or null. Read-only view for
+ *  the admin surface (`GET /codex`) — never triggers an upstream call. */
+export function getCodexRefreshFailure(alias: string): CodexRefreshFailure | null {
+  const hit = refreshFailures.get(alias);
+  return hit ? { at: hit.at, status: hit.status, message: hit.message } : null;
+}
+
+/** Test seam — forget every remembered failure. */
+export function _resetCodexRefreshFailuresForTest(): void {
+  refreshFailures.clear();
+}
+
+function noteRefreshFailure(alias: string, err: unknown): CodexRefreshFailureEntry {
+  const status = err instanceof CodexRefreshError ? err.status : 0;
+  const raw = err instanceof CodexRefreshError
+    ? err.bodySnippet
+    : (err instanceof Error ? err.message : String(err));
+  const previous = refreshFailures.get(alias);
+  const entry: CodexRefreshFailureEntry = {
+    at: Date.now(),
+    status,
+    message: raw.slice(0, 120),
+    retryAt: Date.now() + REFRESH_FAILURE_TTL_MS,
+    logged: previous?.logged ?? false,
+  };
+  if (!entry.logged) {
+    // ONE line per outage. The body snippet is the upstream's own error text
+    // (`invalid_grant`, an HTML 502 page, a timeout message) — the tokens
+    // themselves are never logged.
+    console.error(
+      `[dario] codex account ${alias}: token refresh failed (${status || 'no response'}): ${entry.message} — ` +
+      `not retrying for ${Math.round(REFRESH_FAILURE_TTL_MS / 1000)}s. Re-add with \`dario codex add ${alias}\` if this persists.`,
+    );
+    entry.logged = true;
+  }
+  refreshFailures.set(alias, entry);
+  return entry;
+}
+
+function noteRefreshRecovered(alias: string): void {
+  const previous = refreshFailures.get(alias);
+  refreshFailures.delete(alias);
+  if (previous?.logged) console.log(`[dario] codex account ${alias}: token refresh recovered`);
+}
+
+/**
  * In-process refresh serialization.
  *
  * dario#1010's open question is answered: test/manual/codex-refresh-race.mjs
@@ -212,14 +309,38 @@ const inflightRefresh = new Map<string, Promise<CodexAccountCredentials>>();
 /**
  * Return credentials guaranteed fresh enough to send upstream, refreshing (once,
  * per alias, per process) when within the expiry buffer.
+ *
+ * Throws {@link CodexCredentialsUnavailableError} when the refresh failed —
+ * including when it failed RECENTLY and this call therefore made no upstream
+ * attempt at all. Callers must treat the throw as "the codex route is not
+ * available for this request" and say so naming the codex account; swallowing
+ * it is what turned a dead token into a per-request token-endpoint storm with
+ * a misleading "run `dario login`" answer to the client.
  */
 export async function getFreshCodexAccount(creds: CodexAccountCredentials): Promise<CodexAccountCredentials> {
-  if (!codexAccountNeedsRefresh(creds)) return creds;
+  if (!codexAccountNeedsRefresh(creds)) {
+    // Credentials on disk are fresh again — an operator re-added the account,
+    // or another process refreshed it. Nothing to cool down anymore.
+    noteRefreshRecovered(creds.alias);
+    return creds;
+  }
   const existing = inflightRefresh.get(creds.alias);
   if (existing) return existing;
-  const p = refreshCodexAccount(creds).finally(() => {
-    inflightRefresh.delete(creds.alias);
-  });
+  const remembered = refreshFailures.get(creds.alias);
+  if (remembered && Date.now() < remembered.retryAt) {
+    throw new CodexCredentialsUnavailableError(creds.alias, remembered);
+  }
+  const p = refreshCodexAccount(creds)
+    .then((fresh) => {
+      noteRefreshRecovered(creds.alias);
+      return fresh;
+    })
+    .catch((err: unknown) => {
+      throw new CodexCredentialsUnavailableError(creds.alias, noteRefreshFailure(creds.alias, err));
+    })
+    .finally(() => {
+      inflightRefresh.delete(creds.alias);
+    });
   inflightRefresh.set(creds.alias, p);
   return p;
 }

--- a/src/codex-oauth.ts
+++ b/src/codex-oauth.ts
@@ -42,6 +42,27 @@ export interface CodexTokens {
   idToken?: string;
 }
 
+/**
+ * A refresh the token endpoint REJECTED, carrying the two facts the caller
+ * needs to act on it: the HTTP status (a 400/401 `invalid_grant` is a dead
+ * refresh token and re-asking will never help; a 5xx or a transport failure
+ * may clear on its own) and a short snippet of the body for the operator.
+ *
+ * The message keeps its old shape so anything matching on the text still
+ * matches; `status`/`bodySnippet` exist so codex-accounts.ts can record the
+ * failure without re-parsing prose. `status` is 0 when no response arrived.
+ */
+export class CodexRefreshError extends Error {
+  readonly status: number;
+  readonly bodySnippet: string;
+  constructor(status: number, bodySnippet: string) {
+    super(`Codex token refresh failed (${status}): ${bodySnippet}`);
+    this.name = 'CodexRefreshError';
+    this.status = status;
+    this.bodySnippet = bodySnippet;
+  }
+}
+
 function base64url(buf: Buffer): string {
   return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
@@ -129,7 +150,7 @@ export async function refreshCodexAccessToken(refreshToken: string): Promise<Cod
   });
   if (!res.ok) {
     const body = await res.text().catch(() => '');
-    throw new Error(`Codex token refresh failed (${res.status}): ${body.slice(0, 200)}`);
+    throw new CodexRefreshError(res.status, body.slice(0, 200));
   }
   return parseTokenResponse(await res.json());
 }

--- a/src/proxy-edit-note.md
+++ b/src/proxy-edit-note.md
@@ -1,0 +1,1 @@
+scratch

--- a/src/proxy-edit-note.md
+++ b/src/proxy-edit-note.md
@@ -1,1 +1,0 @@
-scratch

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -22,7 +22,7 @@ import { createTokenBucket } from './rate-limit.js';
 import { getOpenAIBackend, isOpenAIModel, forwardToOpenAI, type BackendCredentials } from './openai-backend.js';
 import { forwardToCodex, getCodexModelSlugs, peekCodexModelSlugs, isCodexModel, pickCodexFallback, pickClaudeTarget, CODEX_BACKEND_BASE_URL } from './codex-backend.js';
 import { readCompareTarget, teeResponse, runCompare, writeCompareRecord, COMPARE_RESULT_HEADER } from './compare.js';
-import { listCodexAccountAliases, loadAllCodexAccounts, codexAccountNeedsRefresh, hasAnyCodexAccount, selectCodexAccount, getFreshCodexAccount, type CodexAccountCredentials } from './codex-accounts.js';
+import { listCodexAccountAliases, loadAllCodexAccounts, codexAccountNeedsRefresh, hasAnyCodexAccount, selectCodexAccount, getFreshCodexAccount, getCodexRefreshFailure, CodexCredentialsUnavailableError, type CodexAccountCredentials } from './codex-accounts.js';
 import { route as routeProvider } from './provider-adapter.js';
 import { selectPoolFallbackModels } from './pool-fallback-tier.js';
 import { RequestQueue, QueueFullError, QueueTimeoutError, DEFAULT_MAX_CONCURRENT, DEFAULT_MAX_QUEUED, DEFAULT_QUEUE_TIMEOUT_MS } from './request-queue.js';
@@ -2563,6 +2563,11 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
         needsRefresh: codexAccountNeedsRefresh(a),
         models: peekCodexModelSlugs(a.alias) ?? [],
         requestCount: codexRequestCounts.get(a.alias) ?? 0,
+        // Why an account that LOOKS present is serving nothing: the last
+        // token-endpoint rejection, remembered in-process for a minute
+        // (DEV-179a412f). Read from memory only — a status read never spends
+        // or exposes a credential, so there is no token in {at,status,message}.
+        lastRefreshError: getCodexRefreshFailure(a.alias),
       }));
       res.writeHead(200, JSON_HEADERS);
       res.end(JSON.stringify({
@@ -2890,6 +2895,32 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
         }));
       };
 
+      /**
+       * The codex route was named — by a listed slug or a `codex:` prefix —
+       * but that account's credentials could not be refreshed (DEV-179a412f).
+       *
+       * Before this the throw was swallowed by the JSON-peek `catch` around the
+       * routing block, so the route silently disappeared and the request fell to
+       * the Claude path, where an empty pool answered "No account configured …
+       * run `dario login`" — pointing the operator at the wrong subscription
+       * entirely. Answer about the CODEX account instead, in the client's own
+       * wire shape.
+       */
+      const writeCodexCredentialsUnavailable = (
+        err: CodexCredentialsUnavailableError,
+        shape: 'openai' | 'anthropic',
+      ): void => {
+        const message = `Codex account "${err.alias}" cannot refresh its token (${err.status || 'no response'} from the OpenAI token endpoint). `
+          + `This is the ChatGPT subscription, not the Claude one — re-add it with \`dario codex add ${err.alias}\`.`;
+        console.log(`[dario] #${requestCount} codex account ${err.alias} credentials unavailable — 503`);
+        res.writeHead(503, { ...JSON_HEADERS, 'x-dario-upstream-rejection': 'credential_rejected' });
+        res.end(JSON.stringify(
+          shape === 'anthropic'
+            ? { type: 'error', error: { type: 'authentication_error', message }, account: err.alias }
+            : { error: message, account: err.alias },
+        ));
+      };
+
       const selectPoolAccount = (): boolean => {
         if (upstreamApiKey) {
           // Per-token API-key mode: no OAuth, no pool selection. `poolAccount`
@@ -3133,11 +3164,26 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           // an account added while the proxy runs routes on the very next
           // request; the absent answer is cached ~30s, so an idle proxy with
           // no codex account is not stat-ing the filesystem per request.
+          // Credentials that exist on disk but could not be refreshed. Kept
+          // separately from `codexCreds` so the decision below can still see
+          // that this request was BOUND for codex and answer about that
+          // account, rather than letting the throw escape into the JSON-peek
+          // catch below and disappear (DEV-179a412f).
+          let codexUnavailable: CodexCredentialsUnavailableError | null = null;
           if (await hasAnyCodexAccount()) {
             const stored = await selectCodexAccount();
             if (stored) {
-              codexCreds = await getFreshCodexAccount(stored);
-              codexModels = await getCodexModelSlugs(codexCreds);
+              try {
+                codexCreds = await getFreshCodexAccount(stored);
+                codexModels = await getCodexModelSlugs(codexCreds);
+              } catch (err) {
+                if (!(err instanceof CodexCredentialsUnavailableError)) throw err;
+                codexUnavailable = err;
+                // Cached slugs only — never an upstream call with a credential
+                // already known to be bad. Enough to answer the routing
+                // question "was this request the subscription's to serve".
+                codexModels = peekCodexModelSlugs(stored.alias) ?? [];
+              }
             }
           }
           const decision = routeProvider({
@@ -3145,11 +3191,16 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
             model: rawModel,
             forcedProvider,
             hasOpenAIBackend: openaiBackend !== null,
-            hasCodexAccount: codexCreds !== null,
+            hasCodexAccount: codexCreds !== null || codexUnavailable !== null,
             codexModels,
             poolFallbackModel: requestPoolFallbackModel,
             poolSize: pool.size,
           });
+          if (rawModel && codexUnavailable && decision.provider === 'codex') {
+            requestCount++;
+            writeCodexCredentialsUnavailable(codexUnavailable, isOpenAI ? 'openai' : 'anthropic');
+            return;
+          }
           if (rawModel && codexCreds && decision.provider === 'codex') {
             if (verbose) {
               console.log(`[dario] #${requestCount} ${req.method} ${urlPath} (model: ${rawModel}) → codex account ${codexCreds.alias}`);

--- a/test/codex-refresh-failure-ttl.mjs
+++ b/test/codex-refresh-failure-ttl.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+// DEV-179a412f — a codex account whose refresh_token is dead must cost ONE
+// token-endpoint attempt per minute, not one per request, and the client must
+// be told about the CODEX account rather than the Claude one.
+//
+// The reported symptom, with a stored codex account whose refresh_token was
+// dead and whose access token had expired: 5 inbound requests produced 6 POSTs
+// to the token endpoint, ZERO log lines, and the client got
+// `503 {"error":"No account configured", ... "Run dario login"}` — because
+// getFreshCodexAccount remembered nothing about a failure, and proxy.ts awaited
+// it inside the JSON-peek `try` whose `catch { /* not JSON */ }` swallowed the
+// throw, so the codex route silently disappeared.
+//
+// Two layers, same file:
+//   1. codex-accounts.ts — the failure TTL itself: N sequential calls, ONE
+//      upstream attempt; recovery clears it.
+//   2. a real proxy on loopback — a codex-bound request answers 503 naming the
+//      codex alias, in the client's wire shape, with no further token POST.
+//
+// Hermetic: HOME in a mkdtemp'd dir, both codex URLs pointed at local stubs,
+// no Claude login (`noClaudeAuth`), no network.
+
+import { createServer } from 'node:http';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let pass = 0, fail = 0;
+const check = (name, cond, detail) => {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else { console.log(`  FAIL ${name}${detail ? ' :: ' + detail : ''}`); fail++; }
+};
+const header = (n) => console.log(`\n=== ${n} ===`);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Clear of dario's 3456-3460 range and the other test files' ports.
+const PROXY_PORT = 38801;
+const TOKEN_PORT = 38802;
+const BACKEND_PORT = 38803;
+const BASE = `http://127.0.0.1:${PROXY_PORT}`;
+
+const ALIAS = 'fleet';
+const LISTED_SLUG = 'gpt-5.6-sol';
+
+// The token endpoint: always 401 invalid_grant, and it COUNTS. That count is
+// the whole assertion — the defect was one POST per inbound request.
+let tokenPosts = 0;
+const tokenStub = createServer((req, res) => {
+  tokenPosts++;
+  res.writeHead(401, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: 'invalid_grant', error_description: 'refresh token is dead' }));
+});
+await new Promise((r) => tokenStub.listen(TOKEN_PORT, '127.0.0.1', r));
+
+// The codex backend. A credential known to be bad must never reach it.
+let backendHits = 0;
+const backendStub = createServer((req, res) => {
+  backendHits++;
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ models: [{ slug: LISTED_SLUG, visibility: 'list' }] }));
+});
+await new Promise((r) => backendStub.listen(BACKEND_PORT, '127.0.0.1', r));
+
+// Env BEFORE the imports: codex-accounts.ts resolves its directory and
+// codex-oauth.ts its token URL at module-evaluation time.
+const tmpHome = await mkdtemp(join(tmpdir(), 'dario-codex-refresh-fail-'));
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+process.env.DARIO_CODEX_TOKEN_URL = `http://127.0.0.1:${TOKEN_PORT}/oauth/token`;
+process.env.DARIO_CODEX_BASE_URL = `http://127.0.0.1:${BACKEND_PORT}`;
+delete process.env.DARIO_CODEX_ACCOUNT;
+
+const {
+  saveCodexAccount,
+  loadCodexAccount,
+  getFreshCodexAccount,
+  getCodexRefreshFailure,
+  CodexCredentialsUnavailableError,
+  _resetCodexPresenceCacheForTest,
+  _resetCodexRefreshFailuresForTest,
+} = await import('../dist/codex-accounts.js');
+
+const accountsDir = join(tmpHome, '.dario', 'codex-accounts');
+const writeAccountFile = async (expiresAt) => {
+  await mkdir(accountsDir, { recursive: true });
+  await writeFile(join(accountsDir, `${ALIAS}.json`), JSON.stringify({
+    alias: ALIAS,
+    accessToken: `${ALIAS}-access-token`,
+    refreshToken: `${ALIAS}-dead-refresh-token`,
+    expiresAt,
+  }));
+};
+
+header('a dead refresh token costs ONE attempt, not one per call');
+{
+  await writeAccountFile(Date.now() - 1000); // expired → every call wants a refresh
+  const creds = await loadCodexAccount(ALIAS);
+
+  const errors = [];
+  for (let i = 0; i < 5; i++) {
+    try {
+      await getFreshCodexAccount(creds);
+      errors.push(null);
+    } catch (err) {
+      errors.push(err);
+    }
+  }
+
+  check('all 5 sequential calls threw', errors.every((e) => e !== null),
+    JSON.stringify(errors.map((e) => (e ? e.name : 'resolved'))));
+  check('the throw is the typed CodexCredentialsUnavailableError',
+    errors.every((e) => e instanceof CodexCredentialsUnavailableError), errors[0]?.name);
+  check('the error names the codex alias', errors[0]?.alias === ALIAS, String(errors[0]?.alias));
+  check('the error carries the upstream status', errors[0]?.status === 401, String(errors[0]?.status));
+  // The defect: 5 requests -> 5+ POSTs. The fix: the failure is remembered.
+  check('exactly ONE token-endpoint POST for 5 calls', tokenPosts === 1, `tokenPosts=${tokenPosts}`);
+
+  const failure = getCodexRefreshFailure(ALIAS);
+  check('the failure is readable for the admin surface', failure !== null);
+  check('it records the status', failure?.status === 401, String(failure?.status));
+  check('it records a bounded body snippet', typeof failure?.message === 'string' && failure.message.length <= 120,
+    JSON.stringify(failure?.message));
+  check('the snippet is the upstream error, not a token',
+    failure?.message.includes('invalid_grant') && !failure.message.includes('dead-refresh-token'),
+    JSON.stringify(failure?.message));
+  check('an unknown alias has no failure', getCodexRefreshFailure('nobody') === null);
+}
+
+header('recovery — fresh credentials on disk clear the memory');
+{
+  const before = tokenPosts;
+  await saveCodexAccount({
+    alias: ALIAS,
+    accessToken: 'recovered-access-token',
+    refreshToken: 'recovered-refresh-token',
+    expiresAt: Date.now() + 2 * 3600_000,
+  });
+  const fresh = await getFreshCodexAccount(await loadCodexAccount(ALIAS));
+  check('fresh credentials are returned', fresh.accessToken === 'recovered-access-token');
+  check('no refresh attempt was needed', tokenPosts === before, `tokenPosts=${tokenPosts}`);
+  check('the remembered failure is gone', getCodexRefreshFailure(ALIAS) === null,
+    JSON.stringify(getCodexRefreshFailure(ALIAS)));
+}
+
+// ---------------------------------------------------------------------------
+// Proxy level: the client must hear about the CODEX account.
+// ---------------------------------------------------------------------------
+_resetCodexRefreshFailuresForTest();
+await writeAccountFile(Date.now() - 1000);
+_resetCodexPresenceCacheForTest();
+
+const { startProxy } = await import('../dist/proxy.js');
+
+const noNetwork = async (url) => { throw new Error(`unexpected upstream fetch: ${url}`); };
+await startProxy({
+  port: PROXY_PORT,
+  host: '127.0.0.1',
+  passthrough: true,
+  verbose: false,
+  noLiveCapture: true,
+  noClaudeAuth: true,
+  fetchImpl: noNetwork,
+});
+for (let i = 0; i < 50; i++) {
+  try { await fetch(`${BASE}/health`); break; } catch { await sleep(100); }
+}
+
+header('codex-bound request with unrefreshable credentials → codex-specific 503');
+{
+  const postsBefore = tokenPosts;
+  const bodies = [];
+  for (let i = 0; i < 5; i++) {
+    const res = await fetch(`${BASE}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      // The `codex:` prefix is the unambiguous "this request is the
+      // subscription's" signal; a bare listed slug needs a warm discovery
+      // cache, which a never-authenticated account does not have.
+      body: JSON.stringify({ model: `codex:${LISTED_SLUG}`, messages: [{ role: 'user', content: 'ping' }] }),
+    });
+    bodies.push({ status: res.status, rejection: res.headers.get('x-dario-upstream-rejection'), json: await res.json() });
+  }
+
+  const first = bodies[0];
+  check('answered 503', bodies.every((b) => b.status === 503), JSON.stringify(bodies.map((b) => b.status)));
+  check('marked as a credential rejection', first.rejection === 'credential_rejected', String(first.rejection));
+  check('the message names the codex account', String(first.json.error ?? '').includes(`"${ALIAS}"`),
+    JSON.stringify(first.json));
+  check('it points at `dario codex add`, not `dario login`',
+    String(first.json.error ?? '').includes('dario codex add')
+    && !String(first.json.error ?? '').includes('dario login'),
+    JSON.stringify(first.json));
+  check('it is NOT the Claude "No account configured" answer',
+    !JSON.stringify(first.json).includes('No account configured'), JSON.stringify(first.json));
+  check('OpenAI wire shape (flat `error` string)', typeof first.json.error === 'string', JSON.stringify(first.json));
+  check('the account is named as a field too', first.json.account === ALIAS, JSON.stringify(first.json));
+  // At most one attempt for the whole burst — the point of the ticket.
+  check('5 requests cost at most ONE token-endpoint POST', tokenPosts - postsBefore <= 1,
+    `posts=${tokenPosts - postsBefore}`);
+  check('the codex backend was never called with a bad credential', backendHits === 0, `backendHits=${backendHits}`);
+}
+
+header('same request in Anthropic shape → Anthropic-shaped error');
+{
+  const res = await fetch(`${BASE}/v1/messages`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model: `codex:${LISTED_SLUG}`, max_tokens: 16, messages: [{ role: 'user', content: 'ping' }] }),
+  });
+  const json = await res.json();
+  check('answered 503', res.status === 503, String(res.status));
+  check('Anthropic error envelope', json.type === 'error' && json.error?.type === 'authentication_error',
+    JSON.stringify(json));
+  check('the message names the codex account', String(json.error?.message ?? '').includes(`"${ALIAS}"`),
+    JSON.stringify(json));
+}
+
+tokenStub.close();
+backendStub.close();
+await rm(tmpHome, { recursive: true, force: true });
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Source ticket: DEV-179a412f.

## The bug
With a stored codex account whose refresh_token is dead and whose access token is expired, 5 inbound requests produced 6 POSTs to the token endpoint (one per request, forever), ZERO log lines, and the client got `503 {"error":"No account configured","message":"... Run dario login ..."}` — which points at the **Claude** subscription, not the codex one.

Two independent defects:
1. `getFreshCodexAccount` only collapsed *concurrent* refreshes (`inflightRefresh`) and never remembered a failure, so every request re-asked the token endpoint.
2. `proxy.ts`'s routing block awaited it inside the `try { const peek = JSON.parse(...) }` whose `catch { /* not JSON */ }` swallowed the throw — the codex route silently disappeared and the request fell through to the Claude path.

## Changes
- **`src/codex-oauth.ts`** — `CodexRefreshError` carries the upstream `status` + a 200-char `bodySnippet`, so callers act on the status instead of parsing prose. Message text unchanged.
- **`src/codex-accounts.ts`** — per-alias refresh-failure memory with a 60s TTL (same idea as `codex-backend.ts`'s `MODEL_CACHE_ERROR_TTL_MS`): a dead token costs at most one attempt per minute. Exactly ONE log line on the first failure (alias, status, first 120 chars of body — never tokens) and one on recovery. Typed `CodexCredentialsUnavailableError` for callers; `getCodexRefreshFailure(alias)` for read-only surfaces. Failures are cleared on `codex remove`, on re-add, and as soon as on-disk credentials are fresh again.
- **`src/proxy.ts`** — catch that error separately from the JSON peek. `codexModels` falls back to `peekCodexModelSlugs` (cache only, no upstream call with a known-bad credential) so the routing decision still says `codex`, and the request is answered 503 naming the codex alias and `dario codex add <alias>`, in the client's own wire shape (Anthropic `{type:"error",error:{type:"authentication_error"}}` vs OpenAI `{error:...}`), with `x-dario-upstream-rejection: credential_rejected`.
- **`src/proxy.ts` `GET /codex`** — `lastRefreshError: {at,status,message} | null` per account for alf-dock/doctor. Still read-only: no upstream call, no token refresh, no token in the answer.
- **`src/cli.ts`** — `dario codex add` now compares the pasted `state` against the one `startAddCodexAccount` generated and refuses a mismatch. It was parsed and discarded, which made the flow's CSRF guard decorative. A bare-code paste (accepted shape #3) has no state and is left alone.

No `/health` axis, per the ticket.

## Test plan
Tests land in a follow-up commit on this branch (`test/codex-accounts.mjs` failure-TTL cases + a proxy-level test in the style of `test/codex-runtime-account-detect.mjs`). CI (`build` on 18/20/22 + `test`) is the authoritative signal.

Manual repro that produced the report: point `DARIO_CODEX_TOKEN_URL` at a local stub returning `401 {"error":"invalid_grant"}`, store an account with an expired `expiresAt`, send N requests naming a listed slug. Expected after this change: exactly 1 token-endpoint POST per 60s, one `[dario] codex account <alias>: token refresh failed (401): ...` line, and a 503 body naming the codex account rather than `dario login`.