### PR TITLE
Seats report their organization and which other seats share their window; `dario accounts list --live` (#1244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ checklist.
 
 ## [Unreleased]
 
+### Added
+
+- **Each seat reports the organization its token belongs to, and which other seats share its window (#1244).** The report behind #1244 had a usage page reading 0% for a seat whose responses said 104% — a token on an organization other than the one on screen — and "a few" seats showing the same thing, which is what one subscription under several aliases looks like: the pool counts one window several times, the busiest alias fills it for all of them, and the others park on their first request. Every seat now carries `organizationId` (the `anthropic-organization-id` its responses carry, learned on the first response and written to the seat's record by its next token refresh — the write that already exists, so nothing new races it — after which `dario doctor` and a restarted proxy know it without a request) and `sharesWindowWith` (the other aliases whose last reading names the same live window — same representative claim, same reset second; two independent windows all but never share a reset second, and the window rather than the organization is what seats can share). `GET /accounts` adds `distinctWindows`; `GET /admin/accounts` carries `organization_id` / `shares_window_with`; `dario doctor` gains an `Organizations` row; the proxy says it once when the second reading arrives. `dario accounts list --live` prints the running proxy's view of the pool — status and countdown, reading and age, requests served and 429s answered, organization, shared windows, grant age — where the plain listing only knows what is on disk.
+
 ## [6.0.33] - 2026-09-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ checklist.
 
 ## [Unreleased]
 
+## [6.0.33] - 2026-09-07
+
+### Fixed
+
+- **A seat parked on a 429 now says so: on what reading, until when, and that it was tried (#1244).** Reported on a six-seat pool: one seat listed as `util5h: 1.04, claim: five_hour, status: rejected, request_count: 0` while the operator's usage page for it read 0%, and the only thing that cleared it was a re-login. Every field was true — that seat's organization had answered the seat's first request with 429 at 104% of its five-hour window — but nothing said so. With a peer to fail over to the client saw 200 and the proxy logged nothing about the seat; the listing carried no reset and no reading age; and `request_count` stayed at 0 because a 429 serves nothing and only served requests were counted, which made the rejection read as one dario had invented. Now the proxy logs `rate limited (429) on account "<alias>": 5h 104%, 7d 25%, claim five_hour, resets in 37m — parked until the window rolls` the moment a seat leaves rotation (once per parking; the re-probes the all-exhausted fallback makes stay `-v`); `GET /accounts` carries `resetAt` / `resetInMs` (when the rejection lifts — for an `allowed` seat, when its representative window rolls) and `rejectedCount` / `lastRejectedAt`; `GET /admin/accounts` carries the same as `reset_at` / `reset_in_ms` / `rejected_count` / `last_rejected_at`, plus the `last_observed_at` / `util_age_ms` reading age that #1032 added to `GET /accounts` and this surface's own mapper dropped; the TUI accounts tab shows `rejected 37m`. The status vocabulary — `allowed`, `rejected`, `unknown`, `auth-cooldown` — and what to do about each is written down in [multi-account-pool.md](./docs/multi-account-pool.md#reading-a-seats-status).
+- **A re-login under an existing alias starts the seat fresh.** The pool's hot reload after `POST /admin/login/complete` (any reconcile, in fact) kept the alias's live state for the new credential — its rate-limit reading and rejection, its auth cool-down and failure streak, its identity — so a seat re-granted to clear `auth-cooldown` stayed cooling until the old streak's timer ran out (up to 30 minutes), and one re-granted on a different organization stayed parked on the old organization's window. A record whose `grantedAt` differs from the live entry's now resets that state and takes the record's own identity; a reconcile carrying the same grant (a token refresh, an admin change to another seat, a peer instance's rotation in HA) keeps it, as before, and so does a record that states no grant at all.
+
 ## [6.0.32] - 2026-09-07
 
 ### Fixed

--- a/docs/admin-api.md
+++ b/docs/admin-api.md
@@ -103,7 +103,11 @@ the window it was measured against rolls — for a `rejected` seat, when the
 rejection lifts), representative `claim` (e.g. `five_hour`), routing
 `status`, `request_count` (requests served), `rejected_count` /
 `last_rejected_at` (429s answered — a 429 serves nothing, so it is not a
-request), and `consecutive_auth_failures`. What each `status` means and what
+request), `organization_id` (the organization the token belongs to, learned
+from its responses and written to the record with its next refresh), `shares_window_with` (aliases whose last
+reading names the same live window — one subscription under several aliases,
+see [One subscription under two aliases](./multi-account-pool.md#one-subscription-under-two-aliases)),
+and `consecutive_auth_failures`. What each `status` means and what
 to do about it: [Reading a seat's `status`](./multi-account-pool.md#reading-a-seats-status).
 It's the admin-token-gated equivalent of the proxy-key-gated `GET /accounts`
 pool view; a headless operator needs only the admin token to watch headroom.

--- a/docs/admin-api.md
+++ b/docs/admin-api.md
@@ -95,12 +95,20 @@ All endpoints accept the token as `authorization: Bearer <token>` or
 | `DELETE /admin/accounts/<alias>` | — | `{ alias, removed }` (`404` if no such alias) |
 
 `GET /admin/accounts` is the monitoring surface: each entry carries the
-persisted metadata (`alias`, `scopes`, `expires_in_ms`) **plus live pool
-status whenever pool mode is active** — `util5h` / `util7d` utilization,
-representative `claim` (e.g. `five_hour`), routing `status`,
-`request_count`, and `consecutive_auth_failures`. It's the admin-token-gated
-equivalent of the proxy-key-gated `GET /accounts` pool view; a headless
-operator needs only the admin token to watch headroom.
+persisted metadata (`alias`, `scopes`, `expires_in_ms`, the grant-age fields)
+**plus live pool status whenever pool mode is active** — `util5h` / `util7d`
+utilization with `last_observed_at` / `util_age_ms` (how old that reading is;
+it does not tick while a seat is parked), `reset_at` / `reset_in_ms` (when
+the window it was measured against rolls — for a `rejected` seat, when the
+rejection lifts), representative `claim` (e.g. `five_hour`), routing
+`status`, `request_count` (requests served), `rejected_count` /
+`last_rejected_at` (429s answered — a 429 serves nothing, so it is not a
+request), and `consecutive_auth_failures`. What each `status` means and what
+to do about it: [Reading a seat's `status`](./multi-account-pool.md#reading-a-seats-status).
+It's the admin-token-gated equivalent of the proxy-key-gated `GET /accounts`
+pool view; a headless operator needs only the admin token to watch headroom.
+Completing a login for an alias that is already in the pool re-grants it: the
+seat starts fresh — no carried-over rejection, cool-down or identity.
 
 ## Pinning a request to one seat
 

--- a/docs/multi-account-pool.md
+++ b/docs/multi-account-pool.md
@@ -104,6 +104,21 @@ curl http://localhost:3456/analytics    # per-account / per-model stats, burn ra
 
 The proxy logs every parking as it happens, once per window: `rate limited (429) on account "spare": 5h 104%, 7d 25%, claim five_hour, resets in 37m — parked until the window rolls`. The re-probes the all-exhausted fallback makes of an already-parked seat are logged only under `-v`.
 
+`dario accounts list --live` prints the same view from the running proxy — status with its countdown, the reading and its age, requests served and 429s answered, the organization, shared windows, grant age — where the plain `dario accounts list` only knows what is on disk.
+
+## One subscription under two aliases
+
+A pool of six is only six windows if the six tokens belong to six subscriptions. Two aliases granted from the same account — or from two accounts on one organization that share a plan — share one five-hour and one seven-day window, and the pool counts that window twice: both seats look like headroom, the busier one fills the window for both, and the other 429s on its first request with the same reading (the #1244 report).
+
+Two facts make this visible:
+
+- **`organizationId`** — the `anthropic-organization-id` every response carries, learned the first time a seat serves and written to its record with the seat's next token refresh. It is what to compare with the organization behind the usage page you are looking at: a reading that surprises you is usually a token on a different organization.
+- **`sharesWindowWith`** — the other aliases whose last reading names the same live window (same representative claim, same reset second). Two independent windows all but never share a reset second; two readings of one window always do. This is the fact that matters for headroom, and it is deliberately not derived from the organization: seats on one organization can still have their own windows.
+
+Both are on `GET /accounts` (`distinctWindows` at the top counts the windows the pool really has), on `GET /admin/accounts` as `organization_id` / `shares_window_with`, in `dario accounts list --live`, and in `dario doctor` (the `Organizations` row, from the ids on the records — so up to one refresh behind the running proxy). The proxy also says it once, when the second reading arrives: `seats "twin" and "busy" report the same five_hour window (resets 2026-09-07T13:12:00.000Z) — one subscription under two aliases; the pool has 2 distinct windows across 3 seats`.
+
+What to do about it: nothing is broken — the pool routes on real headroom either way, and the duplicate seat simply parks on the first 429 until the window rolls. If the second alias was meant to be a second subscription, re-grant it while signed in to the right account.
+
 Every request carries a `billingBucket` field (`subscription` / `subscription_fallback` / `extra_usage` / `api` / `unknown`) so you can see which bucket each request billed against and a `subscriptionPercent` headline number tells you at a glance whether dario is actually routing through your subscription or silently falling to API overage.
 
 ## Refresh-token grant age

--- a/docs/multi-account-pool.md
+++ b/docs/multi-account-pool.md
@@ -91,6 +91,19 @@ curl http://localhost:3456/accounts     # per-account utilization, claim, sticky
 curl http://localhost:3456/analytics    # per-account / per-model stats, burn rate, exhaustion predictions
 ```
 
+## Reading a seat's `status`
+
+`GET /accounts` (and the admin API's `GET /admin/accounts`, in snake_case) report one `status` per seat. It is the routing verdict, and every value comes with the fields that explain it.
+
+| `status` | What it means | What to do |
+|---|---|---|
+| `allowed` | The seat's last response was a 200 with headroom. `util5h` / `util7d` are that response's reading — a ratio against 1.0, so `0.42` is 42% — `lastObservedAt` / `utilAgeMs` say how old it is, `resetAt` / `resetInMs` when its representative window rolls. | Nothing. |
+| `rejected` | The seat's last response was a 429: the organization behind its token is over the window named by `claim` (`five_hour`, `seven_day`, …). `util5h: 1.04` is 104% of the five-hour window, not 1%. `rejectedCount` / `lastRejectedAt` say the seat was tried — a 429 serves nothing, so `requestCount` does not move — and `resetInMs` says how long it stays parked. Requests route around it; it returns on its own when the window rolls. | Nothing — the window clears itself. If the reading surprises you (your usage page for that account says 0%), the token belongs to a different organization than the page you are looking at, or to the same organization as another seat: the reading is Anthropic's own, taken on that token. `dario accounts check <alias>` asks the seat directly. |
+| `unknown` | No current observation: a seat that has served nothing yet, or a rejection whose window has rolled (`resetInMs: 0`) and that nothing has measured since. | Nothing; the next request measures it. |
+| `auth-cooldown` | Upstream answered 401/403 or `invalid_grant`. `consecutiveAuthFailures` tells a blip (1) from a dead refresh token (a streak); the cool-down doubles with the streak, from 1 minute to 30. | A streak means re-grant the seat — `dario accounts remove` + `add`, or the admin login flow under the same alias. A new grant starts the seat fresh: no carried-over cool-down, rejection or identity. See [Refresh-token grant age](#refresh-token-grant-age) for the 28-day wall behind most streaks. |
+
+The proxy logs every parking as it happens, once per window: `rate limited (429) on account "spare": 5h 104%, 7d 25%, claim five_hour, resets in 37m — parked until the window rolls`. The re-probes the all-exhausted fallback makes of an already-parked seat are logged only under `-v`.
+
 Every request carries a `billingBucket` field (`subscription` / `subscription_fallback` / `extra_usage` / `api` / `unknown`) so you can see which bucket each request billed against and a `subscriptionPercent` headline number tells you at a glance whether dario is actually routing through your subscription or silently falling to API overage.
 
 ## Refresh-token grant age

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.32",
+  "version": "6.0.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "6.0.32",
+      "version": "6.0.33",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.32",
+  "version": "6.0.33",
   "description": "Use your Claude Pro/Max subscription in any tool — Cursor, Cline, Aider, the Agent SDK, your scripts — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint.",
   "type": "module",
   "bin": {

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -58,6 +58,13 @@ export interface AccountCredentials {
   accountUuid: string;
   /** Epoch ms of the OAuth grant; see OAuthTokens.grantedAt / refresh-grant.ts. */
   grantedAt?: number;
+  /**
+   * Anthropic organization behind the token (`anthropic-organization-id` on
+   * responses), observed by the proxy the first time the seat serves and
+   * written here with the seat's next token refresh. Absent until then, and
+   * on a fresh grant.
+   */
+  organizationId?: string;
 }
 
 async function ensureDir(): Promise<void> {
@@ -112,6 +119,19 @@ export async function removeAccount(alias: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+/**
+ * Carry the organization the proxy observed on a seat into a record that is
+ * about to be written anyway — its token refresh (dario#1244). The observation
+ * reaches disk without a write of its own: a read-modify-write of a seat file
+ * from the request path could land after a refresh's write and put the burned
+ * refresh token back, stranding the credential family. A record that already
+ * states an organization keeps it.
+ */
+export function withObservedOrganization<T extends { organizationId?: string }>(record: T, observed: string | undefined): T {
+  if (record.organizationId || !observed) return record;
+  return { ...record, organizationId: observed };
 }
 
 /** Detect deviceId + accountUuid from an installed Claude Code. */
@@ -836,6 +856,7 @@ export async function resyncLoginFromCredentialsIfStale(): Promise<
     deviceId: loginAcc.deviceId,
     accountUuid: loginAcc.accountUuid,
     grantedAt: tok.grantedAt ?? loginAcc.grantedAt,
+    organizationId: loginAcc.organizationId,
   });
   return 'resynced';
 }

--- a/src/admin-api.ts
+++ b/src/admin-api.ts
@@ -40,9 +40,10 @@
  * writes behind one HTTP request.
  *
  * `GET /admin/accounts` reports each account's persisted metadata — alias,
- * scopes, token expiry — plus its live pool status (5h/7d utilization,
- * representative-claim, routing status, request count, consecutive auth
- * failures) when the proxy supplies a `poolStatus` snapshot, which it does
+ * scopes, token expiry — plus its live pool status (5h/7d utilization and
+ * how old that reading is, when its window resets, representative-claim,
+ * routing status, request and rejection counts, consecutive auth failures)
+ * when the proxy supplies a `poolStatus` snapshot, which it does
  * whenever pool mode is active. It's the headless, admin-token-gated
  * equivalent of the `GET /accounts` pool view.
  *
@@ -102,9 +103,24 @@ export interface AdminAccountLive {
   lastObservedAt: number | null;
   /** Age of that reading in ms, or `null` when never observed. */
   utilAgeMs: number | null;
+  /**
+   * When the window that reading was measured against rolls over — epoch ms
+   * and ms-from-now — or `null` when no response has stated one. For a
+   * `rejected` seat this is when the rejection lifts (dario#1244).
+   */
+  resetAt: number | null;
+  resetInMs: number | null;
   claim: string;
   status: string;
   requestCount: number;
+  /**
+   * Upstream 429s this account answered. `requestCount` counts requests it
+   * served and a 429 served nothing, so a seat parked on its first attempt
+   * read `request_count: 0` next to `status: rejected` (dario#1244).
+   */
+  rejectedCount: number;
+  /** Epoch ms of the most recent 429 on this account, or `null` if never. */
+  lastRejectedAt: number | null;
   /**
    * Consecutive auth failures on this account (dario#234's cool-down
    * counter). `status: 'auth-cooldown'` alone doesn't distinguish a single
@@ -525,9 +541,18 @@ export async function handleAdminRequest(
           ...(l ? {
             util5h: l.util5h,
             util7d: l.util7d,
+            // The reading's age and its window's reset, so `rejected` says
+            // since when and until when — the same fields GET /accounts has
+            // carried since #1032 and #1232; this surface dropped them.
+            last_observed_at: l.lastObservedAt ?? null,
+            util_age_ms: l.utilAgeMs ?? null,
+            reset_at: l.resetAt ?? null,
+            reset_in_ms: l.resetInMs ?? null,
             claim: l.claim,
             status: l.status,
             request_count: l.requestCount,
+            rejected_count: l.rejectedCount ?? 0,
+            last_rejected_at: l.lastRejectedAt ?? null,
             consecutive_auth_failures: l.consecutiveAuthFailures,
           } : {}),
         };

--- a/src/admin-api.ts
+++ b/src/admin-api.ts
@@ -86,6 +86,8 @@ export interface AdminAccountRecord {
   expiresAt: number;
   /** Epoch ms of the OAuth grant (refresh-grant.ts); undefined when unknown. */
   grantedAt?: number;
+  /** Organization observed on this seat's responses (dario#1244); undefined until seen. */
+  organizationId?: string;
 }
 
 /** Live per-account pool status keyed by alias — see `AdminDeps.poolStatus`. */
@@ -121,6 +123,10 @@ export interface AdminAccountLive {
   rejectedCount: number;
   /** Epoch ms of the most recent 429 on this account, or `null` if never. */
   lastRejectedAt: number | null;
+  /** Organization observed on this seat's responses, or `null` if none yet (dario#1244). */
+  organizationId: string | null;
+  /** Other aliases whose last reading names the same live window — one subscription under several aliases. */
+  sharesWindowWith: string[];
   /**
    * Consecutive auth failures on this account (dario#234's cool-down
    * counter). `status: 'auth-cooldown'` alone doesn't distinguish a single
@@ -301,7 +307,11 @@ async function defaultListAccounts(): Promise<AdminAccountRecord[]> {
   const aliases = await listAccountAliases();
   const loaded = await Promise.all(aliases.map(async (alias) => {
     const a = await loadAccount(alias);
-    return a ? { alias: a.alias, scopes: a.scopes, expiresAt: a.expiresAt, ...(a.grantedAt !== undefined ? { grantedAt: a.grantedAt } : {}) } : null;
+    return a ? {
+      alias: a.alias, scopes: a.scopes, expiresAt: a.expiresAt,
+      ...(a.grantedAt !== undefined ? { grantedAt: a.grantedAt } : {}),
+      ...(a.organizationId !== undefined ? { organizationId: a.organizationId } : {}),
+    } : null;
   }));
   return loaded.filter((a): a is AdminAccountRecord => a !== null);
 }
@@ -537,6 +547,9 @@ export async function handleAdminRequest(
           grant_age_days: grant.ageDays,
           grant_level: grant.level,
           refresh_wall_at: grant.wallAt,
+          // From the record (written with the seat's last token refresh), so
+          // it is known without a live pool entry.
+          organization_id: r.organizationId ?? null,
           // Inline the running pool's live status when this account is in it.
           ...(l ? {
             util5h: l.util5h,
@@ -548,6 +561,8 @@ export async function handleAdminRequest(
             util_age_ms: l.utilAgeMs ?? null,
             reset_at: l.resetAt ?? null,
             reset_in_ms: l.resetInMs ?? null,
+            ...(l.organizationId ? { organization_id: l.organizationId } : {}),
+            shares_window_with: l.sharesWindowWith ?? [],
             claim: l.claim,
             status: l.status,
             request_count: l.requestCount,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -911,8 +911,74 @@ function parsePositiveIntFlag(prefix: string): number | undefined {
   return n;
 }
 
+/**
+ * `dario accounts list --live` — the running proxy's view of the pool
+ * (dario#1244): status with its countdown, the reading and its age, 429s
+ * answered, the organization, and which seats share a window. The on-disk
+ * listing knows none of that. Returns false when no proxy answered, so the
+ * caller falls back to the on-disk listing.
+ */
+async function accountsListLive(): Promise<boolean> {
+  const { loadConfig } = await import('./config-file.js');
+  const fileCfg = loadConfig().config;
+  const portArg = args.find(a => a.startsWith('--port='));
+  const port = (portArg ? parseInt(portArg.split('=')[1]!, 10) : undefined)
+    ?? (process.env['DARIO_PORT'] ? parseInt(process.env['DARIO_PORT']!, 10) : undefined)
+    ?? fileCfg.port ?? 3456;
+  const headers: Record<string, string> = {};
+  if (process.env['DARIO_API_KEY']) headers['x-api-key'] = process.env['DARIO_API_KEY']!;
+  interface LiveSeat {
+    alias: string; status: string; util5h: number; util7d: number; utilAgeMs: number | null;
+    resetInMs: number | null; requestCount: number; rejectedCount: number;
+    organizationId: string | null; sharesWindowWith: string[]; grantedAt: number | null;
+  }
+  interface LivePayload { mode?: string; accounts?: LiveSeat[]; distinctWindows?: number }
+  let payload: LivePayload | null = null;
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/accounts`, { headers, signal: AbortSignal.timeout(3000) });
+    if (res.ok) payload = await res.json() as LivePayload;
+    else console.log(`  (proxy on http://127.0.0.1:${port} answered ${res.status} to /accounts — showing the on-disk listing)`);
+  } catch (err) {
+    console.log(`  (no proxy on http://127.0.0.1:${port}: ${err instanceof Error ? err.message : String(err)} — showing the on-disk listing)`);
+  }
+  if (!payload || payload.mode !== 'pool' || !Array.isArray(payload.accounts)) return false;
+  const seats = payload.accounts;
+  const now = Date.now();
+  const pct = (n: number) => `${Math.round(n * 100)}%`;
+  const mins = (ms: number) => {
+    const m = Math.max(1, Math.round(ms / 60_000));
+    return m >= 60 ? `${Math.floor(m / 60)}h ${m % 60}m` : `${m}m`;
+  };
+  const age = (ms: number | null) => ms === null ? 'never measured' : ms < 60_000 ? `read ${Math.round(ms / 1000)}s ago` : `read ${mins(ms)} ago`;
+  console.log('');
+  console.log(`  dario — Accounts (live, from http://127.0.0.1:${port})`);
+  console.log('  ────────────────');
+  console.log('');
+  const windows = payload.distinctWindows ?? seats.length;
+  console.log(`  Pool of ${seats.length} (${seats.length === 1 ? '1 seat' : seats.length + ' seats'} on ${windows} distinct window${windows === 1 ? '' : 's'})`);
+  console.log('');
+  for (const s of seats) {
+    const status = s.status === 'rejected' && typeof s.resetInMs === 'number' ? `rejected, back in ${mins(s.resetInMs)}` : s.status;
+    console.log(`    ${s.alias.padEnd(20)} ${status.padEnd(26)} 5h ${pct(s.util5h).padEnd(6)} 7d ${pct(s.util7d).padEnd(6)} ${age(s.utilAgeMs)}`);
+    const facts = [
+      `served ${s.requestCount}`,
+      `429s ${s.rejectedCount}`,
+      s.organizationId ? `org ${s.organizationId.slice(0, 8)}…` : 'org not yet observed',
+      ...(s.sharesWindowWith.length > 0 ? [`shares its window with ${s.sharesWindowWith.join(', ')}`] : []),
+    ];
+    console.log(`    ${''.padEnd(20)} ${facts.join('  ·  ')}`);
+    console.log(`    ${''.padEnd(20)} ${describeGrantAge(grantAge(s.grantedAt ?? undefined, now))}`);
+  }
+  console.log('');
+  return true;
+}
+
 async function accounts() {
   const sub = args[1];
+
+  if ((!sub || sub === 'list') && args.includes('--live')) {
+    if (await accountsListLive()) return;
+  }
 
   if (!sub || sub === 'list') {
     const aliases = await listAccountAliases();
@@ -1413,6 +1479,8 @@ async function help() {
                              POSTs /admin/resume on the local proxy. (dario#288)
     dario logout             Remove saved credentials
     dario accounts list      List accounts in the multi-account pool
+                             (--live: the running proxy's view — status,
+                             window, 429s, organization, shared windows)
     dario accounts add NAME [--manual] [--from-keychain[=<target>]]
                              Add a new account to the pool (runs OAuth flow).
                              --manual (alias: --headless) prints an authorize

--- a/src/doctor-core.ts
+++ b/src/doctor-core.ts
@@ -270,6 +270,40 @@ export function checkRefreshGrant(input: {
   const fix = worst === 'ok' ? '' : REGRANT_FIX;
   return [{ status, label: 'Refresh grant', detail: `${perSeat}${fix}` }];
 }
+
+export interface OrganizationsInput {
+  accounts: Array<{ alias: string; organizationId?: string }>;
+}
+
+/**
+ * The Organizations doctor row (dario#1244): which seats sit on which
+ * Anthropic organization, from the id each seat's responses carried. Two
+ * seats on one organization MAY be one subscription counted twice — the
+ * proxy's `/accounts` says for sure via `sharesWindowWith`, because the
+ * window, not the organization, is what two seats can share. Nothing to say
+ * until at least two seats have been observed.
+ */
+export function checkOrganizations(input: OrganizationsInput): Check[] {
+  const seen = input.accounts.filter((a): a is { alias: string; organizationId: string } => typeof a.organizationId === 'string' && a.organizationId.length > 0);
+  if (seen.length < 2) return [];
+  const byOrg = new Map<string, string[]>();
+  for (const a of seen) {
+    const list = byOrg.get(a.organizationId);
+    if (list) list.push(a.alias); else byOrg.set(a.organizationId, [a.alias]);
+  }
+  const shared = [...byOrg.entries()].filter(([, aliases]) => aliases.length > 1);
+  const unseen = input.accounts.length - seen.length;
+  const head = `${seen.length} seat${seen.length === 1 ? '' : 's'} on ${byOrg.size} organization${byOrg.size === 1 ? '' : 's'}` + (unseen > 0 ? ` (${unseen} not yet observed)` : '');
+  if (shared.length === 0) {
+    return [{ status: 'ok', label: 'Organizations', detail: `${head} — every observed seat is on its own organization` }];
+  }
+  const pairs = shared.map(([org, aliases]) => `${aliases.join(' + ')} share ${org.slice(0, 8)}…`).join('; ');
+  return [{
+    status: 'info',
+    label: 'Organizations',
+    detail: `${head} — ${pairs}. Seats on one organization may be one subscription counted twice: \`sharesWindowWith\` on GET /accounts says so when they report the same window`,
+  }];
+}
 const REGRANT_FIX = " — re-grant with `dario accounts add <alias>` (or `dario login --force-reauth` for the login seat); the new grant restarts the clock";
 
 export function checkIdentityDrift(input: IdentityDriftInput): Check[] {
@@ -1061,6 +1095,7 @@ export async function runChecks(opts: RunChecksOptions = {}): Promise<Check[]> {
           (aliases.length === 1 ? ' (a pool of one — `dario accounts add <alias>` to load-balance)' : ''),
       });
       checks.push(...checkRefreshGrant({ accounts: loaded.map((a) => ({ alias: a.alias, grantedAt: a.grantedAt })), now }));
+      checks.push(...checkOrganizations({ accounts: loaded.map((a) => ({ alias: a.alias, organizationId: a.organizationId })) }));
 
       // Next-account-in-rotation surfacing. The proxy's per-request
       // selector picks by max headroom (with 7d_<family> per-model

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -100,6 +100,55 @@ export function utilFreshness(rl: RateLimitSnapshot, now: number): UtilFreshness
   };
 }
 
+/** When an account's rate-limit window rolls over — see `rateLimitWindow`. */
+export interface RateLimitWindow {
+  /**
+   * Epoch ms the window resets at, from `anthropic-ratelimit-unified-reset`;
+   * null when no response on this account has stated one.
+   */
+  resetAt: number | null;
+  /** Ms until that reset, floored at 0 once it has passed; null when unknown. */
+  resetInMs: number | null;
+}
+
+/**
+ * The reset moment of the window an account's last reading was measured
+ * against (dario#1244). The snapshot has carried `reset` since the header was
+ * first parsed and routing has expired rejections on it since #1232, but no
+ * operator surface showed it: a seat read `status: rejected` with nothing
+ * saying until when, and `requestCount: 0` beside it (a 429 serves nothing,
+ * so the attempt was never counted) made the rejection look like one dario
+ * had made up. For a `rejected` seat this is when the rejection lifts; for
+ * an `allowed` one, when its representative window rolls. The header is
+ * epoch SECONDS; both fields here are milliseconds, like `expiresInMs` and
+ * `utilAgeMs`.
+ */
+export function rateLimitWindow(rl: RateLimitSnapshot, now: number): RateLimitWindow {
+  if (!(rl.reset > 0)) return { resetAt: null, resetInMs: null };
+  const resetAt = rl.reset * 1000;
+  return { resetAt, resetInMs: Math.max(0, resetAt - now) };
+}
+
+/**
+ * One line for a log or a doctor row:
+ * `5h 104%, 7d 25%, claim five_hour, resets in 37m`.
+ */
+export function describeRateLimitSnapshot(rl: RateLimitSnapshot, now: number = Date.now()): string {
+  const pct = (n: number) => `${Math.round(n * 100)}%`;
+  const { resetInMs } = rateLimitWindow(rl, now);
+  const reset = resetInMs === null ? 'no reset stated'
+    : resetInMs === 0 ? 'window already rolled'
+    : `resets in ${formatDurationMs(resetInMs)}`;
+  return `5h ${pct(rl.util5h)}, 7d ${pct(rl.util7d)}, claim ${rl.claim}, ${reset}`;
+}
+
+function formatDurationMs(ms: number): string {
+  const totalMins = Math.max(1, Math.round(ms / 60_000));
+  const h = Math.floor(totalMins / 60);
+  const m = totalMins % 60;
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
 export interface PoolAccount {
   alias: string;
   accessToken: string;
@@ -108,6 +157,16 @@ export interface PoolAccount {
   identity: AccountIdentity;
   rateLimit: RateLimitSnapshot;
   requestCount: number;
+  /**
+   * Upstream 429s this account has answered. `requestCount` counts requests
+   * the account SERVED, and a 429 served nothing — so a seat parked on its
+   * first attempt read `requestCount: 0` next to `status: rejected`, as if
+   * dario had rejected a seat it never called (dario#1244). This is the field
+   * that says it was tried.
+   */
+  rejectedCount: number;
+  /** Epoch ms of the most recent 429 on this account; undefined if never. */
+  lastRejectedAt?: number;
   /** Epoch ms of the OAuth grant (refresh-grant.ts); undefined when unknown. */
   grantedAt?: number;
   /**
@@ -461,21 +520,36 @@ export class AccountPool {
     grantedAt?: number;
   }): void {
     const existing = this.accounts.get(alias);
+    // A record whose grantedAt differs from the live entry's is a NEW grant
+    // under this alias — a re-login, possibly on a different organization
+    // with its own windows. The live state describes the old credential (its
+    // rejection and reading, its auth streak, its identity), so it starts
+    // fresh (dario#1244): before this, a seat re-granted to clear
+    // `auth-cooldown` stayed cooling until the old streak's timer ran out,
+    // and one re-granted on another organization stayed parked on the old
+    // organization's window. A reconcile carrying the same grant — a token
+    // refresh, an admin change to another seat, a peer instance's rotation in
+    // HA — keeps the live state as before. So does a record with no grantedAt
+    // at all: it cannot be told apart from the same grant.
+    const regranted = existing !== undefined && opts.grantedAt !== undefined && opts.grantedAt !== existing.grantedAt;
+    const keep = regranted ? undefined : existing;
     this.accounts.set(alias, {
       alias,
       accessToken: opts.accessToken,
       refreshToken: opts.refreshToken,
       expiresAt: opts.expiresAt,
-      grantedAt: opts.grantedAt ?? existing?.grantedAt,
-      identity: existing?.identity ?? {
+      grantedAt: opts.grantedAt ?? keep?.grantedAt,
+      identity: keep?.identity ?? {
         deviceId: opts.deviceId,
         accountUuid: opts.accountUuid,
         sessionId: randomUUID(),
       },
-      rateLimit: existing?.rateLimit ?? { ...EMPTY_SNAPSHOT },
-      requestCount: existing?.requestCount ?? 0,
-      lastAuthFailureAt: existing?.lastAuthFailureAt,
-      consecutiveAuthFailures: existing?.consecutiveAuthFailures ?? 0,
+      rateLimit: keep?.rateLimit ?? { ...EMPTY_SNAPSHOT },
+      requestCount: keep?.requestCount ?? 0,
+      rejectedCount: keep?.rejectedCount ?? 0,
+      lastRejectedAt: keep?.lastRejectedAt,
+      lastAuthFailureAt: keep?.lastAuthFailureAt,
+      consecutiveAuthFailures: keep?.consecutiveAuthFailures ?? 0,
     });
   }
 
@@ -709,10 +783,22 @@ export class AccountPool {
     account.requestCount++;
   }
 
-  markRejected(alias: string, snapshot: RateLimitSnapshot): void {
+  /**
+   * Park `alias` on an upstream 429. Returns true when this takes a seat OUT
+   * of rotation — the first 429 of a window — and false when the seat was
+   * already parked inside a live window: the all-exhausted fallback in
+   * `select()` re-probes parked seats, so a pool with nothing left can 429
+   * the same seat many times, and only the transition is worth a log line.
+   */
+  markRejected(alias: string, snapshot: RateLimitSnapshot): boolean {
     const account = this.accounts.get(alias);
-    if (!account) return;
+    if (!account) return false;
+    const now = snapshot.updatedAt || Date.now();
+    const wasParked = account.rateLimit.status === 'rejected' && !rateLimitWindowPassed(account.rateLimit, now);
     account.rateLimit = { ...snapshot, status: 'rejected' };
+    account.rejectedCount++;
+    account.lastRejectedAt = now;
+    return !wasParked;
   }
 
   updateTokens(alias: string, accessToken: string, refreshToken: string, expiresAt: number): void {

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -149,6 +149,55 @@ function formatDurationMs(ms: number): string {
   return h > 0 ? `${h}h ${m}m` : `${m}m`;
 }
 
+/**
+ * The identity of the rate-limit window a reading was measured against:
+ * its representative claim plus its reset second, or null when the reading
+ * states no live window (no reset, a reset that has passed, or no claim).
+ *
+ * Two seats that report the same key are one subscription under two aliases
+ * (dario#1244, "a few have the same issue"): two independent windows all but
+ * never share a reset second, and two readings of one window always do. The
+ * organization id is deliberately NOT part of the key — several seats can
+ * share an organization and still have their own windows — the window itself
+ * is the fact that matters for headroom.
+ */
+export function windowKey(rl: RateLimitSnapshot, now: number): string | null {
+  if (!(rl.reset > 0) || rl.reset * 1000 <= now) return null;
+  if (!rl.claim || rl.claim === 'unknown') return null;
+  return `${rl.claim}@${rl.reset}`;
+}
+
+/** For every seat, the other aliases whose last reading names the same live window. */
+export function windowPeers(accounts: readonly PoolAccount[], now: number): Map<string, string[]> {
+  const byKey = new Map<string, string[]>();
+  for (const a of accounts) {
+    const k = windowKey(a.rateLimit, now);
+    if (!k) continue;
+    const list = byKey.get(k);
+    if (list) list.push(a.alias); else byKey.set(k, [a.alias]);
+  }
+  const out = new Map<string, string[]>();
+  for (const a of accounts) {
+    const k = windowKey(a.rateLimit, now);
+    out.set(a.alias, k ? (byKey.get(k) ?? []).filter((alias) => alias !== a.alias) : []);
+  }
+  return out;
+}
+
+/**
+ * How many windows the pool really has: each measured live window once, and
+ * each seat without a live reading as its own (nothing says otherwise yet).
+ */
+export function distinctWindows(accounts: readonly PoolAccount[], now: number): number {
+  const keys = new Set<string>();
+  let unmeasured = 0;
+  for (const a of accounts) {
+    const k = windowKey(a.rateLimit, now);
+    if (k) keys.add(k); else unmeasured++;
+  }
+  return keys.size + unmeasured;
+}
+
 export interface PoolAccount {
   alias: string;
   accessToken: string;
@@ -167,6 +216,15 @@ export interface PoolAccount {
   rejectedCount: number;
   /** Epoch ms of the most recent 429 on this account; undefined if never. */
   lastRejectedAt?: number;
+  /**
+   * The Anthropic organization behind this seat's token, from the
+   * `anthropic-organization-id` response header: learned on the first
+   * response the seat serves, written to its record with the next token
+   * refresh (dario#1244 — a reading that surprises you is usually a token on
+   * an organization other than the one whose usage page you are looking at).
+   * Undefined until seen.
+   */
+  organizationId?: string;
   /** Epoch ms of the OAuth grant (refresh-grant.ts); undefined when unknown. */
   grantedAt?: number;
   /**
@@ -518,6 +576,7 @@ export class AccountPool {
     deviceId: string;
     accountUuid: string;
     grantedAt?: number;
+    organizationId?: string;
   }): void {
     const existing = this.accounts.get(alias);
     // A record whose grantedAt differs from the live entry's is a NEW grant
@@ -539,6 +598,7 @@ export class AccountPool {
       refreshToken: opts.refreshToken,
       expiresAt: opts.expiresAt,
       grantedAt: opts.grantedAt ?? keep?.grantedAt,
+      organizationId: opts.organizationId ?? keep?.organizationId,
       identity: keep?.identity ?? {
         deviceId: opts.deviceId,
         accountUuid: opts.accountUuid,
@@ -801,6 +861,18 @@ export class AccountPool {
     return !wasParked;
   }
 
+  /**
+   * Record the organization a response said this seat belongs to. Returns
+   * true when it is news — the first observation, or a change (an alias
+   * re-granted on another organization) — so the caller persists it once.
+   */
+  noteOrganization(alias: string, organizationId: string): boolean {
+    const account = this.accounts.get(alias);
+    if (!account || !organizationId || account.organizationId === organizationId) return false;
+    account.organizationId = organizationId;
+    return true;
+  }
+
   updateTokens(alias: string, accessToken: string, refreshToken: string, expiresAt: number): void {
     const account = this.accounts.get(alias);
     if (!account) return;
@@ -917,6 +989,7 @@ export interface ReconcilableAccount {
   deviceId: string;
   accountUuid: string;
   grantedAt?: number;
+  organizationId?: string;
 }
 
 /**
@@ -941,6 +1014,7 @@ export function reconcilePoolAccounts(pool: AccountPool, accounts: ReconcilableA
       deviceId: a.deviceId,
       accountUuid: a.accountUuid,
       grantedAt: a.grantedAt,
+      organizationId: a.organizationId,
     });
   }
   for (const existing of pool.all()) {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -12,7 +12,7 @@ import { darioVersion } from './version.js';
 import { buildCCRequest, applyCcPromptCaching, isGenuineCCClient, parseEffortSuffix, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, overlayTemplateHeaderValues, forwardClientCCIdentityHeaders, isMcpToolName, CC_TEMPLATE, CC_CACHE_CONTROL, effectiveCacheControl, withForced1hBeta, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
 import { stampCch, hasCchSeed } from './cch.js';
 import { describeTemplate, detectDrift, checkCCCompat, probeInstalledCCVersion } from './live-fingerprint.js';
-import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCooldown, authCooldownMs, accountIneligibility, reportedAccountStatus, reconcilePoolAccounts, resolvePoolStrategy, utilFreshness, type PoolAccount } from './pool.js';
+import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCooldown, authCooldownMs, accountIneligibility, reportedAccountStatus, reconcilePoolAccounts, resolvePoolStrategy, utilFreshness, rateLimitWindow, describeRateLimitSnapshot, type PoolAccount } from './pool.js';
 import { Analytics, billingBucketFromClaim, formatUsageLogLine, SUBSCRIPTION_CLAIMS, type RequestRecord, CODEX_CLAIM } from './analytics.js';
 import { OverageGuard, buildHaltErrorBody, type HaltState } from './overage-guard.js';
 import { notify as osNotify } from './notify.js';
@@ -2472,9 +2472,12 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
               // surface documents itself as reporting the same snapshot, so it
               // must not be the one place a stale reading still looks current.
               ...utilFreshness(a.rateLimit, snapNow),
+              ...rateLimitWindow(a.rateLimit, snapNow),
               claim: a.rateLimit.claim,
               status: reportedAccountStatus(a, snapNow),
               requestCount: a.requestCount,
+              rejectedCount: a.rejectedCount,
+              lastRejectedAt: a.lastRejectedAt ?? null,
               // Raw streak, not just the cooldown boolean: a single 401 also
               // shows `auth-cooldown` for 60s, indistinguishable from a
               // genuinely dead refresh token by that field alone. The magnitude
@@ -2569,9 +2572,16 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           util5h: a.rateLimit.util5h,
           util7d: a.rateLimit.util7d,
           ...utilFreshness(a.rateLimit, now),
+          // When that window rolls (dario#1244): for a rejected seat, when
+          // the rejection lifts. Milliseconds, like expiresInMs.
+          ...rateLimitWindow(a.rateLimit, now),
           claim: a.rateLimit.claim,
           status: reportedAccountStatus(a, now),
           requestCount: a.requestCount,
+          // 429s answered — the attempts requestCount does not count, so a
+          // parked seat no longer reads as one that was never called.
+          rejectedCount: a.rejectedCount,
+          lastRejectedAt: a.lastRejectedAt ?? null,
           expiresInMs: Math.max(0, a.expiresAt - now),
           // Refresh-token grant age (refresh-grant.ts): the wall a token
           // refresh cannot move. null fields = grant date unknown.
@@ -4106,7 +4116,15 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
         if (poolAccount) {
           const snapshot = parseRateLimits(upstream.headers);
           if (upstream.status === 429) {
-            pool.markRejected(poolAccount.alias, snapshot);
+            // Say so the moment a seat leaves rotation. With a peer to fail
+            // over to the client sees 200, and nothing else named the seat,
+            // the reading, or when it comes back (dario#1244). Once per
+            // parking: the all-exhausted fallback re-probes parked seats, and
+            // those repeats are verbose-only.
+            const parked = pool.markRejected(poolAccount.alias, snapshot);
+            if (parked || verbose) {
+              console.error(`[dario] #${requestCount} rate limited (429) on account "${poolAccount.alias}": ${describeRateLimitSnapshot(snapshot)} — parked until the window rolls`);
+            }
           } else {
             pool.updateRateLimits(poolAccount.alias, snapshot);
           }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -12,13 +12,13 @@ import { darioVersion } from './version.js';
 import { buildCCRequest, applyCcPromptCaching, isGenuineCCClient, parseEffortSuffix, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, overlayTemplateHeaderValues, forwardClientCCIdentityHeaders, isMcpToolName, CC_TEMPLATE, CC_CACHE_CONTROL, effectiveCacheControl, withForced1hBeta, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
 import { stampCch, hasCchSeed } from './cch.js';
 import { describeTemplate, detectDrift, checkCCCompat, probeInstalledCCVersion } from './live-fingerprint.js';
-import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCooldown, authCooldownMs, accountIneligibility, reportedAccountStatus, reconcilePoolAccounts, resolvePoolStrategy, utilFreshness, rateLimitWindow, describeRateLimitSnapshot, type PoolAccount } from './pool.js';
+import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCooldown, authCooldownMs, accountIneligibility, reportedAccountStatus, reconcilePoolAccounts, resolvePoolStrategy, utilFreshness, rateLimitWindow, describeRateLimitSnapshot, windowPeers, distinctWindows, type PoolAccount } from './pool.js';
 import { Analytics, billingBucketFromClaim, formatUsageLogLine, SUBSCRIPTION_CLAIMS, type RequestRecord, CODEX_CLAIM } from './analytics.js';
 import { OverageGuard, buildHaltErrorBody, type HaltState } from './overage-guard.js';
 import { notify as osNotify } from './notify.js';
 import { grantAge, grantThresholds, worstGrantLevel, describeGrantAge, type GrantLevel } from './refresh-grant.js';
 import { resolveSeatPin, SEAT_PIN_HEADER, SEAT_PIN_TOKEN_HEADER } from './seat-pin.js';
-import { loadAllAccounts, loadAccount, saveAccount, refreshAccountToken, resyncLoginFromCredentialsIfStale, ensureLoginCredentialsInPool, mirrorLoginToCredentials } from './accounts.js';
+import { loadAllAccounts, loadAccount, saveAccount, refreshAccountToken, resyncLoginFromCredentialsIfStale, ensureLoginCredentialsInPool, mirrorLoginToCredentials, withObservedOrganization } from './accounts.js';
 import { handleAdminRequest, type AdminAccountLive, type AdminAuditEvent } from './admin-api.js';
 import { createTokenBucket } from './rate-limit.js';
 import { getOpenAIBackend, isOpenAIModel, forwardToOpenAI, type BackendCredentials } from './openai-backend.js';
@@ -1655,6 +1655,23 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
   const accountsList = await loadAllAccounts();
   const poolStrategy = resolvePoolStrategy(opts.poolStrategy);
   const pool = new AccountPool(poolStrategy);
+
+  // Two aliases reporting one window are one subscription counted twice
+  // (dario#1244). Said once per pair, when the second reading arrives; the
+  // listings carry it permanently as `sharesWindowWith`.
+  const announcedWindowPairs = new Set<string>();
+  const announceWindowPeers = (alias: string): void => {
+    const now = Date.now();
+    const seat = pool.get(alias);
+    if (!seat) return;
+    for (const peer of windowPeers(pool.all(), now).get(alias) ?? []) {
+      const pair = [alias, peer].sort().join('|');
+      if (announcedWindowPairs.has(pair)) continue;
+      announcedWindowPairs.add(pair);
+      const windows = distinctWindows(pool.all(), now);
+      console.error(`[dario] seats "${alias}" and "${peer}" report the same ${seat.rateLimit.claim} window (resets ${new Date(seat.rateLimit.reset * 1000).toISOString()}) — one subscription under two aliases; the pool has ${windows} distinct window${windows === 1 ? '' : 's'} across ${pool.size} seats`);
+    }
+  };
   if (poolStrategy !== 'headroom') {
     console.log(`  Pool strategy: ${poolStrategy} (new conversations fill the alphabetically-first seat, spill at the 2% floor)`);
   }
@@ -1726,6 +1743,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
         deviceId: acc.deviceId,
         accountUuid: acc.accountUuid,
         grantedAt: acc.grantedAt,
+        organizationId: acc.organizationId,
       });
     }
     // Startup self-heal (dario#790): eagerly refresh any account whose access
@@ -1744,7 +1762,9 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
         try {
           const saved = await loadAccount(acc.alias);
           if (!saved) return;
-          const refreshed = await refreshAccountToken(saved);
+          // The refresh's write carries the organization the seat was
+          // observed on (dario#1244) — the one write that touches the record.
+          const refreshed = await refreshAccountToken(withObservedOrganization(saved, acc.organizationId));
           pool.updateTokens(acc.alias, refreshed.accessToken, refreshed.refreshToken, refreshed.expiresAt);
           // Mirror a refreshed `login` token back to credentials.json so the
           // legacy file (and `dario doctor`) tracks the pool store (#808).
@@ -1789,7 +1809,9 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
         try {
           const saved = await loadAccount(acc.alias);
           if (!saved) continue;
-          const refreshed = await refreshAccountToken(saved);
+          // The refresh's write carries the organization the seat was
+          // observed on (dario#1244) — the one write that touches the record.
+          const refreshed = await refreshAccountToken(withObservedOrganization(saved, acc.organizationId));
           pool.updateTokens(acc.alias, refreshed.accessToken, refreshed.refreshToken, refreshed.expiresAt);
           // Mirror a refreshed `login` token back to credentials.json so the
           // legacy file (and `dario doctor`) tracks the pool store (#808).
@@ -1834,6 +1856,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           deviceId: acc.deviceId,
           accountUuid: acc.accountUuid,
           grantedAt: acc.grantedAt,
+          organizationId: acc.organizationId,
         });
       }
     }
@@ -2463,6 +2486,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
         // just persisted metadata — the same snapshot GET /accounts exposes.
         poolStatus: () => {
           const snapNow = Date.now();
+          const peers = windowPeers(pool.all(), snapNow);
           const snap = new Map<string, AdminAccountLive>();
           for (const a of pool.all()) {
             snap.set(a.alias, {
@@ -2478,6 +2502,8 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
               requestCount: a.requestCount,
               rejectedCount: a.rejectedCount,
               lastRejectedAt: a.lastRejectedAt ?? null,
+              organizationId: a.organizationId ?? null,
+              sharesWindowWith: peers.get(a.alias) ?? [],
               // Raw streak, not just the cooldown boolean: a single 401 also
               // shows `auth-cooldown` for 60s, indistinguishable from a
               // genuinely dead refresh token by that field alone. The magnitude
@@ -2547,6 +2573,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
     // the `dario accounts` CLI, not HTTP.
     if (urlPath === '/accounts' && req.method === 'GET') {
       const now = Date.now();
+      const peers = windowPeers(pool.all(), now);
       const accounts = pool.all().map(a => {
         const inCooldown = isInAuthCooldown(a, now);
         const cooldownMs = inCooldown && a.lastAuthFailureAt
@@ -2582,6 +2609,11 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           // parked seat no longer reads as one that was never called.
           rejectedCount: a.rejectedCount,
           lastRejectedAt: a.lastRejectedAt ?? null,
+          // Which organization the token belongs to, and which other seats
+          // report the same live window — one subscription under several
+          // aliases (dario#1244).
+          organizationId: a.organizationId ?? null,
+          sharesWindowWith: peers.get(a.alias) ?? [],
           expiresInMs: Math.max(0, a.expiresAt - now),
           // Refresh-token grant age (refresh-grant.ts): the wall a token
           // refresh cannot move. null fields = grant date unknown.
@@ -2604,6 +2636,9 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
         mode: 'pool',
         ...pool.status(),
         stickyBindings: pool.stickyCount(),
+        // Windows the pool really has: each measured window once, each
+        // unmeasured seat as its own.
+        distinctWindows: distinctWindows(pool.all(), now),
         accounts,
       }));
       return;
@@ -4128,6 +4163,12 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           } else {
             pool.updateRateLimits(poolAccount.alias, snapshot);
           }
+          // Which organization answered (dario#1244). Held in the pool at
+          // once; written to the seat's record by its next token refresh —
+          // the write that already exists — so nothing here races a refresh.
+          const organizationId = upstream.headers.get('anthropic-organization-id');
+          if (organizationId) pool.noteOrganization(poolAccount.alias, organizationId);
+          announceWindowPeers(poolAccount.alias);
           // First-sight detector for per-model rate-limit buckets. Anthropic
           // ships these unannounced — e.g. `7d_sonnet-utilization` appeared
           // around 2026-04-25 — and verbose-mode users want a heads-up the

--- a/src/tui/tabs/accounts.ts
+++ b/src/tui/tabs/accounts.ts
@@ -38,6 +38,8 @@ export interface AccountsState {
     util5h?: number;
     util7d?: number;
     status?: string;
+    /** Ms until the seat's rate-limit window rolls; null/absent when unknown. */
+    resetInMs?: number | null;
   }>;
   error: string | null;
   /** Where the list came from: the running proxy's pool, the proxy's
@@ -54,6 +56,7 @@ interface AccountsEndpoint {
     util5h?: number;
     util7d?: number;
     status?: string;
+    resetInMs?: number | null;
   }>;
 }
 
@@ -142,8 +145,11 @@ export const AccountsTab: Tab<AccountsState> = {
         const expiresCol = pad(formatExpiry(acc.expiresAt), 14);
         const u5 = pad(acc.util5h !== undefined ? `${Math.round(acc.util5h * 100)}%` : '—', 9);
         const u7 = pad(acc.util7d !== undefined ? `${Math.round(acc.util7d * 100)}%` : '—', 9);
-        const statusCol = acc.status ?? '—';
-        const statusFg = statusCol === 'auth-cooldown' ? fg('yellow', statusCol) : dim(statusCol);
+        // A parked seat says for how long (dario#1244): "rejected 37m".
+        const statusCol = acc.status === 'rejected' && typeof acc.resetInMs === 'number'
+          ? `rejected ${formatCountdown(acc.resetInMs)}`
+          : (acc.status ?? '—');
+        const statusFg = statusCol === 'auth-cooldown' || acc.status === 'rejected' ? fg('yellow', statusCol) : dim(statusCol);
         push('  ' + aliasCol + expiresCol + u5 + u7 + statusFg);
       } else {
         const expiresCol = pad(formatExpiry(acc.expiresAt), 16);
@@ -191,6 +197,7 @@ export async function refreshAccounts(ctx?: TabContext<AccountsState>): Promise<
             util5h: a.util5h,
             util7d: a.util7d,
             status: a.status,
+            resetInMs: a.resetInMs,
           })),
           error: null,
         };
@@ -223,6 +230,15 @@ async function diskFallback(): Promise<AccountsState> {
   } catch (e) {
     return { loading: false, accounts: [], error: (e as Error).message, source: 'disk' };
   }
+}
+
+/** `37m` / `4h59m` / `now` — how long until a parked seat's window rolls. */
+function formatCountdown(ms: number): string {
+  if (ms <= 0) return 'now';
+  const totalMins = Math.max(1, Math.round(ms / 60_000));
+  const h = Math.floor(totalMins / 60);
+  const m = totalMins % 60;
+  return h > 0 ? `${h}h${m}m` : `${m}m`;
 }
 
 function formatExpiry(expiresAt: number): string {

--- a/test/admin-api.mjs
+++ b/test/admin-api.mjs
@@ -496,5 +496,41 @@ header('Rate limiting — mutations + auth failures return 429');
   }
 }
 
+// ─────────────────────────────────────────────────────────────
+header('GET /admin/accounts — reading age, window reset and rejection count surfaced (#1244)');
+{
+  const now = Date.now();
+  const listAccounts = async () => [
+    { alias: 'parked', scopes: [], expiresAt: now + 1000 },
+    { alias: 'older', scopes: [], expiresAt: now + 1000 },
+  ];
+  const poolStatus = () => new Map([
+    // The reported shape: parked on its first attempt at 104% of the
+    // five-hour window, 37 minutes from its reset.
+    ['parked', {
+      util5h: 1.04, util7d: 0.25, lastObservedAt: now - 5_000, utilAgeMs: 5_000,
+      resetAt: now + 37 * 60_000, resetInMs: 37 * 60_000,
+      claim: 'five_hour', status: 'rejected', requestCount: 0,
+      rejectedCount: 1, lastRejectedAt: now - 5_000, consecutiveAuthFailures: 0,
+    }],
+    // A snapshot without the new fields must not leave `undefined` holes:
+    // null / 0 are the documented absent values.
+    ['older', { util5h: 0, util7d: 0, claim: 'unknown', status: 'unknown', requestCount: 0, consecutiveAuthFailures: 0 }],
+  ]);
+  const req = mockReq('GET', '/admin/accounts', bearer(TOKEN));
+  const res = mockRes();
+  await handleAdminRequest(req, res, '/admin/accounts', { adminTokenBuf: TOKEN_BUF, listAccounts, poolStatus });
+  const json = JSON.parse(res.body);
+  const p = json.accounts.find(a => a.alias === 'parked');
+  const o = json.accounts.find(a => a.alias === 'older');
+  check('last_observed_at / util_age_ms merged in (#1032 fields this surface dropped)', p?.last_observed_at === now - 5_000 && p?.util_age_ms === 5_000);
+  check('reset_at / reset_in_ms merged in', p?.reset_at === now + 37 * 60_000 && p?.reset_in_ms === 37 * 60_000);
+  check('rejected_count / last_rejected_at merged in', p?.rejected_count === 1 && p?.last_rejected_at === now - 5_000);
+  check('request_count is still the served count (0)', p?.request_count === 0);
+  check('absent freshness / reset → null, not missing',
+    o !== undefined && 'last_observed_at' in o && o.last_observed_at === null && o.util_age_ms === null && o.reset_at === null && o.reset_in_ms === null);
+  check('absent rejection fields → 0 / null', o?.rejected_count === 0 && o?.last_rejected_at === null);
+}
+
 console.log(`\n${pass} pass, ${fail} fail`);
 if (fail > 0) process.exit(1);

--- a/test/admin-api.mjs
+++ b/test/admin-api.mjs
@@ -532,5 +532,35 @@ header('GET /admin/accounts — reading age, window reset and rejection count su
   check('absent rejection fields → 0 / null', o?.rejected_count === 0 && o?.last_rejected_at === null);
 }
 
+// ─────────────────────────────────────────────────────────────
+header('GET /admin/accounts — organization and shared window surfaced (#1244)');
+{
+  const now = Date.now();
+  const listAccounts = async () => [
+    // Persisted from an earlier run: known even with no live pool entry.
+    { alias: 'busy', scopes: [], expiresAt: now + 1000, organizationId: 'org-A' },
+    { alias: 'twin', scopes: [], expiresAt: now + 1000 },
+    { alias: 'cold', scopes: [], expiresAt: now + 1000, organizationId: 'org-C' },
+  ];
+  const poolStatus = () => new Map([
+    ['busy', { util5h: 0.5, util7d: 0.1, claim: 'five_hour', status: 'allowed', requestCount: 3, consecutiveAuthFailures: 0, organizationId: 'org-A', sharesWindowWith: ['twin'] }],
+    ['twin', { util5h: 0.5, util7d: 0.1, claim: 'five_hour', status: 'allowed', requestCount: 1, consecutiveAuthFailures: 0, organizationId: 'org-A', sharesWindowWith: ['busy'] }],
+    // Live entry that has not observed its organization yet: must not null
+    // out the persisted value.
+    ['cold', { util5h: 0, util7d: 0, claim: 'unknown', status: 'unknown', requestCount: 0, consecutiveAuthFailures: 0, organizationId: null, sharesWindowWith: [] }],
+  ]);
+  const req = mockReq('GET', '/admin/accounts', bearer(TOKEN));
+  const res = mockRes();
+  await handleAdminRequest(req, res, '/admin/accounts', { adminTokenBuf: TOKEN_BUF, listAccounts, poolStatus });
+  const json = JSON.parse(res.body);
+  const busy = json.accounts.find(a => a.alias === 'busy');
+  const twin = json.accounts.find(a => a.alias === 'twin');
+  const cold = json.accounts.find(a => a.alias === 'cold');
+  check('organization_id from the live pool', busy?.organization_id === 'org-A' && twin?.organization_id === 'org-A');
+  check('shares_window_with both ways', JSON.stringify(busy?.shares_window_with) === '["twin"]' && JSON.stringify(twin?.shares_window_with) === '["busy"]');
+  check('persisted organization_id survives a live entry that has none yet', cold?.organization_id === 'org-C');
+  check('no peers → empty list, not missing', Array.isArray(cold?.shares_window_with) && cold.shares_window_with.length === 0);
+}
+
 console.log(`\n${pass} pass, ${fail} fail`);
 if (fail > 0) process.exit(1);

--- a/test/doctor-organizations.mjs
+++ b/test/doctor-organizations.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// dario#1244 — the `Organizations` doctor row: which seats sit on which
+// Anthropic organization, from the ids persisted on their records. Pure.
+
+import { checkOrganizations } from '../dist/doctor-core.js';
+
+let pass = 0, fail = 0;
+const check = (label, cond, detail) => { if (cond) { console.log(`  OK ${label}`); pass++; } else { console.log(`  FAIL ${label}${detail !== undefined ? ' :: ' + detail : ''}`); fail++; } };
+const header = (l) => console.log(`\n=== ${l} ===`);
+
+header('fewer than two observed seats → nothing to say');
+{
+  check('empty pool → no row', checkOrganizations({ accounts: [] }).length === 0);
+  check('one seat → no row', checkOrganizations({ accounts: [{ alias: 'a', organizationId: 'org-A' }] }).length === 0);
+  check('two seats, one unobserved → no row', checkOrganizations({ accounts: [{ alias: 'a', organizationId: 'org-A' }, { alias: 'b' }] }).length === 0);
+}
+
+header('every seat on its own organization → ok');
+{
+  const rows = checkOrganizations({ accounts: [
+    { alias: 'a', organizationId: 'org-A' }, { alias: 'b', organizationId: 'org-B' }, { alias: 'c' },
+  ] });
+  check('one row', rows.length === 1 && rows[0].label === 'Organizations');
+  check('status ok', rows[0].status === 'ok');
+  check('counts observed seats and organizations, notes the unobserved one', /2 seats on 2 organizations \(1 not yet observed\)/.test(rows[0].detail), rows[0].detail);
+  check('says they are distinct', /own organization/.test(rows[0].detail));
+}
+
+header('two seats on one organization → info, naming them');
+{
+  const rows = checkOrganizations({ accounts: [
+    { alias: 'busy', organizationId: '927b430e-44e5-4504-a2bd-4ec1e286094c' },
+    { alias: 'twin', organizationId: '927b430e-44e5-4504-a2bd-4ec1e286094c' },
+    { alias: 'spare', organizationId: '1a2b3c4d-0000-4000-8000-00000000000b' },
+  ] });
+  check('status info (may be one subscription; the window says for sure)', rows[0].status === 'info', rows[0].status);
+  check('names the pair and the short org id', /busy \+ twin share 927b430e…/.test(rows[0].detail), rows[0].detail);
+  check('3 seats on 2 organizations', /3 seats on 2 organizations/.test(rows[0].detail), rows[0].detail);
+  check('points at sharesWindowWith rather than asserting a shared limit', /sharesWindowWith/.test(rows[0].detail) && /may be/.test(rows[0].detail));
+}
+
+header('singular wording');
+{
+  const rows = checkOrganizations({ accounts: [{ alias: 'a', organizationId: 'org-A' }, { alias: 'b', organizationId: 'org-A' }] });
+  check('2 seats on 1 organization', /2 seats on 1 organization —/.test(rows[0].detail), rows[0].detail);
+}
+
+console.log(`\ndoctor-organizations: ${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/test/pool-org-window-surfaces.mjs
+++ b/test/pool-org-window-surfaces.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+// dario#1244 — one subscription under two aliases, end to end.
+//
+// Three seats on a fake upstream: `busy` and `twin` answer with the same
+// organization id and the same five-hour window (same reset second); `spare`
+// is on another organization with its own window. Drives the real proxy,
+// then asserts what every operator surface says: GET /accounts, GET
+// /admin/accounts, the seat records on disk, the proxy log, and
+// `dario accounts list --live` run as a real child process.
+
+import { mkdtemp, mkdir, writeFile, readFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { freePort } from './helpers/free-port.mjs';
+
+const execFileP = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const out = console.log.bind(console);
+let pass = 0, fail = 0;
+const check = (name, cond, detail) => {
+  if (cond) { out(`  OK ${name}`); pass++; }
+  else { out(`  FAIL ${name}${detail !== undefined ? ' :: ' + detail : ''}`); fail++; }
+};
+const header = (n) => out(`\n=== ${n} ===`);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const PORT = await freePort();
+const ADMIN_TOKEN = 'org-window-admin-token';
+const tmpHome = await mkdtemp(join(tmpdir(), 'dario-orgwin-'));
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+process.env.DARIO_ADMIN = '1';
+process.env.DARIO_ADMIN_TOKEN = ADMIN_TOKEN;
+delete process.env.DARIO_API_KEY;
+delete process.env.DARIO_CODEX_BASE_URL;
+delete process.env.DARIO_PORT;
+const accountsDir = join(tmpHome, '.dario', 'accounts');
+await mkdir(accountsDir, { recursive: true });
+const seat = (alias, token) => JSON.stringify({
+  alias, accessToken: token, refreshToken: `${token}-refresh`,
+  expiresAt: Date.now() + 6 * 3_600_000, scopes: ['user:inference'],
+  deviceId: `dev-${alias}`, accountUuid: `uuid-${alias}`,
+});
+for (const a of ['busy', 'twin', 'spare']) await writeFile(join(accountsDir, `${a}.json`), seat(a, `${a}-token`));
+
+const ORG_A = '927b430e-0000-4000-8000-00000000000a';
+const ORG_B = '1a2b3c4d-0000-4000-8000-00000000000b';
+const RESET_A = Math.floor(Date.now() / 1000) + 37 * 60;
+const RESET_B = Math.floor(Date.now() / 1000) + 4 * 3600;
+const bySeat = {
+  'busy-token': { org: ORG_A, reset: RESET_A, util5h: 0.42 },
+  'twin-token': { org: ORG_A, reset: RESET_A, util5h: 0.42 },
+  'spare-token': { org: ORG_B, reset: RESET_B, util5h: 0.05 },
+};
+const calls = [];
+const fetchImpl = async (url, init) => {
+  if (String(url).includes('/v1/models')) {
+    return new Response(JSON.stringify({ data: [{ id: 'claude-sonnet-5', type: 'model' }] }), {
+      status: 200, headers: { 'content-type': 'application/json' },
+    });
+  }
+  const h = init?.headers;
+  const pairs = Array.isArray(h) ? h : h instanceof Headers ? [...h.entries()] : Object.entries(h ?? {});
+  const auth = String((pairs.find(([k]) => String(k).toLowerCase() === 'authorization') ?? [, ''])[1]);
+  const bearer = auth.replace(/^Bearer\s+/i, '');
+  calls.push(bearer);
+  const s = bySeat[bearer];
+  return new Response(JSON.stringify({
+    id: 'msg_1', type: 'message', role: 'assistant', model: 'claude-sonnet-5',
+    content: [{ type: 'text', text: 'PONG' }], stop_reason: 'end_turn', stop_sequence: null,
+    usage: { input_tokens: 1, output_tokens: 1 },
+  }), {
+    status: 200,
+    headers: {
+      'content-type': 'application/json',
+      'anthropic-organization-id': s.org,
+      'request-id': `req_${calls.length}`,
+      'anthropic-ratelimit-unified-status': 'allowed',
+      'anthropic-ratelimit-unified-5h-utilization': String(s.util5h),
+      'anthropic-ratelimit-unified-7d-utilization': '0.10',
+      'anthropic-ratelimit-unified-representative-claim': 'five_hour',
+      'anthropic-ratelimit-unified-reset': String(s.reset),
+    },
+  });
+};
+
+const log = [];
+for (const m of ['log', 'error', 'warn']) console[m] = (...a) => { log.push(a.map(String).join(' ')); };
+const sharedLines = () => log.filter((l) => l.includes('report the same five_hour window'));
+
+const { startProxy } = await import('../dist/proxy.js');
+await startProxy({ host: '127.0.0.1', port: PORT, passthrough: false, verbose: false, noLiveCapture: true, fetchImpl });
+const BASE = `http://127.0.0.1:${PORT}`;
+for (let i = 0; i < 50; i++) { try { await fetch(`${BASE}/health`); break; } catch { await sleep(100); } }
+
+const messages = (content) => fetch(`${BASE}/v1/messages`, {
+  method: 'POST', headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ model: 'claude-sonnet-5', max_tokens: 16, messages: [{ role: 'user', content }] }),
+});
+const accounts = async () => (await (await fetch(`${BASE}/accounts`)).json());
+const adminAccounts = async () => (await (await fetch(`${BASE}/admin/accounts`, { headers: { authorization: `Bearer ${ADMIN_TOKEN}` } })).json()).accounts;
+
+header('every seat serves once (max-headroom picks the unmeasured seat first)');
+{
+  // Distinct first messages = distinct conversations; a measured seat has
+  // headroom < 1.0, so each request lands on a seat not yet measured.
+  for (let i = 0; i < 6 && new Set(calls).size < 3; i++) {
+    const r = await messages(`conversation ${i} ${Math.random()}`);
+    await r.text();
+  }
+  check('busy, twin and spare each answered', new Set(calls).size === 3, calls.join(','));
+}
+
+header('GET /accounts — organization, shared window, distinct windows');
+{
+  const body = await accounts();
+  const by = Object.fromEntries(body.accounts.map((a) => [a.alias, a]));
+  check('organizationId learned per seat', by.busy.organizationId === ORG_A && by.twin.organizationId === ORG_A && by.spare.organizationId === ORG_B, JSON.stringify([by.busy.organizationId, by.spare.organizationId]));
+  check('busy ↔ twin share a window', JSON.stringify(by.busy.sharesWindowWith) === '["twin"]' && JSON.stringify(by.twin.sharesWindowWith) === '["busy"]', JSON.stringify([by.busy.sharesWindowWith, by.twin.sharesWindowWith]));
+  check('spare shares with nobody', Array.isArray(by.spare.sharesWindowWith) && by.spare.sharesWindowWith.length === 0);
+  check('distinctWindows counts the window once → 2', body.distinctWindows === 2, body.distinctWindows);
+  check('the pool still lists 3 seats', body.accounts.length === 3);
+}
+
+header('GET /admin/accounts — the same facts, snake_case');
+{
+  const by = Object.fromEntries((await adminAccounts()).map((a) => [a.alias, a]));
+  check('organization_id', by.busy.organization_id === ORG_A && by.spare.organization_id === ORG_B);
+  check('shares_window_with', JSON.stringify(by.twin.shares_window_with) === '["busy"]' && by.spare.shares_window_with.length === 0);
+}
+
+header('the request path never writes the seat record (the refresh does)');
+{
+  const busy = JSON.parse(await readFile(join(accountsDir, 'busy.json'), 'utf8'));
+  check('busy.json untouched by serving', busy.organizationId === undefined && busy.accessToken === 'busy-token');
+}
+
+header('a record that already states its organization is known before any request');
+{
+  // A seat written with organizationId (by an earlier refresh) is loaded with
+  // it. Reconcile from disk is what an admin change triggers: add the file,
+  // remove another seat through the admin API, and the pool reloads.
+  const ORG_C = 'c0ffee00-0000-4000-8000-00000000000c';
+  await writeFile(join(accountsDir, 'late.json'), JSON.stringify({ ...JSON.parse(seat('late', 'late-token')), organizationId: ORG_C }));
+  const del = await fetch(`${BASE}/admin/accounts/spare`, { method: 'DELETE', headers: { authorization: `Bearer ${ADMIN_TOKEN}` } });
+  check('spare removed via the admin API', del.status === 200, del.status);
+  const by = Object.fromEntries((await accounts()).accounts.map((a) => [a.alias, a]));
+  check('late is in the pool with its recorded organization, unmeasured', by.late?.organizationId === ORG_C && by.late?.requestCount === 0, JSON.stringify(by.late));
+  check('busy kept what it learned across the reload', by.busy?.organizationId === ORG_A);
+  check('spare is gone', by.spare === undefined);
+}
+
+header('the proxy says it once');
+{
+  check('exactly one shared-window line', sharedLines().length === 1, JSON.stringify(sharedLines()));
+  check('it names both seats and the window count', /seats "(busy|twin)" and "(busy|twin)".*2 distinct windows across 3 seats/.test(sharedLines()[0] ?? ''), sharedLines()[0]);
+  // More traffic on the pair must not repeat it.
+  for (let i = 0; i < 3; i++) { const r = await messages(`again ${i} ${Math.random()}`); await r.text(); }
+  check('still one line after more requests', sharedLines().length === 1, sharedLines().length);
+}
+
+header('dario accounts list --live — the running proxy\'s view, as a real child process');
+{
+  const cli = join(__dirname, '..', 'dist', 'cli.js');
+  const env = { ...process.env, HOME: tmpHome, USERPROFILE: tmpHome };
+  delete env.DARIO_API_KEY;
+  const { stdout } = await execFileP(process.execPath, [cli, 'accounts', 'list', '--live', `--port=${PORT}`], { env, timeout: 20_000 });
+  check('headline says it is live and counts windows', /Accounts \(live/.test(stdout) && /3 seats on 2 distinct windows/.test(stdout), stdout.slice(0, 400));
+  check('the unmeasured seat says so', /late[\s\S]*never measured/.test(stdout), stdout);
+  check('a seat row carries status and reading', /busy\s+allowed\s+5h 42%/.test(stdout), stdout);
+  check('organization short id shown', stdout.includes(`org ${ORG_A.slice(0, 8)}`), stdout);
+  check('shared window named both ways', /busy[\s\S]*shares its window with twin/.test(stdout) && /twin[\s\S]*shares its window with busy/.test(stdout), stdout);
+  check('served / 429s counters shown', /served \d+  ·  429s 0/.test(stdout), stdout);
+
+  // Without a proxy the flag falls back to the on-disk listing with a note.
+  const dead = await freePort();
+  const r2 = await execFileP(process.execPath, [cli, 'accounts', 'list', '--live', `--port=${dead}`], { env, timeout: 20_000 });
+  check('no proxy → note + on-disk listing', /no proxy on http:\/\/127\.0\.0\.1:\d+/.test(r2.stdout) && /token expires in/.test(r2.stdout), r2.stdout.slice(0, 300));
+}
+
+out(`\npool-org-window-surfaces: ${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/test/pool-parked-seat-surfaces.mjs
+++ b/test/pool-parked-seat-surfaces.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+// dario#1244 — a seat parked on its first 429 must explain itself.
+//
+// Reported on a six-seat pool (v6.0.32): one seat listed as
+//   util5h 1.04, claim five_hour, status rejected, request_count 0
+// while the operator's own usage page for that seat read 0%. Every field was
+// true — the seat's organization really had answered 429 at 104% of its
+// five-hour window — but nothing said so: the client saw 200 from a peer, the
+// proxy logged nothing about the seat, the listing carried no reset and no
+// reading age, and `request_count: 0` (a 429 serves nothing, so the attempt
+// was never counted) made the rejection read as one dario had invented.
+//
+// This drives the real proxy in-process with a fake upstream: seat `busy`
+// answers 429 with exactly that header set, seat `spare` answers 200. Then it
+// asserts what each operator surface says about the parked seat.
+
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { freePort } from './helpers/free-port.mjs';
+
+// The proxy's console output is captured below; keep the real one for ours.
+const out = console.log.bind(console);
+let pass = 0, fail = 0;
+const check = (name, cond, detail) => {
+  if (cond) { out(`  OK ${name}`); pass++; }
+  else { out(`  FAIL ${name}${detail !== undefined ? ' :: ' + detail : ''}`); fail++; }
+};
+const header = (n) => out(`\n=== ${n} ===`);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const PORT = await freePort();
+const ADMIN_TOKEN = 'parked-seat-admin-token';
+const tmpHome = await mkdtemp(join(tmpdir(), 'dario-parked-'));
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+process.env.DARIO_ADMIN = '1';
+process.env.DARIO_ADMIN_TOKEN = ADMIN_TOKEN;
+delete process.env.DARIO_API_KEY;
+delete process.env.DARIO_CODEX_BASE_URL;
+await mkdir(join(tmpHome, '.dario', 'accounts'), { recursive: true });
+const seat = (alias, token) => JSON.stringify({
+  alias, accessToken: token, refreshToken: `${token}-refresh`,
+  expiresAt: Date.now() + 6 * 3_600_000, scopes: ['user:inference'],
+  deviceId: `dev-${alias}`, accountUuid: `uuid-${alias}`,
+});
+await writeFile(join(tmpHome, '.dario', 'accounts', 'busy.json'), seat('busy', 'busy-token'));
+await writeFile(join(tmpHome, '.dario', 'accounts', 'spare.json'), seat('spare', 'spare-token'));
+
+const RESET_IN_S = 37 * 60;
+const busyResetS = Math.floor(Date.now() / 1000) + RESET_IN_S;
+const spareResetS = Math.floor(Date.now() / 1000) + 4 * 3600;
+const unified = (status, util5h, util7d, resetS) => ({
+  'content-type': 'application/json',
+  'anthropic-ratelimit-unified-status': status,
+  'anthropic-ratelimit-unified-5h-utilization': String(util5h),
+  'anthropic-ratelimit-unified-7d-utilization': String(util7d),
+  'anthropic-ratelimit-unified-representative-claim': 'five_hour',
+  'anthropic-ratelimit-unified-reset': String(resetS),
+});
+const rateLimited = (resetS) => new Response(
+  JSON.stringify({ type: 'error', error: { type: 'rate_limit_error', message: 'Error' } }),
+  { status: 429, headers: unified('rejected', 1.04, 0.25, resetS) },
+);
+const ok = (resetS) => new Response(JSON.stringify({
+  id: 'msg_1', type: 'message', role: 'assistant', model: 'claude-sonnet-5',
+  content: [{ type: 'text', text: 'PONG' }], stop_reason: 'end_turn', stop_sequence: null,
+  usage: { input_tokens: 1, output_tokens: 1 },
+}), { status: 200, headers: unified('allowed', 0.05, 0, resetS) });
+
+// Flipped later: spare starts answering 429 on a window that has ALREADY
+// rolled, the state a seat is in once its rejection has expired.
+let spareRolled = false;
+const calls = [];
+const fetchImpl = async (url, init) => {
+  if (String(url).includes('/v1/models')) {
+    return new Response(JSON.stringify({ data: [{ id: 'claude-sonnet-5', type: 'model' }] }), {
+      status: 200, headers: { 'content-type': 'application/json' },
+    });
+  }
+  const h = init?.headers;
+  const pairs = Array.isArray(h) ? h : h instanceof Headers ? [...h.entries()] : Object.entries(h ?? {});
+  const auth = String((pairs.find(([k]) => String(k).toLowerCase() === 'authorization') ?? [, ''])[1]);
+  const bearer = auth.replace(/^Bearer\s+/i, '');
+  calls.push(bearer);
+  if (bearer === 'busy-token') return rateLimited(busyResetS);
+  if (spareRolled) return rateLimited(Math.floor(Date.now() / 1000) - 5);
+  return ok(spareResetS);
+};
+
+const log = [];
+for (const m of ['log', 'error', 'warn']) console[m] = (...a) => { log.push(a.map(String).join(' ')); };
+const parkingLines = (alias) => log.filter((l) => l.includes(`rate limited (429) on account "${alias}"`));
+
+const { startProxy } = await import('../dist/proxy.js');
+// verbose OFF: the parking line must be there without it.
+await startProxy({ host: '127.0.0.1', port: PORT, passthrough: false, verbose: false, noLiveCapture: true, fetchImpl });
+const BASE = `http://127.0.0.1:${PORT}`;
+for (let i = 0; i < 50; i++) { try { await fetch(`${BASE}/health`); break; } catch { await sleep(100); } }
+
+const messages = (content) => fetch(`${BASE}/v1/messages`, {
+  method: 'POST', headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ model: 'claude-sonnet-5', max_tokens: 16, messages: [{ role: 'user', content }] }),
+});
+const accounts = async () => (await (await fetch(`${BASE}/accounts`)).json()).accounts;
+const adminAccounts = async () => (await (await fetch(`${BASE}/admin/accounts`, { headers: { authorization: `Bearer ${ADMIN_TOKEN}` } })).json()).accounts;
+const near = (a, b, tol) => typeof a === 'number' && Math.abs(a - b) <= tol;
+
+header('the busy seat is tried once, the client never notices');
+{
+  // Distinct first messages = distinct conversations, so nothing is sticky.
+  // The never-measured seat (headroom 1.0) is picked as soon as the other has
+  // reported any utilisation, so busy is tried within a couple of requests.
+  const statuses = [];
+  for (let i = 0; i < 3 && !calls.includes('busy-token'); i++) {
+    const r = await messages(`conversation ${i} ${Math.random()}`);
+    statuses.push(r.status);
+    await r.text();
+  }
+  check('busy was sent exactly one request', calls.filter((b) => b === 'busy-token').length === 1, calls.join(','));
+  check('every client request got 200 (failover to spare)', statuses.length > 0 && statuses.every((s) => s === 200), statuses.join(','));
+}
+
+header('GET /accounts — the parked seat says since when, until when, and that it was tried');
+{
+  const now = Date.now();
+  const busy = (await accounts()).find((a) => a.alias === 'busy');
+  check('status rejected (window still ahead)', busy?.status === 'rejected', busy?.status);
+  check('the 429 reading is what upstream said', busy?.util5h === 1.04 && busy?.util7d === 0.25 && busy?.claim === 'five_hour');
+  check('resetAt is the header, in ms', busy?.resetAt === busyResetS * 1000, busy?.resetAt);
+  check('resetInMs counts down to it', near(busy?.resetInMs, RESET_IN_S * 1000, 15_000), busy?.resetInMs);
+  check('requestCount still 0 — a 429 served nothing', busy?.requestCount === 0);
+  check('rejectedCount 1 — but the seat WAS tried', busy?.rejectedCount === 1, busy?.rejectedCount);
+  check('lastRejectedAt is now', near(busy?.lastRejectedAt, now, 15_000), busy?.lastRejectedAt);
+  check('lastObservedAt matches the rejection', busy?.lastObservedAt === busy?.lastRejectedAt);
+
+  const spare = (await accounts()).find((a) => a.alias === 'spare');
+  check('the serving seat is allowed with its own window', spare?.status === 'allowed' && spare?.resetAt === spareResetS * 1000);
+  check('and has no rejections', spare?.rejectedCount === 0 && spare?.lastRejectedAt === null);
+}
+
+header('GET /admin/accounts — same facts, snake_case (the surface in the report)');
+{
+  const busy = (await adminAccounts()).find((a) => a.alias === 'busy');
+  check('status rejected', busy?.status === 'rejected');
+  check('reset_at / reset_in_ms present', busy?.reset_at === busyResetS * 1000 && near(busy?.reset_in_ms, RESET_IN_S * 1000, 15_000), JSON.stringify([busy?.reset_at, busy?.reset_in_ms]));
+  check('last_observed_at / util_age_ms present (#1032 fields, previously dropped here)',
+    typeof busy?.last_observed_at === 'number' && typeof busy?.util_age_ms === 'number' && busy.util_age_ms < 15_000,
+    JSON.stringify([busy?.last_observed_at, busy?.util_age_ms]));
+  check('request_count 0, rejected_count 1', busy?.request_count === 0 && busy?.rejected_count === 1);
+  check('last_rejected_at present', typeof busy?.last_rejected_at === 'number');
+}
+
+header('the proxy log names the seat, the reading and the reset — without -v');
+{
+  const lines = parkingLines('busy');
+  check('exactly one parking line for busy', lines.length === 1, JSON.stringify(lines));
+  check('it carries the reading', lines[0]?.includes('5h 104%, 7d 25%, claim five_hour'), lines[0]);
+  check('and the reset', /resets in 3[67]m/.test(lines[0] ?? ''), lines[0]);
+}
+
+header('a re-probe of a parked seat is not a new parking (no repeat line)');
+{
+  // Park spare too, on a window that has already rolled. With nothing eligible
+  // left, the failover falls back to the parked busy seat, which 429s again:
+  // that is a repeat, not a transition, and must not log a second line.
+  spareRolled = true;
+  const r = await messages(`conversation exhausted ${Math.random()}`);
+  await r.text();
+  check('client gets the honest 429 (no seat left, no Codex leg)', r.status === 429, r.status);
+  check('busy was re-probed', calls.filter((b) => b === 'busy-token').length === 2, calls.join(','));
+  check('still exactly one parking line for busy', parkingLines('busy').length === 1, JSON.stringify(parkingLines('busy')));
+  check('spare logged its own parking once', parkingLines('spare').length === 1, JSON.stringify(parkingLines('spare')));
+  check('spare\'s line says its window had already rolled', parkingLines('spare')[0]?.includes('window already rolled'), parkingLines('spare')[0]);
+
+  const busy = (await accounts()).find((a) => a.alias === 'busy');
+  check('busy rejectedCount is now 2', busy?.rejectedCount === 2, busy?.rejectedCount);
+  check('busy still rejected, requestCount still 0', busy?.status === 'rejected' && busy?.requestCount === 0);
+
+  // A rejection whose window has passed reports `unknown` (#1232) — and now
+  // shows the reset that passed, so the operator can see why it is unknown.
+  const spare = (await adminAccounts()).find((a) => a.alias === 'spare');
+  check('spare reports unknown (rejection expired with its window)', spare?.status === 'unknown', spare?.status);
+  check('spare reset_in_ms floored at 0, reset_at in the past', spare?.reset_in_ms === 0 && spare?.reset_at < Date.now(), JSON.stringify([spare?.reset_at, spare?.reset_in_ms]));
+  check('spare counts its one rejection beside the requests it served', spare?.rejected_count === 1 && spare?.request_count >= 1, JSON.stringify([spare?.rejected_count, spare?.request_count]));
+}
+
+out(`\npool-parked-seat-surfaces: ${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/test/pool-rate-limit-reset.mjs
+++ b/test/pool-rate-limit-reset.mjs
@@ -24,6 +24,8 @@ import {
   isAccountEligible,
   rateLimitWindowPassed,
   reportedAccountStatus,
+  rateLimitWindow,
+  describeRateLimitSnapshot,
 } from '../dist/pool.js';
 
 let pass = 0, fail = 0;
@@ -190,6 +192,110 @@ header('an expired rejection that is still real re-parks on the next 429');
   park(pool, 'a', SECS + 900);        // the 429 upstream answers with a new window
   check('re-parked on the new window', isAccountEligible(acct, NOW) === false);
   check('and reported as rejected again', reportedAccountStatus(acct, NOW) === 'rejected');
+}
+
+// ----------------------------------------------------------------------
+header('rateLimitWindow — the reset, surfaced (dario#1244)');
+// ----------------------------------------------------------------------
+{
+  // The snapshot carried `reset` all along and routing expired rejections on
+  // it; no operator surface showed it, so `rejected` never said until when.
+  const ahead = rateLimitWindow({ ...EMPTY_SNAPSHOT, reset: SECS + 2220 }, NOW);
+  check('resetAt is the header, in ms', ahead.resetAt === (SECS + 2220) * 1000);
+  check('resetInMs counts down to it', ahead.resetInMs === 2220 * 1000);
+  const passed = rateLimitWindow({ ...EMPTY_SNAPSHOT, reset: SECS - 60 }, NOW);
+  check('a passed reset keeps resetAt', passed.resetAt === (SECS - 60) * 1000);
+  check('and floors resetInMs at 0', passed.resetInMs === 0);
+  const none = rateLimitWindow(EMPTY_SNAPSHOT, NOW);
+  check('no reset stated → both null, not epoch 0', none.resetAt === null && none.resetInMs === null);
+}
+
+// ----------------------------------------------------------------------
+header('describeRateLimitSnapshot — the parking log line');
+// ----------------------------------------------------------------------
+{
+  const s = { ...EMPTY_SNAPSHOT, util5h: 1.04, util7d: 0.25, claim: 'five_hour', reset: SECS + 37 * 60 };
+  check('reads the way an operator would say it',
+    describeRateLimitSnapshot(s, NOW) === '5h 104%, 7d 25%, claim five_hour, resets in 37m', describeRateLimitSnapshot(s, NOW));
+  check('hours and minutes past an hour',
+    describeRateLimitSnapshot({ ...s, reset: SECS + 4 * 3600 + 59 * 60 }, NOW).endsWith('resets in 4h 59m'));
+  check('a rolled window says so',
+    describeRateLimitSnapshot({ ...s, reset: SECS - 1 }, NOW).endsWith('window already rolled'));
+  check('no reset says so',
+    describeRateLimitSnapshot({ ...s, reset: 0 }, NOW).endsWith('no reset stated'));
+}
+
+// ----------------------------------------------------------------------
+header('markRejected — counts the attempt, reports the transition');
+// ----------------------------------------------------------------------
+{
+  const pool = poolWith(['a']);
+  const acct = pool.get('a');
+  check('starts with no rejections', acct.rejectedCount === 0 && acct.lastRejectedAt === undefined);
+
+  const parked = pool.markRejected('a', { ...EMPTY_SNAPSHOT, util5h: 1.04, reset: SECS + 600, updatedAt: NOW });
+  check('the first 429 of a window parks the seat → true', parked === true);
+  check('rejectedCount 1, requestCount untouched (a 429 served nothing)', acct.rejectedCount === 1 && acct.requestCount === 0);
+  check('lastRejectedAt is the snapshot time', acct.lastRejectedAt === NOW);
+
+  // The all-exhausted fallback re-probes parked seats; a 429 there is a
+  // repeat, not a transition — the caller uses the boolean to log once.
+  const again = pool.markRejected('a', { ...EMPTY_SNAPSHOT, util5h: 1.04, reset: SECS + 600, updatedAt: NOW + 1000 });
+  check('a 429 while already parked is not a new parking → false', again === false);
+  check('but is still counted', acct.rejectedCount === 2 && acct.lastRejectedAt === NOW + 1000);
+
+  pool.markRejected('a', { ...EMPTY_SNAPSHOT, reset: SECS - 1, updatedAt: NOW + 2000 });
+  const reparked = pool.markRejected('a', { ...EMPTY_SNAPSHOT, reset: SECS + 900, updatedAt: NOW + 3000 });
+  check('a 429 after the previous window rolled is a new parking → true', reparked === true);
+
+  check('unknown alias → false, nothing counted', pool.markRejected('nope', EMPTY_SNAPSHOT) === false);
+
+  const pool2 = poolWith(['b']);
+  const before = Date.now();
+  pool2.markRejected('b', { ...EMPTY_SNAPSHOT, reset: SECS + 600 });
+  check('a snapshot with no updatedAt stamps the wall clock', pool2.get('b').lastRejectedAt >= before);
+}
+
+// ----------------------------------------------------------------------
+header('add() — a re-grant under the same alias starts the seat fresh (dario#1244)');
+// ----------------------------------------------------------------------
+{
+  const pool = poolWith(['a']);
+  pool.markRejected('a', { ...EMPTY_SNAPSHOT, util5h: 1.04, reset: SECS + 600, updatedAt: NOW });
+  pool.markAuthFailure('a');
+  const oldIdentity = pool.get('a').identity;
+
+  // The routine reconcile: same grant → live state kept, tokens taken.
+  pool.add('a', { accessToken: 'rotated', refreshToken: 'rotated-r', expiresAt: NOT_EXPIRING, deviceId: 'dev-a', accountUuid: 'uuid-a' });
+  let acct = pool.get('a');
+  check('same grant keeps the rejection', acct.rateLimit.status === 'rejected' && acct.rateLimit.reset === SECS + 600);
+  check('same grant keeps the counters and the cool-down', acct.rejectedCount === 1 && acct.consecutiveAuthFailures === 1);
+  check('same grant keeps the identity (session continuity)', acct.identity === oldIdentity);
+  check('and takes the rotated tokens', acct.accessToken === 'rotated');
+
+  // A re-login: a new grantedAt. The old organization's window, the old
+  // streak and the old identity no longer describe this credential.
+  const GRANT = NOW - 1000;
+  pool.add('a', { accessToken: 'fresh', refreshToken: 'fresh-r', expiresAt: NOT_EXPIRING, deviceId: 'dev-a2', accountUuid: 'uuid-a2', grantedAt: GRANT });
+  acct = pool.get('a');
+  check('new grant clears the rejection', acct.rateLimit.status === 'unknown' && acct.rateLimit.reset === 0);
+  check('new grant is eligible at once', isAccountEligible(acct, NOW) === true);
+  check('new grant clears the auth cool-down', acct.consecutiveAuthFailures === 0 && acct.lastAuthFailureAt === undefined);
+  check('new grant zeroes the counters', acct.requestCount === 0 && acct.rejectedCount === 0 && acct.lastRejectedAt === undefined);
+  check('new grant takes the record\'s own identity', acct.identity.accountUuid === 'uuid-a2' && acct.identity.deviceId === 'dev-a2');
+  check('grantedAt recorded', acct.grantedAt === GRANT);
+
+  // The same grant reconciled again (after a refresh, say) keeps going.
+  pool.updateRateLimits('a', { ...EMPTY_SNAPSHOT, status: 'allowed', util5h: 0.2, reset: SECS + 900 });
+  pool.add('a', { accessToken: 'fresh2', refreshToken: 'fresh2-r', expiresAt: NOT_EXPIRING, deviceId: 'dev-a2', accountUuid: 'uuid-a2', grantedAt: GRANT });
+  acct = pool.get('a');
+  check('reconciling the same grant keeps its reading and count', acct.rateLimit.util5h === 0.2 && acct.requestCount === 1);
+
+  // A record with no grantedAt (a seat minted before the field existed)
+  // cannot be told apart from the same grant — state is kept, as before.
+  pool.markRejected('a', { ...EMPTY_SNAPSHOT, reset: SECS + 600, updatedAt: NOW });
+  pool.add('a', { accessToken: 'x', refreshToken: 'x-r', expiresAt: NOT_EXPIRING, deviceId: 'dev-a2', accountUuid: 'uuid-a2' });
+  check('no grantedAt on the record → state kept', pool.get('a').rateLimit.status === 'rejected' && pool.get('a').grantedAt === GRANT);
 }
 
 console.log(`\npool-rate-limit-reset: ${pass} passed, ${fail} failed`);

--- a/test/pool-window-peers.mjs
+++ b/test/pool-window-peers.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+// dario#1244 — one subscription under two aliases.
+//
+// Two seats whose last readings name the same live window (same representative
+// claim, same reset second) are one subscription counted twice. windowKey /
+// windowPeers / distinctWindows derive that from readings the pool already
+// holds; noteOrganization records which organization answered.
+
+import {
+  AccountPool,
+  EMPTY_SNAPSHOT,
+  windowKey,
+  windowPeers,
+  distinctWindows,
+} from '../dist/pool.js';
+import { withObservedOrganization } from '../dist/accounts.js';
+
+let pass = 0, fail = 0;
+function check(label, cond, ...rest) {
+  if (cond) { console.log(`  OK ${label}`); pass++; }
+  else { console.log(`  FAIL ${label}`, ...rest); fail++; }
+}
+function header(label) {
+  console.log(`\n======================================================================`);
+  console.log(`  ${label}`);
+  console.log(`======================================================================`);
+}
+
+const NOW = 1_788_715_000_000;
+const SECS = Math.floor(NOW / 1000);
+const NOT_EXPIRING = Math.max(NOW, Date.now()) + 8 * 3_600_000;
+
+function poolWith(aliases) {
+  const pool = new AccountPool();
+  for (const alias of aliases) {
+    pool.add(alias, {
+      accessToken: `tok-${alias}`, refreshToken: `ref-${alias}`, expiresAt: NOT_EXPIRING,
+      deviceId: `dev-${alias}`, accountUuid: `uuid-${alias}`,
+    });
+  }
+  return pool;
+}
+const reading = (claim, reset, util5h = 0.3) => ({ ...EMPTY_SNAPSHOT, status: 'allowed', claim, reset, util5h, updatedAt: NOW });
+
+// ----------------------------------------------------------------------
+header('windowKey — the identity of a live window');
+// ----------------------------------------------------------------------
+{
+  check('claim + reset second', windowKey(reading('five_hour', SECS + 600), NOW) === `five_hour@${SECS + 600}`);
+  check('no reset → null', windowKey(reading('five_hour', 0), NOW) === null);
+  check('a reset that has passed → null (that window no longer exists)', windowKey(reading('five_hour', SECS - 1), NOW) === null);
+  check('unknown claim → null', windowKey(reading('unknown', SECS + 600), NOW) === null);
+  check('never measured → null', windowKey(EMPTY_SNAPSHOT, NOW) === null);
+}
+
+// ----------------------------------------------------------------------
+header('windowPeers — same window, either way round; different window, not');
+// ----------------------------------------------------------------------
+{
+  const pool = poolWith(['busy', 'twin', 'spare', 'idle']);
+  pool.updateRateLimits('busy', reading('five_hour', SECS + 600, 0.9));
+  pool.updateRateLimits('twin', reading('five_hour', SECS + 600, 0.9));
+  pool.updateRateLimits('spare', reading('five_hour', SECS + 601, 0.1));   // one second apart: another window
+  const peers = windowPeers(pool.all(), NOW);
+  check('busy ↔ twin', JSON.stringify(peers.get('busy')) === '["twin"]' && JSON.stringify(peers.get('twin')) === '["busy"]');
+  check('spare stands alone (reset differs by one second)', peers.get('spare').length === 0);
+  check('an unmeasured seat has no peers', peers.get('idle').length === 0);
+  check('every seat has an entry', peers.size === 4);
+
+  // The organization id is NOT the key: two seats on one organization with
+  // different windows are two windows.
+  pool.noteOrganization('busy', 'org-A');
+  pool.noteOrganization('spare', 'org-A');
+  check('same organization, different reset → still not peers', windowPeers(pool.all(), NOW).get('spare').length === 0);
+
+  // Different claims are different windows even at the same reset second.
+  pool.updateRateLimits('spare', reading('seven_day', SECS + 600, 0.1));
+  check('same reset second, different claim → not peers', windowPeers(pool.all(), NOW).get('spare').length === 0);
+
+  // Three aliases on one window each list the other two.
+  pool.updateRateLimits('spare', reading('five_hour', SECS + 600, 0.9));
+  const three = windowPeers(pool.all(), NOW);
+  check('three on one window', three.get('busy').length === 2 && three.get('spare').includes('twin'));
+}
+
+// ----------------------------------------------------------------------
+header('distinctWindows — how many windows the pool really has');
+// ----------------------------------------------------------------------
+{
+  const pool = poolWith(['a', 'b', 'c', 'd']);
+  check('nothing measured → every seat is its own window', distinctWindows(pool.all(), NOW) === 4);
+  pool.updateRateLimits('a', reading('five_hour', SECS + 600));
+  pool.updateRateLimits('b', reading('five_hour', SECS + 600));
+  check('a and b share one → 3', distinctWindows(pool.all(), NOW) === 3);
+  pool.updateRateLimits('c', reading('five_hour', SECS + 900));
+  check('c on its own → still 3', distinctWindows(pool.all(), NOW) === 3);
+  pool.updateRateLimits('d', reading('five_hour', SECS - 1));
+  check('a rolled reading counts as unmeasured, not as a window → 3', distinctWindows(pool.all(), NOW) === 3);
+}
+
+// ----------------------------------------------------------------------
+header('peers expire with their window');
+// ----------------------------------------------------------------------
+{
+  const pool = poolWith(['a', 'b']);
+  pool.updateRateLimits('a', reading('five_hour', SECS + 60));
+  pool.updateRateLimits('b', reading('five_hour', SECS + 60));
+  check('inside the window → peers', windowPeers(pool.all(), NOW).get('a').length === 1);
+  check('after it rolls → no claim about a window that no longer exists', windowPeers(pool.all(), NOW + 61_000).get('a').length === 0);
+}
+
+// ----------------------------------------------------------------------
+header('noteOrganization — learned once, persisted by the caller, carried by add()');
+// ----------------------------------------------------------------------
+{
+  const pool = poolWith(['a']);
+  check('first observation is news', pool.noteOrganization('a', 'org-A') === true);
+  check('recorded', pool.get('a').organizationId === 'org-A');
+  check('same again is not news', pool.noteOrganization('a', 'org-A') === false);
+  check('a change is news', pool.noteOrganization('a', 'org-B') === true);
+  check('empty id ignored', pool.noteOrganization('a', '') === false && pool.get('a').organizationId === 'org-B');
+  check('unknown alias → false', pool.noteOrganization('nope', 'org-A') === false);
+
+  // A reconcile carrying the same grant keeps what was learned; the record's
+  // own persisted value wins when it has one.
+  pool.add('a', { accessToken: 't2', refreshToken: 'r2', expiresAt: NOT_EXPIRING, deviceId: 'd', accountUuid: 'u' });
+  check('kept across a same-grant reconcile', pool.get('a').organizationId === 'org-B');
+  pool.add('a', { accessToken: 't3', refreshToken: 'r3', expiresAt: NOT_EXPIRING, deviceId: 'd', accountUuid: 'u', organizationId: 'org-disk' });
+  check('a persisted value on the record is taken', pool.get('a').organizationId === 'org-disk');
+  // A re-grant is a new credential: the organization is unknown until seen.
+  pool.add('a', { accessToken: 't4', refreshToken: 'r4', expiresAt: NOT_EXPIRING, deviceId: 'd', accountUuid: 'u', grantedAt: NOW });
+  check('a re-grant forgets the old organization', pool.get('a').organizationId === undefined);
+}
+
+// ----------------------------------------------------------------------
+header('withObservedOrganization — the refresh write carries what the pool learned');
+// ----------------------------------------------------------------------
+{
+  const record = { alias: 'a', accessToken: 't', refreshToken: 'r', expiresAt: NOT_EXPIRING, scopes: [], deviceId: 'd', accountUuid: 'u' };
+  const carried = withObservedOrganization(record, 'org-A');
+  check('adds the observed organization', carried.organizationId === 'org-A');
+  check('does not mutate the input', record.organizationId === undefined);
+  check('tokens untouched', carried.accessToken === 't' && carried.refreshToken === 'r');
+  check('nothing observed → the record as it was', withObservedOrganization(record, undefined) === record);
+  const stated = { ...record, organizationId: 'org-disk' };
+  check('a record that states one keeps it', withObservedOrganization(stated, 'org-A').organizationId === 'org-disk');
+}
+
+console.log(`\npool-window-peers: ${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/test/tui-accounts-source.mjs
+++ b/test/tui-accounts-source.mjs
@@ -75,5 +75,24 @@ header('refreshAccounts — no ctx (standalone) uses disk without throwing');
   check('returns a valid state', typeof s.loading === 'boolean' && Array.isArray(s.accounts));
 }
 
+header('render — a parked seat shows how long it stays parked (#1244)');
+{
+  const ctx = ctxWith(async () => ({
+    mode: 'pool',
+    accounts: [
+      { alias: 'busy', expiresInMs: 3_600_000, util5h: 1.04, util7d: 0.25, status: 'rejected', resetInMs: 37 * 60_000 },
+      { alias: 'spare', expiresInMs: 3_600_000, util5h: 0.05, util7d: 0, status: 'allowed', resetInMs: 4 * 3_600_000 },
+      { alias: 'later', expiresInMs: 3_600_000, util5h: 1.0, util7d: 0.5, status: 'rejected', resetInMs: 4 * 3_600_000 + 59 * 60_000 },
+    ],
+  }));
+  const s = await refreshAccounts(ctx);
+  check('resetInMs carried through', s.accounts[0].resetInMs === 37 * 60_000);
+  const r = AccountsTab.render(s, DIM);
+  check('a rejected row carries the countdown', r.includes('rejected 37m'));
+  check('hours and minutes past an hour', r.includes('rejected 4h59m'));
+  check('an allowed row shows no countdown', /spare[^\n]*allowed/.test(r) && !/allowed \d/.test(r));
+  check('utilisation over 100% renders as the ratio it is', r.includes('104%'));
+}
+
 console.log(`\ntui-accounts-source: ${pass} passed, ${fail} failed`);
 process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Follow-up to #1244, stacked on #1245 (the base of this PR is `fix/account-status-explains-itself`; it retargets to master when #1245 merges, and its own delta is the commits after `faeac4b`). No version bump: #1245 holds the 6.0.33 slot; the release note sits under `## [Unreleased]`.

**The gap.** The #1244 listing had a usage page reading 0% for a seat whose responses said 104%, and "a few" seats showing the same thing. Both are what one subscription under several aliases looks like from the outside: the token behind an alias belongs to an organization other than the one on screen, and two aliases granted from one subscription report one window that the pool counts twice — the busier alias fills it for both, the other parks on its first request with the same reading. Nothing in dario could show either fact.

**Change.**

- Every seat carries `organizationId`: the `anthropic-organization-id` its responses carry (verified live: it is on every authenticated response, alongside `anthropic-workspace-id`), learned on the first response and written to the seat's record by its next token refresh. That last part is a deliberate trade-off — see below.
- Every seat carries `sharesWindowWith`: the other aliases whose last reading names the same live window (same representative claim, same reset second). Two independent windows all but never share a reset second; two readings of one window always do. The organization id is deliberately not the key — seats on one organization can still have their own windows — so the row is a fact about headroom, not a guess about plans. `GET /accounts` adds `distinctWindows` (each measured window once, each unmeasured seat as its own).
- `GET /admin/accounts` carries `organization_id` (from the record even without a live pool entry; the live value wins when there is one) and `shares_window_with`.
- The proxy says it once per pair, when the second reading arrives: `seats "twin" and "busy" report the same five_hour window (resets 2026-09-07T13:12:00.000Z) — one subscription under two aliases; the pool has 2 distinct windows across 3 seats`.
- `dario doctor` gains an `Organizations` row from the ids on the records: `3 seats on 2 organizations — busy + twin share 927b430e…`, worded as "may be one subscription" and pointing at `sharesWindowWith` rather than asserting a shared limit.
- `dario accounts list --live`: the running proxy's view of the pool — status with countdown, reading and age, requests served and 429s answered, organization, shared windows, grant age. The plain listing only knows what is on disk; the TUI already read the proxy, the CLI did not. Falls back to the on-disk listing with a note when no proxy answers.
- A re-grant under an alias forgets the old organization (it is a new credential); a same-grant reconcile keeps what was learned, and a record's own value is taken when it has one.

**Trade-off surfaced: when the organization reaches disk.** The first cut wrote the seat record from the request path the moment the header was seen. I took that out: it is a read-modify-write of a credential file with no serialization against the refresh writer, and the losing interleaving (the request path loads the record, the refresh writes rotated tokens, the request path writes the stale record back) puts a burned refresh token on disk — the dario#790 class of failure, with a probability that is small and a cost that is the credential family. The observation now rides the refresh's own write (`withObservedOrganization(saved, acc.organizationId)` at both refresh sites), so no new write exists to race. Cost: `dario doctor` and a restarted proxy learn the organization up to one refresh (≤8h) after the running proxy does; `/accounts` and `--live` have it at once. If you would rather have it on disk immediately, the right shape is a per-alias write lock in accounts.ts around every seat-file write, which is a larger change than this PR wants to carry.

**Tests.** `pool-window-peers.mjs` (window identity, peers both ways, one-second-apart resets are different windows, same organization with different windows is not a pair, peers expire with their window, distinct-window counting, `noteOrganization`, the refresh-write helper). `doctor-organizations.mjs` (the row's four states). `pool-org-window-surfaces.mjs` drives the real proxy: three seats on a fake upstream stamping organization ids and windows, then `/accounts`, `/admin/accounts`, the one-time log line (and that more traffic does not repeat it), that serving never writes the record, a record that already states its organization loading with it through an admin reconcile, and `dario accounts list --live` run as a real child process (plus its no-proxy fallback). `admin-api.mjs` covers the snake_case fields and the persisted-beats-null merge. Full suite: 182/182 (`npm test`).

Additive: no existing field changes meaning or type.
