### PR TITLE
ci: surface the Codex model snapshot in the job summary and document baseline seeding

### DIFF
--- a/.github/workflows/codex-drift-watch.yml
+++ b/.github/workflows/codex-drift-watch.yml
@@ -73,17 +73,17 @@ jobs:
         if: always() && hashFiles('live-models.json') != ''
         run: |
           {
-          cat <<'HEADER'
-### Account-visible Codex models
+            cat <<'HEADER'
+          ### Account-visible Codex models
 
-Copy verbatim to `test/fixtures/codex-models.snapshot.json` to seed or update the baseline.
+          Copy verbatim to `test/fixtures/codex-models.snapshot.json` to seed or update the baseline.
 
-```json
-HEADER
-          cat live-models.json
-          cat <<'FOOTER'
-```
-FOOTER
+          ```json
+          HEADER
+            cat live-models.json
+            cat <<'FOOTER'
+          ```
+          FOOTER
           } >> "$GITHUB_STEP_SUMMARY"
           echo '--- live-models.json ---'
           cat live-models.json

--- a/.github/workflows/codex-drift-watch.yml
+++ b/.github/workflows/codex-drift-watch.yml
@@ -3,6 +3,15 @@ name: Codex drift watch
 # Inert until the operator sets DARIO_CODEX_LIVE_HOME in this self-hosted
 # runner's repository variables. It must name a HOME containing
 # .dario/codex-accounts; no credential is committed or copied.
+#
+# First-run baseline seeding. test/fixtures/codex-models.snapshot.json ships
+# empty, so the first enabled run reports drift by construction. To seed it:
+#   1. Run this workflow (Actions -> Codex drift watch -> Run workflow).
+#   2. Read the generated list in the run's job summary, or download the
+#      codex-live-models-<run_id> artifact for the same bytes.
+#   3. Copy it verbatim to test/fixtures/codex-models.snapshot.json and open a
+#      PR. Later runs compare against it and only report a real change.
+# The same review-then-copy path applies to every subsequent drift report.
 on:
   schedule:
     - cron: '29 5 * * *'
@@ -60,6 +69,20 @@ jobs:
       # The committed fixture ships empty, so the first enabled run reports drift
       # by construction. Publish the generated list so the operator can review it
       # and seed test/fixtures/codex-models.snapshot.json from that same run.
+      - name: Publish live model snapshot to the job summary
+        if: always() && hashFiles('live-models.json') != ''
+        run: |
+          {
+            echo '### Account-visible Codex models'
+            echo
+            echo 'Copy verbatim to `test/fixtures/codex-models.snapshot.json` to seed or update the baseline.'
+            echo
+            echo '```json'
+            cat live-models.json
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo '--- live-models.json ---'
+          cat live-models.json
       - name: Upload live model snapshot
         if: always() && hashFiles('live-models.json') != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -72,7 +95,7 @@ jobs:
         run: |
           gh label create codex-drift --color BFD4F2 --description 'Codex wire or model-list drift' --force -R "$GITHUB_REPOSITORY" || true
           existing=$(gh issue list -R "$GITHUB_REPOSITORY" --label codex-drift --state open --json number --jq '.[0].number // ""')
-          body="Codex wire-contract validation or the account-visible model list drifted. See [run #$GITHUB_RUN_ID](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
+          body="Codex wire-contract validation or the account-visible model list drifted. See [run #$GITHUB_RUN_ID](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) — the account-visible model list is in that run's job summary and in the codex-live-models-$GITHUB_RUN_ID artifact."
           if [ -n "$existing" ]; then gh issue comment "$existing" -R "$GITHUB_REPOSITORY" --body "$body"; else gh issue create -R "$GITHUB_REPOSITORY" --title 'Codex drift detected' --label codex-drift --body "$body"; fi
       - name: Close Codex drift issue on recovery
         if: steps.check.outputs.exit_code == '0'

--- a/.github/workflows/codex-drift-watch.yml
+++ b/.github/workflows/codex-drift-watch.yml
@@ -73,13 +73,17 @@ jobs:
         if: always() && hashFiles('live-models.json') != ''
         run: |
           {
-            echo '### Account-visible Codex models'
-            echo
-            echo 'Copy verbatim to `test/fixtures/codex-models.snapshot.json` to seed or update the baseline.'
-            echo
-            echo '```json'
-            cat live-models.json
-            echo '```'
+          cat <<'HEADER'
+### Account-visible Codex models
+
+Copy verbatim to `test/fixtures/codex-models.snapshot.json` to seed or update the baseline.
+
+```json
+HEADER
+          cat live-models.json
+          cat <<'FOOTER'
+```
+FOOTER
           } >> "$GITHUB_STEP_SUMMARY"
           echo '--- live-models.json ---'
           cat live-models.json


### PR DESCRIPTION
Follow-up to #1208 (ticket DEV-8dfba913).

## Context

The second-read finding asked for two things: expose the generated `live-models.json`, and document the bootstrap path in the workflow header. The first half **already landed in #1208 itself** — commit `ci: publish the generated Codex model snapshot as an artifact` added the `Upload live model snapshot` step before merge, so the finding was partly stale by the time the ticket dispatched. This PR closes what is genuinely still missing.

## Changes

`.github/workflows/codex-drift-watch.yml` only:

1. **Workflow header** now documents the first-run baseline seeding flow explicitly: dispatch the workflow, read the list, copy it verbatim to `test/fixtures/codex-models.snapshot.json`, open a PR. Explains *why* the first run always reports drift (the fixture ships as `{"models": []}`).
2. **New `Publish live model snapshot to the job summary` step** writes the JSON to `$GITHUB_STEP_SUMMARY` in a fenced block and echoes it to the job log. Reviewing a baseline no longer requires downloading and unzipping an artifact — the copy-paste source is on the run page. Same `always() && hashFiles(...)` guard as the upload step, so it is a no-op when the fetch failed or the run skipped.
3. **Drift issue body** now points at the job summary and names the `codex-live-models-<run_id>` artifact, so someone arriving via the issue knows where the list is.

The artifact upload is unchanged and still the durable copy.

## Test plan

- Workflow-only change; no source or test files touched.
- The workflow is inert until `vars.DARIO_CODEX_LIVE_HOME` is set, so this cannot be exercised by CI on this PR. Actionlint/workflow validation in CI covers the syntax.
- Behavioural verification comes on the next operator-dispatched run: the job summary should render the model list, and the artifact should contain identical bytes.

Source ticket: DEV-8dfba913