### PR TITLE
A pool with every seat parked answers 429 locally instead of re-probing a parked seat on every request (#1244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ checklist.
 
 ## [Unreleased]
 
+## [6.0.35] - 2026-09-07
+
+### Fixed
+- **A pool with every seat parked answers 429 locally instead of re-probing a parked seat on every request (#1244 follow-up).** When no seat was eligible, `select()` handed back the seat with the earliest reset and the request went upstream anyway — one guaranteed 429 per request, and mid-flight failover then walked every other parked seat too. On the #1244 gateway that put `rejected_count: 500` next to `request_count: 1` on one seat inside a single window, which read as a seat that needed a re-login. A seat parked inside a live window is now never re-probed: the request is answered with `429`, `retry-after` at the earliest reset and `x-dario-upstream-rejection: pool_parked`, nothing goes upstream, the Claude provider is cooled to that reset so an armed fallback chain sees the state, and one log line marks the transition. A rejection with no stated reset stays probeable, since asking is its only way back; a parked seat returns on its own when its window rolls, as since 6.0.30.
+
+### Added
+- **`action` on both account listings (#1244).** `GET /accounts` and `GET /admin/accounts` carry the operator's next step next to `status`: `none`, `wait` (a live rate-limit window, or a single auth blip — the seat comes back on its own) or `regrant` (an auth-failure streak, a dead refresh token). "Do I have to re-login?" is now one field. `dario accounts list --live` prints it as a `next:` fact on the seat.
+
 ## [6.0.34] - 2026-09-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 <p><strong>One local endpoint. Every AI tool you own. The subscriptions you already pay for.</strong></p>
 
-<sub><code>npm i -g @askalf/dario</code> · <strong>0</strong> runtime deps · <a href="https://www.npmjs.com/package/@askalf/dario">SLSA-attested</a> every release · nothing phones home · ~31k lines you can read in a weekend · independent, unofficial, third-party (<a href="DISCLAIMER.md">DISCLAIMER.md</a>)</sub>
+<sub><code>npm i -g @askalf/dario</code> · <strong>0</strong> runtime deps · <a href="https://www.npmjs.com/package/@askalf/dario">SLSA-attested</a> every release · nothing phones home · ~32k lines you can read in a weekend · independent, unofficial, third-party (<a href="DISCLAIMER.md">DISCLAIMER.md</a>)</sub>
 
 <sub><a href="#start-in-60-seconds">Start</a> · <a href="#point-your-tools-at-it">Your tools</a> · <a href="#what-it-does-with-a-request">Routing</a> · <a href="#two-plans-one-endpoint">Two plans</a> · <a href="#many-seats-one-endpoint">Pool</a> · <a href="#it-tracks-a-moving-target">Drift</a> · <a href="#trust--transparency">Trust</a> · <a href="#will-my-account-get-suspended">Risk</a> · <a href="#commands">Commands</a> · <a href="#faq">FAQ</a> · <a href="docs/returning.md">Coming back after a while?</a></sub>
 
@@ -405,7 +405,7 @@ The split isn't live, but it was announced once on short notice and could return
 
 | Signal | Status |
 |---|---|
-| Source | **~31k** lines of TypeScript across **67** files, auditable in a weekend. One credential path since v5: the pool. |
+| Source | **~32k** lines of TypeScript across **68** files, auditable in a weekend. One credential path since v5: the pool. |
 | Dependencies | **0 runtime.** Verify: `npm ls --production` |
 | Provenance | Every release [SLSA-attested](https://www.npmjs.com/package/@askalf/dario) via GitHub Actions + Sigstore, published with OIDC trusted publishing — no long-lived npm token exists to leak |
 | Scanning | [CodeQL](https://github.com/askalf/dario/actions/workflows/codeql.yml) on every push and weekly · [ClusterFuzzLite](./.github/workflows/cflite.yml) fuzzes the SSE translator and rejection parsers weekly · [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/askalf/dario) and [Best Practices](https://www.bestpractices.dev/projects/13638) badges above are live |

--- a/docs/multi-account-pool.md
+++ b/docs/multi-account-pool.md
@@ -93,7 +93,7 @@ curl http://localhost:3456/analytics    # per-account / per-model stats, burn ra
 
 ## Reading a seat's `status`
 
-`GET /accounts` (and the admin API's `GET /admin/accounts`, in snake_case) report one `status` per seat. It is the routing verdict, and every value comes with the fields that explain it.
+`GET /accounts` (and the admin API's `GET /admin/accounts`, in snake_case) report one `status` per seat. It is the routing verdict, and every value comes with the fields that explain it. Next to it, `action` is the last column of this table in one word: `none`, `wait` (the seat comes back on its own; `resetInMs` says when) or `regrant` (an auth-failure streak, which is a dead refresh token).
 
 | `status` | What it means | What to do |
 |---|---|---|
@@ -101,6 +101,8 @@ curl http://localhost:3456/analytics    # per-account / per-model stats, burn ra
 | `rejected` | The seat's last response was a 429: the organization behind its token is over the window named by `claim` (`five_hour`, `seven_day`, …). `util5h: 1.04` is 104% of the five-hour window, not 1%. `rejectedCount` / `lastRejectedAt` say the seat was tried — a 429 serves nothing, so `requestCount` does not move — and `resetInMs` says how long it stays parked. Requests route around it; it returns on its own when the window rolls. | Nothing — the window clears itself. If the reading surprises you (your usage page for that account says 0%), the token belongs to a different organization than the page you are looking at, or to the same organization as another seat: the reading is Anthropic's own, taken on that token. `dario accounts check <alias>` asks the seat directly. |
 | `unknown` | No current observation: a seat that has served nothing yet, or a rejection whose window has rolled (`resetInMs: 0`) and that nothing has measured since. | Nothing; the next request measures it. |
 | `auth-cooldown` | Upstream answered 401/403 or `invalid_grant`. `consecutiveAuthFailures` tells a blip (1) from a dead refresh token (a streak); the cool-down doubles with the streak, from 1 minute to 30. | A streak means re-grant the seat — `dario accounts remove` + `add`, or the admin login flow under the same alias. A new grant starts the seat fresh: no carried-over cool-down, rejection or identity. See [Refresh-token grant age](#refresh-token-grant-age) for the 28-day wall behind most streaks. |
+
+**When every seat is parked.** A pool whose seats are all `rejected` inside live windows does not probe them again: dario answers the request itself with `429`, `retry-after` set to the earliest reset, `x-dario-upstream-rejection: pool_parked`, and nothing sent upstream. One log line marks the transition (`pool parked: all 6 seats are over their rate-limit windows, earliest resets in 21m`). Before 6.0.35 every such request re-probed the earliest-reset seat, so `rejectedCount` on that seat grew by one per request — a seat reading `rejected_count: 500` next to `request_count: 1` was that, not a seat that needed a re-login. With a `--pool-fallback` armed, the request goes to the fallback instead, as before.
 
 The proxy logs every parking as it happens, once per window: `rate limited (429) on account "spare": 5h 104%, 7d 25%, claim five_hour, resets in 37m — parked until the window rolls`. The re-probes the all-exhausted fallback makes of an already-parked seat are logged only under `-v`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.34",
+  "version": "6.0.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "6.0.34",
+      "version": "6.0.35",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.34",
+  "version": "6.0.35",
   "description": "Use your Claude and ChatGPT subscriptions in Cursor, Cline, Aider, Claude Code and the Agent SDK — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint: either plan answers either wire shape, with automatic failover when one hits its limit.",
   "type": "module",
   "bin": {

--- a/src/admin-api.ts
+++ b/src/admin-api.ts
@@ -114,6 +114,8 @@ export interface AdminAccountLive {
   resetInMs: number | null;
   claim: string;
   status: string;
+  /** none · wait · regrant — the operator's next step (dario#1244). */
+  action?: 'none' | 'wait' | 'regrant';
   requestCount: number;
   /**
    * Upstream 429s this account answered. `requestCount` counts requests it
@@ -568,6 +570,7 @@ export async function handleAdminRequest(
             reading_from: l.readingFrom ?? null,
             claim: l.claim,
             status: l.status,
+            action: l.action ?? 'none',
             request_count: l.requestCount,
             rejected_count: l.rejectedCount ?? 0,
             last_rejected_at: l.lastRejectedAt ?? null,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -941,7 +941,7 @@ async function accountsListLive(): Promise<boolean> {
   const headers: Record<string, string> = {};
   if (process.env['DARIO_API_KEY']) headers['x-api-key'] = process.env['DARIO_API_KEY']!;
   interface LiveSeat {
-    alias: string; status: string; util5h: number; util7d: number; utilAgeMs: number | null;
+    alias: string; status: string; action?: 'none' | 'wait' | 'regrant'; util5h: number; util7d: number; utilAgeMs: number | null;
     resetInMs: number | null; requestCount: number; rejectedCount: number;
     organizationId: string | null; sharesWindowWith: string[]; grantedAt: number | null;
   }
@@ -973,9 +973,15 @@ async function accountsListLive(): Promise<boolean> {
   for (const s of seats) {
     const status = s.status === 'rejected' && typeof s.resetInMs === 'number' ? `rejected, back in ${mins(s.resetInMs)}` : s.status;
     console.log(`    ${s.alias.padEnd(20)} ${status.padEnd(26)} 5h ${pct(s.util5h).padEnd(6)} 7d ${pct(s.util7d).padEnd(6)} ${age(s.utilAgeMs)}`);
+    // The one-word next step (dario#1244): a parked seat wants nothing from
+    // the operator; an auth-failure streak wants a re-grant.
+    const next = s.action === 'regrant' ? 'next: re-grant this seat (dario accounts remove + add)'
+      : s.action === 'wait' ? 'next: nothing, it comes back on its own'
+      : null;
     const facts = [
       `served ${s.requestCount}`,
       `429s ${s.rejectedCount}`,
+      ...(next ? [next] : []),
       s.organizationId ? `org ${s.organizationId.slice(0, 8)}…` : 'org not yet observed',
       ...(s.sharesWindowWith.length > 0 ? [`shares its window with ${s.sharesWindowWith.join(', ')}`] : []),
     ];

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -743,20 +743,19 @@ export class AccountPool {
   }
 
   /**
-   * When no seat can be selected and at least one is parked inside a live
-   * window: the epoch ms the earliest such window rolls, i.e. the moment the
-   * pool can serve again without a probe. Null whenever `select()` would
-   * return a seat, so a caller answers locally only when there is truly
-   * nothing to try (dario#1244).
+   * When EVERY seat is parked inside a live rate-limit window: the epoch ms
+   * the earliest window rolls, i.e. the moment the pool can serve again
+   * without a probe. Null otherwise — including a pool mixing parked seats
+   * with an auth-cooling or token-expired one, which is not "all seats over
+   * their windows" and must not be reported (or cooled) as if it were; those
+   * pools stay on the existing unavailable handling (dario#1244, and the
+   * review on dario#1254 that caught the mixed case).
    */
   parkedUntil(now: number = Date.now()): number | null {
     if (this.accounts.size === 0) return null;
     const all = [...this.accounts.values()];
-    if (all.some(a => isAccountEligible(a, now))) return null;
-    if (all.some(a => !isInAuthCooldown(a, now) && !isParkedInLiveWindow(a, now))) return null;
-    const parked = all.filter(a => isParkedInLiveWindow(a, now));
-    if (parked.length === 0) return null;
-    return Math.min(...parked.map(a => a.rateLimit.reset * 1000));
+    if (!all.every(a => isParkedInLiveWindow(a, now))) return null;
+    return Math.min(...all.map(a => a.rateLimit.reset * 1000));
   }
 
   /** Seats currently parked inside a live window (dario#1244). */

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -360,6 +360,31 @@ export function isAccountEligible(account: PoolAccount, now: number = Date.now()
   return accountIneligibility(account, now) === null;
 }
 
+/**
+ * A seat parked on a 429 whose stated window has not rolled yet — the one
+ * state the router must never re-probe: the 429 named the reset, the clock
+ * has not reached it, and a probe can only 429 again. A rejection with no
+ * stated reset is NOT this: with nothing to expire, asking is the only way
+ * back, so it stays probeable (dario#1244).
+ */
+export function isParkedInLiveWindow(account: PoolAccount, now: number = Date.now()): boolean {
+  const rl = account.rateLimit;
+  return rl.status === 'rejected' && rl.reset > 0 && rl.reset * 1000 > now;
+}
+
+/**
+ * The operator's next step for one seat, next to `status` on both listings
+ * (dario#1244 — "do I have to re-login?" should not need the docs table).
+ * `wait`: the seat comes back on its own (a live rate-limit window, or a
+ * single auth blip cooling down). `regrant`: an auth-failure streak, which is
+ * a dead refresh token. `none`: nothing to do.
+ */
+export function accountAction(account: PoolAccount, now: number = Date.now()): 'none' | 'wait' | 'regrant' {
+  if (isInAuthCooldown(account, now)) return account.consecutiveAuthFailures >= 2 ? 'regrant' : 'wait';
+  if (isParkedInLiveWindow(account, now)) return 'wait';
+  return 'none';
+}
+
 export interface PoolStatus {
   accounts: number;
   healthy: number;
@@ -698,20 +723,45 @@ export class AccountPool {
       return pickMaxHeadroom(eligible, family);
     }
 
-    // All accounts exhausted — return the one with the earliest reset.
-    // Auth-cooldown'd accounts are excluded from this fallback too: we
-    // know upstream rejected their tokens, so picking them on rate-limit
-    // grounds wouldn't help. Better to return null and let the caller
-    // surface "no account available" than to hand back a dead account.
-    const withReset = all.filter(a => a.rateLimit.reset > 0 && !isInAuthCooldown(a, now));
-    if (withReset.length > 0) {
-      return withReset.reduce((a, b) => a.rateLimit.reset < b.rateLimit.reset ? a : b);
-    }
+    // No seat is eligible. A seat parked inside a live window is not
+    // re-probed: its 429 named the reset, the clock has not reached it, and a
+    // probe there is one upstream round trip that can only 429 again — on the
+    // dario#1244 gateway that was 500 probes of one seat inside a single
+    // window, `rejectedCount` climbing by one each time and the operator
+    // reading it as a seat that needed a re-login. The caller reads
+    // `parkedUntil()` and answers the client itself; the seat returns on its
+    // own when the window rolls (`rateLimitWindowPassed` makes it eligible
+    // again). Auth-cooldown seats are skipped for the same reason: upstream
+    // already rejected their tokens.
+    //
+    // What is left — a rejection with no stated reset (nothing to expire, so
+    // asking is the only way back) or an expiring token — is tried least-used
+    // first, as before.
+    const probeable = all.filter(a => !isInAuthCooldown(a, now) && !isParkedInLiveWindow(a, now));
+    if (probeable.length === 0) return null;
+    return probeable.reduce((a, b) => a.requestCount < b.requestCount ? a : b);
+  }
 
-    // No rate-limit data at all — least-used first, still skipping cool-downs.
-    const usable = all.filter(a => !isInAuthCooldown(a, now));
-    if (usable.length === 0) return null;
-    return usable.reduce((a, b) => a.requestCount < b.requestCount ? a : b);
+  /**
+   * When no seat can be selected and at least one is parked inside a live
+   * window: the epoch ms the earliest such window rolls, i.e. the moment the
+   * pool can serve again without a probe. Null whenever `select()` would
+   * return a seat, so a caller answers locally only when there is truly
+   * nothing to try (dario#1244).
+   */
+  parkedUntil(now: number = Date.now()): number | null {
+    if (this.accounts.size === 0) return null;
+    const all = [...this.accounts.values()];
+    if (all.some(a => isAccountEligible(a, now))) return null;
+    if (all.some(a => !isInAuthCooldown(a, now) && !isParkedInLiveWindow(a, now))) return null;
+    const parked = all.filter(a => isParkedInLiveWindow(a, now));
+    if (parked.length === 0) return null;
+    return Math.min(...parked.map(a => a.rateLimit.reset * 1000));
+  }
+
+  /** Seats currently parked inside a live window (dario#1244). */
+  parkedCount(now: number = Date.now()): number {
+    return [...this.accounts.values()].filter(a => isParkedInLiveWindow(a, now)).length;
   }
 
   /**
@@ -837,8 +887,13 @@ export class AccountPool {
       return pickMaxHeadroom(eligible, family);
     }
 
-    if (candidates.length > 0) {
-      return candidates.reduce((a, b) => a.requestCount < b.requestCount ? a : b);
+    // Mid-flight: the seats a 429 could still hand this request to. A seat
+    // parked inside a live window is not one of them — on the dario#1244
+    // gateway every request walked all six parked seats, six guaranteed 429s
+    // a request. Cool-downs are skipped for the same reason.
+    const probeable = candidates.filter(a => !isInAuthCooldown(a, now) && !isParkedInLiveWindow(a, now));
+    if (probeable.length > 0) {
+      return probeable.reduce((a, b) => a.requestCount < b.requestCount ? a : b);
     }
 
     return null;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -12,7 +12,7 @@ import { darioVersion } from './version.js';
 import { buildCCRequest, applyCcPromptCaching, isGenuineCCClient, parseEffortSuffix, reverseMapResponse, createStreamingReverseMapper, orderHeadersForOutbound, overlayTemplateHeaderValues, forwardClientCCIdentityHeaders, isMcpToolName, CC_TEMPLATE, CC_CACHE_CONTROL, effectiveCacheControl, withForced1hBeta, type ToolMapping, type RequestContext, type EffortValue } from './cc-template.js';
 import { stampCch, hasCchSeed } from './cch.js';
 import { describeTemplate, detectDrift, checkCCCompat, probeInstalledCCVersion } from './live-fingerprint.js';
-import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCooldown, authCooldownMs, accountIneligibility, reportedAccountStatus, reconcilePoolAccounts, resolvePoolStrategy, utilFreshness, rateLimitWindow, describeRateLimitSnapshot, windowPeers, distinctWindows, type PoolAccount } from './pool.js';
+import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCooldown, authCooldownMs, accountIneligibility, reportedAccountStatus, reconcilePoolAccounts, resolvePoolStrategy, utilFreshness, rateLimitWindow, describeRateLimitSnapshot, windowPeers, distinctWindows, accountAction, type PoolAccount } from './pool.js';
 import { PoolSync, DEFAULT_POOL_SYNC_INTERVAL_MS } from './pool-sync.js';
 import { Analytics, billingBucketFromClaim, formatUsageLogLine, SUBSCRIPTION_CLAIMS, consumerFromHeader, consumerFromBody, CONSUMER_HEADER, type RequestRecord, CODEX_CLAIM } from './analytics.js';
 import { OverageGuard, buildHaltErrorBody, type HaltState } from './overage-guard.js';
@@ -33,7 +33,7 @@ import { selectPoolFallbackModels } from './pool-fallback-tier.js';
 import { RequestQueue, QueueFullError, QueueTimeoutError, DEFAULT_MAX_CONCURRENT, DEFAULT_MAX_QUEUED, DEFAULT_QUEUE_TIMEOUT_MS } from './request-queue.js';
 import { redactSecrets } from './redact.js';
 import { BAKED_BASE_MODELS, withLongContextVariants, buildOpenAIModelsList, getModelCatalog, getCachedBases, resolveAliasAgainst, prewarmModelCatalog, retryModelCatalogNow, isSuspendedModel, type CatalogDeps } from './model-catalog.js';
-import { classifyUpstreamRejection, diagnosticSnippet } from './upstream-rejection.js';
+import { classifyUpstreamRejection, diagnosticSnippet, POOL_PARKED } from './upstream-rejection.js';
 import {
   ProviderCooldowns, canAttempt, allProvidersCooled, cooldownRetryAfterMs, parseRetryAfterMs,
   ALL_PROVIDERS_RATE_LIMITED,
@@ -1988,6 +1988,9 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
     overlayTemplateHeaderValues(staticHeaders, CC_TEMPLATE.header_values);
   }
   let requestCount = 0;
+  // dario#1244: the "pool parked" line is logged on the transition into the
+  // state, not on every request that arrives while it holds.
+  let poolParkedAnnounced = false;
   const queue = new RequestQueue({
     maxConcurrent: opts.maxConcurrent ?? DEFAULT_MAX_CONCURRENT,
     maxQueued: opts.maxQueued ?? DEFAULT_MAX_QUEUED,
@@ -2533,6 +2536,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
               ...rateLimitWindow(a.rateLimit, snapNow),
               claim: a.rateLimit.claim,
               status: reportedAccountStatus(a, snapNow),
+              action: accountAction(a, snapNow),
               requestCount: a.requestCount,
               rejectedCount: a.rejectedCount,
               lastRejectedAt: a.lastRejectedAt ?? null,
@@ -2639,6 +2643,8 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           ...rateLimitWindow(a.rateLimit, now),
           claim: a.rateLimit.claim,
           status: reportedAccountStatus(a, now),
+          // The one-word next step: none · wait · regrant (dario#1244).
+          action: accountAction(a, now),
           requestCount: a.requestCount,
           // 429s answered — the attempts requestCount does not count, so a
           // parked seat no longer reads as one that was never called.
@@ -2993,6 +2999,32 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
       //
       // Shared because two callers must agree: the selector, and the dispatch
       // below for a request the selector DEFERRED but no provider could serve.
+      /**
+       * Every seat in the pool is parked inside a live window (dario#1244).
+       * The old fallback re-probed the earliest-reset seat on every request:
+       * one upstream round trip per request that could only 429,
+       * `rejectedCount` climbing by one each time — 500 on one seat inside a
+       * single window on the reporter's gateway — and the client waiting on a
+       * verdict dario already held. Answer it here: 429, `retry-after` at the
+       * earliest reset, the marker in the same channel the other rejection
+       * classes use, and nothing sent upstream.
+       */
+      const writePoolParked = (untilMs: number): void => {
+        const retryAfterSec = Math.max(1, Math.ceil((untilMs - Date.now()) / 1000));
+        res.writeHead(429, {
+          ...JSON_HEADERS,
+          'retry-after': String(retryAfterSec),
+          'x-dario-upstream-rejection': POOL_PARKED,
+        });
+        res.end(JSON.stringify({
+          error: {
+            type: 'rate_limit_error',
+            message: `All ${pool.size} pool seat${pool.size === 1 ? '' : 's'} are over their rate-limit windows; the earliest resets in ${retryAfterSec}s. Nothing was sent upstream.`,
+          },
+          reason: POOL_PARKED,
+        }));
+      };
+
       const writePoolUnavailable = (): void => {
         res.writeHead(503, JSON_HEADERS);
         res.end(JSON.stringify(
@@ -3116,6 +3148,19 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           return true;
         }
         poolAccount = pool.select();
+        if (poolAccount) poolParkedAnnounced = false;
+        // Every seat parked inside a live window (dario#1244): cool the
+        // provider to the earliest reset so a fallback chain sees the Claude
+        // half as what it is, say so once, and — unless a fallback is armed —
+        // answer the client here instead of spending a probe that can only 429.
+        const parkedUntil = poolAccount ? null : pool.parkedUntil();
+        if (parkedUntil !== null) {
+          providerCooldowns.note('claude', parkedUntil - Date.now());
+          if (!poolParkedAnnounced) {
+            poolParkedAnnounced = true;
+            console.error(`[dario] #${requestCount} pool parked: all ${pool.size} seats are over their rate-limit windows, earliest resets in ${Math.max(1, Math.ceil((parkedUntil - Date.now()) / 60000))}m — answering 429 locally until then, nothing sent upstream`);
+          }
+        }
         if (!poolAccount) {
           // Pool-exhausted fallback: when armed, the pool HAS accounts (all
           // drained / cooling), and the client speaks OpenAI shape, defer —
@@ -3141,7 +3186,8 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
           // see, not traffic to quietly re-bill somewhere else.
           const fallbackViable = poolFallbackModels.length > 0 && pool.size > 0;
           if (!fallbackViable) {
-            writePoolUnavailable();
+            if (parkedUntil !== null) writePoolParked(parkedUntil);
+            else writePoolUnavailable();
             return false;
           }
         }
@@ -3673,6 +3719,13 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
       // would fall through to the Claude path with no account and an empty
       // bearer token, turning a clean 503 into a confusing upstream 401.
       if (!upstreamApiKey && !poolAccount) {
+        // A fallback was armed but nothing could serve, and the pool itself is
+        // parked: the exact reset beats a cool-down estimate (dario#1244).
+        const parkedNow = pool.parkedUntil();
+        if (parkedNow !== null) {
+          writePoolParked(parkedNow);
+          return;
+        }
         // A chain where every entry is cooling is a rate limit, not a
         // misconfiguration — say so in the machine-readable way, once.
         if (allProvidersCooled(poolFallbackModels.length > 0 ? ['codex', 'claude'] : ['claude'], providerCooldowns)) {

--- a/src/upstream-rejection.ts
+++ b/src/upstream-rejection.ts
@@ -13,6 +13,12 @@ export interface UpstreamRejection {
  * every "this request was not served" verdict.
  */
 export const MODEL_UNROUTABLE = 'model_unroutable';
+/**
+ * Every seat in the pool is parked inside a live rate-limit window, so dario
+ * answered 429 itself, with `retry-after` at the earliest reset, and sent
+ * nothing upstream (dario#1244).
+ */
+export const POOL_PARKED = 'pool_parked';
 
 /** Classify subscription entitlement failures separately from temporary quota exhaustion. */
 export function classifyUpstreamRejection(status: number, body: string): UpstreamRejection {

--- a/test/pool-e2e.mjs
+++ b/test/pool-e2e.mjs
@@ -150,10 +150,13 @@ header('429 failover loop — selectExcluding cascades then exhausts');
   acct = pool.selectExcluding(tried, family);
   check('failover #3 → null (pool exhausted)', acct === null);
 
-  // With every account rejected, a fresh select() falls back to earliest-reset,
-  // never returns a still-usable illusion.
+  // With every account parked inside a live window, a fresh select() returns
+  // null rather than re-probing the earliest-reset seat (dario#1244: that probe
+  // was one guaranteed 429 per request), and parkedUntil() names the reset the
+  // caller answers the client with.
   const fallback = pool.select(family);
-  check('all-rejected select falls back to an earliest-reset account (not null)', fallback !== null);
+  check('all-parked select returns null (no re-probe of a live window)', fallback === null);
+  check('parkedUntil() names the earliest reset', typeof pool.parkedUntil() === "number" && pool.parkedUntil() > Date.now());
 }
 
 // ── Sticky session survives a mid-conversation failover ──

--- a/test/pool-parked-local-429.mjs
+++ b/test/pool-parked-local-429.mjs
@@ -62,6 +62,27 @@ header('AccountPool: a seat parked inside a live window is never selected');
   check('after b\'s reset passes, parkedUntil() is null again', pool.parkedUntil(LATER) === null);
   check('and b reports action none (window rolled, status unknown)', accountAction(pool.get('b'), LATER) === 'none');
 
+  // Mixed pool (the dario#1254 review case): one seat parked on a 30-minute
+  // window, one seat in a 60-second auth cool-down. That is not "every seat
+  // over its window": parkedUntil() must stay null so the proxy does not
+  // answer pool_parked with a 30-minute retry-after and cool the provider
+  // for a seat that is usable again in a minute.
+  const mixed = new AccountPool();
+  for (const alias of ['rl', 'auth']) {
+    mixed.add(alias, { accessToken: `tok-${alias}`, refreshToken: `ref-${alias}`, expiresAt: NOW + 8 * 3_600_000, deviceId: `dev-${alias}`, accountUuid: `uuid-${alias}` });
+  }
+  mixed.markRejected('rl', { ...EMPTY_SNAPSHOT, util5h: 1, reset: SECS + 1800, updatedAt: NOW });
+  mixed.markAuthFailure('auth');
+  check('mixed pool: no seat is selectable right now', mixed.select() === null);
+  check('mixed pool: parkedUntil() is null (not every seat is rate-limit parked)', mixed.parkedUntil(NOW) === null, mixed.parkedUntil(NOW));
+  check('mixed pool: parkedCount() still reports the one parked seat', mixed.parkedCount(NOW) === 1);
+  // A token-expired seat beside a parked one is the same shape.
+  const mixed2 = new AccountPool();
+  mixed2.add('rl', { accessToken: 'tok', refreshToken: 'ref', expiresAt: NOW + 8 * 3_600_000, deviceId: 'd', accountUuid: 'u' });
+  mixed2.add('stale', { accessToken: 'tok2', refreshToken: 'ref2', expiresAt: NOW - 1, deviceId: 'd2', accountUuid: 'u2' });
+  mixed2.markRejected('rl', { ...EMPTY_SNAPSHOT, util5h: 1, reset: SECS + 1800, updatedAt: NOW });
+  check('parked + token-expired: parkedUntil() is null', mixed2.parkedUntil(NOW) === null, mixed2.parkedUntil(NOW));
+
   // Auth streak → regrant; single blip → wait.
   const p2 = new AccountPool();
   p2.add('d', { accessToken: 'tok-d', refreshToken: 'ref-d', expiresAt: NOW + 8 * 3_600_000, deviceId: 'dev-d', accountUuid: 'uuid-d' });
@@ -180,6 +201,7 @@ header('the log marks the transition once, not per request');
   check('it names the earliest reset in minutes', /earliest resets in 2[01]m/.test(parked[0] ?? ''), parked[0]);
   check('each seat logged its own parking exactly once', log.filter((l) => l.includes('rate limited (429) on account "one"')).length === 1 && log.filter((l) => l.includes('rate limited (429) on account "two"')).length === 1);
 }
+
 
 out(`\npool-parked-local-429: ${pass} passed, ${fail} failed`);
 process.exit(fail === 0 ? 0 : 1);

--- a/test/pool-parked-local-429.mjs
+++ b/test/pool-parked-local-429.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+// dario#1244 follow-up — a pool with every seat parked answers locally.
+//
+// The report's second listing (v6.0.33, six-seat team gateway):
+//   util5h 1, reset_in_ms 1288011, status rejected,
+//   request_count 1, rejected_count 500
+// Five hundred rejections on one seat inside one window. Every request that
+// arrived while all six seats were parked re-probed the earliest-reset seat
+// (`select()`'s all-exhausted fallback) and then, mid-flight, every other
+// parked seat too — each a guaranteed 429, each bumping `rejectedCount`, and
+// the operator read the number as a seat that needed a re-login.
+//
+// Now: no seat inside a live window is probed. The client gets 429 with
+// `retry-after` at the earliest reset and `x-dario-upstream-rejection:
+// pool_parked`, nothing goes upstream, the transition is logged once, and
+// both listings say `action: wait`.
+
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { freePort } from './helpers/free-port.mjs';
+
+const out = console.log.bind(console);
+let pass = 0, fail = 0;
+const check = (name, cond, detail) => {
+  if (cond) { out(`  OK ${name}`); pass++; }
+  else { out(`  FAIL ${name}${detail !== undefined ? ' :: ' + detail : ''}`); fail++; }
+};
+const header = (n) => out(`\n=== ${n} ===`);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ── pure pool behaviour first ──────────────────────────────────────────
+header('AccountPool: a seat parked inside a live window is never selected');
+{
+  const { AccountPool, EMPTY_SNAPSHOT, isParkedInLiveWindow, accountAction } = await import('../dist/pool.js');
+  const NOW = Date.now();
+  const SECS = Math.floor(NOW / 1000);
+  const pool = new AccountPool();
+  for (const alias of ['a', 'b', 'c']) {
+    pool.add(alias, { accessToken: `tok-${alias}`, refreshToken: `ref-${alias}`, expiresAt: NOW + 8 * 3_600_000, deviceId: `dev-${alias}`, accountUuid: `uuid-${alias}` });
+  }
+  // a and b parked on live windows (b earlier), c parked with NO stated reset.
+  pool.markRejected('a', { ...EMPTY_SNAPSHOT, util5h: 1, reset: SECS + 1800, updatedAt: NOW });
+  pool.markRejected('b', { ...EMPTY_SNAPSHOT, util5h: 1.04, reset: SECS + 600, updatedAt: NOW });
+  pool.markRejected('c', { ...EMPTY_SNAPSHOT, util5h: 1, reset: 0, updatedAt: NOW });
+  check('a and b are parked in live windows, c is not (no reset to expire)',
+    isParkedInLiveWindow(pool.get('a'), NOW) && isParkedInLiveWindow(pool.get('b'), NOW) && !isParkedInLiveWindow(pool.get('c'), NOW));
+  check('with c probeable, select() returns c (the old least-used probe), not the earliest-reset seat b',
+    pool.select()?.alias === 'c', pool.select()?.alias);
+  check('and parkedUntil() is null — there is still something to try', pool.parkedUntil(NOW) === null);
+  check('action on a parked seat is wait', accountAction(pool.get('a'), NOW) === 'wait');
+
+  // Park c on a live window too: now nothing is probeable.
+  pool.markRejected('c', { ...EMPTY_SNAPSHOT, util5h: 1, reset: SECS + 900, updatedAt: NOW });
+  check('select() returns null instead of re-probing a parked seat', pool.select() === null);
+  check('parkedUntil() is the earliest reset (b, +600s), in ms', pool.parkedUntil(NOW) === (SECS + 600) * 1000, pool.parkedUntil(NOW));
+  check('parkedCount() is 3', pool.parkedCount(NOW) === 3);
+  check('selectExcluding() does not hand a parked seat to mid-flight failover', pool.selectExcluding(new Set(['a'])) === null);
+
+  // b's window rolls: it is eligible again on its own.
+  const LATER = (SECS + 601) * 1000;
+  check('after b\'s reset passes, parkedUntil() is null again', pool.parkedUntil(LATER) === null);
+  check('and b reports action none (window rolled, status unknown)', accountAction(pool.get('b'), LATER) === 'none');
+
+  // Auth streak → regrant; single blip → wait.
+  const p2 = new AccountPool();
+  p2.add('d', { accessToken: 'tok-d', refreshToken: 'ref-d', expiresAt: NOW + 8 * 3_600_000, deviceId: 'dev-d', accountUuid: 'uuid-d' });
+  p2.markAuthFailure('d');
+  check('one auth failure → wait', accountAction(p2.get('d')) === 'wait', accountAction(p2.get('d')));
+  // A second failure inside the cool-down does not escalate (#642-audit), so
+  // stage a genuine streak the way two separate cool-downs would leave it.
+  p2.get('d').consecutiveAuthFailures = 2;
+  p2.get('d').lastAuthFailureAt = Date.now();
+  check('a streak → regrant', accountAction(p2.get('d')) === 'regrant', accountAction(p2.get('d')));
+  check('a parked seat with an auth streak still says regrant (auth outranks the window)',
+    (p2.markRejected('d', { ...EMPTY_SNAPSHOT, reset: SECS + 600, updatedAt: NOW }), accountAction(p2.get('d'))) === 'regrant');
+}
+
+// ── the real proxy, in-process, every seat answering 429 ───────────────
+const PORT = await freePort();
+const ADMIN_TOKEN = 'parked-pool-admin-token';
+const tmpHome = await mkdtemp(join(tmpdir(), 'dario-parked-pool-'));
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+process.env.DARIO_ADMIN = '1';
+process.env.DARIO_ADMIN_TOKEN = ADMIN_TOKEN;
+delete process.env.DARIO_API_KEY;
+delete process.env.DARIO_CODEX_BASE_URL;
+delete process.env.DARIO_POOL_FALLBACK;
+await mkdir(join(tmpHome, '.dario', 'accounts'), { recursive: true });
+const seat = (alias, token) => JSON.stringify({
+  alias, accessToken: token, refreshToken: `${token}-refresh`,
+  expiresAt: Date.now() + 6 * 3_600_000, scopes: ['user:inference'],
+  deviceId: `dev-${alias}`, accountUuid: `uuid-${alias}`,
+});
+await writeFile(join(tmpHome, '.dario', 'accounts', 'one.json'), seat('one', 'one-token'));
+await writeFile(join(tmpHome, '.dario', 'accounts', 'two.json'), seat('two', 'two-token'));
+
+const RESET_ONE_S = 21 * 60;   // the report's 1288011 ms
+const RESET_TWO_S = 45 * 60;
+const oneResetS = Math.floor(Date.now() / 1000) + RESET_ONE_S;
+const twoResetS = Math.floor(Date.now() / 1000) + RESET_TWO_S;
+const rateLimited = (resetS) => new Response(
+  JSON.stringify({ type: 'error', error: { type: 'rate_limit_error', message: 'Error' } }),
+  { status: 429, headers: {
+    'content-type': 'application/json',
+    'anthropic-ratelimit-unified-status': 'rejected',
+    'anthropic-ratelimit-unified-5h-utilization': '1',
+    'anthropic-ratelimit-unified-7d-utilization': '0.09',
+    'anthropic-ratelimit-unified-representative-claim': 'five_hour',
+    'anthropic-ratelimit-unified-reset': String(resetS),
+    'anthropic-organization-id': 'org-shared',
+  } },
+);
+const calls = [];
+const fetchImpl = async (url, init) => {
+  if (String(url).includes('/v1/models')) {
+    return new Response(JSON.stringify({ data: [{ id: 'claude-sonnet-5', type: 'model' }] }), {
+      status: 200, headers: { 'content-type': 'application/json' },
+    });
+  }
+  const h = init?.headers;
+  const pairs = Array.isArray(h) ? h : h instanceof Headers ? [...h.entries()] : Object.entries(h ?? {});
+  const auth = String((pairs.find(([k]) => String(k).toLowerCase() === 'authorization') ?? [, ''])[1]);
+  const bearer = auth.replace(/^Bearer\s+/i, '');
+  calls.push(bearer);
+  return rateLimited(bearer === 'one-token' ? oneResetS : twoResetS);
+};
+
+const log = [];
+for (const m of ['log', 'error', 'warn']) console[m] = (...a) => { log.push(a.map(String).join(' ')); };
+
+const { startProxy } = await import('../dist/proxy.js');
+await startProxy({ host: '127.0.0.1', port: PORT, passthrough: false, verbose: false, noLiveCapture: true, fetchImpl });
+const BASE = `http://127.0.0.1:${PORT}`;
+for (let i = 0; i < 50; i++) { try { await fetch(`${BASE}/health`); break; } catch { await sleep(100); } }
+
+const messages = (content) => fetch(`${BASE}/v1/messages`, {
+  method: 'POST', headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ model: 'claude-sonnet-5', max_tokens: 16, messages: [{ role: 'user', content }] }),
+});
+const accounts = async () => (await (await fetch(`${BASE}/accounts`)).json()).accounts;
+const adminAccounts = async () => (await (await fetch(`${BASE}/admin/accounts`, { headers: { authorization: `Bearer ${ADMIN_TOKEN}` } })).json()).accounts;
+
+header('request 1: both seats are tried once, the client gets the upstream 429');
+{
+  const r = await messages(`conversation 1 ${Math.random()}`);
+  await r.text();
+  check('client got 429', r.status === 429, r.status);
+  check('each seat was probed exactly once', calls.filter((b) => b === 'one-token').length === 1 && calls.filter((b) => b === 'two-token').length === 1, calls.join(','));
+}
+
+header('requests 2..21: answered locally — nothing upstream, counters frozen');
+{
+  const before = calls.length;
+  const statuses = [];
+  let last;
+  for (let i = 2; i <= 21; i++) {
+    last = await messages(`conversation ${i} ${Math.random()}`);
+    statuses.push(last.status);
+    await last.text();
+  }
+  check('twenty more requests, zero upstream calls', calls.length === before, `${calls.length - before} upstream calls`);
+  check('every one a 429', statuses.every((s) => s === 429), statuses.join(','));
+  const retryAfter = Number(last.headers.get('retry-after'));
+  check('retry-after is the earliest reset (seat one, ~21m), not a cool-down estimate',
+    retryAfter > RESET_ONE_S - 60 && retryAfter <= RESET_ONE_S, retryAfter);
+  check('marker x-dario-upstream-rejection: pool_parked', last.headers.get('x-dario-upstream-rejection') === 'pool_parked', last.headers.get('x-dario-upstream-rejection'));
+  const one = (await accounts()).find((a) => a.alias === 'one');
+  check('rejectedCount on seat one stayed at 1 (this is the 500 of the report)', one?.rejectedCount === 1, one?.rejectedCount);
+  check('status rejected, action wait', one?.status === 'rejected' && one?.action === 'wait', JSON.stringify([one?.status, one?.action]));
+  const adminOne = (await adminAccounts()).find((a) => a.alias === 'one');
+  check('admin listing: rejected_count 1, action wait', adminOne?.rejected_count === 1 && adminOne?.action === 'wait', JSON.stringify([adminOne?.rejected_count, adminOne?.action]));
+}
+
+header('the log marks the transition once, not per request');
+{
+  const parked = log.filter((l) => l.includes('pool parked: all 2 seats'));
+  check('exactly one "pool parked" line', parked.length === 1, JSON.stringify(parked));
+  check('it names the earliest reset in minutes', /earliest resets in 2[01]m/.test(parked[0] ?? ''), parked[0]);
+  check('each seat logged its own parking exactly once', log.filter((l) => l.includes('rate limited (429) on account "one"')).length === 1 && log.filter((l) => l.includes('rate limited (429) on account "two"')).length === 1);
+}
+
+out(`\npool-parked-local-429: ${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/test/pool-parked-seat-surfaces.mjs
+++ b/test/pool-parked-seat-surfaces.mjs
@@ -159,23 +159,25 @@ header('the proxy log names the seat, the reading and the reset — without -v')
   check('and the reset', /resets in 3[67]m/.test(lines[0] ?? ''), lines[0]);
 }
 
-header('a re-probe of a parked seat is not a new parking (no repeat line)');
+header('a seat parked inside a live window is not re-probed when the pool runs dry');
 {
   // Park spare too, on a window that has already rolled. With nothing eligible
-  // left, the failover falls back to the parked busy seat, which 429s again:
-  // that is a repeat, not a transition, and must not log a second line.
+  // left, the old fallback re-probed the parked busy seat — a guaranteed 429
+  // that only inflated its rejectedCount (500 of them on the dario#1244
+  // gateway). Now busy is left alone: the client gets the honest 429 from the
+  // seat that was actually tried, and busy's counters do not move.
   spareRolled = true;
   const r = await messages(`conversation exhausted ${Math.random()}`);
   await r.text();
   check('client gets the honest 429 (no seat left, no Codex leg)', r.status === 429, r.status);
-  check('busy was re-probed', calls.filter((b) => b === 'busy-token').length === 2, calls.join(','));
+  check('busy was NOT re-probed (its window is still live)', calls.filter((b) => b === 'busy-token').length === 1, calls.join(','));
   check('still exactly one parking line for busy', parkingLines('busy').length === 1, JSON.stringify(parkingLines('busy')));
   check('spare logged its own parking once', parkingLines('spare').length === 1, JSON.stringify(parkingLines('spare')));
   check('spare\'s line says its window had already rolled', parkingLines('spare')[0]?.includes('window already rolled'), parkingLines('spare')[0]);
 
   const busy = (await accounts()).find((a) => a.alias === 'busy');
-  check('busy rejectedCount is now 2', busy?.rejectedCount === 2, busy?.rejectedCount);
-  check('busy still rejected, requestCount still 0', busy?.status === 'rejected' && busy?.requestCount === 0);
+  check('busy rejectedCount is still 1', busy?.rejectedCount === 1, busy?.rejectedCount);
+  check('busy still rejected, requestCount still 0, action wait', busy?.status === 'rejected' && busy?.requestCount === 0 && busy?.action === 'wait', JSON.stringify([busy?.status, busy?.requestCount, busy?.action]));
 
   // A rejection whose window has passed reports `unknown` (#1232) — and now
   // shows the reset that passed, so the operator can see why it is unknown.


### PR DESCRIPTION
Follow-up to #1244. The reporter's second listing (v6.0.33, six-seat team gateway) read:

```
"util5h": 1, "reset_in_ms": 1288011, "status": "rejected",
"request_count": 1, "rejected_count": 500
```

and the question was "do I have to re-login?" No: that is 500 requests that arrived while every seat was over its window, each one re-probing this seat.

**Cause.** `select()`'s all-exhausted branch returned the seat with the earliest reset and the request went upstream — a guaranteed 429 — and `selectExcluding()` then offered every other parked seat mid-flight. One request could spend six upstream 429s, bump six `rejectedCount`s, and the client still waited on a verdict dario already held.

**Fix.** A seat parked inside a live window (`rejected`, `reset` in the future) is never re-probed:

- `select()` returns null; `pool.parkedUntil()` names the earliest reset. The proxy answers `429` with `retry-after` at that reset, `x-dario-upstream-rejection: pool_parked`, nothing upstream, cools the Claude provider to the reset so an armed `--pool-fallback` chain sees the state, and logs the transition once (`pool parked: all 6 seats are over their rate-limit windows, earliest resets in 21m`).
- `selectExcluding()` no longer hands a parked seat to mid-flight failover.
- A rejection with **no stated reset** stays probeable, as before: with nothing to expire, asking is its only way back. A parked seat still returns on its own when its window rolls (6.0.30).

**Added.** `action` on `GET /accounts` and `GET /admin/accounts` next to `status`: `none` · `wait` (live window, or a single auth blip) · `regrant` (auth-failure streak). `dario accounts list --live` prints it as `next: …`.

**Tests.** New `test/pool-parked-local-429.mjs`: pure pool (parked vs probeable, `parkedUntil`, `selectExcluding`, `action` for each state) and the real proxy in-process with two seats answering 429 — 21 requests, exactly 2 upstream calls, `rejectedCount` frozen at 1, `retry-after` ≈ 21 min, the marker, one log line, `action: wait` on both listings. `pool-e2e.mjs` and `pool-parked-seat-surfaces.mjs` asserted the re-probe and now assert its absence. Full suite 186/186.

Version 6.0.35; CHANGELOG and `docs/multi-account-pool.md` updated.
