### PR TITLE
chore(release): bump to v6.0.28 for #1232

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ checklist.
 
 ## [Unreleased]
 
+## [6.0.28] - 2026-09-06
+
 - **A rate-limited seat returns to the pool when its window resets.** A `rejected` account is filtered out of selection, so nothing sent it another request, so its snapshot never refreshed — the rejection outlived the window that caused it, and the only ways back into rotation were the all-exhausted fallback in `select()` or a proxy restart. On a two-seat pool that meant a seat could stay parked long past its own reset for as long as the other one held out. Eligibility now expires the rejection against `anthropic-ratelimit-unified-reset`. `GET /accounts` and `GET /admin/accounts` report such a seat as `unknown` rather than `rejected` — the window rolled over, but nothing has measured it since. A seat whose snapshot states no reset stays parked, and a fresh 429 re-parks it on the new window.
 
 ## [6.0.27] - 2026-09-06

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.27",
+  "version": "6.0.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "6.0.27",
+      "version": "6.0.28",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.27",
+  "version": "6.0.28",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release-gate fix for #1232 (ticket 00MTQ3TS0Y248B079CD5225745).

#1232 changes shipping files (`src/pool.ts` +47, `src/proxy.ts` ±3) but leaves `package.json` at 6.0.27, so `cc-drift-auto-release` would find the existing `v6.0.27` tag and short-circuit — merging it as-is ships nothing.

**Based on `fix/rate-limit-reset-eligibility`, not master, on purpose.** A bump PR against master would consume the next version slot for itself and the gate would short-circuit again one version later. This way the bump becomes part of #1232's own diff.

## Changes
- `package.json`: 6.0.27 → 6.0.28
- `package-lock.json`: both version slots (root + `.packages[""]`) → 6.0.28 — `scripts/preflight.mjs` (required `validate-package-json` check) asserts all three agree
- `CHANGELOG.md`: renamed nothing; inserted a `## [6.0.28] - 2026-09-06` heading under `## [Unreleased]` so the existing rate-limit bullet sits under a real release heading

No source or workflow files touched — this is a pure release trigger.

## Test plan
- `node scripts/preflight.mjs` → clean: version agrees across package.json + lockfile (6.0.28), CHANGELOG top heading matches ([6.0.28])
- CI `validate-package-json` on this PR

## Merge order
1. Merge THIS PR into `fix/rate-limit-reset-eligibility`
2. Then merge #1232 into `master` — the bump rides along and `cc-drift-auto-release` cuts `v6.0.28`