### PR TITLE
accounts list --live: survive a pre-upgrade proxy payload (v6.0.36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ checklist.
 
 ## [Unreleased]
 
+## [6.0.36] - 2026-09-07
+
+### Fixed
+- **`dario accounts list --live` no longer crashes against a proxy from the previous release.** The `/accounts` response is accepted on `mode` plus `accounts` being an array, and nothing checked the seats themselves — so during a normal upgrade, where the newly installed CLI queries a still-running older proxy, `sharesWindowWith` was absent and `.length` on it threw `TypeError: Cannot read properties of undefined`. The command then neither rendered live data nor took the on-disk listing it advertises as the fallback. Every additive field the team-gateway work introduced (`sharesWindowWith`, `organizationId`, `grantedAt`, `action`) is now defaulted at that client boundary, along with the counters and the utilisation readings, so a pre-upgrade payload prints a thinner seat line instead of dying. The renderer is split out as a pure function and covered by a legacy-payload test.
+
 ## [6.0.35] - 2026-09-07
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.35",
+  "version": "6.0.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "6.0.35",
+      "version": "6.0.36",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.35",
+  "version": "6.0.36",
   "description": "Use your Claude and ChatGPT subscriptions in Cursor, Cline, Aider, Claude Code and the Agent SDK — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint: either plan answers either wire shape, with automatic failover when one hits its limit.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -983,7 +983,7 @@ async function accountsListLive(): Promise<boolean> {
       `429s ${s.rejectedCount}`,
       ...(next ? [next] : []),
       s.organizationId ? `org ${s.organizationId.slice(0, 8)}…` : 'org not yet observed',
-      ...(s.sharesWindowWith.length > 0 ? [`shares its window with ${s.sharesWindowWith.join(', ')}`] : []),
+      ...(Array.isArray(s.sharesWindowWith) && s.sharesWindowWith.length > 0 ? [`shares its window with ${s.sharesWindowWith.join(', ')}`] : []),
     ];
     console.log(`    ${''.padEnd(20)} ${facts.join('  ·  ')}`);
     console.log(`    ${''.padEnd(20)} ${describeGrantAge(grantAge(s.grantedAt ?? undefined, now))}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -925,6 +925,73 @@ function parsePositiveIntFlag(prefix: string): number | undefined {
 }
 
 /**
+ * The seat shape a running proxy returns from `/accounts`.
+ *
+ * Everything past `alias` is optional on purpose. A freshly installed CLI
+ * routinely queries a proxy still running the PREVIOUS release, whose seats
+ * predate whichever field the newest feature added — `sharesWindowWith`,
+ * `organizationId` and `grantedAt` all arrived that way (dario#1248 review).
+ * The payload is accepted on `mode` + `accounts` alone, so the renderer, not
+ * the fetch, is where a missing field would throw. Defaulting each one here
+ * keeps `accounts list --live` degrading to a thinner line instead of dying
+ * with a TypeError and skipping the on-disk fallback it advertises.
+ */
+export interface LiveSeat {
+  alias?: string; status?: string; action?: 'none' | 'wait' | 'regrant';
+  util5h?: number; util7d?: number; utilAgeMs?: number | null;
+  resetInMs?: number | null; requestCount?: number; rejectedCount?: number;
+  organizationId?: string | null; sharesWindowWith?: string[]; grantedAt?: number | null;
+}
+export interface LivePayload { mode?: string; accounts?: LiveSeat[]; distinctWindows?: number }
+
+/**
+ * Render the live pool listing. Pure — returns the lines rather than printing
+ * them, so a legacy payload can be driven straight through it in a test.
+ */
+export function formatLiveAccountsListing(payload: LivePayload, port: number, now: number): string[] {
+  const seats = Array.isArray(payload.accounts) ? payload.accounts : [];
+  const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
+  const pct = (n: unknown) => `${Math.round(num(n) * 100)}%`;
+  const mins = (ms: number) => {
+    const m = Math.max(1, Math.round(ms / 60_000));
+    return m >= 60 ? `${Math.floor(m / 60)}h ${m % 60}m` : `${m}m`;
+  };
+  const age = (ms: number | null | undefined) => typeof ms !== 'number' || !Number.isFinite(ms)
+    ? 'never measured'
+    : ms < 60_000 ? `read ${Math.round(ms / 1000)}s ago` : `read ${mins(ms)} ago`;
+  const lines: string[] = [];
+  lines.push('');
+  lines.push(`  dario — Accounts (live, from http://127.0.0.1:${port})`);
+  lines.push('  ────────────────');
+  lines.push('');
+  const windows = typeof payload.distinctWindows === 'number' ? payload.distinctWindows : seats.length;
+  lines.push(`  Pool of ${seats.length} (${seats.length === 1 ? '1 seat' : seats.length + ' seats'} on ${windows} distinct window${windows === 1 ? '' : 's'})`);
+  lines.push('');
+  for (const s of seats) {
+    const alias = typeof s.alias === 'string' ? s.alias : '(unnamed)';
+    const rawStatus = typeof s.status === 'string' ? s.status : 'unknown';
+    const status = rawStatus === 'rejected' && typeof s.resetInMs === 'number' ? `rejected, back in ${mins(s.resetInMs)}` : rawStatus;
+    lines.push(`    ${alias.padEnd(20)} ${status.padEnd(26)} 5h ${pct(s.util5h).padEnd(6)} 7d ${pct(s.util7d).padEnd(6)} ${age(s.utilAgeMs)}`);
+    // The one-word next step (dario#1244): a parked seat wants nothing from
+    // the operator; an auth-failure streak wants a re-grant.
+    const next = s.action === 'regrant' ? 'next: re-grant this seat (dario accounts remove + add)'
+      : s.action === 'wait' ? 'next: nothing, it comes back on its own'
+      : null;
+    const facts = [
+      `served ${num(s.requestCount)}`,
+      `429s ${num(s.rejectedCount)}`,
+      ...(next ? [next] : []),
+      typeof s.organizationId === 'string' && s.organizationId ? `org ${s.organizationId.slice(0, 8)}…` : 'org not yet observed',
+      ...(Array.isArray(s.sharesWindowWith) && s.sharesWindowWith.length > 0 ? [`shares its window with ${s.sharesWindowWith.join(', ')}`] : []),
+    ];
+    lines.push(`    ${''.padEnd(20)} ${facts.join('  ·  ')}`);
+    lines.push(`    ${''.padEnd(20)} ${describeGrantAge(grantAge(typeof s.grantedAt === 'number' ? s.grantedAt : undefined, now))}`);
+  }
+  lines.push('');
+  return lines;
+}
+
+/**
  * `dario accounts list --live` — the running proxy's view of the pool
  * (dario#1244): status with its countdown, the reading and its age, 429s
  * answered, the organization, and which seats share a window. The on-disk
@@ -940,12 +1007,6 @@ async function accountsListLive(): Promise<boolean> {
     ?? fileCfg.port ?? 3456;
   const headers: Record<string, string> = {};
   if (process.env['DARIO_API_KEY']) headers['x-api-key'] = process.env['DARIO_API_KEY']!;
-  interface LiveSeat {
-    alias: string; status: string; action?: 'none' | 'wait' | 'regrant'; util5h: number; util7d: number; utilAgeMs: number | null;
-    resetInMs: number | null; requestCount: number; rejectedCount: number;
-    organizationId: string | null; sharesWindowWith: string[]; grantedAt: number | null;
-  }
-  interface LivePayload { mode?: string; accounts?: LiveSeat[]; distinctWindows?: number }
   let payload: LivePayload | null = null;
   try {
     const res = await fetch(`http://127.0.0.1:${port}/accounts`, { headers, signal: AbortSignal.timeout(3000) });
@@ -955,40 +1016,7 @@ async function accountsListLive(): Promise<boolean> {
     console.log(`  (no proxy on http://127.0.0.1:${port}: ${err instanceof Error ? err.message : String(err)} — showing the on-disk listing)`);
   }
   if (!payload || payload.mode !== 'pool' || !Array.isArray(payload.accounts)) return false;
-  const seats = payload.accounts;
-  const now = Date.now();
-  const pct = (n: number) => `${Math.round(n * 100)}%`;
-  const mins = (ms: number) => {
-    const m = Math.max(1, Math.round(ms / 60_000));
-    return m >= 60 ? `${Math.floor(m / 60)}h ${m % 60}m` : `${m}m`;
-  };
-  const age = (ms: number | null) => ms === null ? 'never measured' : ms < 60_000 ? `read ${Math.round(ms / 1000)}s ago` : `read ${mins(ms)} ago`;
-  console.log('');
-  console.log(`  dario — Accounts (live, from http://127.0.0.1:${port})`);
-  console.log('  ────────────────');
-  console.log('');
-  const windows = payload.distinctWindows ?? seats.length;
-  console.log(`  Pool of ${seats.length} (${seats.length === 1 ? '1 seat' : seats.length + ' seats'} on ${windows} distinct window${windows === 1 ? '' : 's'})`);
-  console.log('');
-  for (const s of seats) {
-    const status = s.status === 'rejected' && typeof s.resetInMs === 'number' ? `rejected, back in ${mins(s.resetInMs)}` : s.status;
-    console.log(`    ${s.alias.padEnd(20)} ${status.padEnd(26)} 5h ${pct(s.util5h).padEnd(6)} 7d ${pct(s.util7d).padEnd(6)} ${age(s.utilAgeMs)}`);
-    // The one-word next step (dario#1244): a parked seat wants nothing from
-    // the operator; an auth-failure streak wants a re-grant.
-    const next = s.action === 'regrant' ? 'next: re-grant this seat (dario accounts remove + add)'
-      : s.action === 'wait' ? 'next: nothing, it comes back on its own'
-      : null;
-    const facts = [
-      `served ${s.requestCount}`,
-      `429s ${s.rejectedCount}`,
-      ...(next ? [next] : []),
-      s.organizationId ? `org ${s.organizationId.slice(0, 8)}…` : 'org not yet observed',
-      ...(Array.isArray(s.sharesWindowWith) && s.sharesWindowWith.length > 0 ? [`shares its window with ${s.sharesWindowWith.join(', ')}`] : []),
-    ];
-    console.log(`    ${''.padEnd(20)} ${facts.join('  ·  ')}`);
-    console.log(`    ${''.padEnd(20)} ${describeGrantAge(grantAge(s.grantedAt ?? undefined, now))}`);
-  }
-  console.log('');
+  for (const line of formatLiveAccountsListing(payload, port, Date.now())) console.log(line);
   return true;
 }
 

--- a/test/accounts-live-legacy-payload.mjs
+++ b/test/accounts-live-legacy-payload.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+// `dario accounts list --live` against a PRE-UPGRADE proxy (ticket
+// 00MTRGHYIREA78C17D935F8CD8, review fix stranded when #1248 closed and the
+// feature re-landed as #1250).
+//
+// The /accounts payload is accepted on `mode === 'pool'` plus `accounts` being
+// an array — nothing checks the seat fields. So a newly installed CLI querying
+// a proxy from the previous release met seats with no `sharesWindowWith`, and
+// `.length` on undefined threw a TypeError: the command neither rendered live
+// data nor took the on-disk fallback it advertises. Every field the team-gateway
+// feature added is exercised here by its absence.
+
+import { formatLiveAccountsListing } from '../dist/cli.js';
+
+let pass = 0, fail = 0;
+function check(name, cond) {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else      { console.log(`  FAIL ${name}`); fail++; }
+}
+function header(n) { console.log(`\n=== ${n} ===`); }
+
+const NOW = 1_757_260_000_000;
+
+// A seat as a v6.0.33-and-earlier proxy serialized it: no sharesWindowWith,
+// no organizationId, no grantedAt, no action.
+const LEGACY_SEAT = {
+  alias: 'seat-a', status: 'ok', util5h: 0.25, util7d: 0.1,
+  utilAgeMs: 30_000, resetInMs: null, requestCount: 12, rejectedCount: 0,
+};
+
+// ─────────────────────────────────────────────────────────────
+header('legacy payload — renders instead of throwing');
+{
+  let lines = null, threw = null;
+  try {
+    lines = formatLiveAccountsListing({ mode: 'pool', accounts: [LEGACY_SEAT] }, 3456, NOW);
+  } catch (err) { threw = err; }
+
+  check('does not throw on a seat with no sharesWindowWith', threw === null);
+  check('returned lines', Array.isArray(lines) && lines.length > 0);
+
+  const text = (lines ?? []).join('\n');
+  check('still names the seat', text.includes('seat-a'));
+  check('still reports the counts', text.includes('served 12') && text.includes('429s 0'));
+  check('omits the shared-window fact rather than inventing one', !text.includes('shares its window with'));
+  check('degrades the absent organization', text.includes('org not yet observed'));
+}
+
+// ─────────────────────────────────────────────────────────────
+header('current payload — the feature fields still render');
+{
+  const modern = {
+    ...LEGACY_SEAT, action: 'wait',
+    organizationId: 'org_abcdef1234567890',
+    sharesWindowWith: ['seat-b', 'seat-c'],
+    grantedAt: NOW - 86_400_000,
+  };
+  const text = formatLiveAccountsListing({ mode: 'pool', accounts: [modern], distinctWindows: 2 }, 3456, NOW).join('\n');
+  check('renders the shared window', text.includes('shares its window with seat-b, seat-c'));
+  check('renders the organization', text.includes('org org_abcd'));
+  check('renders the next step', text.includes('nothing, it comes back on its own'));
+  check('honours distinctWindows', text.includes('on 2 distinct windows'));
+}
+
+// ─────────────────────────────────────────────────────────────
+header('a seat missing EVERY optional field');
+{
+  // The degenerate end of the same class: an older proxy, or one mid-restart,
+  // that hands back a seat carrying only an alias.
+  let threw = null, text = '';
+  try {
+    text = formatLiveAccountsListing({ mode: 'pool', accounts: [{ alias: 'bare' }] }, 3456, NOW).join('\n');
+  } catch (err) { threw = err; }
+  check('does not throw', threw === null);
+  check('names the seat', text.includes('bare'));
+  check('zeroes the missing counters', text.includes('served 0') && text.includes('429s 0'));
+  check('reports an unmeasured reading rather than NaN', text.includes('never measured') && !text.includes('NaN'));
+}
+
+// ─────────────────────────────────────────────────────────────
+header('an empty pool');
+{
+  let threw = null, text = '';
+  try {
+    text = formatLiveAccountsListing({ mode: 'pool', accounts: [] }, 3456, NOW).join('\n');
+  } catch (err) { threw = err; }
+  check('does not throw', threw === null);
+  check('reports a pool of 0', text.includes('Pool of 0'));
+}
+
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Applies the gating review fix from #1248 that did not travel when the feature re-landed as #1250.

## The defect

`src/cli.ts` accepts the `/accounts` response on `mode === 'pool'` plus `accounts` being an array — nothing validates the seats. During a normal upgrade the newly installed CLI queries a **still-running proxy from the previous release**, whose seat objects predate the additive `sharesWindowWith` field, and:

```
...(s.sharesWindowWith.length > 0 ? [...] : [])
```

throws `TypeError: Cannot read properties of undefined`. The command then neither renders live data nor takes the on-disk listing it advertises as its fallback.

## The fix

The reviewer suggested an `Array.isArray` guard on the one field; this does that and then the thing they asked for underneath it — validates the whole payload at the client boundary rather than one field. Every additive field the team-gateway work introduced carries the same assumption: `organizationId`, `grantedAt` and `action` are all as absent as `sharesWindowWith` on a pre-upgrade seat, as are the counters and utilisation readings.

- `LiveSeat` / `LivePayload` lift to module scope with every field past `alias` optional, which is what the wire actually guarantees.
- The renderer is extracted as pure `formatLiveAccountsListing(payload, port, now)` returning lines instead of printing, so a legacy payload can be driven straight through it.
- Each field is defaulted at read: absent counters render `0`, an absent reading renders `never measured` (not `NaN%`), an absent org keeps the existing `org not yet observed`, and an absent/empty `sharesWindowWith` omits the fact rather than inventing one. A pre-upgrade payload prints a thinner seat line.

## Test plan

New `test/accounts-live-legacy-payload.mjs` (auto-discovered by `test/all.test.mjs`):

- a legacy seat — no `sharesWindowWith`, `organizationId`, `grantedAt` or `action` — renders instead of throwing, and still shows the alias and counts
- the modern payload still renders the shared window, org, next-step and `distinctWindows`, so this is not a silent feature regression
- the degenerate case: a seat carrying only `alias` renders, zeroes its counters and reports `never measured` rather than `NaN`
- an empty pool renders `Pool of 0`

`node scripts/preflight.mjs` clean. Version bumped to 6.0.36 with CHANGELOG re-headed per the release gate; `src/cli.ts` is shipped code.

Source ticket: 00MTRGHYIREA78C17D935F8CD8. Finding: 00MTRGHMLPC23964166520A002.