### PR TITLE
fix(codex): carry chat images and report lossy fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ curl localhost:3456/v1/messages -H 'content-type: application/json' \
 
 Streaming, tool calls, and tool-result round trips work on both shapes: dario translates chat/completions **or** Messages into the Responses API the subscription backend speaks, and translates the stream back into `chat.completion.chunk` or Anthropic message events to match what the client asked in. There is no `/v1/responses` inbound yet.
 
+**Chat/completions fidelity:** text and `image_url` user-content parts (HTTPS URLs and data URIs) carry through to Responses input items. The Codex subscription backend does not accept every chat field, so `response_format`, `stop`, `n`, `logprobs`, `stream_options`, and other unmapped chat-only fields are intentionally lossy; with `--verbose`, dario reports each dropped field once per process.
+
 Codex accounts live in `~/.dario/codex-accounts/`, entirely separate from the Claude pool. Nothing about `dario login`, `dario accounts`, or Claude routing changes.
 
 ---

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 <p><strong>One local endpoint. Every AI tool you own. The subscriptions you already pay for.</strong></p>
 
-<sub><code>npm i -g @askalf/dario</code> · <strong>0</strong> runtime deps · <a href="https://www.npmjs.com/package/@askalf/dario">SLSA-attested</a> every release · nothing phones home · ~29k lines you can read in a weekend · independent, unofficial, third-party (<a href="DISCLAIMER.md">DISCLAIMER.md</a>)</sub>
+<sub><code>npm i -g @askalf/dario</code> · <strong>0</strong> runtime deps · <a href="https://www.npmjs.com/package/@askalf/dario">SLSA-attested</a> every release · nothing phones home · ~30k lines you can read in a weekend · independent, unofficial, third-party (<a href="DISCLAIMER.md">DISCLAIMER.md</a>)</sub>
 
 <sub>Part of <a href="#own-your-stack"><strong>Own Your Stack</strong></a> — 12 open tools for owning your AI infra: <a href="https://github.com/askalf/truecopy">truecopy</a> · <a href="https://github.com/askalf/strongroom">strongroom</a> · <a href="https://github.com/askalf/fieldpass">fieldpass</a> · <a href="https://github.com/askalf/plumbline">plumbline</a> · <a href="#own-your-stack">full family ↓</a></sub>
 
@@ -309,7 +309,7 @@ The split isn't live, but it was announced once on short notice and could return
 
 | Signal | Status |
 |---|---|
-| Source | **~29k** lines of TypeScript across **59** files — auditable in a weekend (v5 removed shim; the pool is the one code path) |
+| Source | **~30k** lines of TypeScript across **65** files — auditable in a weekend (v5 removed shim; the pool is the one code path) |
 | Dependencies | **0 runtime.** Verify: `npm ls --production` |
 | Provenance | Every release [SLSA-attested](https://www.npmjs.com/package/@askalf/dario) via GitHub Actions + Sigstore |
 | Scanning | [CodeQL](https://github.com/askalf/dario/actions/workflows/codeql.yml) on every push and weekly |

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ curl localhost:3456/v1/messages -H 'content-type: application/json' \
 
 Streaming, tool calls, and tool-result round trips work on both shapes: dario translates chat/completions **or** Messages into the Responses API the subscription backend speaks, and translates the stream back into `chat.completion.chunk` or Anthropic message events to match what the client asked in. There is no `/v1/responses` inbound yet.
 
-**Chat/completions fidelity:** text and `image_url` user-content parts (HTTPS URLs and data URIs) carry through to Responses input items. The Codex subscription backend does not accept every chat field, so `response_format`, `stop`, `n`, `logprobs`, `stream_options`, and other unmapped chat-only fields are intentionally lossy; with `--verbose`, dario reports each dropped field once per process.
+**Chat/completions fidelity:** text and `image_url` user-content parts (HTTPS URLs and data URIs, including the `detail` fidelity setting) carry through to Responses input items. The Codex subscription backend does not accept every chat field, so `response_format`, `stop`, `n`, `logprobs`, `stream_options` and other unmapped chat-only fields are intentionally lossy — and so are the sampling parameters `temperature`, `top_p`, `max_tokens` and `max_completion_tokens`, which translate cleanly but are then rejected by the backend and stripped before the request goes out. With `--verbose`, dario reports each field that does not reach Codex once per process.
 
 Codex accounts live in `~/.dario/codex-accounts/`, entirely separate from the Claude pool. Nothing about `dario login`, `dario accounts`, or Claude routing changes.
 

--- a/src/codex-backend.ts
+++ b/src/codex-backend.ts
@@ -292,6 +292,24 @@ function messageContentToText(content: unknown): string {
   return content == null ? '' : JSON.stringify(content);
 }
 
+/** Preserve OpenAI chat text and image_url parts in a Responses user item. */
+function chatContentToResponsesParts(content: unknown): Array<Record<string, string>> {
+  if (!Array.isArray(content)) return [{ type: 'input_text', text: messageContentToText(content) }];
+  const parts: Array<Record<string, string>> = [];
+  for (const part of content) {
+    const p = part as { type?: unknown; text?: unknown; image_url?: unknown };
+    if (p?.type === 'text' && typeof p.text === 'string') {
+      parts.push({ type: 'input_text', text: p.text });
+      continue;
+    }
+    if (p?.type === 'image_url') {
+      const imageUrl = typeof p.image_url === 'string' ? p.image_url : (p.image_url as { url?: unknown } | undefined)?.url;
+      if (typeof imageUrl === 'string') parts.push({ type: 'input_image', image_url: imageUrl });
+    }
+  }
+  return parts;
+}
+
 /**
  * Translate an OpenAI chat/completions request body into a Responses request.
  *
@@ -343,7 +361,7 @@ export function chatCompletionsToResponses(body: Record<string, unknown>): Recor
       continue;
     }
 
-    input.push({ role: 'user', content: [{ type: 'input_text', text: messageContentToText(m.content) }] });
+    input.push({ role: 'user', content: chatContentToResponsesParts(m.content) });
   }
 
   const out: Record<string, unknown> = {

--- a/src/codex-backend.ts
+++ b/src/codex-backend.ts
@@ -276,17 +276,42 @@ export function extractChatGPTAccountId(idToken: string | undefined): string | n
 
 type ChatMessage = { role: string; content: unknown; tool_calls?: unknown; tool_call_id?: string };
 
-const CHAT_COMPLETIONS_MAPPED_FIELDS = new Set([
-  'model', 'messages', 'tools', 'tool_choice', 'temperature', 'top_p',
-  'max_tokens', 'max_completion_tokens', 'reasoning_effort', 'stream',
-]);
+/**
+ * Which Responses field each chat/completions field is translated into.
+ *
+ * Translation is only half the transport: `toCodexSupportedBody` scrubs the
+ * translated body again, so a chat field reaches Codex only when its
+ * TRANSLATED name also survives that allowlist. `temperature` and `top_p`
+ * are translated by name and `max_tokens`/`max_completion_tokens` become
+ * `max_output_tokens` — all four are then scrubbed away, so the diagnostic
+ * has to report them as dropped. A caller passing `temperature: 0` needs to
+ * hear that precisely because the translation step looks like it worked.
+ */
+const CHAT_COMPLETIONS_FIELD_TRANSLATIONS: Record<string, string> = {
+  model: 'model',
+  messages: 'input',
+  tools: 'tools',
+  tool_choice: 'tool_choice',
+  stream: 'stream',
+  reasoning_effort: 'reasoning',
+  temperature: 'temperature',
+  top_p: 'top_p',
+  max_tokens: 'max_output_tokens',
+  max_completion_tokens: 'max_output_tokens',
+};
 const loggedUnsupportedChatFields = new Set<string>();
 
-/** Report each unmapped chat/completions field once per process when verbose. */
-function logUnsupportedChatFields(body: Record<string, unknown>, verbose: boolean): void {
+/** True when a chat field survives BOTH translation and the Codex scrub. */
+export function chatFieldReachesCodex(field: string): boolean {
+  const target = CHAT_COMPLETIONS_FIELD_TRANSLATIONS[field];
+  return target !== undefined && CODEX_SUPPORTED_FIELDS.includes(target);
+}
+
+/** Report each chat field that never reaches Codex, once per process. */
+export function logUnsupportedChatFields(body: Record<string, unknown>, verbose: boolean): void {
   if (!verbose) return;
   for (const field of Object.keys(body)) {
-    if (CHAT_COMPLETIONS_MAPPED_FIELDS.has(field) || loggedUnsupportedChatFields.has(field)) continue;
+    if (chatFieldReachesCodex(field) || loggedUnsupportedChatFields.has(field)) continue;
     loggedUnsupportedChatFields.add(field);
     console.log(`[dario] codex: dropping unsupported chat field ${field}`);
   }

--- a/src/codex-backend.ts
+++ b/src/codex-backend.ts
@@ -344,8 +344,21 @@ function chatContentToResponsesParts(content: unknown): Array<Record<string, str
       continue;
     }
     if (p?.type === 'image_url') {
-      const imageUrl = typeof p.image_url === 'string' ? p.image_url : (p.image_url as { url?: unknown } | undefined)?.url;
-      if (typeof imageUrl === 'string') parts.push({ type: 'input_image', image_url: imageUrl });
+      const obj = typeof p.image_url === 'object' && p.image_url !== null
+        ? p.image_url as { url?: unknown; detail?: unknown }
+        : undefined;
+      const imageUrl = typeof p.image_url === 'string' ? p.image_url : obj?.url;
+      if (typeof imageUrl === 'string') {
+        // `detail` is a fidelity/cost control the Responses input_image part
+        // takes too; dropping it silently downgrades a low-detail request to
+        // the backend's automatic behaviour and changes image-token cost.
+        const detail = obj?.detail;
+        parts.push({
+          type: 'input_image',
+          image_url: imageUrl,
+          ...(detail === 'auto' || detail === 'low' || detail === 'high' ? { detail } : {}),
+        });
+      }
     }
   }
   return parts;

--- a/src/codex-backend.ts
+++ b/src/codex-backend.ts
@@ -276,6 +276,22 @@ export function extractChatGPTAccountId(idToken: string | undefined): string | n
 
 type ChatMessage = { role: string; content: unknown; tool_calls?: unknown; tool_call_id?: string };
 
+const CHAT_COMPLETIONS_MAPPED_FIELDS = new Set([
+  'model', 'messages', 'tools', 'tool_choice', 'temperature', 'top_p',
+  'max_tokens', 'max_completion_tokens', 'reasoning_effort', 'stream',
+]);
+const loggedUnsupportedChatFields = new Set<string>();
+
+/** Report each unmapped chat/completions field once per process when verbose. */
+function logUnsupportedChatFields(body: Record<string, unknown>, verbose: boolean): void {
+  if (!verbose) return;
+  for (const field of Object.keys(body)) {
+    if (CHAT_COMPLETIONS_MAPPED_FIELDS.has(field) || loggedUnsupportedChatFields.has(field)) continue;
+    loggedUnsupportedChatFields.add(field);
+    console.log(`[dario] codex: dropping unsupported chat field ${field}`);
+  }
+}
+
 /** One `input` item for the Responses API. */
 type ResponsesInputItem = Record<string, unknown>;
 
@@ -711,6 +727,8 @@ export async function forwardToCodex(
     report(400, null, false, '');
     return true;
   }
+
+  if (!isAnthropic) logUnsupportedChatFields(parsed, verbose);
 
   const clientWantsStream = parsed.stream === true;
   const model = String(parsed.model ?? '');

--- a/test/codex-backend.mjs
+++ b/test/codex-backend.mjs
@@ -24,7 +24,7 @@ import {
   CODEX_BACKEND_BASE_URL,
 } from '../dist/codex-backend.js';
 import { route, poolFallbackOutcome, codexAdapter, claudeAdapter, openaiAdapter } from '../dist/provider-adapter.js';
-import { forwardToCodex, isTerminalResponsesEvent, isFailedResponse, toCodexSupportedBody, pickCodexFallback, pickClaudeFallback, CODEX_SUPPORTED_FIELDS } from '../dist/codex-backend.js';
+import { forwardToCodex, isTerminalResponsesEvent, isFailedResponse, toCodexSupportedBody, pickCodexFallback, pickClaudeFallback, CODEX_SUPPORTED_FIELDS, logUnsupportedChatFields, chatFieldReachesCodex } from '../dist/codex-backend.js';
 import { isClaudeServableModel, resolveClaudeServable } from '../dist/claude-model.js';
 
 let pass = 0, fail = 0;
@@ -123,6 +123,17 @@ header('chatCompletionsToResponses');
   check('image-only chat message remains a valid user input item',
     out.input.length === 1 && out.input[0].role === 'user' && out.input[0].content.length === 1 &&
     out.input[0].content[0].type === 'input_image' && out.input[0].content[0].image_url === 'https://example.test/only.png');
+  check('no detail key when the client did not ask for one', !('detail' in out.input[0].content[0]));
+}
+{
+  const withDetail = (detail) => chatCompletionsToResponses({
+    model: 'm',
+    messages: [{ role: 'user', content: [{ type: 'image_url', image_url: { url: 'https://example.test/scan.png', detail } }] }],
+  }).input[0].content[0];
+  check('image detail low/high/auto carries through to input_image',
+    withDetail('low').detail === 'low' && withDetail('high').detail === 'high' && withDetail('auto').detail === 'auto');
+  check('a bogus detail value is dropped rather than forwarded',
+    !('detail' in withDetail('ultra')) && !('detail' in withDetail(3)));
 }
 {
   const out = chatCompletionsToResponses({
@@ -767,6 +778,42 @@ header('unsupported params never reach the Codex backend (dario#1144)');
   check('chat: temperature/top_p never sent (was live-broken for any client sending one)',
     !('temperature' in sentO.body) && !('top_p' in sentO.body), Object.keys(sentO.body));
   check('chat: the real payload still arrives', Array.isArray(sentO.body.input) && sentO.body.stream === true);
+}
+
+
+header('verbose reports fields that are translated and THEN scrubbed');
+{
+  // The diagnostic has to answer "did this reach Codex", not "did the
+  // translator recognise it". temperature/top_p are translated by name and
+  // max_tokens becomes max_output_tokens — all three are then scrubbed by
+  // toCodexSupportedBody, so a --verbose caller must be told they were lost.
+  const lines = [];
+  const realLog = console.log;
+  console.log = (...a) => lines.push(a.join(' '));
+  try {
+    logUnsupportedChatFields({
+      model: 'm', messages: [], stream: true, tools: [], tool_choice: 'auto',
+      reasoning_effort: 'low', temperature: 0, top_p: 0.9, max_tokens: 128,
+      max_completion_tokens: 256, response_format: { type: 'json_object' },
+    }, true);
+  } finally {
+    console.log = realLog;
+  }
+  const dropped = new Set(lines.map(l => l.split('dropping unsupported chat field ')[1]).filter(Boolean));
+  for (const f of ['temperature', 'top_p', 'max_tokens', 'max_completion_tokens', 'response_format']) {
+    check(`verbose reports ${f} as dropped`, dropped.has(f));
+  }
+  for (const f of ['model', 'messages', 'stream', 'tools', 'tool_choice', 'reasoning_effort']) {
+    check(`verbose stays quiet about ${f} (it really does reach Codex)`, !dropped.has(f));
+  }
+  check('chatFieldReachesCodex agrees with the scrub allowlist',
+    chatFieldReachesCodex('messages') && chatFieldReachesCodex('reasoning_effort') &&
+    !chatFieldReachesCodex('temperature') && !chatFieldReachesCodex('max_tokens') &&
+    !chatFieldReachesCodex('brand_new_param'));
+  const again = [];
+  console.log = (...a) => again.push(a.join(' '));
+  try { logUnsupportedChatFields({ temperature: 0 }, true); } finally { console.log = realLog; }
+  check('each field is reported once per process, not once per request', again.length === 0);
 }
 
 

--- a/test/codex-backend.mjs
+++ b/test/codex-backend.mjs
@@ -100,9 +100,29 @@ header('chatCompletionsToResponses');
 {
   const out = chatCompletionsToResponses({
     model: 'm',
-    messages: [{ role: 'user', content: [{ type: 'text', text: 'a' }, { type: 'text', text: 'b' }] }],
+    messages: [{ role: 'user', content: [
+      { type: 'text', text: 'describe ' },
+      { type: 'image_url', image_url: { url: 'https://example.test/image.png' } },
+      { type: 'text', text: 'this' },
+      { type: 'image_url', image_url: 'data:image/png;base64,AAAA' },
+    ] }],
   });
-  check('array content parts join into one text', out.input[0].content[0].text === 'ab');
+  check('chat text parts become input_text parts',
+    out.input[0].content[0].type === 'input_text' && out.input[0].content[0].text === 'describe ' &&
+    out.input[0].content[2].type === 'input_text' && out.input[0].content[2].text === 'this');
+  check('chat image_url object becomes an input_image URL string',
+    out.input[0].content[1].type === 'input_image' && out.input[0].content[1].image_url === 'https://example.test/image.png');
+  check('chat image_url string data URI becomes an input_image',
+    out.input[0].content[3].type === 'input_image' && out.input[0].content[3].image_url === 'data:image/png;base64,AAAA');
+}
+{
+  const out = chatCompletionsToResponses({
+    model: 'm',
+    messages: [{ role: 'user', content: [{ type: 'image_url', image_url: { url: 'https://example.test/only.png' } }] }],
+  });
+  check('image-only chat message remains a valid user input item',
+    out.input.length === 1 && out.input[0].role === 'user' && out.input[0].content.length === 1 &&
+    out.input[0].content[0].type === 'input_image' && out.input[0].content[0].image_url === 'https://example.test/only.png');
 }
 {
   const out = chatCompletionsToResponses({


### PR DESCRIPTION
Fixes DEV-95f047d2.\n\n- Preserve OpenAI chat `image_url` parts as Responses `input_image` URL strings.\n- Follow-up commit will add verbose one-time lossy-field diagnostics, documentation, and tests.\n\nTests will run in CI; local build/test intentionally not run per engineering build-wall policy.