### PR TITLE
codex: flatten tool_choice only when type === 'function'

### DIFF
--- a/src/codex-backend.ts
+++ b/src/codex-backend.ts
@@ -379,7 +379,8 @@ function chatContentToResponsesParts(content: unknown): Array<Record<string, str
  */
 export function toResponsesToolChoice(choice: unknown): unknown {
   if (choice == null || typeof choice !== 'object') return choice;
-  const c = choice as { function?: { name?: unknown } };
+  const c = choice as { type?: unknown; function?: { name?: unknown } };
+  if (c.type !== 'function') return choice;
   const name = c.function?.name;
   if (typeof name === 'string' && name.length > 0) {
     return { type: 'function', name };

--- a/test/codex-backend.mjs
+++ b/test/codex-backend.mjs
@@ -170,6 +170,13 @@ header('chatCompletionsToResponses');
   const unknown = { type: 'allowed_tools', mode: 'auto' };
   check('unknown tool_choice object passes through by identity',
     toResponsesToolChoice(unknown) === unknown);
+  // …including one that happens to carry a function.name: only type === 'function'
+  // is the chat/completions forced-tool form, so nothing else gets flattened.
+  const namedUnknown = { type: 'allowed_tools', mode: 'auto', function: { name: 'get_weather' } };
+  check('unknown tool_choice type with a function.name is not flattened',
+    toResponsesToolChoice(namedUnknown) === namedUnknown);
+  const untyped = { function: { name: 'get_weather' } };
+  check('tool_choice with no type is not flattened', toResponsesToolChoice(untyped) === untyped);
   const emptyName = { type: 'function', function: { name: '' } };
   check('empty forced-tool name is not flattened', toResponsesToolChoice(emptyName) === emptyName);
 }


### PR DESCRIPTION
Source ticket: DEV-b946de69 (second-read finding on #1204, accepted by operator triage 2026-09-05).

## Problem

`toResponsesToolChoice` documents that anything other than the chat/completions
forced-tool form "passes through untouched: an unknown object is the backend's to
reject, not ours to guess at". The implementation did not honour that — it keyed
solely on the presence of a non-empty `function.name`, so **any** object carrying
that path was rewritten to `{ type: 'function', name }`, discarding its own `type`
and every sibling field.

Concretely, `{ type: 'allowed_tools', mode: 'auto', function: { name: 'get_weather' } }`
became `{ type: 'function', name: 'get_weather' }` — a silent semantic change to a
shape we had promised not to interpret.

## Fix

`src/codex-backend.ts` — gate the flattening on `c.type !== 'function'` before
reading `function.name`. One added guard line; the forced-tool path is unchanged.

## Test plan

`test/codex-backend.mjs` — two regression cases next to the existing pass-through
checks, both asserting identity (the very same object reference survives):

- `{ type: 'allowed_tools', mode: 'auto', function: { name: 'get_weather' } }` — an
  unknown type that carries a `function.name`. **This is the case that failed before
  the fix**; the pre-existing "unknown tool_choice object passes through" test used a
  shape with no `function.name`, so it passed either way and did not cover the bug.
- `{ function: { name: 'get_weather' } }` — no `type` at all.

Existing coverage still applies unchanged: `auto`/`none`/`required` strings pass
through, the real forced-tool form still flattens and drops its `function` key, and
an empty forced-tool name is still left alone.

Not verified locally — the suite is compiled by CI per repo convention, so the
node --test run on this PR is the authoritative signal for both cases.