### PR TITLE
Refuse a model no provider lists instead of forwarding it to the Claude pool to 404 (#1236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ checklist.
 
 ## [Unreleased]
 
+## [6.0.32] - 2026-09-07
+
+### Fixed
+
+- **A model no provider lists is refused locally instead of forwarded to the Claude pool to 404 (#1236).** The Claude adapter claims any request the Codex and openai adapters decline, so a name none of them lists — a ChatGPT slug the account does not have (`gpt-5.6-terra`), a slug de-listed or missing while discovery is degraded, a typo that belongs to no family (`gtp-5.6-sol`) — went to `api.anthropic.com` verbatim and came back as Anthropic's `404 not_found_error "model: …"`, attributed to whichever seat sent it, after spending a pool request. The router now asks the positive question the failover chain already asks (`isClaudeServableModel`) and answers `400` locally in the endpoint's own wire shape, with `x-dario-upstream-rejection: model_unroutable` and a message naming the providers consulted; under `--verbose` the log line reads `no provider lists <model>; refusing`, so a fleet log can tell it from a real Anthropic model error. Deliberately still forwarded: a `claude-*` name the catalog does not know (the live catalog can lag a brand-new model, and Anthropic's own 404 stays authoritative there), a request under a server-wide `--model`/`--fast-model` override, upstream API-key mode (no pool to protect), and an OpenAI-shape name the legacy `OPENAI_MODEL_MAP` translates.
+- **A dated model id is servable when the catalog knows its short form, and vice versa.** The catalog keeps one spelling per model (the short id when upstream lists both — `normalizeUpstreamIds`), while clients and `--pool-fallback` chains may use either; the servability test compared spellings literally, so a chain entry like `claude-opus-4-8-20260101` was silently skipped. Compared with the date stripped on both sides now; the name is forwarded as written, since Anthropic accepts both forms.
+
 ### Changed
 
 - **proxy: the request body is JSON.parsed once per request again.** The invalid-body guard from #1231 parsed the body to validate it, then the provider-prefix block and the codex model peek each parsed the same bytes a second and third time. The guard's object is now the shared `parsedBody`; no behaviour change, one parse less per request on large prompts (second-read finding on #1231).

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ flowchart LR
 
 The tool doesn't know. The backend doesn't know. dario is the seam.
 
-**The full Claude lineup, autodetected.** Fable 5, Opus 5, Sonnet 5 and Haiku 4.5, plus `[1m]` long-context variants on every family except Haiku, by full id (`claude-opus-5`) or shortcut (`fable` / `opus` / `sonnet` / `haiku`; append `1m` for the long-context form; `opus48` / `opus47` / `opus46` / `sonnet46` pin a generation and never float). `GET /v1/models` reads Anthropic's live catalog (TTL-cached, baked fallback offline), so a new model resolves the day it lands with no dario release, and the model-specific request shape is applied automatically. Families pulled upstream are filtered from both the live catalog and the fallback, so `/v1/models` never advertises a model that 404s.
+**The full Claude lineup, autodetected.** Fable 5, Opus 5, Sonnet 5 and Haiku 4.5, plus `[1m]` long-context variants on every family except Haiku, by full id (`claude-opus-5`) or shortcut (`fable` / `opus` / `sonnet` / `haiku`; append `1m` for the long-context form; `opus48` / `opus47` / `opus46` / `sonnet46` pin a generation and never float). `GET /v1/models` reads Anthropic's live catalog (TTL-cached, baked fallback offline), so a new model resolves the day it lands with no dario release, and the model-specific request shape is applied automatically. Families pulled upstream are filtered from both the live catalog and the fallback, so `/v1/models` never advertises a model that 404s. A name no provider lists at all, such as a ChatGPT slug your account doesn't have or a typo that belongs to no family, is refused locally with `400` and `x-dario-upstream-rejection: model_unroutable` instead of spending a pool request on an upstream 404.
 
 ## Two plans, one endpoint
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.31",
+  "version": "6.0.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "6.0.31",
+      "version": "6.0.32",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.31",
+  "version": "6.0.32",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/claude-model.ts
+++ b/src/claude-model.ts
@@ -84,7 +84,18 @@ function servableTarget(target: string, bases: readonly string[]): string | null
   if (stripped === null) return null;
   const resolved = resolveAliasAgainst(stripped, bases) ?? stripped;
   const base = resolved.endsWith('[1m]') ? resolved.slice(0, -4) : resolved;
-  return bases.some((b) => b.toLowerCase() === base) ? resolved : null;
+  // The catalog keeps ONE spelling per model — the short id when upstream
+  // lists both `claude-opus-4-8` and `claude-opus-4-8-YYYYMMDD` (see
+  // normalizeUpstreamIds) — while a client may send either. Compare with the
+  // date stripped on both sides, and return the name as written: Anthropic
+  // accepts both forms, so the pool forwards whichever the caller chose.
+  const key = undated(base);
+  return bases.some((b) => undated(b.toLowerCase()) === key) ? resolved : null;
+}
+
+/** `claude-opus-4-8-20260101` → `claude-opus-4-8`; anything else unchanged. */
+function undated(id: string): string {
+  return id.replace(/-\d{8}$/, '');
 }
 
 /**

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -23,6 +23,8 @@ import { handleAdminRequest, type AdminAccountLive, type AdminAuditEvent } from 
 import { createTokenBucket } from './rate-limit.js';
 import { getOpenAIBackend, isOpenAIModel, forwardToOpenAI, type BackendCredentials } from './openai-backend.js';
 import { forwardToCodex, getCodexModelSlugs, peekCodexModelSlugs, isCodexModel, pickCodexFallback, pickClaudeTarget, CODEX_BACKEND_BASE_URL } from './codex-backend.js';
+import { isClaudeServableModel } from './claude-model.js';
+import { MODEL_UNROUTABLE } from './upstream-rejection.js';
 import { readCompareTarget, teeResponse, runCompare, writeCompareRecord, COMPARE_RESULT_HEADER } from './compare.js';
 import { listCodexAccountAliases, loadAllCodexAccounts, codexAccountNeedsRefresh, hasAnyCodexAccount, selectCodexAccount, getFreshCodexAccount, getCodexRefreshFailure, CodexCredentialsUnavailableError, type CodexAccountCredentials } from './codex-accounts.js';
 import { route as routeProvider } from './provider-adapter.js';
@@ -3478,6 +3480,41 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
               req, res, body, openaiBackend, corsOrigin, SECURITY_HEADERS,
               upstreamTimeoutMs, verbose,
             );
+            return;
+          }
+          // dario#1236 — the Claude adapter claims by default, so a model NO
+          // provider lists used to reach api.anthropic.com verbatim and come
+          // back as Anthropic's 404 `model: gpt-5.6-sol`, attributed to
+          // whichever seat sent it, after spending a pool request. Ask the
+          // positive question the failover chain already asks (claude-model.ts)
+          // and refuse locally instead.
+          //
+          // Deliberately NOT refused: a `claude-*` name the catalog does not
+          // know (the live catalog can lag a model by a fetch, and on a cold
+          // start it is the baked list — Anthropic's own 404 stays
+          // authoritative for those); a request under a server-wide
+          // --model/--fast-model override, which replaces the name; upstream
+          // API-key mode, which has no pool to protect and may reach models the
+          // OAuth catalog never lists; and an OpenAI-shape name the legacy
+          // OPENAI_MODEL_MAP translates to a Claude model.
+          if (rawModel && decision.provider === 'claude' && !upstreamApiKey && !modelOverride && !fastModelOverride
+            && !(isOpenAI && OPENAI_MODEL_MAP[rawModel])
+            && !/^claude-/i.test(rawModel.trim())
+            && !isClaudeServableModel(rawModel, getCachedBases(), (m) => resolveClaudeAlias(applyModelAlias(m, modelAliases) ?? m))) {
+            const consulted = [
+              codexCreds || codexUnavailable
+                ? `codex account ${(codexCreds ?? codexUnavailable)!.alias} (${codexModels.length} listed slug${codexModels.length === 1 ? '' : 's'})`
+                : 'no codex account',
+              openaiBackend ? `openai backend ${openaiBackend.name}${isOpenAI ? '' : ' (OpenAI path only)'}` : 'no openai backend',
+              `claude catalog (${getCachedBases().length} bases)`,
+            ].join(', ');
+            if (verbose) console.log(`[dario] #${requestCount} ${req.method} ${urlPath} (model: ${rawModel}) no provider lists ${rawModel}; refusing — consulted ${consulted}`);
+            requestCount++;
+            const message = `no provider lists model "${rawModel}" (consulted ${consulted}); refused locally rather than forwarded to the Claude pool, which would 404 it after spending a request`;
+            res.writeHead(400, { ...JSON_HEADERS, 'x-dario-upstream-rejection': MODEL_UNROUTABLE });
+            res.end(JSON.stringify(isOpenAI
+              ? { error: { message, type: 'invalid_request_error', param: 'model', code: 'model_not_found' } }
+              : { type: 'error', error: { type: 'invalid_request_error', message } }));
             return;
           }
         } catch { /* not JSON — fall through to existing path */ }

--- a/src/upstream-rejection.ts
+++ b/src/upstream-rejection.ts
@@ -5,6 +5,15 @@ export interface UpstreamRejection {
   marker: 'billing_required' | 'rate_limited' | 'credential_rejected' | 'upstream_rejected';
 }
 
+/**
+ * `x-dario-upstream-rejection` value for a request dario refused LOCALLY
+ * because no provider lists its model (dario#1236). Not a classification of
+ * an upstream answer — there was no upstream request, which is the point — but
+ * it rides the same header so a fleet log or tracker reads one field for
+ * every "this request was not served" verdict.
+ */
+export const MODEL_UNROUTABLE = 'model_unroutable';
+
 /** Classify subscription entitlement failures separately from temporary quota exhaustion. */
 export function classifyUpstreamRejection(status: number, body: string): UpstreamRejection {
   const normalized = body.toLowerCase();

--- a/test/claude-model-dated-ids.mjs
+++ b/test/claude-model-dated-ids.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// claude-model.ts: a dated id is servable when the catalog knows its short
+// form, and vice versa. The catalog keeps one spelling per model (the short id
+// when upstream lists both — normalizeUpstreamIds), while clients send either;
+// before dario#1236 the servability test compared spellings literally, so a
+// failover chain entry like `claude-opus-4-8-20260101` was silently skipped and
+// the new local model-unroutable refusal would have refused a valid request.
+
+import { isClaudeServableModel, resolveClaudeServable, resolveClaudeTarget } from '../dist/claude-model.js';
+
+let pass = 0, fail = 0;
+const check = (name, cond, detail) => {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else { console.log(`  FAIL ${name}${detail ? ' :: ' + detail : ''}`); fail++; }
+};
+
+const bases = ['claude-opus-5', 'claude-opus-4-8', 'claude-sonnet-5'];
+
+console.log('\n=== dated request against a short-id catalog ===');
+check('claude-opus-4-8-20260101 is servable', isClaudeServableModel('claude-opus-4-8-20260101', bases));
+check('…and is forwarded as written (Anthropic accepts the dated form)',
+  resolveClaudeServable('claude-opus-4-8-20260101', bases) === 'claude-opus-4-8-20260101',
+  resolveClaudeServable('claude-opus-4-8-20260101', bases));
+check('dated + [1m]', resolveClaudeServable('claude-opus-4-8-20260101[1m]', bases) === 'claude-opus-4-8-20260101[1m]');
+check('dated behind a claude: prefix', resolveClaudeServable('claude:claude-opus-4-8-20260101', bases) === 'claude-opus-4-8-20260101');
+// The bare `-high` spelling (what Cursor sends) and the prefixed `claude:…:high`
+// form are the two effort spellings resolveClaudeTarget accepts; a bare
+// `name:high` reads its colon as a provider prefix and always did.
+check('dated with an effort suffix keeps the effort',
+  JSON.stringify(resolveClaudeTarget('claude-opus-4-8-20260101-high', bases)) === JSON.stringify({ model: 'claude-opus-4-8-20260101', effort: 'high' }),
+  JSON.stringify(resolveClaudeTarget('claude-opus-4-8-20260101-high', bases)));
+check('…and behind a claude: prefix with the colon form',
+  JSON.stringify(resolveClaudeTarget('claude:claude-opus-4-8-20260101:high', bases)) === JSON.stringify({ model: 'claude-opus-4-8-20260101', effort: 'high' }),
+  JSON.stringify(resolveClaudeTarget('claude:claude-opus-4-8-20260101:high', bases)));
+
+console.log('\n=== short request against a dated-only catalog (upstream listed only the dated form) ===');
+const datedOnly = ['claude-opus-5', 'claude-sonnet-4-6-20260115'];
+check('claude-sonnet-4-6 is servable', isClaudeServableModel('claude-sonnet-4-6', datedOnly));
+check('…forwarded as written', resolveClaudeServable('claude-sonnet-4-6', datedOnly) === 'claude-sonnet-4-6');
+
+console.log('\n=== the date rule does not widen anything else ===');
+check('a typo stays unservable', !isClaudeServableModel('claude-sonnet-6', bases));
+check('a date on an unknown base stays unservable', !isClaudeServableModel('claude-sonnet-6-20260101', bases));
+check('a non-8-digit suffix is not a date', !isClaudeServableModel('claude-opus-4-8-2026', bases));
+check('a gpt slug stays unservable', !isClaudeServableModel('gpt-5.6-sol', bases));
+check('short id against a short-id catalog still resolves', resolveClaudeServable('claude-opus-4-8', bases) === 'claude-opus-4-8');
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/test/model-unroutable.mjs
+++ b/test/model-unroutable.mjs
@@ -34,7 +34,7 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // Kernel-assigned so no other process or test file can hold it (helpers/free-port.mjs).
 const PROXY_PORT = await freePort();
-const APIKEY_PROXY_PORT = await freePort();
+const BYPASS_POOL_PROXY_PORT = await freePort();
 const OVERRIDE_PROXY_PORT = await freePort();
 const CODEX_PORT = await freePort();
 
@@ -120,9 +120,9 @@ const fakeFetch = async (url, init) => {
 
 const common = { host: '127.0.0.1', verbose: false, noLiveCapture: true, fetchImpl: fakeFetch };
 await startProxy({ ...common, port: PROXY_PORT, modelAliases: { 'my-fast': 'claude-haiku-4-5' } });
-await startProxy({ ...common, port: APIKEY_PROXY_PORT, upstreamApiKey: 'sk-ant-test-key' });
+await startProxy({ ...common, port: BYPASS_POOL_PROXY_PORT, upstreamApiKey: 'sk-ant-test-key' });
 await startProxy({ ...common, port: OVERRIDE_PROXY_PORT, model: 'claude-haiku-4-5' });
-for (const port of [PROXY_PORT, APIKEY_PROXY_PORT, OVERRIDE_PROXY_PORT]) {
+for (const port of [PROXY_PORT, BYPASS_POOL_PROXY_PORT, OVERRIDE_PROXY_PORT]) {
   for (let i = 0; i < 50; i++) {
     try { await fetch(`http://127.0.0.1:${port}/health`); break; } catch { await sleep(100); }
   }
@@ -222,7 +222,7 @@ header('still forwarded: a claude-* name the catalog does not know — Anthropic
 header('exempt: upstream API-key mode and a server-wide --model override refuse nothing');
 {
   const before = anthropic.calls;
-  const k = await post(APIKEY_PROXY_PORT, '/v1/messages', UNLISTED_SLUG);
+  const k = await post(BYPASS_POOL_PROXY_PORT, '/v1/messages', UNLISTED_SLUG);
   check('api-key mode forwards the unlisted name (upstream decides)', anthropic.calls === before + 1 && k.marker !== 'model_unroutable', `calls ${before}→${anthropic.calls} ${k.status} ${k.marker}`);
   const o = await post(OVERRIDE_PROXY_PORT, '/v1/messages', UNLISTED_SLUG);
   check('--model override serves it as the override', o.status === 200 && anthropic.models[anthropic.models.length - 1] === 'claude-haiku-4-5', `${o.status} last=${anthropic.models[anthropic.models.length - 1]}`);

--- a/test/model-unroutable.mjs
+++ b/test/model-unroutable.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+// dario#1236 — a model NO provider lists is refused locally with 400 and
+// `x-dario-upstream-rejection: model_unroutable`, in the endpoint's own wire
+// shape, without spending a pool request. Before this the Claude adapter's
+// unconditional default claim forwarded `gpt-5.6-terra` (a slug the Codex
+// account does not list) to api.anthropic.com verbatim, and the client got
+// Anthropic's 404 `model: gpt-5.6-terra` attributed to whichever seat sent it.
+//
+// The refusal is narrow on purpose, and every exemption is asserted here:
+// servable names in each spelling still reach the pool (canonical, family
+// shorthand, `[1m]`, `claude:` prefix, dated id, operator alias); a listed
+// codex slug still reaches the subscription; an OpenAI-shape name the legacy
+// OPENAI_MODEL_MAP translates is still served; a `claude-*` name the catalog
+// does not know is still forwarded (Anthropic's 404 is authoritative there —
+// the live catalog can lag a brand-new model); and a proxy in upstream API-key
+// mode or under a server-wide --model override refuses nothing.
+//
+// Hermetic: real proxies on loopback, HOME in a mkdtemp'd dir with one pool
+// seat and one codex account, a local codex stub, fetchImpl for Anthropic.
+
+import { createServer } from 'node:http';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { freePort } from './helpers/free-port.mjs';
+
+let pass = 0, fail = 0;
+const check = (name, cond, detail) => {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else { console.log(`  FAIL ${name}${detail ? ' :: ' + detail : ''}`); fail++; }
+};
+const header = (n) => console.log(`\n=== ${n} ===`);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Kernel-assigned so no other process or test file can hold it (helpers/free-port.mjs).
+const PROXY_PORT = await freePort();
+const APIKEY_PROXY_PORT = await freePort();
+const OVERRIDE_PROXY_PORT = await freePort();
+const CODEX_PORT = await freePort();
+
+const LISTED_SLUG = 'gpt-5.6-sol';
+const UNLISTED_SLUG = 'gpt-5.6-terra';
+
+// ── stub ChatGPT backend: /models discovery + /responses SSE ───────────────
+const codexSeen = { models: 0, responses: 0 };
+const codexStub = createServer((req, res) => {
+  if (req.url.startsWith('/models')) {
+    codexSeen.models++;
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ models: [{ slug: LISTED_SLUG, visibility: 'list' }] }));
+    return;
+  }
+  if (req.url.startsWith('/responses')) {
+    codexSeen.responses++;
+    req.on('data', () => {});
+    req.on('end', () => {
+      res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+      res.write('data: {"type":"response.created","response":{"id":"resp_1"}}\n\n');
+      res.write('data: {"type":"response.output_text.delta","delta":"hi from codex"}\n\n');
+      res.write('data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1}}}\n\n');
+      res.end();
+    });
+    return;
+  }
+  res.writeHead(404).end();
+});
+await new Promise((r) => codexStub.listen(CODEX_PORT, '127.0.0.1', r));
+
+const tmpHome = await mkdtemp(join(tmpdir(), 'dario-unroutable-'));
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+process.env.DARIO_CODEX_BASE_URL = `http://127.0.0.1:${CODEX_PORT}`;
+delete process.env.ANTHROPIC_UPSTREAM_API_KEY;
+
+await mkdir(join(tmpHome, '.dario', 'accounts'), { recursive: true });
+await writeFile(join(tmpHome, '.dario', 'accounts', 'main.json'), JSON.stringify({
+  alias: 'main', accessToken: 'claude-access-token', refreshToken: 'claude-refresh-token',
+  expiresAt: Date.now() + 6 * 3_600_000, scopes: ['user:inference'], deviceId: 'dev-1', accountUuid: 'uuid-1',
+}));
+await mkdir(join(tmpHome, '.dario', 'codex-accounts'), { recursive: true });
+await writeFile(join(tmpHome, '.dario', 'codex-accounts', 'live.json'), JSON.stringify({
+  alias: 'live', accessToken: 'codex-access-token', refreshToken: 'codex-refresh-token', expiresAt: Date.now() + 6 * 3_600_000,
+}));
+
+const { startProxy } = await import('../dist/proxy.js');
+
+// ── fake Anthropic: a catalog, a 200 for known models, Anthropic's own 404 otherwise ──
+const CATALOG = ['claude-opus-5', 'claude-sonnet-5', 'claude-haiku-4-5', 'claude-opus-4-8'];
+const anthropic = { calls: 0, models: [] };
+const fakeFetch = async (url, init) => {
+  const target = String(url);
+  if (target.includes('/v1/models')) {
+    return new Response(JSON.stringify({ data: CATALOG.map((id) => ({ id, type: 'model' })) }), {
+      status: 200, headers: { 'content-type': 'application/json' },
+    });
+  }
+  if (!target.includes('/v1/messages')) {
+    return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+  }
+  anthropic.calls++;
+  let model = '?';
+  try {
+    // dario hands fetch a Buffer (or a stream), not a string.
+    const raw = typeof init?.body === 'string' ? init.body : await new Response(init?.body ?? '').text();
+    model = JSON.parse(raw || '{}').model ?? '?';
+  } catch { /* keep ? — the checks below report it */ }
+  anthropic.models.push(model);
+  const known = CATALOG.includes(model.replace(/\[1m\]$/, '').replace(/-\d{8}$/, ''));
+  if (!known) {
+    return new Response(JSON.stringify({ type: 'error', error: { type: 'not_found_error', message: `model: ${model}` } }), {
+      status: 404, headers: { 'content-type': 'application/json' },
+    });
+  }
+  return new Response(JSON.stringify({
+    id: 'msg_1', type: 'message', role: 'assistant', model,
+    content: [{ type: 'text', text: `served as ${model}` }], stop_reason: 'end_turn',
+    usage: { input_tokens: 1, output_tokens: 1 },
+  }), { status: 200, headers: { 'content-type': 'application/json' } });
+};
+
+const common = { host: '127.0.0.1', verbose: false, noLiveCapture: true, fetchImpl: fakeFetch };
+await startProxy({ ...common, port: PROXY_PORT, modelAliases: { 'my-fast': 'claude-haiku-4-5' } });
+await startProxy({ ...common, port: APIKEY_PROXY_PORT, upstreamApiKey: 'sk-ant-test-key' });
+await startProxy({ ...common, port: OVERRIDE_PROXY_PORT, model: 'claude-haiku-4-5' });
+for (const port of [PROXY_PORT, APIKEY_PROXY_PORT, OVERRIDE_PROXY_PORT]) {
+  for (let i = 0; i < 50; i++) {
+    try { await fetch(`http://127.0.0.1:${port}/health`); break; } catch { await sleep(100); }
+  }
+}
+
+const post = async (port, path, model) => {
+  const isOpenAI = path === '/v1/chat/completions';
+  const body = isOpenAI
+    ? { model, messages: [{ role: 'user', content: 'ping' }] }
+    : { model, max_tokens: 16, messages: [{ role: 'user', content: 'ping' }] };
+  const res = await fetch(`http://127.0.0.1:${port}${path}`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  let json = null;
+  try { json = JSON.parse(text); } catch { /* the checks report it */ }
+  return { status: res.status, marker: res.headers.get('x-dario-upstream-rejection'), json, text };
+};
+
+header('refused locally: a model no provider lists, on both wire shapes');
+{
+  const before = { anthropic: anthropic.calls, codex: codexSeen.responses };
+  const a = await post(PROXY_PORT, '/v1/messages', UNLISTED_SLUG);
+  check('/v1/messages → 400', a.status === 400, `${a.status} ${a.text.slice(0, 200)}`);
+  check('marker header names the verdict', a.marker === 'model_unroutable', String(a.marker));
+  check('Anthropic wire shape: {type:"error", error:{type, message}}',
+    a.json?.type === 'error' && a.json?.error?.type === 'invalid_request_error' && typeof a.json?.error?.message === 'string', a.text.slice(0, 200));
+  check('message names the model and what was consulted',
+    (a.json?.error?.message ?? '').includes(UNLISTED_SLUG) && /codex account live \(1 listed slug\)/.test(a.json?.error?.message ?? ''), a.json?.error?.message);
+
+  const o = await post(PROXY_PORT, '/v1/chat/completions', UNLISTED_SLUG);
+  check('/v1/chat/completions → 400', o.status === 400, `${o.status} ${o.text.slice(0, 200)}`);
+  check('OpenAI wire shape: {error:{message, type, param:"model", code}}',
+    typeof o.json?.error?.message === 'string' && o.json?.error?.param === 'model' && o.json?.error?.code === 'model_not_found', o.text.slice(0, 200));
+  check('marker header on the OpenAI shape too', o.marker === 'model_unroutable', String(o.marker));
+
+  const t = await post(PROXY_PORT, '/v1/messages', 'gtp-5.6-sol');
+  check('a typo that belongs to no family is refused too', t.status === 400 && t.marker === 'model_unroutable', `${t.status} ${t.marker}`);
+
+  check('no pool request was spent', anthropic.calls === before.anthropic, `calls ${before.anthropic} → ${anthropic.calls}`);
+  check('the subscription was not asked either', codexSeen.responses === before.codex, `responses ${before.codex} → ${codexSeen.responses}`);
+}
+
+header('still served: every servable spelling reaches the pool as the right id');
+{
+  const cases = [
+    ['claude-sonnet-5', 'claude-sonnet-5'],
+    ['claude:opus', 'claude-opus-5'],
+    ['claude:sonnet1m', 'claude-sonnet-5[1m]'],
+    ['anthropic:claude-opus-4-8', 'claude-opus-4-8'],
+    ['claude-opus-4-8-20260101', 'claude-opus-4-8-20260101'],
+    ['my-fast', 'claude-haiku-4-5'],
+  ];
+  for (const [asked, forwarded] of cases) {
+    const before = anthropic.calls;
+    const r = await post(PROXY_PORT, '/v1/messages', asked);
+    check(`${asked} → 200`, r.status === 200, `${r.status} ${r.text.slice(0, 160)}`);
+    check(`${asked} reached the pool as ${forwarded}`,
+      anthropic.calls === before + 1 && anthropic.models[anthropic.models.length - 1] === forwarded,
+      `calls ${before}→${anthropic.calls} last=${anthropic.models[anthropic.models.length - 1]}`);
+  }
+  // A bare family shorthand in the body (`opus`, no prefix) is servable by the
+  // resolver, so it is NOT refused — and, as before this change, the Claude
+  // path forwards it as written (only the `claude:` prefix and --model resolve
+  // shorthands). That gap is pre-existing and out of scope here; this pins
+  // that the refusal does not touch it either way.
+  for (const asked of ['opus', 'sonnet1m']) {
+    const before = anthropic.calls;
+    const r = await post(PROXY_PORT, '/v1/messages', asked);
+    check(`${asked} (bare shorthand) is not refused — forwarded for upstream to answer`,
+      r.marker !== 'model_unroutable' && anthropic.calls === before + 1 && anthropic.models[anthropic.models.length - 1] === asked,
+      `${r.status} ${r.marker} calls ${before}→${anthropic.calls} last=${anthropic.models[anthropic.models.length - 1]}`);
+  }
+}
+
+header('still served: a listed codex slug, and an OpenAI-shape name the legacy map translates');
+{
+  const before = { anthropic: anthropic.calls, codex: codexSeen.responses };
+  const c = await post(PROXY_PORT, '/v1/chat/completions', LISTED_SLUG);
+  check(`${LISTED_SLUG} → 200 from the subscription`, c.status === 200 && c.text.includes('hi from codex'), `${c.status} ${c.text.slice(0, 160)}`);
+  check('codex stub answered it', codexSeen.responses === before.codex + 1, `${before.codex}→${codexSeen.responses}`);
+  const m = await post(PROXY_PORT, '/v1/chat/completions', 'gpt-5.4');
+  check('gpt-5.4 on chat/completions → OPENAI_MODEL_MAP → the pool (200)', m.status === 200, `${m.status} ${m.text.slice(0, 160)}`);
+  check('…forwarded as claude-opus-4-8', anthropic.models[anthropic.models.length - 1] === 'claude-opus-4-8', anthropic.models[anthropic.models.length - 1]);
+}
+
+header('still forwarded: a claude-* name the catalog does not know — Anthropic answers');
+{
+  const before = anthropic.calls;
+  const r = await post(PROXY_PORT, '/v1/messages', 'claude-sonnet-6');
+  check('forwarded, not refused locally', anthropic.calls === before + 1, `calls ${before}→${anthropic.calls}`);
+  check('the upstream 404 comes back as the answer', r.status === 404 && r.marker !== 'model_unroutable', `${r.status} ${r.marker} ${r.text.slice(0, 120)}`);
+}
+
+header('exempt: upstream API-key mode and a server-wide --model override refuse nothing');
+{
+  const before = anthropic.calls;
+  const k = await post(APIKEY_PROXY_PORT, '/v1/messages', UNLISTED_SLUG);
+  check('api-key mode forwards the unlisted name (upstream decides)', anthropic.calls === before + 1 && k.marker !== 'model_unroutable', `calls ${before}→${anthropic.calls} ${k.status} ${k.marker}`);
+  const o = await post(OVERRIDE_PROXY_PORT, '/v1/messages', UNLISTED_SLUG);
+  check('--model override serves it as the override', o.status === 200 && anthropic.models[anthropic.models.length - 1] === 'claude-haiku-4-5', `${o.status} last=${anthropic.models[anthropic.models.length - 1]}`);
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+codexStub.close();
+process.exit(fail === 0 ? 0 : 1);

--- a/test/model-unroutable.mjs
+++ b/test/model-unroutable.mjs
@@ -171,7 +171,9 @@ header('still served: every servable spelling reaches the pool as the right id')
   const cases = [
     ['claude-sonnet-5', 'claude-sonnet-5'],
     ['claude:opus', 'claude-opus-5'],
-    ['claude:sonnet1m', 'claude-sonnet-5[1m]'],
+    // `[1m]` is a client-side label: the Claude path strips it and rides the
+    // context-1m beta instead, so the pool sees the base id.
+    ['claude:sonnet1m', 'claude-sonnet-5'],
     ['anthropic:claude-opus-4-8', 'claude-opus-4-8'],
     ['claude-opus-4-8-20260101', 'claude-opus-4-8-20260101'],
     ['my-fast', 'claude-haiku-4-5'],


### PR DESCRIPTION
Closes #1236.

## The bug

`claudeAdapter.claimsPrimary()` returns true unconditionally, so a model that neither the Codex account lists nor the Claude catalog knows was forwarded to `api.anthropic.com` verbatim. The client got Anthropic's `404 not_found_error "model: gpt-5.6-terra"` with an upstream request id, attributed to whichever seat sent it, after spending a pool request. The fleet hit that shape on 2026-08-29 (four executions) for causes fixed since; the fall-through itself was unchanged on master `ed7460a`.

## The fix

In the routing block, after the codex and openai adapters have declined and the decision is the Claude default, ask the positive question the failover chain already asks — `isClaudeServableModel(model, getCachedBases(), <the proxy's own resolver>)` — and refuse locally:

- `400`, in the endpoint's own wire shape (`{type:"error",error:{type:"invalid_request_error",…}}` on `/v1/messages`; `{error:{message,type,param:"model",code:"model_not_found"}}` on `/v1/chat/completions`), with `x-dario-upstream-rejection: model_unroutable`
- the message names what was consulted: `codex account live (1 listed slug), no openai backend, claude catalog (8 bases)`
- under `--verbose`: `no provider lists <model>; refusing — consulted …`, so a fleet log can tell it from a real Anthropic model error
- no upstream request, no pool seat touched

**Deliberately not refused**, each asserted in the test:
- a `claude-*` name the catalog does not know (`claude-sonnet-6`): still forwarded. The live catalog can lag a brand-new model by a fetch and is the baked list on a cold start; Anthropic's own 404 stays authoritative for those. The issue's strict reading would refuse typos too; I chose the pool-quota win without the new-model-day risk. Easy to tighten later if the catalog gains a freshness signal.
- a request under a server-wide `--model` / `--fast-model` override (the name is replaced anyway)
- upstream API-key mode (no pool to protect; an API key may reach models the OAuth catalog never lists)
- an OpenAI-shape name the legacy `OPENAI_MODEL_MAP` translates (`gpt-5.4` → `claude-opus-4-8`)

## Also fixed on the way, because the refusal would have hit it

`isClaudeServableModel` compared spellings literally, while the catalog keeps one spelling per model (the short id when upstream lists both, `normalizeUpstreamIds`). So a dated id like `claude-opus-4-8-20260101` — which Anthropic accepts — was "unservable": a `--pool-fallback` chain entry spelled that way was silently skipped, and the new refusal would have rejected a valid request. `claude-model.ts` now compares with the date stripped on both sides and forwards the name as written. Unit test: `test/claude-model-dated-ids.mjs`.

## Tests

`test/model-unroutable.mjs` — three real proxies on loopback (pool seat + codex stub; upstream API-key mode; `--model` override), fake Anthropic that answers the catalog and 404s unknown ids the way the real one does. Refused on both shapes with no pool request spent; every servable spelling still reaches the pool as the right id (canonical, `claude:opus`, `claude:sonnet1m`, `anthropic:` prefix, dated id, operator alias); a listed codex slug still reaches the subscription; the OPENAI_MODEL_MAP path still works; the unknown `claude-*` name is still forwarded; the two exempt proxies refuse nothing. 32 assertions. Full suite 178/178.

One thing the test pins without changing: a **bare** family shorthand in the body (`opus`, no prefix) is forwarded as written — only the `claude:` prefix and `--model` resolve shorthands today. Pre-existing, separate from this issue, noted so nobody reads the README's "or shortcut" as covering the bare form.

## Release

Ships as **6.0.32** (package.json, lockfile, CHANGELOG heading promoted; preflight clean). If a drift-bot bump lands first I will re-slot.
