### PR TITLE
/status reports the build that is running, not the one on disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ checklist.
 
 ## [Unreleased]
 
+## [6.0.36] - 2026-09-07
+
+### Fixed
+
+- **`/status` and `/health` report the version the proxy is actually running (#1244 follow-up).** `darioVersion()` read `package.json` lazily on the first call and cached that, so an `npm i -g` under a running proxy — which rewrites `package.json` in place without touching the process — moved the reported version without moving a line of the code answering requests. A proxy that had not served `/status` before the upgrade answered its first one with the **new** number while still executing the **old** build, the exact opposite of what the field was added for (#640: confirm an auto-update actually rolled the running proxy). It is how #1244 lost a round trip: `/status` read `6.0.34` while `GET /admin/accounts` was still emitting the 6.0.33 field set with no `organization_id`, so "upgrade, then read `organization_id`" looked already done and the seat's real diagnosis stayed out of reach. The version is read at module load now, which for the proxy is process start, so the number moves only when the process does. A missing or malformed `package.json` still reports `unknown` and never throws.
+
 ## [6.0.35] - 2026-09-07
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.35",
+  "version": "6.0.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "6.0.35",
+      "version": "6.0.36",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.35",
+  "version": "6.0.36",
   "description": "Use your Claude and ChatGPT subscriptions in Cursor, Cline, Aider, Claude Code and the Agent SDK — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint: either plan answers either wire shape, with automatic failover when one hits its limit.",
   "type": "module",
   "bin": {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,27 +1,43 @@
 /**
- * dario's own package version, read once from the bundled package.json.
+ * dario's own package version, bound at module load.
  *
  * Surfaced on `/status` and `/health` (#640) so a headless operator can confirm
  * an auto-update actually rolled the running proxy — `curl /health | jq .version`
  * beats exec-ing into the container to read package.json.
+ *
+ * WHY AT MODULE LOAD, NOT ON FIRST CALL. This used to read package.json lazily
+ * the first time someone asked, and cache that. `npm i -g` rewrites
+ * package.json under the running install without touching the process, so a
+ * proxy that had not served `/status` before an upgrade answered its first one
+ * with the NEW version while still executing the OLD code — precisely the
+ * opposite of what the field exists to report. It cost the reporter on #1244 a
+ * round trip: `/status` read 6.0.34 while `GET /admin/accounts` was still
+ * emitting the 6.0.33 field set, so the advice he had been given ("upgrade,
+ * then read `organization_id`") looked already done.
+ *
+ * Reading at import binds the value to the process. proxy.ts imports this at
+ * startup, so `/status` reports the build that is actually answering until it
+ * restarts — the only claim the field can honestly make.
  */
 import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-let cached: string | null = null;
-
-export function darioVersion(): string {
-  if (cached !== null) return cached;
-  let v = 'unknown';
+function readVersion(): string {
   try {
     // dist/version.js → ../package.json (same layout the MCP server + CLI use).
     const here = dirname(fileURLToPath(import.meta.url));
     const pkg = JSON.parse(readFileSync(join(here, '..', 'package.json'), 'utf-8'));
-    if (typeof pkg.version === 'string') v = pkg.version;
+    if (typeof pkg.version === 'string') return pkg.version;
   } catch {
-    // package.json missing/malformed — keep 'unknown', never throw.
+    // package.json missing/malformed — report 'unknown', never throw.
   }
-  cached = v;
-  return v;
+  return 'unknown';
+}
+
+/** Read once, at import. See the note above for why not on first call. */
+const VERSION = readVersion();
+
+export function darioVersion(): string {
+  return VERSION;
 }

--- a/test/version-binding.mjs
+++ b/test/version-binding.mjs
@@ -1,0 +1,97 @@
+// src/version.ts — `/status` and `/health` must report the build that is
+// RUNNING, not whatever package.json says on disk when someone first asks.
+//
+// The regression this locks: darioVersion() used to read package.json lazily
+// on the first call and cache that. `npm i -g` rewrites package.json under the
+// running install, so a proxy that had never served /status before an upgrade
+// answered its first one with the NEW version while executing the OLD code.
+// On #1244 that reported 6.0.34 from a process still emitting the 6.0.33
+// /admin/accounts field set, and cost the reporter a round trip.
+//
+// Each case gets its own throwaway install root with its own copy of
+// dist/version.js, so the module is imported fresh against a known
+// package.json. No network, no writes outside the temp dir.
+
+import { mkdtemp, rm, mkdir, writeFile, copyFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BUILT = join(__dirname, '..', 'dist', 'version.js');
+
+let pass = 0, fail = 0;
+function check(label, cond, detail) {
+  if (cond) { console.log(`  ✅ ${label}`); pass++; }
+  else { console.log(`  ❌ ${label}${detail ? ` :: ${detail}` : ''}`); fail++; }
+}
+function header(label) {
+  console.log(`\n======================================================================`);
+  console.log(`  ${label}`);
+  console.log(`======================================================================`);
+}
+
+/**
+ * A throwaway install root: `<root>/package.json` is the one under test (what
+ * `dist/version.js` reads as `../package.json`), and `<root>/dist/package.json`
+ * only tells Node the copied file is ESM — so a missing or malformed root
+ * package.json is a clean case rather than a module-resolution warning.
+ */
+async function installRoot(version) {
+  const root = await mkdtemp(join(tmpdir(), 'dario-version-'));
+  await mkdir(join(root, 'dist'), { recursive: true });
+  await copyFile(BUILT, join(root, 'dist', 'version.js'));
+  await writeFile(join(root, 'dist', 'package.json'), JSON.stringify({ type: 'module' }));
+  await writePackage(root, version);
+  return root;
+}
+const writePackage = (root, version) =>
+  writeFile(join(root, 'package.json'), JSON.stringify({ name: '@askalf/dario', version }));
+const load = (root) => import(pathToFileURL(join(root, 'dist', 'version.js')).href);
+
+header('the version is bound to the process, not to the file on disk');
+{
+  // The proxy starts on 6.0.33 and imports the module.
+  const root = await installRoot('6.0.33');
+  const { darioVersion } = await load(root);
+
+  // `npm i -g @askalf/dario@6.0.34` rewrites package.json under the same
+  // install path. The proxy is never restarted.
+  await writePackage(root, '6.0.34');
+
+  // The first /status this process has ever served.
+  const first = darioVersion();
+  check('an upgrade under a running process does not move /status', first === '6.0.33',
+    `got ${first} — the lazy read is back, and /status is reporting a build it is not running`);
+
+  // And it stays put on every later call, disk notwithstanding.
+  await writePackage(root, '6.0.99');
+  check('later calls stay on the running build', darioVersion() === '6.0.33');
+  await rm(root, { recursive: true, force: true });
+}
+
+header('it still reports the version it was actually installed at');
+{
+  const root = await installRoot('7.1.2');
+  const { darioVersion } = await load(root);
+  check('a fresh process reads its own package.json', darioVersion() === '7.1.2');
+  await rm(root, { recursive: true, force: true });
+}
+
+header('a missing or malformed package.json reports "unknown", never throws');
+{
+  const gone = await installRoot('6.0.33');
+  await rm(join(gone, 'package.json'));
+  const missing = await load(gone);
+  check('missing package.json → "unknown"', missing.darioVersion() === 'unknown');
+  await rm(gone, { recursive: true, force: true });
+
+  const bad = await installRoot('6.0.33');
+  await writeFile(join(bad, 'package.json'), '{ not json');
+  const broken = await load(bad);
+  check('malformed package.json → "unknown"', broken.darioVersion() === 'unknown');
+  await rm(bad, { recursive: true, force: true });
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+if (fail > 0) process.exit(1);


### PR DESCRIPTION
Addresses #1244 — specifically the round trip it cost, which was not the seat's fault.

**The bug.** `darioVersion()` read `package.json` lazily on the first call and cached that. `npm i -g` rewrites `package.json` in place under the running install without touching the process, so the reported version could move without a single line of the code answering requests moving with it. A proxy that had not served `/status` before an upgrade answered its first one with the **new** number while still executing the **old** build.

That is the exact opposite of what the field was added for in #640 — *"so a headless operator can confirm an auto-update actually rolled the running proxy — `curl /health | jq .version` beats exec-ing into the container to read package.json."* It confirmed the upgrade had landed at precisely the moment it had not.

**How it surfaced.** On #1244 the reporter pasted `/status` reading `6.0.34` alongside a `GET /admin/accounts` seat with no `organization_id`, no `shares_window_with`, no `reading_from` — all three unconditional on that endpoint since 6.0.34. Running his exact seat numbers through the real handler on master confirms it: the current build emits `"organization_id": null` even for a seat whose organization was never observed. His listing was the 6.0.33 field set, from a process that had been upgraded on disk and never restarted.

The cost was not cosmetic. He had been told to upgrade and read `organization_id` to see which organization his token belonged to; `/status` told him he already had, so the one field that explains his 0%-vs-100% discrepancy stayed out of reach and the thread went another round.

**The fix.** Read at module load. `proxy.ts` is the only importer and imports it statically at startup, so the value is bound to the process and the number moves only when the process does. A missing or malformed `package.json` still reports `unknown` and never throws — unchanged.

**Test.** `test/version-binding.mjs` drives the built `dist/version.js` in a throwaway install root: imported at `6.0.33`, `package.json` rewritten to `6.0.34` underneath it, and the first call must still say `6.0.33`. Plus a fresh process reading its own version, and the missing / malformed cases.

Checked against the unfixed file rather than assumed — `git stash` the fix, rebuild, and the same test fails 2 of 5 and reports `6.0.34`, which is the symptom from the issue verbatim:

```
❌ an upgrade under a running process does not move /status
   :: got 6.0.34 — the lazy read is back, and /status is reporting a build it is not running
❌ later calls stay on the running build
```

**Note on the diagnosis path:** three other places read `package.json` for their own version (`config-report.ts`, `doctor-core.ts`, `subagent.ts`). All three are short-lived CLI paths where process start and first call are the same moment, so none has this failure mode. Left alone rather than unified.

Version is **6.0.37** so this ships. #1256 shipped 6.0.36 while this was open — `accounts list --live` surviving a pre-upgrade proxy payload, the same pre-upgrade class of problem seen from the other side. Its CHANGELOG entry keeps 6.0.36 and this one sits above it; both sections verified through `extract-release-notes.mjs --file`. Nothing but the release heading conflicted.
