### PR TITLE
fix(pool): let a rate-limit rejection expire with its own window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ checklist.
 
 ## [Unreleased]
 
+## [6.0.28] - 2026-09-06
+
 - **A rate-limited seat returns to the pool when its window resets.** A `rejected` account is filtered out of selection, so nothing sent it another request, so its snapshot never refreshed — the rejection outlived the window that caused it, and the only ways back into rotation were the all-exhausted fallback in `select()` or a proxy restart. On a two-seat pool that meant a seat could stay parked long past its own reset for as long as the other one held out. Eligibility now expires the rejection against `anthropic-ratelimit-unified-reset`. `GET /accounts` and `GET /admin/accounts` report such a seat as `unknown` rather than `rejected` — the window rolled over, but nothing has measured it since. A seat whose snapshot states no reset stays parked, and a fresh 429 re-parks it on the new window.
 
 ## [6.0.27] - 2026-09-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ checklist.
 
 ## [Unreleased]
 
+- **A rate-limited seat returns to the pool when its window resets.** A `rejected` account is filtered out of selection, so nothing sent it another request, so its snapshot never refreshed — the rejection outlived the window that caused it, and the only ways back into rotation were the all-exhausted fallback in `select()` or a proxy restart. On a two-seat pool that meant a seat could stay parked long past its own reset for as long as the other one held out. Eligibility now expires the rejection against `anthropic-ratelimit-unified-reset`. `GET /accounts` and `GET /admin/accounts` report such a seat as `unknown` rather than `rejected` — the window rolled over, but nothing has measured it since. A seat whose snapshot states no reset stays parked, and a fresh 429 re-parks it on the new window.
+
 ## [6.0.27] - 2026-09-06
 
 - **`dario doctor` no longer claims a seat whose identity differs from `~/.claude.json` will 401.** The Identity row is now `info`, not `warn`: a differing identity is the expected state for any seat added from another machine or headless (a minted identity), and a minted identity served Sonnet 5 / Opus 5 / Haiku with 200 on 2026-09-06 on a plan with Extra Usage disabled. The only 401 ever observed came from an identity that belongs to a *different account* than the seat's bearer (a half-copied transplant), so the row now says exactly that and keeps the remove-then-add re-snapshot as the fix for that symptom. The no-`~/.claude.json` row stops asserting an Extra Usage billing outcome dario cannot observe; pool seats carry their own snapshot identity regardless.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.27",
+  "version": "6.0.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "6.0.27",
+      "version": "6.0.28",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.27",
+  "version": "6.0.28",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -175,11 +175,57 @@ export type AccountIneligibility = 'rate-limited' | 'token-expired' | 'auth-cool
  * need to name the failure, and a boolean forces each of them to re-derive it
  * and drift again.
  */
+/**
+ * Has the window that produced a `rejected` reading rolled over?
+ *
+ * A rejection is a verdict with an expiry date: `anthropic-ratelimit-unified-reset`
+ * names the moment the window that refused the request resets. Past it, the old
+ * reading says nothing about the account any more.
+ *
+ * This matters because a rejected account is filtered out of `select()`, so it
+ * is sent no further requests, so `updateRateLimits` never runs for it and its
+ * snapshot never refreshes. The only routes back into rotation were the
+ * all-exhausted fallback in `select()` and a proxy restart. Observed on the
+ * fleet box (2026-09-06): one seat sat parked on a 106% five-hour reading while
+ * a second subscription carried every request, and it would have stayed parked
+ * past its own reset for as long as the other seat held out.
+ *
+ * `reset` is epoch SECONDS — the header's own unit, the same one `formatReset`
+ * scales — so it is converted here. A snapshot with no reset (0) keeps its
+ * rejection: with no stated rollover there is nothing to expire, and guessing
+ * would push a genuinely throttled account back into rotation.
+ */
+export function rateLimitWindowPassed(rl: RateLimitSnapshot, now: number = Date.now()): boolean {
+  return rl.reset > 0 && rl.reset * 1000 <= now;
+}
+
+/**
+ * The status string the operator-facing surfaces report for one account —
+ * `GET /accounts` and `GET /admin/accounts`, which must agree with each other
+ * and with what routing actually does.
+ *
+ * Auth cool-down outranks the rate-limit reading: a 401 streak is both the more
+ * urgent fact and the one the rate-limit headers cannot describe, since 401
+ * responses carry none. An expired rejection degrades to `unknown` rather than
+ * `allowed` — the window rolled over, but nothing has measured the account
+ * since, and reporting `allowed` would assert a serving capacity no request has
+ * demonstrated. `unknown` is what a never-used account already reports, which is
+ * exactly the state this is: no current observation.
+ */
+export function reportedAccountStatus(account: PoolAccount, now: number = Date.now()): string {
+  if (isInAuthCooldown(account, now)) return 'auth-cooldown';
+  if (account.rateLimit.status === 'rejected' && rateLimitWindowPassed(account.rateLimit, now)) return 'unknown';
+  return account.rateLimit.status;
+}
+
 export function accountIneligibility(
   account: PoolAccount,
   now: number = Date.now(),
 ): AccountIneligibility | null {
-  if (account.rateLimit.status === 'rejected') return 'rate-limited';
+  // A rejection outlives its own window unless it is allowed to expire:
+  // nothing refreshes a parked account's snapshot, because being parked is
+  // what stops it being sent requests.
+  if (account.rateLimit.status === 'rejected' && !rateLimitWindowPassed(account.rateLimit, now)) return 'rate-limited';
   if (account.expiresAt <= now + TOKEN_EXPIRY_MARGIN_MS) return 'token-expired';
   if (isInAuthCooldown(account, now)) return 'auth-cooldown';
   return null;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -12,7 +12,7 @@ import { darioVersion } from './version.js';
 import { buildCCRequest, applyCcPromptCaching, isGenuineCCClient, parseEffortSuffix, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, overlayTemplateHeaderValues, forwardClientCCIdentityHeaders, isMcpToolName, CC_TEMPLATE, CC_CACHE_CONTROL, effectiveCacheControl, withForced1hBeta, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
 import { stampCch, hasCchSeed } from './cch.js';
 import { describeTemplate, detectDrift, checkCCCompat, probeInstalledCCVersion } from './live-fingerprint.js';
-import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCooldown, authCooldownMs, accountIneligibility, reconcilePoolAccounts, resolvePoolStrategy, utilFreshness, type PoolAccount } from './pool.js';
+import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCooldown, authCooldownMs, accountIneligibility, reportedAccountStatus, reconcilePoolAccounts, resolvePoolStrategy, utilFreshness, type PoolAccount } from './pool.js';
 import { Analytics, billingBucketFromClaim, formatUsageLogLine, SUBSCRIPTION_CLAIMS, type RequestRecord, CODEX_CLAIM } from './analytics.js';
 import { OverageGuard, buildHaltErrorBody, type HaltState } from './overage-guard.js';
 import { notify as osNotify } from './notify.js';
@@ -2470,7 +2470,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
               // must not be the one place a stale reading still looks current.
               ...utilFreshness(a.rateLimit, snapNow),
               claim: a.rateLimit.claim,
-              status: isInAuthCooldown(a, snapNow) ? 'auth-cooldown' : a.rateLimit.status,
+              status: reportedAccountStatus(a, snapNow),
               requestCount: a.requestCount,
               // Raw streak, not just the cooldown boolean: a single 401 also
               // shows `auth-cooldown` for 60s, indistinguishable from a
@@ -2567,7 +2567,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           util7d: a.rateLimit.util7d,
           ...utilFreshness(a.rateLimit, now),
           claim: a.rateLimit.claim,
-          status: inCooldown ? 'auth-cooldown' : a.rateLimit.status,
+          status: reportedAccountStatus(a, now),
           requestCount: a.requestCount,
           expiresInMs: Math.max(0, a.expiresAt - now),
           // Refresh-token grant age (refresh-grant.ts): the wall a token

--- a/test/pool-rate-limit-reset.mjs
+++ b/test/pool-rate-limit-reset.mjs
@@ -1,0 +1,196 @@
+// A rate-limit rejection expires with the window that produced it.
+//
+// A `rejected` account is filtered out of `select()`, so it is sent no further
+// requests, so `updateRateLimits` never runs for it and its snapshot never
+// refreshes. The rejection therefore outlived the window it described: the only
+// ways back into rotation were the all-exhausted fallback inside `select()` and
+// a proxy restart.
+//
+// Observed on the fleet box (2026-09-06): one seat sat parked on a 106%
+// five-hour reading while a second subscription carried every request. Its
+// window reset twenty minutes later and it would have stayed parked regardless,
+// for as long as the healthy seat held out — reported to the operator as
+// `status: rejected` the whole time.
+//
+// `anthropic-ratelimit-unified-reset` states when the window rolls over, so the
+// rejection is allowed to expire on it. The unit trap is that the header is
+// epoch SECONDS while `now` is milliseconds; the units block below is what
+// fails if the conversion is ever dropped.
+
+import {
+  AccountPool,
+  EMPTY_SNAPSHOT,
+  accountIneligibility,
+  isAccountEligible,
+  rateLimitWindowPassed,
+  reportedAccountStatus,
+} from '../dist/pool.js';
+
+let pass = 0, fail = 0;
+function check(label, cond, ...rest) {
+  if (cond) { console.log(`  OK ${label}`); pass++; }
+  else { console.log(`  FAIL ${label}`, ...rest); fail++; }
+}
+function header(label) {
+  console.log(`\n======================================================================`);
+  console.log(`  ${label}`);
+  console.log(`======================================================================`);
+}
+
+const NOW = 1_788_715_000_000;          // fixed clock, ms
+const SECS = Math.floor(NOW / 1000);
+const HOUR_MS = 3_600_000;
+// Token expiry has to clear BOTH clocks: the frozen NOW the pure-function
+// checks pass in, and the real one `select()` reads for itself. Anchoring to
+// whichever is later keeps that true however long after NOW the suite runs.
+const NOT_EXPIRING = Math.max(NOW, Date.now()) + 8 * HOUR_MS;
+
+function poolWith(aliases) {
+  const pool = new AccountPool();          // default strategy: max-headroom
+  for (const alias of aliases) {
+    pool.add(alias, {
+      accessToken: `tok-${alias}`,
+      refreshToken: `ref-${alias}`,
+      expiresAt: NOT_EXPIRING,
+      deviceId: `dev-${alias}`,
+      accountUuid: `uuid-${alias}`,
+    });
+  }
+  return pool;
+}
+
+/** Park `alias` as rate-limited, with a reset at `resetSecs` (epoch seconds). */
+function park(pool, alias, resetSecs, util5h = 1.06) {
+  pool.markRejected(alias, { ...EMPTY_SNAPSHOT, util5h, reset: resetSecs });
+}
+
+// ----------------------------------------------------------------------
+header('rateLimitWindowPassed — the reset moment, in the header\'s own unit');
+// ----------------------------------------------------------------------
+{
+  check('reset in the past → passed',
+    rateLimitWindowPassed({ ...EMPTY_SNAPSHOT, reset: SECS - 60 }, NOW) === true);
+  check('reset in the future → not passed',
+    rateLimitWindowPassed({ ...EMPTY_SNAPSHOT, reset: SECS + 60 }, NOW) === false);
+  check('reset exactly now → passed (the window has rolled)',
+    rateLimitWindowPassed({ ...EMPTY_SNAPSHOT, reset: SECS }, NOW) === true);
+  check('no reset stated (0) → never passes, nothing to expire',
+    rateLimitWindowPassed({ ...EMPTY_SNAPSHOT, reset: 0 }, NOW) === false);
+
+  // The unit trap. `reset` is epoch SECONDS; `now` is milliseconds. Drop the
+  // x1000 and every future reset (~1.79e9) compares below every now (~1.79e12),
+  // so EVERY rejection would read as expired and a genuinely throttled account
+  // would be handed straight back to the router.
+  check('a reset an hour in the FUTURE is not treated as expired (seconds vs ms)',
+    rateLimitWindowPassed({ ...EMPTY_SNAPSHOT, reset: SECS + 3600 }, NOW) === false);
+  check('a reset a full day ahead is not treated as expired',
+    rateLimitWindowPassed({ ...EMPTY_SNAPSHOT, reset: SECS + 86400 }, NOW) === false);
+}
+
+// ----------------------------------------------------------------------
+header('accountIneligibility — a parked seat returns when its window rolls');
+// ----------------------------------------------------------------------
+{
+  const pool = poolWith(['a']);
+  const acct = pool.get('a');
+
+  park(pool, 'a', SECS + 600);
+  check('rejected, reset still ahead → rate-limited',
+    accountIneligibility(acct, NOW) === 'rate-limited');
+  check('and therefore not eligible', isAccountEligible(acct, NOW) === false);
+
+  park(pool, 'a', SECS - 1);
+  check('rejected, reset passed → eligible again',
+    accountIneligibility(acct, NOW) === null);
+  check('isAccountEligible agrees', isAccountEligible(acct, NOW) === true);
+
+  park(pool, 'a', 0);
+  check('rejected with no reset stated → stays parked',
+    accountIneligibility(acct, NOW) === 'rate-limited');
+}
+
+// ----------------------------------------------------------------------
+header('the other ineligibility reasons still outrank an expired rejection');
+// ----------------------------------------------------------------------
+{
+  const pool = poolWith(['a']);
+  const acct = pool.get('a');
+  park(pool, 'a', SECS - 1);          // expired rejection = no longer a reason
+
+  acct.expiresAt = NOW - 1;
+  check('expired token still ineligible, not resurrected by the reset',
+    accountIneligibility(acct, NOW) === 'token-expired');
+
+  acct.expiresAt = NOT_EXPIRING;
+  pool.markAuthFailure('a');
+  check('auth cool-down still ineligible',
+    accountIneligibility(acct, Date.now()) === 'auth-cooldown');
+  pool.clearAuthFailure('a');
+  check('cleared → eligible again', isAccountEligible(acct, NOW) === true);
+}
+
+// ----------------------------------------------------------------------
+header('reportedAccountStatus — what the operator surfaces say');
+// ----------------------------------------------------------------------
+{
+  const pool = poolWith(['a']);
+  const acct = pool.get('a');
+
+  park(pool, 'a', SECS + 600);
+  check('still inside the window → rejected', reportedAccountStatus(acct, NOW) === 'rejected');
+
+  park(pool, 'a', SECS - 1);
+  // Not 'allowed': the window rolled over, but nothing has measured the account
+  // since. 'unknown' is what a never-used seat reports, and that is this state.
+  check('window rolled, nothing measured since → unknown',
+    reportedAccountStatus(acct, NOW) === 'unknown');
+
+  pool.updateRateLimits('a', { ...EMPTY_SNAPSHOT, status: 'allowed', util5h: 0.1, reset: SECS + 600 });
+  check('a real reading wins → allowed', reportedAccountStatus(acct, NOW) === 'allowed');
+
+  pool.markAuthFailure('a');
+  check('auth cool-down outranks the rate-limit reading',
+    reportedAccountStatus(acct, Date.now()) === 'auth-cooldown');
+}
+
+// ----------------------------------------------------------------------
+header('routing — a recovered seat is reachable again, not just re-labelled');
+// ----------------------------------------------------------------------
+{
+  // `a` is parked on a stale rejection but has far more headroom than the
+  // healthy `b`. While the rejection stands, `select()` can only see `b`.
+  //
+  // These offsets are anchored to the REAL clock, not the frozen NOW above:
+  // `select()` reads `Date.now()` itself and takes no `now` parameter, so a
+  // fixed constant silently drifts into the past and a reset meant to be in
+  // the future expires for real once the suite has been around long enough.
+  const realSecs = Math.floor(Date.now() / 1000);
+  const pool = poolWith(['a', 'b']);
+  pool.updateRateLimits('b', { ...EMPTY_SNAPSHOT, status: 'allowed', util5h: 0.80, reset: realSecs + 600 });
+
+  park(pool, 'a', realSecs + 600, 0.10);
+  check('inside its window, the parked seat is skipped', pool.select()?.alias === 'b');
+
+  park(pool, 'a', realSecs - 1, 0.10);
+  check('once the window rolls, the seat with the real headroom is chosen',
+    pool.select()?.alias === 'a');
+}
+
+// ----------------------------------------------------------------------
+header('an expired rejection that is still real re-parks on the next 429');
+// ----------------------------------------------------------------------
+{
+  // Letting the rejection expire is a decision to re-probe, not a claim the
+  // account is free. If it 429s again, the fresh snapshot parks it again.
+  const pool = poolWith(['a']);
+  const acct = pool.get('a');
+  park(pool, 'a', SECS - 1);
+  check('re-probe allowed', isAccountEligible(acct, NOW) === true);
+
+  park(pool, 'a', SECS + 900);        // the 429 upstream answers with a new window
+  check('re-parked on the new window', isAccountEligible(acct, NOW) === false);
+  check('and reported as rejected again', reportedAccountStatus(acct, NOW) === 'rejected');
+}
+
+console.log(`\npool-rate-limit-reset: ${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## What

A seat marked `rejected` stays out of the pool until the proxy restarts, even after the window that rejected it has rolled over. Eligibility now expires the rejection against `anthropic-ratelimit-unified-reset`.

## Why

Found on the fleet box today. The Claude pool had one seat, upstream returned 429 with `unified-5h-status: rejected` and `unified-5h-utilization: 1.06` against `surpassed-threshold: 1.0`, so the seat was genuinely over its five-hour window and correctly parked. Its reset was twenty minutes out.

The problem is what happens after those twenty minutes. `markRejected` sets the status, `accountIneligibility` filters the account out of `select()`, and `updateRateLimits` only runs when a request completes on that account. Being parked is exactly what stops it being sent a request, so the snapshot cannot refresh itself. The rejection has no expiry.

Once a second subscription was added the pool had a healthy seat, so the parked one was never reached by the fallback at `pool.ts:518` either. It would have read `rate-limited` to routing, and `rejected` to the operator, for as long as the healthy seat held out. `GET /accounts` already carries a comment describing this staleness as self-correcting because "the pool does return parked accounts to service on its own" — that is only true when every seat is ineligible at once.

## Changes

- `rateLimitWindowPassed()` in `src/pool.ts`. `reset` is epoch **seconds** (the header's unit, the same one `formatReset` scales) while `now` is milliseconds, so the conversion is explicit. A snapshot with no stated reset (`0`) keeps its rejection rather than guessing.
- `accountIneligibility()` treats a rejection as spent once its window has rolled. `isAccountEligible` and `selectSticky` inherit this, since both route through it. Token expiry and auth cool-down are unaffected and still outrank it.
- `reportedAccountStatus()` consolidates the status derivation that `GET /accounts` and `GET /admin/accounts` were each doing inline. An expired rejection reports `unknown`, not `allowed`: the window rolled over, but nothing has measured the account since, and `unknown` is already what a never-used seat reports.

## Notes

Letting the rejection expire is a decision to re-probe, not a claim the seat is free. If it 429s again the fresh snapshot re-parks it on the new window, which the last test block covers.

Selection order is unchanged. A recovered seat competes on headroom like any other, so it is only preferred when its own reading says it has more.

## Testing

`test/pool-rate-limit-reset.mjs`, 23 checks: the reset boundary, the seconds-vs-milliseconds trap, the other ineligibility reasons still outranking, both reported statuses, a routing case where a recovered seat becomes reachable again, and re-parking on a fresh 429.

Verified as a real regression test by reverting the eligibility line in `dist/` and re-running: 7 of the 23 fail, including the routing case.

`npm test` 172/172, preflight clean, changelog gate ok, README line-count ok.
