### PR TITLE
ci(live-test): stop the probe proxy on every path, and reap what earlier runs left

### DIFF
--- a/.github/workflows/live-test.yml
+++ b/.github/workflows/live-test.yml
@@ -224,32 +224,43 @@ jobs:
         if: always()
         run: |
           set +e -uo pipefail
+          # stop <pid>: TERM the process group (falls back to the pid when it is
+          # not a group leader — an orphan from before setsid), wait up to 10s,
+          # escalate to KILL, wait again. Returns 0 only once the pid is GONE;
+          # a delivered signal is not a stopped process (review on #1240).
+          stop() {
+            local p="$1"
+            kill -TERM -- "-$p" 2>/dev/null || kill -TERM "$p" 2>/dev/null || return 0   # already gone
+            for _ in $(seq 1 10); do kill -0 "$p" 2>/dev/null || return 0; sleep 1; done
+            echo "::warning::dario proxy $p ignored SIGTERM for 10s — sending SIGKILL"
+            kill -KILL -- "-$p" 2>/dev/null || kill -KILL "$p" 2>/dev/null
+            for _ in $(seq 1 5); do kill -0 "$p" 2>/dev/null || return 0; sleep 1; done
+            return 1
+          }
           pidfile="${WT_HOME:-/nonexistent}/proxy.pid"
           if [ -s "$pidfile" ]; then
             pid="$(cat "$pidfile")"
             if kill -0 "$pid" 2>/dev/null; then
-              kill -TERM -- "-$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null
-              for _ in $(seq 1 10); do kill -0 "$pid" 2>/dev/null || break; sleep 1; done
-              if kill -0 "$pid" 2>/dev/null; then
-                echo "::warning::probe proxy $pid ignored SIGTERM for 10s — sending SIGKILL"
-                kill -KILL -- "-$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null
-              fi
+              stop "$pid" || echo "::error::probe proxy $pid survived SIGKILL — the runner needs a look"
             fi
           fi
-          reaped=0
+          reaped=0; survived=0
           for p in $(pgrep -f 'dist/cli\.js proxy' 2>/dev/null); do
             [ "$(ps -o ppid= -p "$p" 2>/dev/null | tr -d ' ')" = "1" ] || continue
             case "$(readlink "/proc/$p/cwd" 2>/dev/null)" in
               "$GITHUB_WORKSPACE"|"$GITHUB_WORKSPACE"/*) ;;
               *) continue ;;
             esac
-            kill -TERM "$p" 2>/dev/null && reaped=$((reaped + 1))
+            if stop "$p"; then reaped=$((reaped + 1)); else survived=$((survived + 1)); echo "::error::orphaned dario proxy $p survived SIGKILL"; fi
           done
-          if [ "$reaped" -gt 0 ]; then
-            echo "::warning::reaped $reaped orphaned dario proxy process(es) from this checkout — something leaked; find the run that started them"
+          if [ "$survived" -gt 0 ]; then
+            echo "::error::$survived orphaned dario proxy process(es) from this checkout could not be stopped"
+          elif [ "$reaped" -gt 0 ]; then
+            echo "::warning::reaped $reaped orphaned dario proxy process(es) from this checkout (confirmed gone) — something leaked; find the run that started them"
           else
             echo "no orphaned proxy processes from this checkout"
           fi
+          [ "$survived" -eq 0 ]
 
       - name: Verdict → one PR comment, and the job's own exit status
         if: always() && steps.pr.outputs.sha != ''

--- a/.github/workflows/live-test.yml
+++ b/.github/workflows/live-test.yml
@@ -172,11 +172,21 @@ jobs:
             echo "live: SKIPPED (no test key configured)" | tee -a "$WT_HOME/report.txt"
             echo "result=skipped" >> "$GITHUB_OUTPUT"; exit 0
           fi
-          run() { env -i PATH="$PATH" HOME="$WT_HOME" TMPDIR="$WT_HOME" LANG=C.UTF-8 DARIO_IGNORE_CC_CREDENTIALS=1 DARIO_CC_PATH="${CC_PATH:-}" CI=1 "$@"; }
           PORT=$((40000 + RANDOM % 20000))
-          run env ANTHROPIC_UPSTREAM_API_KEY="$DARIO_TEST_UPSTREAM_API_KEY" \
+          # Launched directly, NOT through a `run() { env -i … "$@"; }` helper:
+          # a backgrounded shell function is a bash subshell, so `$!` named the
+          # subshell, the `kill` below only ever reached that, and node was
+          # reparented to init and lived on — one per run. 176 of them, 10 GB
+          # RSS, were found on the runner on 2026-09-07 (see #1237's body).
+          # `setsid` gives the proxy its own process group so the stop step can
+          # take out anything it spawns with one group kill (the Bun relaunch
+          # in src/cli.ts keeps a node parent waiting on a bun child).
+          setsid env -i PATH="$PATH" HOME="$WT_HOME" TMPDIR="$WT_HOME" LANG=C.UTF-8 \
+            DARIO_IGNORE_CC_CREDENTIALS=1 DARIO_CC_PATH="${CC_PATH:-}" CI=1 \
+            ANTHROPIC_UPSTREAM_API_KEY="$DARIO_TEST_UPSTREAM_API_KEY" \
             node dist/cli.js proxy --port="$PORT" --passthrough > "$WT_HOME/proxy.log" 2>&1 &
           PROXY_PID=$!
+          echo "$PROXY_PID" > "$WT_HOME/proxy.pid"
           ready=false
           for _ in $(seq 1 30); do
             curl -sf -o /dev/null --max-time 2 "http://127.0.0.1:$PORT/health" && { ready=true; break; }
@@ -194,13 +204,52 @@ jobs:
           else
             echo "proxy never reached /health" > "$WT_HOME/probe.txt"
           fi
-          kill "$PROXY_PID" 2>/dev/null; wait "$PROXY_PID" 2>/dev/null || true
+          # Normal-path stop; the always() step below repeats it for every
+          # other path (probe failure, cancel, timeout) and reports leftovers.
+          kill -TERM -- "-$PROXY_PID" 2>/dev/null || kill -TERM "$PROXY_PID" 2>/dev/null || true
+          wait "$PROXY_PID" 2>/dev/null || true
           case "$result" in
             pong)  echo "live: PASS (pong)" ;;
             error) echo "live: ERROR (upstream rejected the TEST KEY — tooling, not the PR)" ;;
             *)     echo "live: FAIL"; echo "    $(cat "$WT_HOME/probe.txt")"; grep -iE 'upstream auth|template|drift|error' "$WT_HOME/proxy.log" | head -20 | sed 's/^/    /' ;;
           esac | tee -a "$WT_HOME/report.txt"
           echo "result=$result" >> "$GITHUB_OUTPUT"
+
+      # Runs on every path the probe step can end on — failure, cancel, the
+      # job timeout — and is the only teardown that survives them. Reads the
+      # pid the probe wrote, ends that process group, and then sweeps for any
+      # proxy from THIS checkout that has already been reparented to init: a
+      # leftover here means a leak, so it is a warning annotation, not silence.
+      - name: Stop the probe proxy and reap anything it left behind
+        if: always()
+        run: |
+          set +e -uo pipefail
+          pidfile="${WT_HOME:-/nonexistent}/proxy.pid"
+          if [ -s "$pidfile" ]; then
+            pid="$(cat "$pidfile")"
+            if kill -0 "$pid" 2>/dev/null; then
+              kill -TERM -- "-$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null
+              for _ in $(seq 1 10); do kill -0 "$pid" 2>/dev/null || break; sleep 1; done
+              if kill -0 "$pid" 2>/dev/null; then
+                echo "::warning::probe proxy $pid ignored SIGTERM for 10s — sending SIGKILL"
+                kill -KILL -- "-$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null
+              fi
+            fi
+          fi
+          reaped=0
+          for p in $(pgrep -f 'dist/cli\.js proxy' 2>/dev/null); do
+            [ "$(ps -o ppid= -p "$p" 2>/dev/null | tr -d ' ')" = "1" ] || continue
+            case "$(readlink "/proc/$p/cwd" 2>/dev/null)" in
+              "$GITHUB_WORKSPACE"|"$GITHUB_WORKSPACE"/*) ;;
+              *) continue ;;
+            esac
+            kill -TERM "$p" 2>/dev/null && reaped=$((reaped + 1))
+          done
+          if [ "$reaped" -gt 0 ]; then
+            echo "::warning::reaped $reaped orphaned dario proxy process(es) from this checkout — something leaked; find the run that started them"
+          else
+            echo "no orphaned proxy processes from this checkout"
+          fi
 
       - name: Verdict → one PR comment, and the job's own exit status
         if: always() && steps.pr.outputs.sha != ''


### PR DESCRIPTION
## What leaked

One `node dist/cli.js proxy --port=<random> --passthrough` per `live-test` run, reparented to init, cwd `/root/actions-runner/_work/dario/dario`. 176 of them on the runner box by 2026-09-07, 10 GB RSS between them, the oldest from 8 days ago — i.e. since this workflow replaced the agent-driven tester. Killed by hand today (host memory in use 5,986 → 4,365 MB); nothing else on the box was touched.

## Why

The live probe launched the proxy through the scrubbed-environment helper, backgrounded:

```bash
run() { env -i PATH=… "$@"; }
run env ANTHROPIC_UPSTREAM_API_KEY=… node dist/cli.js proxy --port="$PORT" --passthrough > … &
PROXY_PID=$!
…
kill "$PROXY_PID"
```

A backgrounded shell function is a bash subshell, so `$!` named the subshell. `kill` reached that and only that; node was orphaned to init and lived on. dario is not at fault: on the runner, a directly launched proxy exits one second after SIGTERM (`[dario] Shutting down...`). The compat and codex-drift workflows launch directly and tear down properly; they did not leak.

## What changes (live-test.yml only)

- The proxy is launched directly, under `setsid`, so `$!` is node and the proxy owns its process group. The normal-path stop signals the group (`kill -TERM -- -$pid`, falling back to the pid).
- A new `if: always()` step **Stop the probe proxy and reap anything it left behind** runs on every path the probe can end on — failure, cancel, job timeout. It reads the pid file, sends TERM, waits up to 10 s, then KILL, then sweeps for any `dist/cli.js proxy` from **this checkout** whose parent is already init and reaps it. A non-zero reap count is a `::warning::` annotation, so a future leak shows up in the run instead of in `ps` a week later. Scope is deliberately narrow: parent must be init and cwd must be under `$GITHUB_WORKSPACE`, so the production container (`/app`) and a concurrent job's live proxy (parent = its step shell) are never candidates.

The Bun relaunch in `src/cli.ts` keeps a node parent waiting on a `bun` child; the group kill covers that shape too, though the runner has no Bun today.

## Verified

- Direct-launch SIGTERM test on the runner: exits in 1 s.
- Hand cleanup of the 176 orphans with the same predicate (pattern + parent = init + runner cwd): 176 selected, 0 remaining, production proxy untouched.
- This PR's own `live-test` run executes the new step; its log should read `no orphaned proxy processes from this checkout`.

## Not in this PR

A host-level reaper (systemd timer) would be belt-and-braces if a runner crashes mid-job, but that lives in the platform's host scripts, not here.
