### PR TITLE
release: 6.0.22 — codex fixes from the 2026-09-04 review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ checklist.
 
 ## [Unreleased]
 
+## [6.0.22] - 2026-09-05
+
 - **Forced tool calls work again on the Codex backend.** A chat/completions named `tool_choice` — `{"type":"function","function":{"name":"f"}}`, which Cursor, Continue and Aider send whenever they force a tool — reached the Responses backend un-flattened and 400'd with `Missing required parameter: 'tool_choice.name'`. It is now translated to the flat Responses form `{"type":"function","name":"f"}`, matching what the Anthropic path already did. String choices (`auto`/`none`/`required`) and unrecognized objects pass through unchanged.
 
 ## [6.0.21] - 2026-09-04

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.21",
+  "version": "6.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "6.0.21",
+      "version": "6.0.22",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.21",
+  "version": "6.0.22",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What

Version bump to 6.0.22 so the codex fixes merged since 6.0.21 actually ship. `cc-drift-auto-release` only publishes when `package.json` moves on master; #1204 and #1205 merged green and shipped nothing.

Carries whatever is under `## [Unreleased]` at merge time — merge this one **last**, after #1206, #1207 and #1208.

## Checks

- [x] `scripts/preflight.mjs` green (three version slots + CHANGELOG heading agree)
- [x] `scripts/check-package-json.mjs` green
