### PR TITLE
A seat parked on a 429 says so: reset, rejection count, reading age, a log line; a re-grant starts the seat fresh (#1244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ checklist.
 
 ## [Unreleased]
 
+## [6.0.33] - 2026-09-07
+
+### Fixed
+
+- **A seat parked on a 429 now says so: on what reading, until when, and that it was tried (#1244).** Reported on a six-seat pool: one seat listed as `util5h: 1.04, claim: five_hour, status: rejected, request_count: 0` while the operator's usage page for it read 0%, and the only thing that cleared it was a re-login. Every field was true — that seat's organization had answered the seat's first request with 429 at 104% of its five-hour window — but nothing said so. With a peer to fail over to the client saw 200 and the proxy logged nothing about the seat; the listing carried no reset and no reading age; and `request_count` stayed at 0 because a 429 serves nothing and only served requests were counted, which made the rejection read as one dario had invented. Now the proxy logs `rate limited (429) on account "<alias>": 5h 104%, 7d 25%, claim five_hour, resets in 37m — parked until the window rolls` the moment a seat leaves rotation (once per parking; the re-probes the all-exhausted fallback makes stay `-v`); `GET /accounts` carries `resetAt` / `resetInMs` (when the rejection lifts — for an `allowed` seat, when its representative window rolls) and `rejectedCount` / `lastRejectedAt`; `GET /admin/accounts` carries the same as `reset_at` / `reset_in_ms` / `rejected_count` / `last_rejected_at`, plus the `last_observed_at` / `util_age_ms` reading age that #1032 added to `GET /accounts` and this surface's own mapper dropped; the TUI accounts tab shows `rejected 37m`. The status vocabulary — `allowed`, `rejected`, `unknown`, `auth-cooldown` — and what to do about each is written down in [multi-account-pool.md](./docs/multi-account-pool.md#reading-a-seats-status).
+- **A re-login under an existing alias starts the seat fresh.** The pool's hot reload after `POST /admin/login/complete` (any reconcile, in fact) kept the alias's live state for the new credential — its rate-limit reading and rejection, its auth cool-down and failure streak, its identity — so a seat re-granted to clear `auth-cooldown` stayed cooling until the old streak's timer ran out (up to 30 minutes), and one re-granted on a different organization stayed parked on the old organization's window. A record whose `grantedAt` differs from the live entry's now resets that state and takes the record's own identity; a reconcile carrying the same grant (a token refresh, an admin change to another seat, a peer instance's rotation in HA) keeps it, as before, and so does a record that states no grant at all.
+
 ## [6.0.32] - 2026-09-07
 
 ### Fixed

--- a/docs/admin-api.md
+++ b/docs/admin-api.md
@@ -95,12 +95,20 @@ All endpoints accept the token as `authorization: Bearer <token>` or
 | `DELETE /admin/accounts/<alias>` | — | `{ alias, removed }` (`404` if no such alias) |
 
 `GET /admin/accounts` is the monitoring surface: each entry carries the
-persisted metadata (`alias`, `scopes`, `expires_in_ms`) **plus live pool
-status whenever pool mode is active** — `util5h` / `util7d` utilization,
-representative `claim` (e.g. `five_hour`), routing `status`,
-`request_count`, and `consecutive_auth_failures`. It's the admin-token-gated
-equivalent of the proxy-key-gated `GET /accounts` pool view; a headless
-operator needs only the admin token to watch headroom.
+persisted metadata (`alias`, `scopes`, `expires_in_ms`, the grant-age fields)
+**plus live pool status whenever pool mode is active** — `util5h` / `util7d`
+utilization with `last_observed_at` / `util_age_ms` (how old that reading is;
+it does not tick while a seat is parked), `reset_at` / `reset_in_ms` (when
+the window it was measured against rolls — for a `rejected` seat, when the
+rejection lifts), representative `claim` (e.g. `five_hour`), routing
+`status`, `request_count` (requests served), `rejected_count` /
+`last_rejected_at` (429s answered — a 429 serves nothing, so it is not a
+request), and `consecutive_auth_failures`. What each `status` means and what
+to do about it: [Reading a seat's `status`](./multi-account-pool.md#reading-a-seats-status).
+It's the admin-token-gated equivalent of the proxy-key-gated `GET /accounts`
+pool view; a headless operator needs only the admin token to watch headroom.
+Completing a login for an alias that is already in the pool re-grants it: the
+seat starts fresh — no carried-over rejection, cool-down or identity.
 
 ## Pinning a request to one seat
 

--- a/docs/multi-account-pool.md
+++ b/docs/multi-account-pool.md
@@ -91,6 +91,19 @@ curl http://localhost:3456/accounts     # per-account utilization, claim, sticky
 curl http://localhost:3456/analytics    # per-account / per-model stats, burn rate, exhaustion predictions
 ```
 
+## Reading a seat's `status`
+
+`GET /accounts` (and the admin API's `GET /admin/accounts`, in snake_case) report one `status` per seat. It is the routing verdict, and every value comes with the fields that explain it.
+
+| `status` | What it means | What to do |
+|---|---|---|
+| `allowed` | The seat's last response was a 200 with headroom. `util5h` / `util7d` are that response's reading — a ratio against 1.0, so `0.42` is 42% — `lastObservedAt` / `utilAgeMs` say how old it is, `resetAt` / `resetInMs` when its representative window rolls. | Nothing. |
+| `rejected` | The seat's last response was a 429: the organization behind its token is over the window named by `claim` (`five_hour`, `seven_day`, …). `util5h: 1.04` is 104% of the five-hour window, not 1%. `rejectedCount` / `lastRejectedAt` say the seat was tried — a 429 serves nothing, so `requestCount` does not move — and `resetInMs` says how long it stays parked. Requests route around it; it returns on its own when the window rolls. | Nothing — the window clears itself. If the reading surprises you (your usage page for that account says 0%), the token belongs to a different organization than the page you are looking at, or to the same organization as another seat: the reading is Anthropic's own, taken on that token. `dario accounts check <alias>` asks the seat directly. |
+| `unknown` | No current observation: a seat that has served nothing yet, or a rejection whose window has rolled (`resetInMs: 0`) and that nothing has measured since. | Nothing; the next request measures it. |
+| `auth-cooldown` | Upstream answered 401/403 or `invalid_grant`. `consecutiveAuthFailures` tells a blip (1) from a dead refresh token (a streak); the cool-down doubles with the streak, from 1 minute to 30. | A streak means re-grant the seat — `dario accounts remove` + `add`, or the admin login flow under the same alias. A new grant starts the seat fresh: no carried-over cool-down, rejection or identity. See [Refresh-token grant age](#refresh-token-grant-age) for the 28-day wall behind most streaks. |
+
+The proxy logs every parking as it happens, once per window: `rate limited (429) on account "spare": 5h 104%, 7d 25%, claim five_hour, resets in 37m — parked until the window rolls`. The re-probes the all-exhausted fallback makes of an already-parked seat are logged only under `-v`.
+
 Every request carries a `billingBucket` field (`subscription` / `subscription_fallback` / `extra_usage` / `api` / `unknown`) so you can see which bucket each request billed against and a `subscriptionPercent` headline number tells you at a glance whether dario is actually routing through your subscription or silently falling to API overage.
 
 ## Refresh-token grant age

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.32",
+  "version": "6.0.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "6.0.32",
+      "version": "6.0.33",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.32",
+  "version": "6.0.33",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/admin-api.ts
+++ b/src/admin-api.ts
@@ -40,9 +40,10 @@
  * writes behind one HTTP request.
  *
  * `GET /admin/accounts` reports each account's persisted metadata — alias,
- * scopes, token expiry — plus its live pool status (5h/7d utilization,
- * representative-claim, routing status, request count, consecutive auth
- * failures) when the proxy supplies a `poolStatus` snapshot, which it does
+ * scopes, token expiry — plus its live pool status (5h/7d utilization and
+ * how old that reading is, when its window resets, representative-claim,
+ * routing status, request and rejection counts, consecutive auth failures)
+ * when the proxy supplies a `poolStatus` snapshot, which it does
  * whenever pool mode is active. It's the headless, admin-token-gated
  * equivalent of the `GET /accounts` pool view.
  *
@@ -102,9 +103,24 @@ export interface AdminAccountLive {
   lastObservedAt: number | null;
   /** Age of that reading in ms, or `null` when never observed. */
   utilAgeMs: number | null;
+  /**
+   * When the window that reading was measured against rolls over — epoch ms
+   * and ms-from-now — or `null` when no response has stated one. For a
+   * `rejected` seat this is when the rejection lifts (dario#1244).
+   */
+  resetAt: number | null;
+  resetInMs: number | null;
   claim: string;
   status: string;
   requestCount: number;
+  /**
+   * Upstream 429s this account answered. `requestCount` counts requests it
+   * served and a 429 served nothing, so a seat parked on its first attempt
+   * read `request_count: 0` next to `status: rejected` (dario#1244).
+   */
+  rejectedCount: number;
+  /** Epoch ms of the most recent 429 on this account, or `null` if never. */
+  lastRejectedAt: number | null;
   /**
    * Consecutive auth failures on this account (dario#234's cool-down
    * counter). `status: 'auth-cooldown'` alone doesn't distinguish a single
@@ -525,9 +541,18 @@ export async function handleAdminRequest(
           ...(l ? {
             util5h: l.util5h,
             util7d: l.util7d,
+            // The reading's age and its window's reset, so `rejected` says
+            // since when and until when — the same fields GET /accounts has
+            // carried since #1032 and #1232; this surface dropped them.
+            last_observed_at: l.lastObservedAt ?? null,
+            util_age_ms: l.utilAgeMs ?? null,
+            reset_at: l.resetAt ?? null,
+            reset_in_ms: l.resetInMs ?? null,
             claim: l.claim,
             status: l.status,
             request_count: l.requestCount,
+            rejected_count: l.rejectedCount ?? 0,
+            last_rejected_at: l.lastRejectedAt ?? null,
             consecutive_auth_failures: l.consecutiveAuthFailures,
           } : {}),
         };

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -100,6 +100,55 @@ export function utilFreshness(rl: RateLimitSnapshot, now: number): UtilFreshness
   };
 }
 
+/** When an account's rate-limit window rolls over — see `rateLimitWindow`. */
+export interface RateLimitWindow {
+  /**
+   * Epoch ms the window resets at, from `anthropic-ratelimit-unified-reset`;
+   * null when no response on this account has stated one.
+   */
+  resetAt: number | null;
+  /** Ms until that reset, floored at 0 once it has passed; null when unknown. */
+  resetInMs: number | null;
+}
+
+/**
+ * The reset moment of the window an account's last reading was measured
+ * against (dario#1244). The snapshot has carried `reset` since the header was
+ * first parsed and routing has expired rejections on it since #1232, but no
+ * operator surface showed it: a seat read `status: rejected` with nothing
+ * saying until when, and `requestCount: 0` beside it (a 429 serves nothing,
+ * so the attempt was never counted) made the rejection look like one dario
+ * had made up. For a `rejected` seat this is when the rejection lifts; for
+ * an `allowed` one, when its representative window rolls. The header is
+ * epoch SECONDS; both fields here are milliseconds, like `expiresInMs` and
+ * `utilAgeMs`.
+ */
+export function rateLimitWindow(rl: RateLimitSnapshot, now: number): RateLimitWindow {
+  if (!(rl.reset > 0)) return { resetAt: null, resetInMs: null };
+  const resetAt = rl.reset * 1000;
+  return { resetAt, resetInMs: Math.max(0, resetAt - now) };
+}
+
+/**
+ * One line for a log or a doctor row:
+ * `5h 104%, 7d 25%, claim five_hour, resets in 37m`.
+ */
+export function describeRateLimitSnapshot(rl: RateLimitSnapshot, now: number = Date.now()): string {
+  const pct = (n: number) => `${Math.round(n * 100)}%`;
+  const { resetInMs } = rateLimitWindow(rl, now);
+  const reset = resetInMs === null ? 'no reset stated'
+    : resetInMs === 0 ? 'window already rolled'
+    : `resets in ${formatDurationMs(resetInMs)}`;
+  return `5h ${pct(rl.util5h)}, 7d ${pct(rl.util7d)}, claim ${rl.claim}, ${reset}`;
+}
+
+function formatDurationMs(ms: number): string {
+  const totalMins = Math.max(1, Math.round(ms / 60_000));
+  const h = Math.floor(totalMins / 60);
+  const m = totalMins % 60;
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
 export interface PoolAccount {
   alias: string;
   accessToken: string;
@@ -108,6 +157,16 @@ export interface PoolAccount {
   identity: AccountIdentity;
   rateLimit: RateLimitSnapshot;
   requestCount: number;
+  /**
+   * Upstream 429s this account has answered. `requestCount` counts requests
+   * the account SERVED, and a 429 served nothing — so a seat parked on its
+   * first attempt read `requestCount: 0` next to `status: rejected`, as if
+   * dario had rejected a seat it never called (dario#1244). This is the field
+   * that says it was tried.
+   */
+  rejectedCount: number;
+  /** Epoch ms of the most recent 429 on this account; undefined if never. */
+  lastRejectedAt?: number;
   /** Epoch ms of the OAuth grant (refresh-grant.ts); undefined when unknown. */
   grantedAt?: number;
   /**
@@ -461,21 +520,36 @@ export class AccountPool {
     grantedAt?: number;
   }): void {
     const existing = this.accounts.get(alias);
+    // A record whose grantedAt differs from the live entry's is a NEW grant
+    // under this alias — a re-login, possibly on a different organization
+    // with its own windows. The live state describes the old credential (its
+    // rejection and reading, its auth streak, its identity), so it starts
+    // fresh (dario#1244): before this, a seat re-granted to clear
+    // `auth-cooldown` stayed cooling until the old streak's timer ran out,
+    // and one re-granted on another organization stayed parked on the old
+    // organization's window. A reconcile carrying the same grant — a token
+    // refresh, an admin change to another seat, a peer instance's rotation in
+    // HA — keeps the live state as before. So does a record with no grantedAt
+    // at all: it cannot be told apart from the same grant.
+    const regranted = existing !== undefined && opts.grantedAt !== undefined && opts.grantedAt !== existing.grantedAt;
+    const keep = regranted ? undefined : existing;
     this.accounts.set(alias, {
       alias,
       accessToken: opts.accessToken,
       refreshToken: opts.refreshToken,
       expiresAt: opts.expiresAt,
-      grantedAt: opts.grantedAt ?? existing?.grantedAt,
-      identity: existing?.identity ?? {
+      grantedAt: opts.grantedAt ?? keep?.grantedAt,
+      identity: keep?.identity ?? {
         deviceId: opts.deviceId,
         accountUuid: opts.accountUuid,
         sessionId: randomUUID(),
       },
-      rateLimit: existing?.rateLimit ?? { ...EMPTY_SNAPSHOT },
-      requestCount: existing?.requestCount ?? 0,
-      lastAuthFailureAt: existing?.lastAuthFailureAt,
-      consecutiveAuthFailures: existing?.consecutiveAuthFailures ?? 0,
+      rateLimit: keep?.rateLimit ?? { ...EMPTY_SNAPSHOT },
+      requestCount: keep?.requestCount ?? 0,
+      rejectedCount: keep?.rejectedCount ?? 0,
+      lastRejectedAt: keep?.lastRejectedAt,
+      lastAuthFailureAt: keep?.lastAuthFailureAt,
+      consecutiveAuthFailures: keep?.consecutiveAuthFailures ?? 0,
     });
   }
 
@@ -709,10 +783,22 @@ export class AccountPool {
     account.requestCount++;
   }
 
-  markRejected(alias: string, snapshot: RateLimitSnapshot): void {
+  /**
+   * Park `alias` on an upstream 429. Returns true when this takes a seat OUT
+   * of rotation — the first 429 of a window — and false when the seat was
+   * already parked inside a live window: the all-exhausted fallback in
+   * `select()` re-probes parked seats, so a pool with nothing left can 429
+   * the same seat many times, and only the transition is worth a log line.
+   */
+  markRejected(alias: string, snapshot: RateLimitSnapshot): boolean {
     const account = this.accounts.get(alias);
-    if (!account) return;
+    if (!account) return false;
+    const now = snapshot.updatedAt || Date.now();
+    const wasParked = account.rateLimit.status === 'rejected' && !rateLimitWindowPassed(account.rateLimit, now);
     account.rateLimit = { ...snapshot, status: 'rejected' };
+    account.rejectedCount++;
+    account.lastRejectedAt = now;
+    return !wasParked;
   }
 
   updateTokens(alias: string, accessToken: string, refreshToken: string, expiresAt: number): void {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -12,7 +12,7 @@ import { darioVersion } from './version.js';
 import { buildCCRequest, applyCcPromptCaching, isGenuineCCClient, parseEffortSuffix, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, overlayTemplateHeaderValues, forwardClientCCIdentityHeaders, isMcpToolName, CC_TEMPLATE, CC_CACHE_CONTROL, effectiveCacheControl, withForced1hBeta, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
 import { stampCch, hasCchSeed } from './cch.js';
 import { describeTemplate, detectDrift, checkCCCompat, probeInstalledCCVersion } from './live-fingerprint.js';
-import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCooldown, authCooldownMs, accountIneligibility, reportedAccountStatus, reconcilePoolAccounts, resolvePoolStrategy, utilFreshness, type PoolAccount } from './pool.js';
+import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCooldown, authCooldownMs, accountIneligibility, reportedAccountStatus, reconcilePoolAccounts, resolvePoolStrategy, utilFreshness, rateLimitWindow, describeRateLimitSnapshot, type PoolAccount } from './pool.js';
 import { Analytics, billingBucketFromClaim, formatUsageLogLine, SUBSCRIPTION_CLAIMS, type RequestRecord, CODEX_CLAIM } from './analytics.js';
 import { OverageGuard, buildHaltErrorBody, type HaltState } from './overage-guard.js';
 import { notify as osNotify } from './notify.js';
@@ -2472,9 +2472,12 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
               // surface documents itself as reporting the same snapshot, so it
               // must not be the one place a stale reading still looks current.
               ...utilFreshness(a.rateLimit, snapNow),
+              ...rateLimitWindow(a.rateLimit, snapNow),
               claim: a.rateLimit.claim,
               status: reportedAccountStatus(a, snapNow),
               requestCount: a.requestCount,
+              rejectedCount: a.rejectedCount,
+              lastRejectedAt: a.lastRejectedAt ?? null,
               // Raw streak, not just the cooldown boolean: a single 401 also
               // shows `auth-cooldown` for 60s, indistinguishable from a
               // genuinely dead refresh token by that field alone. The magnitude
@@ -2569,9 +2572,16 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           util5h: a.rateLimit.util5h,
           util7d: a.rateLimit.util7d,
           ...utilFreshness(a.rateLimit, now),
+          // When that window rolls (dario#1244): for a rejected seat, when
+          // the rejection lifts. Milliseconds, like expiresInMs.
+          ...rateLimitWindow(a.rateLimit, now),
           claim: a.rateLimit.claim,
           status: reportedAccountStatus(a, now),
           requestCount: a.requestCount,
+          // 429s answered — the attempts requestCount does not count, so a
+          // parked seat no longer reads as one that was never called.
+          rejectedCount: a.rejectedCount,
+          lastRejectedAt: a.lastRejectedAt ?? null,
           expiresInMs: Math.max(0, a.expiresAt - now),
           // Refresh-token grant age (refresh-grant.ts): the wall a token
           // refresh cannot move. null fields = grant date unknown.
@@ -4106,7 +4116,15 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
         if (poolAccount) {
           const snapshot = parseRateLimits(upstream.headers);
           if (upstream.status === 429) {
-            pool.markRejected(poolAccount.alias, snapshot);
+            // Say so the moment a seat leaves rotation. With a peer to fail
+            // over to the client sees 200, and nothing else named the seat,
+            // the reading, or when it comes back (dario#1244). Once per
+            // parking: the all-exhausted fallback re-probes parked seats, and
+            // those repeats are verbose-only.
+            const parked = pool.markRejected(poolAccount.alias, snapshot);
+            if (parked || verbose) {
+              console.error(`[dario] #${requestCount} rate limited (429) on account "${poolAccount.alias}": ${describeRateLimitSnapshot(snapshot)} — parked until the window rolls`);
+            }
           } else {
             pool.updateRateLimits(poolAccount.alias, snapshot);
           }

--- a/src/tui/tabs/accounts.ts
+++ b/src/tui/tabs/accounts.ts
@@ -38,6 +38,8 @@ export interface AccountsState {
     util5h?: number;
     util7d?: number;
     status?: string;
+    /** Ms until the seat's rate-limit window rolls; null/absent when unknown. */
+    resetInMs?: number | null;
   }>;
   error: string | null;
   /** Where the list came from: the running proxy's pool, the proxy's
@@ -54,6 +56,7 @@ interface AccountsEndpoint {
     util5h?: number;
     util7d?: number;
     status?: string;
+    resetInMs?: number | null;
   }>;
 }
 
@@ -142,8 +145,11 @@ export const AccountsTab: Tab<AccountsState> = {
         const expiresCol = pad(formatExpiry(acc.expiresAt), 14);
         const u5 = pad(acc.util5h !== undefined ? `${Math.round(acc.util5h * 100)}%` : '—', 9);
         const u7 = pad(acc.util7d !== undefined ? `${Math.round(acc.util7d * 100)}%` : '—', 9);
-        const statusCol = acc.status ?? '—';
-        const statusFg = statusCol === 'auth-cooldown' ? fg('yellow', statusCol) : dim(statusCol);
+        // A parked seat says for how long (dario#1244): "rejected 37m".
+        const statusCol = acc.status === 'rejected' && typeof acc.resetInMs === 'number'
+          ? `rejected ${formatCountdown(acc.resetInMs)}`
+          : (acc.status ?? '—');
+        const statusFg = statusCol === 'auth-cooldown' || acc.status === 'rejected' ? fg('yellow', statusCol) : dim(statusCol);
         push('  ' + aliasCol + expiresCol + u5 + u7 + statusFg);
       } else {
         const expiresCol = pad(formatExpiry(acc.expiresAt), 16);
@@ -191,6 +197,7 @@ export async function refreshAccounts(ctx?: TabContext<AccountsState>): Promise<
             util5h: a.util5h,
             util7d: a.util7d,
             status: a.status,
+            resetInMs: a.resetInMs,
           })),
           error: null,
         };
@@ -223,6 +230,15 @@ async function diskFallback(): Promise<AccountsState> {
   } catch (e) {
     return { loading: false, accounts: [], error: (e as Error).message, source: 'disk' };
   }
+}
+
+/** `37m` / `4h59m` / `now` — how long until a parked seat's window rolls. */
+function formatCountdown(ms: number): string {
+  if (ms <= 0) return 'now';
+  const totalMins = Math.max(1, Math.round(ms / 60_000));
+  const h = Math.floor(totalMins / 60);
+  const m = totalMins % 60;
+  return h > 0 ? `${h}h${m}m` : `${m}m`;
 }
 
 function formatExpiry(expiresAt: number): string {

--- a/test/admin-api.mjs
+++ b/test/admin-api.mjs
@@ -496,5 +496,41 @@ header('Rate limiting — mutations + auth failures return 429');
   }
 }
 
+// ─────────────────────────────────────────────────────────────
+header('GET /admin/accounts — reading age, window reset and rejection count surfaced (#1244)');
+{
+  const now = Date.now();
+  const listAccounts = async () => [
+    { alias: 'parked', scopes: [], expiresAt: now + 1000 },
+    { alias: 'older', scopes: [], expiresAt: now + 1000 },
+  ];
+  const poolStatus = () => new Map([
+    // The reported shape: parked on its first attempt at 104% of the
+    // five-hour window, 37 minutes from its reset.
+    ['parked', {
+      util5h: 1.04, util7d: 0.25, lastObservedAt: now - 5_000, utilAgeMs: 5_000,
+      resetAt: now + 37 * 60_000, resetInMs: 37 * 60_000,
+      claim: 'five_hour', status: 'rejected', requestCount: 0,
+      rejectedCount: 1, lastRejectedAt: now - 5_000, consecutiveAuthFailures: 0,
+    }],
+    // A snapshot without the new fields must not leave `undefined` holes:
+    // null / 0 are the documented absent values.
+    ['older', { util5h: 0, util7d: 0, claim: 'unknown', status: 'unknown', requestCount: 0, consecutiveAuthFailures: 0 }],
+  ]);
+  const req = mockReq('GET', '/admin/accounts', bearer(TOKEN));
+  const res = mockRes();
+  await handleAdminRequest(req, res, '/admin/accounts', { adminTokenBuf: TOKEN_BUF, listAccounts, poolStatus });
+  const json = JSON.parse(res.body);
+  const p = json.accounts.find(a => a.alias === 'parked');
+  const o = json.accounts.find(a => a.alias === 'older');
+  check('last_observed_at / util_age_ms merged in (#1032 fields this surface dropped)', p?.last_observed_at === now - 5_000 && p?.util_age_ms === 5_000);
+  check('reset_at / reset_in_ms merged in', p?.reset_at === now + 37 * 60_000 && p?.reset_in_ms === 37 * 60_000);
+  check('rejected_count / last_rejected_at merged in', p?.rejected_count === 1 && p?.last_rejected_at === now - 5_000);
+  check('request_count is still the served count (0)', p?.request_count === 0);
+  check('absent freshness / reset → null, not missing',
+    o !== undefined && 'last_observed_at' in o && o.last_observed_at === null && o.util_age_ms === null && o.reset_at === null && o.reset_in_ms === null);
+  check('absent rejection fields → 0 / null', o?.rejected_count === 0 && o?.last_rejected_at === null);
+}
+
 console.log(`\n${pass} pass, ${fail} fail`);
 if (fail > 0) process.exit(1);

--- a/test/pool-parked-seat-surfaces.mjs
+++ b/test/pool-parked-seat-surfaces.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+// dario#1244 — a seat parked on its first 429 must explain itself.
+//
+// Reported on a six-seat pool (v6.0.32): one seat listed as
+//   util5h 1.04, claim five_hour, status rejected, request_count 0
+// while the operator's own usage page for that seat read 0%. Every field was
+// true — the seat's organization really had answered 429 at 104% of its
+// five-hour window — but nothing said so: the client saw 200 from a peer, the
+// proxy logged nothing about the seat, the listing carried no reset and no
+// reading age, and `request_count: 0` (a 429 serves nothing, so the attempt
+// was never counted) made the rejection read as one dario had invented.
+//
+// This drives the real proxy in-process with a fake upstream: seat `busy`
+// answers 429 with exactly that header set, seat `spare` answers 200. Then it
+// asserts what each operator surface says about the parked seat.
+
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { freePort } from './helpers/free-port.mjs';
+
+// The proxy's console output is captured below; keep the real one for ours.
+const out = console.log.bind(console);
+let pass = 0, fail = 0;
+const check = (name, cond, detail) => {
+  if (cond) { out(`  OK ${name}`); pass++; }
+  else { out(`  FAIL ${name}${detail !== undefined ? ' :: ' + detail : ''}`); fail++; }
+};
+const header = (n) => out(`\n=== ${n} ===`);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const PORT = await freePort();
+const ADMIN_TOKEN = 'parked-seat-admin-token';
+const tmpHome = await mkdtemp(join(tmpdir(), 'dario-parked-'));
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+process.env.DARIO_ADMIN = '1';
+process.env.DARIO_ADMIN_TOKEN = ADMIN_TOKEN;
+delete process.env.DARIO_API_KEY;
+delete process.env.DARIO_CODEX_BASE_URL;
+await mkdir(join(tmpHome, '.dario', 'accounts'), { recursive: true });
+const seat = (alias, token) => JSON.stringify({
+  alias, accessToken: token, refreshToken: `${token}-refresh`,
+  expiresAt: Date.now() + 6 * 3_600_000, scopes: ['user:inference'],
+  deviceId: `dev-${alias}`, accountUuid: `uuid-${alias}`,
+});
+await writeFile(join(tmpHome, '.dario', 'accounts', 'busy.json'), seat('busy', 'busy-token'));
+await writeFile(join(tmpHome, '.dario', 'accounts', 'spare.json'), seat('spare', 'spare-token'));
+
+const RESET_IN_S = 37 * 60;
+const busyResetS = Math.floor(Date.now() / 1000) + RESET_IN_S;
+const spareResetS = Math.floor(Date.now() / 1000) + 4 * 3600;
+const unified = (status, util5h, util7d, resetS) => ({
+  'content-type': 'application/json',
+  'anthropic-ratelimit-unified-status': status,
+  'anthropic-ratelimit-unified-5h-utilization': String(util5h),
+  'anthropic-ratelimit-unified-7d-utilization': String(util7d),
+  'anthropic-ratelimit-unified-representative-claim': 'five_hour',
+  'anthropic-ratelimit-unified-reset': String(resetS),
+});
+const rateLimited = (resetS) => new Response(
+  JSON.stringify({ type: 'error', error: { type: 'rate_limit_error', message: 'Error' } }),
+  { status: 429, headers: unified('rejected', 1.04, 0.25, resetS) },
+);
+const ok = (resetS) => new Response(JSON.stringify({
+  id: 'msg_1', type: 'message', role: 'assistant', model: 'claude-sonnet-5',
+  content: [{ type: 'text', text: 'PONG' }], stop_reason: 'end_turn', stop_sequence: null,
+  usage: { input_tokens: 1, output_tokens: 1 },
+}), { status: 200, headers: unified('allowed', 0.05, 0, resetS) });
+
+// Flipped later: spare starts answering 429 on a window that has ALREADY
+// rolled, the state a seat is in once its rejection has expired.
+let spareRolled = false;
+const calls = [];
+const fetchImpl = async (url, init) => {
+  if (String(url).includes('/v1/models')) {
+    return new Response(JSON.stringify({ data: [{ id: 'claude-sonnet-5', type: 'model' }] }), {
+      status: 200, headers: { 'content-type': 'application/json' },
+    });
+  }
+  const h = init?.headers;
+  const pairs = Array.isArray(h) ? h : h instanceof Headers ? [...h.entries()] : Object.entries(h ?? {});
+  const auth = String((pairs.find(([k]) => String(k).toLowerCase() === 'authorization') ?? [, ''])[1]);
+  const bearer = auth.replace(/^Bearer\s+/i, '');
+  calls.push(bearer);
+  if (bearer === 'busy-token') return rateLimited(busyResetS);
+  if (spareRolled) return rateLimited(Math.floor(Date.now() / 1000) - 5);
+  return ok(spareResetS);
+};
+
+const log = [];
+for (const m of ['log', 'error', 'warn']) console[m] = (...a) => { log.push(a.map(String).join(' ')); };
+const parkingLines = (alias) => log.filter((l) => l.includes(`rate limited (429) on account "${alias}"`));
+
+const { startProxy } = await import('../dist/proxy.js');
+// verbose OFF: the parking line must be there without it.
+await startProxy({ host: '127.0.0.1', port: PORT, passthrough: false, verbose: false, noLiveCapture: true, fetchImpl });
+const BASE = `http://127.0.0.1:${PORT}`;
+for (let i = 0; i < 50; i++) { try { await fetch(`${BASE}/health`); break; } catch { await sleep(100); } }
+
+const messages = (content) => fetch(`${BASE}/v1/messages`, {
+  method: 'POST', headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ model: 'claude-sonnet-5', max_tokens: 16, messages: [{ role: 'user', content }] }),
+});
+const accounts = async () => (await (await fetch(`${BASE}/accounts`)).json()).accounts;
+const adminAccounts = async () => (await (await fetch(`${BASE}/admin/accounts`, { headers: { authorization: `Bearer ${ADMIN_TOKEN}` } })).json()).accounts;
+const near = (a, b, tol) => typeof a === 'number' && Math.abs(a - b) <= tol;
+
+header('the busy seat is tried once, the client never notices');
+{
+  // Distinct first messages = distinct conversations, so nothing is sticky.
+  // The never-measured seat (headroom 1.0) is picked as soon as the other has
+  // reported any utilisation, so busy is tried within a couple of requests.
+  const statuses = [];
+  for (let i = 0; i < 3 && !calls.includes('busy-token'); i++) {
+    const r = await messages(`conversation ${i} ${Math.random()}`);
+    statuses.push(r.status);
+    await r.text();
+  }
+  check('busy was sent exactly one request', calls.filter((b) => b === 'busy-token').length === 1, calls.join(','));
+  check('every client request got 200 (failover to spare)', statuses.length > 0 && statuses.every((s) => s === 200), statuses.join(','));
+}
+
+header('GET /accounts — the parked seat says since when, until when, and that it was tried');
+{
+  const now = Date.now();
+  const busy = (await accounts()).find((a) => a.alias === 'busy');
+  check('status rejected (window still ahead)', busy?.status === 'rejected', busy?.status);
+  check('the 429 reading is what upstream said', busy?.util5h === 1.04 && busy?.util7d === 0.25 && busy?.claim === 'five_hour');
+  check('resetAt is the header, in ms', busy?.resetAt === busyResetS * 1000, busy?.resetAt);
+  check('resetInMs counts down to it', near(busy?.resetInMs, RESET_IN_S * 1000, 15_000), busy?.resetInMs);
+  check('requestCount still 0 — a 429 served nothing', busy?.requestCount === 0);
+  check('rejectedCount 1 — but the seat WAS tried', busy?.rejectedCount === 1, busy?.rejectedCount);
+  check('lastRejectedAt is now', near(busy?.lastRejectedAt, now, 15_000), busy?.lastRejectedAt);
+  check('lastObservedAt matches the rejection', busy?.lastObservedAt === busy?.lastRejectedAt);
+
+  const spare = (await accounts()).find((a) => a.alias === 'spare');
+  check('the serving seat is allowed with its own window', spare?.status === 'allowed' && spare?.resetAt === spareResetS * 1000);
+  check('and has no rejections', spare?.rejectedCount === 0 && spare?.lastRejectedAt === null);
+}
+
+header('GET /admin/accounts — same facts, snake_case (the surface in the report)');
+{
+  const busy = (await adminAccounts()).find((a) => a.alias === 'busy');
+  check('status rejected', busy?.status === 'rejected');
+  check('reset_at / reset_in_ms present', busy?.reset_at === busyResetS * 1000 && near(busy?.reset_in_ms, RESET_IN_S * 1000, 15_000), JSON.stringify([busy?.reset_at, busy?.reset_in_ms]));
+  check('last_observed_at / util_age_ms present (#1032 fields, previously dropped here)',
+    typeof busy?.last_observed_at === 'number' && typeof busy?.util_age_ms === 'number' && busy.util_age_ms < 15_000,
+    JSON.stringify([busy?.last_observed_at, busy?.util_age_ms]));
+  check('request_count 0, rejected_count 1', busy?.request_count === 0 && busy?.rejected_count === 1);
+  check('last_rejected_at present', typeof busy?.last_rejected_at === 'number');
+}
+
+header('the proxy log names the seat, the reading and the reset — without -v');
+{
+  const lines = parkingLines('busy');
+  check('exactly one parking line for busy', lines.length === 1, JSON.stringify(lines));
+  check('it carries the reading', lines[0]?.includes('5h 104%, 7d 25%, claim five_hour'), lines[0]);
+  check('and the reset', /resets in 3[67]m/.test(lines[0] ?? ''), lines[0]);
+}
+
+header('a re-probe of a parked seat is not a new parking (no repeat line)');
+{
+  // Park spare too, on a window that has already rolled. With nothing eligible
+  // left, the failover falls back to the parked busy seat, which 429s again:
+  // that is a repeat, not a transition, and must not log a second line.
+  spareRolled = true;
+  const r = await messages(`conversation exhausted ${Math.random()}`);
+  await r.text();
+  check('client gets the honest 429 (no seat left, no Codex leg)', r.status === 429, r.status);
+  check('busy was re-probed', calls.filter((b) => b === 'busy-token').length === 2, calls.join(','));
+  check('still exactly one parking line for busy', parkingLines('busy').length === 1, JSON.stringify(parkingLines('busy')));
+  check('spare logged its own parking once', parkingLines('spare').length === 1, JSON.stringify(parkingLines('spare')));
+  check('spare\'s line says its window had already rolled', parkingLines('spare')[0]?.includes('window already rolled'), parkingLines('spare')[0]);
+
+  const busy = (await accounts()).find((a) => a.alias === 'busy');
+  check('busy rejectedCount is now 2', busy?.rejectedCount === 2, busy?.rejectedCount);
+  check('busy still rejected, requestCount still 0', busy?.status === 'rejected' && busy?.requestCount === 0);
+
+  // A rejection whose window has passed reports `unknown` (#1232) — and now
+  // shows the reset that passed, so the operator can see why it is unknown.
+  const spare = (await adminAccounts()).find((a) => a.alias === 'spare');
+  check('spare reports unknown (rejection expired with its window)', spare?.status === 'unknown', spare?.status);
+  check('spare reset_in_ms floored at 0, reset_at in the past', spare?.reset_in_ms === 0 && spare?.reset_at < Date.now(), JSON.stringify([spare?.reset_at, spare?.reset_in_ms]));
+  check('spare counts its one rejection beside the requests it served', spare?.rejected_count === 1 && spare?.request_count >= 1, JSON.stringify([spare?.rejected_count, spare?.request_count]));
+}
+
+out(`\npool-parked-seat-surfaces: ${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/test/pool-rate-limit-reset.mjs
+++ b/test/pool-rate-limit-reset.mjs
@@ -24,6 +24,8 @@ import {
   isAccountEligible,
   rateLimitWindowPassed,
   reportedAccountStatus,
+  rateLimitWindow,
+  describeRateLimitSnapshot,
 } from '../dist/pool.js';
 
 let pass = 0, fail = 0;
@@ -190,6 +192,110 @@ header('an expired rejection that is still real re-parks on the next 429');
   park(pool, 'a', SECS + 900);        // the 429 upstream answers with a new window
   check('re-parked on the new window', isAccountEligible(acct, NOW) === false);
   check('and reported as rejected again', reportedAccountStatus(acct, NOW) === 'rejected');
+}
+
+// ----------------------------------------------------------------------
+header('rateLimitWindow — the reset, surfaced (dario#1244)');
+// ----------------------------------------------------------------------
+{
+  // The snapshot carried `reset` all along and routing expired rejections on
+  // it; no operator surface showed it, so `rejected` never said until when.
+  const ahead = rateLimitWindow({ ...EMPTY_SNAPSHOT, reset: SECS + 2220 }, NOW);
+  check('resetAt is the header, in ms', ahead.resetAt === (SECS + 2220) * 1000);
+  check('resetInMs counts down to it', ahead.resetInMs === 2220 * 1000);
+  const passed = rateLimitWindow({ ...EMPTY_SNAPSHOT, reset: SECS - 60 }, NOW);
+  check('a passed reset keeps resetAt', passed.resetAt === (SECS - 60) * 1000);
+  check('and floors resetInMs at 0', passed.resetInMs === 0);
+  const none = rateLimitWindow(EMPTY_SNAPSHOT, NOW);
+  check('no reset stated → both null, not epoch 0', none.resetAt === null && none.resetInMs === null);
+}
+
+// ----------------------------------------------------------------------
+header('describeRateLimitSnapshot — the parking log line');
+// ----------------------------------------------------------------------
+{
+  const s = { ...EMPTY_SNAPSHOT, util5h: 1.04, util7d: 0.25, claim: 'five_hour', reset: SECS + 37 * 60 };
+  check('reads the way an operator would say it',
+    describeRateLimitSnapshot(s, NOW) === '5h 104%, 7d 25%, claim five_hour, resets in 37m', describeRateLimitSnapshot(s, NOW));
+  check('hours and minutes past an hour',
+    describeRateLimitSnapshot({ ...s, reset: SECS + 4 * 3600 + 59 * 60 }, NOW).endsWith('resets in 4h 59m'));
+  check('a rolled window says so',
+    describeRateLimitSnapshot({ ...s, reset: SECS - 1 }, NOW).endsWith('window already rolled'));
+  check('no reset says so',
+    describeRateLimitSnapshot({ ...s, reset: 0 }, NOW).endsWith('no reset stated'));
+}
+
+// ----------------------------------------------------------------------
+header('markRejected — counts the attempt, reports the transition');
+// ----------------------------------------------------------------------
+{
+  const pool = poolWith(['a']);
+  const acct = pool.get('a');
+  check('starts with no rejections', acct.rejectedCount === 0 && acct.lastRejectedAt === undefined);
+
+  const parked = pool.markRejected('a', { ...EMPTY_SNAPSHOT, util5h: 1.04, reset: SECS + 600, updatedAt: NOW });
+  check('the first 429 of a window parks the seat → true', parked === true);
+  check('rejectedCount 1, requestCount untouched (a 429 served nothing)', acct.rejectedCount === 1 && acct.requestCount === 0);
+  check('lastRejectedAt is the snapshot time', acct.lastRejectedAt === NOW);
+
+  // The all-exhausted fallback re-probes parked seats; a 429 there is a
+  // repeat, not a transition — the caller uses the boolean to log once.
+  const again = pool.markRejected('a', { ...EMPTY_SNAPSHOT, util5h: 1.04, reset: SECS + 600, updatedAt: NOW + 1000 });
+  check('a 429 while already parked is not a new parking → false', again === false);
+  check('but is still counted', acct.rejectedCount === 2 && acct.lastRejectedAt === NOW + 1000);
+
+  pool.markRejected('a', { ...EMPTY_SNAPSHOT, reset: SECS - 1, updatedAt: NOW + 2000 });
+  const reparked = pool.markRejected('a', { ...EMPTY_SNAPSHOT, reset: SECS + 900, updatedAt: NOW + 3000 });
+  check('a 429 after the previous window rolled is a new parking → true', reparked === true);
+
+  check('unknown alias → false, nothing counted', pool.markRejected('nope', EMPTY_SNAPSHOT) === false);
+
+  const pool2 = poolWith(['b']);
+  const before = Date.now();
+  pool2.markRejected('b', { ...EMPTY_SNAPSHOT, reset: SECS + 600 });
+  check('a snapshot with no updatedAt stamps the wall clock', pool2.get('b').lastRejectedAt >= before);
+}
+
+// ----------------------------------------------------------------------
+header('add() — a re-grant under the same alias starts the seat fresh (dario#1244)');
+// ----------------------------------------------------------------------
+{
+  const pool = poolWith(['a']);
+  pool.markRejected('a', { ...EMPTY_SNAPSHOT, util5h: 1.04, reset: SECS + 600, updatedAt: NOW });
+  pool.markAuthFailure('a');
+  const oldIdentity = pool.get('a').identity;
+
+  // The routine reconcile: same grant → live state kept, tokens taken.
+  pool.add('a', { accessToken: 'rotated', refreshToken: 'rotated-r', expiresAt: NOT_EXPIRING, deviceId: 'dev-a', accountUuid: 'uuid-a' });
+  let acct = pool.get('a');
+  check('same grant keeps the rejection', acct.rateLimit.status === 'rejected' && acct.rateLimit.reset === SECS + 600);
+  check('same grant keeps the counters and the cool-down', acct.rejectedCount === 1 && acct.consecutiveAuthFailures === 1);
+  check('same grant keeps the identity (session continuity)', acct.identity === oldIdentity);
+  check('and takes the rotated tokens', acct.accessToken === 'rotated');
+
+  // A re-login: a new grantedAt. The old organization's window, the old
+  // streak and the old identity no longer describe this credential.
+  const GRANT = NOW - 1000;
+  pool.add('a', { accessToken: 'fresh', refreshToken: 'fresh-r', expiresAt: NOT_EXPIRING, deviceId: 'dev-a2', accountUuid: 'uuid-a2', grantedAt: GRANT });
+  acct = pool.get('a');
+  check('new grant clears the rejection', acct.rateLimit.status === 'unknown' && acct.rateLimit.reset === 0);
+  check('new grant is eligible at once', isAccountEligible(acct, NOW) === true);
+  check('new grant clears the auth cool-down', acct.consecutiveAuthFailures === 0 && acct.lastAuthFailureAt === undefined);
+  check('new grant zeroes the counters', acct.requestCount === 0 && acct.rejectedCount === 0 && acct.lastRejectedAt === undefined);
+  check('new grant takes the record\'s own identity', acct.identity.accountUuid === 'uuid-a2' && acct.identity.deviceId === 'dev-a2');
+  check('grantedAt recorded', acct.grantedAt === GRANT);
+
+  // The same grant reconciled again (after a refresh, say) keeps going.
+  pool.updateRateLimits('a', { ...EMPTY_SNAPSHOT, status: 'allowed', util5h: 0.2, reset: SECS + 900 });
+  pool.add('a', { accessToken: 'fresh2', refreshToken: 'fresh2-r', expiresAt: NOT_EXPIRING, deviceId: 'dev-a2', accountUuid: 'uuid-a2', grantedAt: GRANT });
+  acct = pool.get('a');
+  check('reconciling the same grant keeps its reading and count', acct.rateLimit.util5h === 0.2 && acct.requestCount === 1);
+
+  // A record with no grantedAt (a seat minted before the field existed)
+  // cannot be told apart from the same grant — state is kept, as before.
+  pool.markRejected('a', { ...EMPTY_SNAPSHOT, reset: SECS + 600, updatedAt: NOW });
+  pool.add('a', { accessToken: 'x', refreshToken: 'x-r', expiresAt: NOT_EXPIRING, deviceId: 'dev-a2', accountUuid: 'uuid-a2' });
+  check('no grantedAt on the record → state kept', pool.get('a').rateLimit.status === 'rejected' && pool.get('a').grantedAt === GRANT);
 }
 
 console.log(`\npool-rate-limit-reset: ${pass} passed, ${fail} failed`);

--- a/test/tui-accounts-source.mjs
+++ b/test/tui-accounts-source.mjs
@@ -75,5 +75,24 @@ header('refreshAccounts — no ctx (standalone) uses disk without throwing');
   check('returns a valid state', typeof s.loading === 'boolean' && Array.isArray(s.accounts));
 }
 
+header('render — a parked seat shows how long it stays parked (#1244)');
+{
+  const ctx = ctxWith(async () => ({
+    mode: 'pool',
+    accounts: [
+      { alias: 'busy', expiresInMs: 3_600_000, util5h: 1.04, util7d: 0.25, status: 'rejected', resetInMs: 37 * 60_000 },
+      { alias: 'spare', expiresInMs: 3_600_000, util5h: 0.05, util7d: 0, status: 'allowed', resetInMs: 4 * 3_600_000 },
+      { alias: 'later', expiresInMs: 3_600_000, util5h: 1.0, util7d: 0.5, status: 'rejected', resetInMs: 4 * 3_600_000 + 59 * 60_000 },
+    ],
+  }));
+  const s = await refreshAccounts(ctx);
+  check('resetInMs carried through', s.accounts[0].resetInMs === 37 * 60_000);
+  const r = AccountsTab.render(s, DIM);
+  check('a rejected row carries the countdown', r.includes('rejected 37m'));
+  check('hours and minutes past an hour', r.includes('rejected 4h59m'));
+  check('an allowed row shows no countdown', /spare[^\n]*allowed/.test(r) && !/allowed \d/.test(r));
+  check('utilisation over 100% renders as the ratio it is', r.includes('104%'));
+}
+
 console.log(`\ntui-accounts-source: ${pass} passed, ${fail} failed`);
 process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Fixes #1244.

**What the reporter saw** (v6.0.32, six-seat pool, `GET /admin/accounts`): one seat at `util5h: 1.04, claim: five_hour, status: rejected, request_count: 0` while the usage page for that account read 0%; a re-login cleared it. Reproduced in-process with a fake upstream answering that seat's first request with 429 at `5h 1.04 / 7d 0.25 / five_hour` and a peer answering 200: the listing came out field-for-field identical, the client saw 200, and the proxy log — with `-v` — had no line about the seat.

**Why it read as a phantom.** Every field was true: Anthropic had answered 429 on that token at 104% of its five-hour window. But

1. `markRejected` did not count the attempt — only served requests bump `requestCount` — so the parked seat read "0 requests";
2. neither listing carried the `reset` the snapshot has held since the header was first parsed (routing has expired rejections on it since #1232), so `rejected` never said until when;
3. `GET /admin/accounts` dropped the `lastObservedAt` / `utilAgeMs` freshness that #1032 added — the adapter in proxy.ts supplied them, the mapper in admin-api.ts never emitted them;
4. with a peer to fail over to, nothing was logged.

**Change.**

- `pool.ts`: `PoolAccount.rejectedCount` / `lastRejectedAt`; `markRejected` counts the attempt and returns whether the seat was newly parked; `rateLimitWindow()` (`resetAt` / `resetInMs`, milliseconds like `expiresInMs`) and `describeRateLimitSnapshot()` (the log line).
- `proxy.ts`: `GET /accounts` gains `resetAt`, `resetInMs`, `rejectedCount`, `lastRejectedAt`; the admin adapter passes the same; the 429 site logs `rate limited (429) on account "busy": 5h 104%, 7d 25%, claim five_hour, resets in 37m — parked until the window rolls` on the transition. The re-probes the all-exhausted fallback makes of an already-parked seat stay `-v` (that path 429s the same seat once per request while nothing is left).
- `admin-api.ts`: `GET /admin/accounts` gains `last_observed_at`, `util_age_ms`, `reset_at`, `reset_in_ms`, `rejected_count`, `last_rejected_at`.
- `tui/tabs/accounts.ts`: the status column reads `rejected 37m`.
- `pool.add()`: a record whose `grantedAt` differs from the live entry's is a re-grant, and the seat starts fresh — rejection and reading, counters, auth cool-down and streak, identity. Before, the hot reload after `POST /admin/login/complete` carried all of it over: a seat re-granted to clear `auth-cooldown` stayed cooling until the old streak's timer ran out (up to 30 min), and one re-granted on another organization stayed parked on the old organization's window. Same `grantedAt` (a token refresh, an admin change to another seat, an HA peer's rotation) or no `grantedAt` at all keeps the live state, as before.
- Docs: `multi-account-pool.md` gains "Reading a seat's `status`" (allowed / rejected / unknown / auth-cooldown, each with what to do); `admin-api.md` lists the new fields. CHANGELOG 6.0.33; version bumped, so this releases on merge.

**Tests.** New `test/pool-parked-seat-surfaces.mjs` drives the real proxy with the reporter's header set: client 200 via failover, the parked seat's `/accounts` and `/admin/accounts` shapes, exactly one log line per parking and none on the re-probe, and a rejection whose window has rolled reporting `unknown` with `reset_in_ms: 0`. `pool-rate-limit-reset.mjs` covers `rateLimitWindow`, `describeRateLimitSnapshot`, the `markRejected` transition and counters, and the re-grant reset (same grant keeps state, new grant clears it, no grant keeps it). `admin-api.mjs` covers the new snake_case fields and null / 0 for a snapshot that lacks them. `tui-accounts-source.mjs` covers the countdown. Full suite green locally (179/179, `npm test`).

Additive: no existing field changes meaning or type. `GET /accounts` is `@experimental`; `GET /admin/accounts` is documented in admin-api.md.
