### PR TITLE
test: take proxy ports from the kernel instead of pinning ephemeral-range numbers

### DIFF
--- a/test/auth-failover-403-proxy.mjs
+++ b/test/auth-failover-403-proxy.mjs
@@ -6,6 +6,7 @@
 import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { freePort } from './helpers/free-port.mjs';
 
 let pass = 0, fail = 0;
 const check = (name, cond, detail = '') => {
@@ -49,7 +50,7 @@ const fakeFetch = async (url, init = {}) => {
 };
 
 const { startProxy } = await import('../dist/proxy.js');
-const port = 38847;
+const port = await freePort();
 await startProxy({ port, host: '127.0.0.1', noLiveCapture: true, fetchImpl: fakeFetch });
 for (let i = 0; i < 50; i++) {
   try { await fetch(`http://127.0.0.1:${port}/health`); break; } catch { await sleep(50); }

--- a/test/codex-admin-surface.mjs
+++ b/test/codex-admin-surface.mjs
@@ -12,6 +12,7 @@ import { createServer } from 'node:http';
 import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { freePort } from './helpers/free-port.mjs';
 
 let pass = 0, fail = 0;
 const check = (name, cond, detail) => {
@@ -21,9 +22,9 @@ const check = (name, cond, detail) => {
 const header = (n) => console.log(`\n=== ${n} ===`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-// Clear of 3456-3460 and the other test files' ports.
-const PROXY_PORT = 38801;
-const STUB_PORT = 38802;
+// Kernel-assigned so no other process or test file can hold it (helpers/free-port.mjs).
+const PROXY_PORT = await freePort();
+const STUB_PORT = await freePort();
 const BASE = `http://127.0.0.1:${PROXY_PORT}`;
 const LISTED_SLUG = 'gpt-5.6-admin';
 

--- a/test/codex-decline-carries-effort.mjs
+++ b/test/codex-decline-carries-effort.mjs
@@ -29,6 +29,7 @@ import { createServer } from 'node:http';
 import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { freePort } from './helpers/free-port.mjs';
 
 let pass = 0, fail = 0;
 const check = (name, cond, detail) => {
@@ -38,8 +39,8 @@ const check = (name, cond, detail) => {
 const header = (n) => console.log(`\n=== ${n} ===`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-const PROXY_PORT = 38841;
-const CODEX_PORT = 38842;
+const PROXY_PORT = await freePort();
+const CODEX_PORT = await freePort();
 const BASE = `http://127.0.0.1:${PROXY_PORT}`;
 
 const LISTED_SLUG = 'gpt-5.6-sol';

--- a/test/codex-pool-fallback-mid-flight.mjs
+++ b/test/codex-pool-fallback-mid-flight.mjs
@@ -31,6 +31,7 @@ import { createServer } from 'node:http';
 import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { freePort } from './helpers/free-port.mjs';
 
 let pass = 0, fail = 0;
 const check = (name, cond, detail) => {
@@ -41,10 +42,10 @@ const header = (n) => console.log(`\n=== ${n} ===`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // Stay clear of dario's 3456-3460 range and the other test files' ports.
-const CODEX_PORT = 38831;
-const PROXY_ANTHROPIC_PORT = 38832;
-const PROXY_OPENAI_PORT = 38833;
-const PROXY_NOSERVE_PORT = 38834;
+const CODEX_PORT = await freePort();
+const PROXY_ANTHROPIC_PORT = await freePort();
+const PROXY_OPENAI_PORT = await freePort();
+const PROXY_NOSERVE_PORT = await freePort();
 
 // A slug the ChatGPT backend "lists" for this account. Deliberately NOT a name
 // isOpenAIModel would recognise on its own — the failover target must come

--- a/test/codex-pool-fallback-mid-flight.mjs
+++ b/test/codex-pool-fallback-mid-flight.mjs
@@ -41,7 +41,7 @@ const check = (name, cond, detail) => {
 const header = (n) => console.log(`\n=== ${n} ===`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-// Stay clear of dario's 3456-3460 range and the other test files' ports.
+// Kernel-assigned so no other process or test file can hold it (helpers/free-port.mjs).
 const CODEX_PORT = await freePort();
 const PROXY_ANTHROPIC_PORT = await freePort();
 const PROXY_OPENAI_PORT = await freePort();

--- a/test/codex-refresh-failure-ttl.mjs
+++ b/test/codex-refresh-failure-ttl.mjs
@@ -34,7 +34,7 @@ const check = (name, cond, detail) => {
 const header = (n) => console.log(`\n=== ${n} ===`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-// Clear of dario's 3456-3460 range and the other test files' ports.
+// Kernel-assigned so no other process or test file can hold it (helpers/free-port.mjs).
 const PROXY_PORT = await freePort();
 const TOKEN_PORT = await freePort();
 const BACKEND_PORT = await freePort();

--- a/test/codex-refresh-failure-ttl.mjs
+++ b/test/codex-refresh-failure-ttl.mjs
@@ -24,6 +24,7 @@ import { createServer } from 'node:http';
 import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { freePort } from './helpers/free-port.mjs';
 
 let pass = 0, fail = 0;
 const check = (name, cond, detail) => {
@@ -34,9 +35,9 @@ const header = (n) => console.log(`\n=== ${n} ===`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // Clear of dario's 3456-3460 range and the other test files' ports.
-const PROXY_PORT = 38801;
-const TOKEN_PORT = 38802;
-const BACKEND_PORT = 38803;
+const PROXY_PORT = await freePort();
+const TOKEN_PORT = await freePort();
+const BACKEND_PORT = await freePort();
 const BASE = `http://127.0.0.1:${PROXY_PORT}`;
 
 const ALIAS = 'fleet';

--- a/test/codex-route-empty-pool.mjs
+++ b/test/codex-route-empty-pool.mjs
@@ -16,6 +16,7 @@ import { createServer } from 'node:http';
 import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { freePort } from './helpers/free-port.mjs';
 
 let pass = 0, fail = 0;
 const check = (name, cond, detail) => {
@@ -26,8 +27,8 @@ const header = (n) => console.log(`\n=== ${n} ===`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // Stay clear of dario's 3456-3460 range and the other test files' ports.
-const PROXY_PORT = 38791;
-const STUB_PORT = 38792;
+const PROXY_PORT = await freePort();
+const STUB_PORT = await freePort();
 const BASE = `http://127.0.0.1:${PROXY_PORT}`;
 
 // A slug the ChatGPT backend "lists" for this account. Deliberately NOT a name

--- a/test/codex-route-empty-pool.mjs
+++ b/test/codex-route-empty-pool.mjs
@@ -26,7 +26,7 @@ const check = (name, cond, detail) => {
 const header = (n) => console.log(`\n=== ${n} ===`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-// Stay clear of dario's 3456-3460 range and the other test files' ports.
+// Kernel-assigned so no other process or test file can hold it (helpers/free-port.mjs).
 const PROXY_PORT = await freePort();
 const STUB_PORT = await freePort();
 const BASE = `http://127.0.0.1:${PROXY_PORT}`;

--- a/test/codex-runtime-account-detect.mjs
+++ b/test/codex-runtime-account-detect.mjs
@@ -21,6 +21,7 @@ import { createServer } from 'node:http';
 import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { freePort } from './helpers/free-port.mjs';
 
 let pass = 0, fail = 0;
 const check = (name, cond, detail) => {
@@ -31,8 +32,8 @@ const header = (n) => console.log(`\n=== ${n} ===`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // Clear of dario's 3456-3460 range and the other test files' ports.
-const PROXY_PORT = 38795;
-const STUB_PORT = 38796;
+const PROXY_PORT = await freePort();
+const STUB_PORT = await freePort();
 const BASE = `http://127.0.0.1:${PROXY_PORT}`;
 
 // Deliberately not a name isOpenAIModel would recognise on its own — routing

--- a/test/codex-runtime-account-detect.mjs
+++ b/test/codex-runtime-account-detect.mjs
@@ -31,7 +31,7 @@ const check = (name, cond, detail) => {
 const header = (n) => console.log(`\n=== ${n} ===`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-// Clear of dario's 3456-3460 range and the other test files' ports.
+// Kernel-assigned so no other process or test file can hold it (helpers/free-port.mjs).
 const PROXY_PORT = await freePort();
 const STUB_PORT = await freePort();
 const BASE = `http://127.0.0.1:${PROXY_PORT}`;

--- a/test/health-codex-serves.mjs
+++ b/test/health-codex-serves.mjs
@@ -28,7 +28,7 @@ const check = (name, cond, detail) => {
 const header = (n) => console.log(`\n=== ${n} ===`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-// Clear of dario's 3456-3460 range and the other test files' ports.
+// Kernel-assigned so no other process or test file can hold it (helpers/free-port.mjs).
 const PROXY_PORT = await freePort();
 const BASE = `http://127.0.0.1:${PROXY_PORT}`;
 

--- a/test/health-codex-serves.mjs
+++ b/test/health-codex-serves.mjs
@@ -18,6 +18,7 @@
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { freePort } from './helpers/free-port.mjs';
 
 let pass = 0, fail = 0;
 const check = (name, cond, detail) => {
@@ -28,7 +29,7 @@ const header = (n) => console.log(`\n=== ${n} ===`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // Clear of dario's 3456-3460 range and the other test files' ports.
-const PROXY_PORT = 38797;
+const PROXY_PORT = await freePort();
 const BASE = `http://127.0.0.1:${PROXY_PORT}`;
 
 // HOME set BEFORE the imports: codex-accounts.ts resolves its directory at

--- a/test/health-probe-e2e.mjs
+++ b/test/health-probe-e2e.mjs
@@ -20,6 +20,7 @@
 
 import { startProxy } from '../dist/proxy.js';
 import { _resetServingProbeForTest } from '../dist/serving-probe.js';
+import { freePort } from './helpers/free-port.mjs';
 
 let pass = 0, fail = 0;
 const check = (name, cond, detail) => {
@@ -29,7 +30,7 @@ const check = (name, cond, detail) => {
 const header = (n) => console.log(`\n=== ${n} ===`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-const PORT = 38781;
+const PORT = await freePort();
 const BASE = `http://127.0.0.1:${PORT}`;
 
 // Every probe the proxy sends, in order. A probe is the only POST to

--- a/test/helpers/free-port.mjs
+++ b/test/helpers/free-port.mjs
@@ -1,0 +1,33 @@
+// A loopback port the kernel says is free right now.
+//
+// The in-process proxy tests used to pin ports like 38838. Linux hands out
+// ephemeral source ports from 32768-60999, so on a busy host a long-lived
+// loopback connection can be sitting on exactly that number — on the
+// self-hosted runner it was cloudflared, `127.0.0.1:38838 -> 127.0.0.1:3005`,
+// ESTABLISHED for hours — and `startProxy` then fails with "Port 38838 is
+// already in use" on every PR until the connection recycles (dario#1235's
+// live-test, 2026-09-06). Asking for port 0 and reading back the assignment
+// sidesteps the whole range.
+//
+// The port is released before it is returned, so there is a short window in
+// which something else could take it. That is the standard trade-off for a
+// proxy that needs to know its port before it listens; the window is
+// microseconds against a collision that used to last for hours.
+//
+// Lives in a subdirectory so all.test.mjs (top-level *.mjs only) does not run
+// it as a test.
+
+import { createServer } from 'node:net';
+
+/** @returns {Promise<number>} */
+export function freePort() {
+  return new Promise((resolve, reject) => {
+    const s = createServer();
+    s.unref();
+    s.on('error', reject);
+    s.listen(0, '127.0.0.1', () => {
+      const { port } = s.address();
+      s.close(() => resolve(port));
+    });
+  });
+}

--- a/test/invalid-json-body.mjs
+++ b/test/invalid-json-body.mjs
@@ -17,6 +17,7 @@
 import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { freePort } from './helpers/free-port.mjs';
 
 let pass = 0, fail = 0;
 const check = (name, cond, detail) => {
@@ -27,7 +28,7 @@ const header = (n) => console.log(`\n=== ${n} ===`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // Clear of dario's 3456-3460 range and the other test files' ports.
-const PROXY_PORT = 38799;
+const PROXY_PORT = await freePort();
 const BASE = `http://127.0.0.1:${PROXY_PORT}`;
 
 const tmpHome = await mkdtemp(join(tmpdir(), 'dario-invalid-body-'));

--- a/test/invalid-json-body.mjs
+++ b/test/invalid-json-body.mjs
@@ -27,7 +27,7 @@ const check = (name, cond, detail) => {
 const header = (n) => console.log(`\n=== ${n} ===`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-// Clear of dario's 3456-3460 range and the other test files' ports.
+// Kernel-assigned so no other process or test file can hold it (helpers/free-port.mjs).
 const PROXY_PORT = await freePort();
 const BASE = `http://127.0.0.1:${PROXY_PORT}`;
 

--- a/test/passthrough-header-forwarding.mjs
+++ b/test/passthrough-header-forwarding.mjs
@@ -16,6 +16,7 @@
  */
 import { startProxy } from '../dist/proxy.js';
 import { forwardClientCCIdentityHeaders } from '../dist/cc-template.js';
+import { freePort } from './helpers/free-port.mjs';
 
 let pass = 0;
 let fail = 0;
@@ -94,7 +95,7 @@ header('3. value handling');
 // ─────────────────────────────────────────────────────────────
 header('4. live request through the real proxy (the layer that caught the bug)');
 {
-  const PORT = 39873;
+  const PORT = await freePort();
   const BASE = `http://127.0.0.1:${PORT}`;
   let upstream = null;
 

--- a/test/pool-exhaustion-gate-wiring.mjs
+++ b/test/pool-exhaustion-gate-wiring.mjs
@@ -34,6 +34,7 @@ import { createServer } from 'node:http';
 import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { freePort } from './helpers/free-port.mjs';
 
 let pass = 0, fail = 0;
 const check = (name, cond, detail) => {
@@ -44,9 +45,9 @@ const header = (n) => console.log(`\n=== ${n} ===`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // Stay clear of dario's 3456-3460 range and the other test files' ports.
-const PROXY_PORT = 38821;
-const CODEX_PORT = 38822;
-const PROXY_NOSERVE_PORT = 38823;
+const PROXY_PORT = await freePort();
+const CODEX_PORT = await freePort();
+const PROXY_NOSERVE_PORT = await freePort();
 const BASE = `http://127.0.0.1:${PROXY_PORT}`;
 const BASE_NOSERVE = `http://127.0.0.1:${PROXY_NOSERVE_PORT}`;
 

--- a/test/pool-exhaustion-gate-wiring.mjs
+++ b/test/pool-exhaustion-gate-wiring.mjs
@@ -44,7 +44,7 @@ const check = (name, cond, detail) => {
 const header = (n) => console.log(`\n=== ${n} ===`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-// Stay clear of dario's 3456-3460 range and the other test files' ports.
+// Kernel-assigned so no other process or test file can hold it (helpers/free-port.mjs).
 const PROXY_PORT = await freePort();
 const CODEX_PORT = await freePort();
 const PROXY_NOSERVE_PORT = await freePort();

--- a/test/pool-exhaustion-midflight-429-wiring.mjs
+++ b/test/pool-exhaustion-midflight-429-wiring.mjs
@@ -25,6 +25,7 @@ import { createServer } from 'node:http';
 import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { freePort } from './helpers/free-port.mjs';
 
 let pass = 0, fail = 0;
 const check = (name, cond, detail) => {
@@ -34,8 +35,8 @@ const check = (name, cond, detail) => {
 const header = (n) => console.log(`\n=== ${n} ===`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-const PROXY_PORT = 38838;
-const CODEX_PORT = 38839;
+const PROXY_PORT = await freePort();
+const CODEX_PORT = await freePort();
 const BASE = `http://127.0.0.1:${PROXY_PORT}`;
 
 const LISTED_SLUG = 'gpt-5.6-sol';

--- a/test/proxy-400-recovery.mjs
+++ b/test/proxy-400-recovery.mjs
@@ -16,6 +16,7 @@
 // what made it look like a warm-up quirk instead of a bug.
 
 import { startProxy } from '../dist/proxy.js';
+import { freePort } from './helpers/free-port.mjs';
 
 let pass = 0, fail = 0;
 const check = (name, cond, detail) => {
@@ -26,7 +27,7 @@ const header = (n) => console.log(`\n=== ${n} ===`);
 
 // Uncommon port: the suite runs at --test-concurrency=8 and other files bind
 // sockets, so stay well clear of dario's 3456-3460 range.
-const PORT = 38761;
+const PORT = await freePort();
 const BASE = `http://127.0.0.1:${PORT}`;
 
 const json = (obj, status = 200) =>

--- a/test/queue-slot-leak.mjs
+++ b/test/queue-slot-leak.mjs
@@ -29,7 +29,7 @@ const check = (name, cond, detail) => {
 const header = (n) => console.log(`\n=== ${n} ===`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-// Stay clear of dario's 3456-3460 range and other test files' ports.
+// Kernel-assigned so no other process or test file can hold it (helpers/free-port.mjs).
 const PORT = await freePort();
 const BASE = `http://127.0.0.1:${PORT}`;
 const UPSTREAM_TIMEOUT_MS = 3_000;

--- a/test/queue-slot-leak.mjs
+++ b/test/queue-slot-leak.mjs
@@ -19,6 +19,7 @@
 
 import net from 'node:net';
 import { startProxy } from '../dist/proxy.js';
+import { freePort } from './helpers/free-port.mjs';
 
 let pass = 0, fail = 0;
 const check = (name, cond, detail) => {
@@ -29,7 +30,7 @@ const header = (n) => console.log(`\n=== ${n} ===`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // Stay clear of dario's 3456-3460 range and other test files' ports.
-const PORT = 38773;
+const PORT = await freePort();
 const BASE = `http://127.0.0.1:${PORT}`;
 const UPSTREAM_TIMEOUT_MS = 3_000;
 

--- a/test/seat-pin-proxy.mjs
+++ b/test/seat-pin-proxy.mjs
@@ -9,6 +9,7 @@ import { createServer } from 'node:http';
 import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { freePort } from './helpers/free-port.mjs';
 
 let pass = 0, fail = 0;
 const check = (name, cond, detail) => {
@@ -18,7 +19,7 @@ const check = (name, cond, detail) => {
 const header = (n) => console.log(`\n=== ${n} ===`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-const PORT = 38851;
+const PORT = await freePort();
 const ADMIN_TOKEN = 'seat-pin-admin-token';
 
 const tmpHome = await mkdtemp(join(tmpdir(), 'dario-seatpin-'));
@@ -64,7 +65,7 @@ const fetchImpl = async (url, init) => {
 
 // The codex backend base URL is captured at module load, so the stub and the
 // env var must exist BEFORE dist/proxy.js is imported.
-const CODEX_PORT = 38853;
+const CODEX_PORT = await freePort();
 const CODEX_SLUG = 'gpt-5.6-sol';
 const codexSeen = { models: 0, responses: 0 };
 const codexStub = createServer((req, res) => {
@@ -155,7 +156,7 @@ header('pin to an unknown alias → 404; malformed alias → 400');
 
 header('upstream API-key mode → pin refused with 409, never served by the key');
 {
-  const PORT2 = 38852;
+  const PORT2 = await freePort();
   const keyCalls = [];
   const keyFetch = async (url, init) => {
     if (String(url).includes('/v1/models')) return fetchImpl(url, init);
@@ -185,7 +186,7 @@ header('a request routed to another provider refuses the pin (409), Codex never 
   // A pin names a Claude POOL seat. Provider routing runs before pool
   // selection, so without the guard a pinned request naming a Codex model
   // would be answered by Codex and report the wrong leg healthy.
-  const PORT3 = 38854;
+  const PORT3 = await freePort();
   await mkdir(join(tmpHome, '.dario', 'codex-accounts'), { recursive: true });
   await writeFile(join(tmpHome, '.dario', 'codex-accounts', 'live.json'), JSON.stringify({
     alias: 'live', accessToken: 'codex-access-token', refreshToken: 'codex-refresh-token',


### PR DESCRIPTION
## Why

`live-test` on the self-hosted runner failed twice today on #1235 (a docs-only PR) with:

```
not ok 107 - pool-exhaustion-midflight-429-wiring.mjs
[dario] Port 38838 is already in use by another process.
```

The test pins `PROXY_PORT = 38838`. Linux hands out ephemeral source ports from 32768–60999, and on the runner box that exact port was taken by a long-lived loopback connection that has nothing to do with dario:

```
ESTAB  127.0.0.1:38838  127.0.0.1:3005  users:(("cloudflared",pid=1202732,fd=8))
```

Until that connection recycles, every PR's required check fails the same way. The same test passes on GitHub-hosted runners and locally, so it read like a flake; it is a deterministic collision with whatever happens to hold the number on a busy host.

## What

Sixteen in-process proxy tests declared 31 fixed ports in that range (two files even shared 38801/38802). Each now takes its port from the kernel:

```js
import { freePort } from './helpers/free-port.mjs';
const PROXY_PORT = await freePort();
```

`test/helpers/free-port.mjs` listens on port 0, reads the assignment, closes, and returns it. The window between release and the proxy's own `listen` is the usual trade-off for a server that has to know its port before it starts; it is microseconds against a collision that lasts hours. It lives in a subdirectory so `all.test.mjs` (top-level `*.mjs` only) does not run it as a test. `openai-backend-passthrough.mjs` and `tui-proxy-client-health.mjs` already did this inline; nothing else changes.

No `src/` change, so no CHANGELOG entry (`check-changelog` diffs `src/`). Verified: every touched file passes on its own and the full `npm test` passes locally.

## Also seen on the runner, not touched here

`ps` on the box shows **170** orphaned `node dist/cli.js proxy --port=NNNNN --passthrough` processes, the oldest 193 hours old, cwd `/root/actions-runner/_work/dario/dario`. That is one leaked proxy per `compat-test-self-hosted` run. They are not what held 38838, but a cleanup step in that workflow (or a `pkill -f` scoped to the runner's workdir in a `post` step) is worth a separate PR; killing them on the box is an operator call.
