### PR TITLE
an effort suffix on a Codex model routes instead of 400ing (v6.0.38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ checklist.
 
 ## [Unreleased]
 
+## [6.0.38] - 2026-09-07
+
+### Fixed
+
+- **An effort suffix on a Codex model name works, instead of answering 400 `model_unroutable` (#1260).** `#419` let a client that cannot set `output_config.effort` choose one by model name (`opus-4-8:high`, or Cursor's `claude-opus-4-8-high`). Only the Claude half ever honoured it: routing matched the model against each provider's list *before* the suffix was stripped, so `gpt-5.6-terra:high` matched nothing and was refused locally while `claude-sonnet-5:high` served fine. The two existing strip sites skip OpenAI-shaped names deliberately, because an openai-compat backend may serve a model whose real id ends in `-high` and a blind strip there would rewrite a legitimate name against a catalog dario cannot see. Codex is the one provider that publishes its routable set, so the strip now also happens after discovery, guarded by the same as-written-wins rule `resolveClaudeTarget` uses for chain entries (#1161): strip only when the name as written matches no slug and the stripped name matches one. A slug that genuinely ends in an effort word is still routed exactly as written, a model no provider lists is still refused, and the suffix never reaches the backend. The named effort is carried into the Codex request as `reasoning.effort`.
+- **A `--pool-fallback` chain entry naming a Codex model may carry an effort suffix too (#1260).** `pickCodexFallback` matched entries against the account's slugs literally, so `gpt-5.6-terra:high` matched nothing and the entry was skipped in silence — no error, no log, just a failover the operator configured that never fired. It now reads the suffix under the same guard and carries the declared effort into the failover request, which is what the Claude end of a chain has done since #1161.
+
+### Changed
+
+- **`reasoning.effort` accepts the levels the backend actually has.** The thinking-budget mapping only ever produced `low`/`medium`/`high`; a named effort can now also be `none`, `minimal`, `xhigh` or `max` (`ultra` is not a level the backend accepts). dario's own `ultracode` tier maps to `max`, the nearest upstream equivalent, rather than being dropped. `REASONING_HEADROOM` gained reservations for the new levels — measured through dario on one identical prompt with only the level changing, `low` returned 1,982 output tokens, `high` 3,947 and `max` 11,160, so the reservations sit above that trend rather than on it. Under-reserving is the failure the table exists to prevent: reasoning eats the whole budget, the response comes back `incomplete`, and the turn arrives empty.
+
 ## [6.0.37] - 2026-09-07
 
 ### Fixed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,6 +74,34 @@ Off by default, each one a deliberate divergence from what real CC sends.
 | `DARIO_EFFORT` | `--effort=` | Forces a reasoning-effort level. Can flip requests to overage billing — watch `-v` logs for representative-claim changes ([`#87`](https://github.com/askalf/dario/issues/87)). |
 | `DARIO_MAX_TOKENS` | `--max-tokens=` | Anthropic enforces the per-model ceiling server-side, so too-high values return a clean 400 ([`#88`](https://github.com/askalf/dario/issues/88)). |
 
+### Per-request effort, by model name
+
+`DARIO_EFFORT` is process-wide: it applies to every caller, Claude and Codex
+alike. A client that has no way to set `output_config.effort` can instead name
+the level in the model itself, and only that request changes:
+
+```
+claude-opus-4-8:high      colon form
+claude-opus-4-8-high      hyphen form, for Cursor, which rewrites colons
+gpt-5.6-terra:high        a Codex model, same two spellings
+```
+
+Levels: `low`, `medium`, `high`, `xhigh`, `max`, plus dario's own `ultracode`
+(which reaches a Codex backend as `max`) and `client`, which forces nothing.
+On the Codex path the level is sent as `reasoning.effort`; on the Claude path
+as `output_config.effort`.
+
+The suffix is only read when the name as written matches no model the provider
+lists, so a real model id that happens to end in an effort word is routed
+exactly as written and never re-read. A `--pool-fallback` chain entry may carry
+one too, which sets the effort the failover request runs at.
+
+Effort is not free. Measured through dario on one prompt with only the level
+changing: `low` returned 1,982 output tokens in 18s, `high` 3,947 in 35s, and
+`max` 11,160 in 100s. Reasoning is billed as output, so `max` is a real cost
+increase on every request that names it, and on a long agent loop it can push a
+run into its own timeout.
+
 ## Pacing
 
 Only meaningful with stealth, and all default to 0 (off) except the cap. See [`wire-fidelity.md`](./wire-fidelity.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,10 +86,15 @@ claude-opus-4-8-high      hyphen form, for Cursor, which rewrites colons
 gpt-5.6-terra:high        a Codex model, same two spellings
 ```
 
-Levels: `low`, `medium`, `high`, `xhigh`, `max`, plus dario's own `ultracode`
-(which reaches a Codex backend as `max`) and `client`, which forces nothing.
-On the Codex path the level is sent as `reasoning.effort`; on the Claude path
-as `output_config.effort`.
+Levels a suffix may name: `low`, `medium`, `high`, `xhigh`, `max`, and dario's
+own `ultracode`, which reaches a Codex backend as `max`. On the Codex path the
+level is sent as `reasoning.effort`; on the Claude path as
+`output_config.effort`.
+
+`client` is a valid `DARIO_EFFORT` value but deliberately **not** a suffix. It
+means "leave the client's own choice alone", so naming it in a model would be a
+no-op, and accepting it would let a model genuinely named `...-client` be
+stripped to a name the backend does not list.
 
 The suffix is only read when the name as written matches no model the provider
 lists, so a real model id that happens to end in an effort word is routed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.37",
+  "version": "6.0.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "6.0.37",
+      "version": "6.0.38",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.37",
+  "version": "6.0.38",
   "description": "Use your Claude and ChatGPT subscriptions in Cursor, Cline, Aider, Claude Code and the Agent SDK — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint: either plan answers either wire shape, with automatic failover when one hits its limit.",
   "type": "module",
   "bin": {

--- a/src/anthropic-responses-translate.ts
+++ b/src/anthropic-responses-translate.ts
@@ -269,7 +269,14 @@ export type ResponsesToolChoice =
   | { type: 'function'; name: string };
 
 export interface ResponsesReasoningConfig {
-  effort?: 'low' | 'medium' | 'high';
+  /**
+   * The backend accepts more levels than the thinking-budget mapping can
+   * produce: probed 2026-08-29 against a live account, `none, minimal, low,
+   * medium, high, xhigh, max` are all valid and `ultra` 400s. The wider set
+   * is reachable only when a caller names an effort outright (dario#1260);
+   * `thinkingToReasoningEffort` still only ever yields low/medium/high.
+   */
+  effort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
   summary?: 'auto' | 'concise' | 'detailed';
 }
 
@@ -607,7 +614,17 @@ function translateToolChoice(
  * client's intended visible-output budget survives on a reasoning model
  * (max_output_tokens caps reasoning + output combined on the Responses API).
  */
-export const REASONING_HEADROOM = { low: 12000, medium: 25000, high: 50000 } as const;
+export const REASONING_HEADROOM = {
+  none: 0, minimal: 6000, low: 12000, medium: 25000, high: 50000,
+  // dario#1260 widened the reachable levels beyond what the thinking-budget
+  // mapping produces. xhigh and max reason MUCH harder — measured through
+  // dario on one identical prompt, same model, only the level changing:
+  // low 1,982 output tokens, high 3,947, max 11,160. Reserve above the trend
+  // rather than on it: under-reserving is the failure this table exists to
+  // prevent (reasoning eats the whole budget, status incomplete, empty turn),
+  // and both values are clamped by RESPONSES_MAX_OUTPUT_CAP anyway.
+  xhigh: 80000, max: 120000,
+} as const;
 /** gpt-5.x / o-series output ceiling (tokens). */
 export const RESPONSES_MAX_OUTPUT_CAP = 128000;
 
@@ -619,6 +636,14 @@ export interface AnthropicToResponsesOptions {
    * Pass `null` to omit `summary` entirely.
    */
   reasoningSummary?: 'auto' | 'concise' | 'detailed' | null;
+  /**
+   * Force `reasoning.effort`, overriding whatever `thinking.budget_tokens`
+   * would have implied. Set from a model-name effort suffix on the Codex
+   * route (dario#1260, `gpt-5.6-terra:high`), which is the only way an
+   * Anthropic-shape caller can choose an effort the budget thresholds cannot
+   * express. Unset means the existing thinking-derived behaviour, unchanged.
+   */
+  effort?: ResponsesReasoningConfig['effort'];
   /**
    * `store`. Default false — dario is stateless and keeps no server-side
    * conversation. Set true only if a caller wants OpenAI-side retention.
@@ -688,7 +713,10 @@ export function anthropicToResponsesRequest(
     out.parallel_tool_calls = false;
   }
 
-  const effort = thinkingToReasoningEffort(body.thinking);
+  // An explicitly named effort wins over the thinking-budget mapping: the
+  // caller asked for a level, not a budget, and the thresholds cannot express
+  // xhigh or max at all.
+  const effort = options.effort ?? thinkingToReasoningEffort(body.thinking);
   if (effort) {
     out.reasoning = { effort };
     const summary = options.reasoningSummary === undefined ? 'auto' : options.reasoningSummary;

--- a/src/codex-backend.ts
+++ b/src/codex-backend.ts
@@ -32,11 +32,13 @@ import {
   createAnthropicMessageAssembler,
   responsesStreamToAnthropicSSE,
   type AnthropicRequest,
+  type ResponsesReasoningConfig,
   type ResponsesResponse,
   type ResponsesStreamEvent,
   type ResponsesUsage,
 } from './anthropic-responses-translate.js';
 import { resolveClaudeTarget, type ModelResolver, type ClaudeTarget } from './claude-model.js';
+import { parseEffortSuffix, type EffortValue } from './effort.js';
 import { BAKED_BASE_MODELS } from './model-catalog.js';
 import { parseRetryAfterMs } from './provider-cooldown.js';
 
@@ -199,8 +201,36 @@ export function isCodexModel(model: string, slugs: readonly string[]): boolean {
  * own. A single-entry chain keeps the pre-6.0 meaning exactly, so configs
  * written before this release behave identically.
  */
-export function pickCodexFallback(models: readonly string[], slugs: readonly string[]): string | null {
-  return models.find(m => isCodexModel(m, slugs)) ?? null;
+export interface CodexTarget {
+  /** The slug as the account lists it — what goes in the outbound body. */
+  model: string;
+  /** Effort the entry declared through a `:high`-style suffix, if any. */
+  effort?: EffortValue;
+}
+
+export function pickCodexFallback(
+  models: readonly string[],
+  slugs: readonly string[],
+): CodexTarget | null {
+  for (const m of models) {
+    // The name AS WRITTEN wins, and only a name that matches no slug at all is
+    // re-read as `model:effort` — the same two-pass rule resolveClaudeTarget
+    // uses for chain entries (dario#1161), so a slug that genuinely ends in an
+    // effort word keeps priority over the suffix reading.
+    //
+    // Without the second pass a codex chain entry carrying the very suffix the
+    // Claude half accepts (`gpt-5.6-terra:high`) matched nothing and was
+    // silently SKIPPED: no error, no log, just a failover the operator
+    // configured that never fired (dario#1260).
+    //
+    // Per entry rather than two passes over the whole list, because the chain is
+    // priority-ordered and a full as-written sweep would let a later entry
+    // overtake an earlier one purely for being spelled without a suffix.
+    if (isCodexModel(m, slugs)) return { model: m };
+    const eff = parseEffortSuffix(m);
+    if (eff.effort && isCodexModel(eff.model, slugs)) return { model: eff.model, effort: eff.effort };
+  }
+  return null;
 }
 
 export function pickClaudeFallback(
@@ -895,6 +925,12 @@ export async function forwardToCodex(
   deferOnUnavailable = false,
   onDone?: (outcome: CodexForwardOutcome) => void,
   onDecline?: (info: CodexDecline) => void,
+  /**
+   * Effort named by a model-name suffix (dario#1260). Anthropic-shape only:
+   * a chat/completions caller sets `reasoning_effort` itself and that already
+   * translates. Undefined leaves the request exactly as it was.
+   */
+  effort?: ResponsesReasoningConfig['effort'],
 ): Promise<boolean> {
   void req;
   const isAnthropic = shape === 'anthropic';
@@ -941,7 +977,7 @@ export async function forwardToCodex(
   const model = String(parsed.model ?? '');
   // stream is forced: the backend is always streamed and collapsed here.
   const upstreamBody = isAnthropic
-    ? { ...anthropicToResponsesRequest(parsed as unknown as AnthropicRequest, model), stream: true }
+    ? { ...anthropicToResponsesRequest(parsed as unknown as AnthropicRequest, model, effort ? { effort } : {}), stream: true }
     : chatCompletionsToResponses(parsed);
   const scrubbed = toCodexSupportedBody({
     ...(upstreamBody as Record<string, unknown>),

--- a/src/effort.ts
+++ b/src/effort.ts
@@ -30,6 +30,29 @@ export const VALID_EFFORT_VALUES: ReadonlyArray<EffortValue> = ['low', 'medium',
  * suffix removed plus the parsed effort (undefined when none). Exported for tests.
  */
 const SUFFIX_EFFORTS: ReadonlyArray<EffortValue> = ['ultracode', 'medium', 'xhigh', 'high', 'low', 'max'];
+/**
+ * dario's effort tiers onto the levels the Codex Responses backend accepts
+ * (dario#1260). Probed 2026-08-29: `none, minimal, low, medium, high, xhigh,
+ * max` are valid upstream; `ultra` 400s.
+ *
+ *   - low/medium/high/xhigh/max pass through — same name on both sides.
+ *   - `ultracode` is dario's own tier with no upstream equivalent. It maps to
+ *     `max`, the nearest thing the backend has, rather than being dropped:
+ *     a caller who asked for the most effort available should not silently
+ *     get the default.
+ *   - `client` means "whatever the client asked for", so it forces nothing
+ *     and the request's own thinking budget decides, as before.
+ */
+export function effortForCodex(effort: EffortValue | undefined):
+  'low' | 'medium' | 'high' | 'xhigh' | 'max' | undefined {
+  switch (effort) {
+    case 'low': case 'medium': case 'high': case 'xhigh': case 'max': return effort;
+    case 'ultracode': return 'max';
+    case 'client': case undefined: return undefined;
+    default: return undefined;
+  }
+}
+
 export function parseEffortSuffix(model: string): { model: string; effort?: EffortValue } {
   for (const e of SUFFIX_EFFORTS) {
     for (const sep of [':', '-']) {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -24,6 +24,7 @@ import { handleAdminRequest, type AdminAccountLive, type AdminAuditEvent } from 
 import { createTokenBucket } from './rate-limit.js';
 import { getOpenAIBackend, isOpenAIModel, forwardToOpenAI, type BackendCredentials } from './openai-backend.js';
 import { forwardToCodex, getCodexModelSlugs, peekCodexModelSlugs, isCodexModel, pickCodexFallback, pickClaudeTarget, CODEX_BACKEND_BASE_URL } from './codex-backend.js';
+import { effortForCodex } from './effort.js';
 import { isClaudeServableModel } from './claude-model.js';
 import { MODEL_UNROUTABLE } from './upstream-rejection.js';
 import { readCompareTarget, teeResponse, runCompare, writeCompareRecord, COMPARE_RESULT_HEADER } from './compare.js';
@@ -2309,8 +2310,9 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
       return false;
     }
     const slugs = await getCodexModelSlugs(creds).catch(() => [] as string[]);
-    const fallbackModel = pickCodexFallback(fallbackModels, slugs);
-    if (!fallbackModel) return false;
+    const fallbackPick = pickCodexFallback(fallbackModels, slugs);
+    if (!fallbackPick) return false;
+    const fallbackModel = fallbackPick.model;
     const fallbackBody = buildPoolFallbackBody(body, fallbackModel);
     if (!fallbackBody) return false;
     console.log(`[dario] #${requestCount} ${why} → codex account ${creds.alias} as ${fallbackModel}`);
@@ -2335,6 +2337,11 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
       // an outage, not quota — cooling it would park a provider that may be
       // back on the next request, which is the opposite of the fix.
       (d) => { if (d.status === 429) providerCooldowns.note('codex', d.retryAfterMs); },
+      // The mirror of the Claude side (dario#1161): an operator who writes
+      // `--pool-fallback=gpt-5.6-terra:high` is choosing the effort the
+      // failover runs at, so the entry's own suffix reaches the request rather
+      // than the failover quietly running at the backend default.
+      effortForCodex(fallbackPick.effort),
     );
     if (served) providerCooldowns.clear('codex');
     return served;
@@ -3431,9 +3438,9 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
       if (body.length > 0) {
         try {
           const peek = (parsedBody ?? {}) as { model?: string }; // parsed once by the invalid-body guard; `body` is re-serialized from it
-          const rawModel = (peek.model || '').toString();
-          const requestPoolFallbackModels = selectPoolFallbackModels(poolFallbackSpec, rawModel);
-          const requestPoolFallbackModel = requestPoolFallbackModels[0] ?? null;
+          // Reassignable: the codex effort-suffix strip below rewrites it, and
+          // every routing decision after that point must see the stripped name.
+          let rawModel = (peek.model || '').toString();
           // Credentials are re-read per request (not cached at startup) because
           // a refresh rotates them on disk; getFreshCodexAccount refreshes when
           // inside the expiry buffer, collapsing concurrent refreshes per alias.
@@ -3468,6 +3475,42 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
               }
             }
           }
+          // dario#1260 — an effort suffix on a CODEX model (`gpt-5.6-terra:high`).
+          // The two strip sites further up deliberately leave OpenAI-shaped names
+          // alone: an openai-compat backend may serve a model whose real id ends
+          // in `-high`/`-low`, and stripping there would rewrite a legitimate
+          // name against a catalog this proxy cannot see. Codex is the one
+          // provider that publishes its routable set, so here — and only here —
+          // the ambiguity is decidable: strip when the name as written matches no
+          // slug and the stripped name matches one.
+          //
+          // That guard is what makes this strictly additive. The only requests
+          // whose routing changes are the ones that answer 400 `model_unroutable`
+          // today, because a name that already routes is never re-read.
+          //
+          // Placed HERE rather than beside its siblings because `codexModels` is
+          // THIS request's account's list, resolved just above; the suffix cannot
+          // be told apart from a real id without it.
+          if (rawModel && codexModels.length > 0 && !isCodexModel(rawModel, codexModels)) {
+            const eff = parseEffortSuffix(rawModel);
+            if (eff.effort && isCodexModel(eff.model, codexModels)) {
+              if (verbose) console.log(`[dario] effort suffix: ${rawModel} → model ${eff.model} (codex, effort: ${eff.effort})`);
+              requestEffort = eff.effort;
+              rawModel = eff.model;
+              // The suffix must not survive into the outbound body: the backend
+              // 400s on a slug it does not list, which is the very failure this
+              // fixes. `body` is re-serialized from `parsedBody` exactly as the
+              // alias and provider-prefix blocks above do.
+              peek.model = eff.model;
+              body = Buffer.from(JSON.stringify(parsedBody));
+            }
+          }
+          // Chosen AFTER the strip above, not before it: a per-model fallback
+          // spec is keyed on the model being routed, and keying it on a name
+          // still carrying a dario-side effort suffix would miss the operator's
+          // own entry for that model and fall back to the unscoped chain.
+          const requestPoolFallbackModels = selectPoolFallbackModels(poolFallbackSpec, rawModel);
+          const requestPoolFallbackModel = requestPoolFallbackModels[0] ?? null;
           const decision = routeProvider({
             isOpenAIPath: isOpenAI,
             model: rawModel,
@@ -3573,6 +3616,10 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
               // is an outage, and parking a provider for that would keep it out
               // of the chain while it was already coming back.
               (d) => { if (d.status === 429) providerCooldowns.note('codex', d.retryAfterMs); },
+              // dario#1260 — the effort named by the model-name suffix stripped
+              // above. Undefined for every request that did not name one, which
+              // leaves the outbound body exactly as it was.
+              effortForCodex(requestEffort),
             );
             if (served) {
               // A provider that just served is not rate-limited.

--- a/test/codex-backend.mjs
+++ b/test/codex-backend.mjs
@@ -937,15 +937,40 @@ header('failover chain selection (v6.0.0)');
 {
   const SLUGS = ['gpt-5.6-sol', 'gpt-5.5'];
   check('the codex end takes the first entry that account lists',
-    pickCodexFallback(['claude-sonnet-5', 'gpt-5.6-sol'], SLUGS) === 'gpt-5.6-sol');
+    pickCodexFallback(['claude-sonnet-5', 'gpt-5.6-sol'], SLUGS)?.model === 'gpt-5.6-sol');
   check('the claude end takes the first entry it does NOT',
     pickClaudeFallback(['gpt-5.6-sol', 'claude-sonnet-5'], SLUGS) === 'claude-sonnet-5');
   check('a single-entry chain still feeds the codex end (pre-6.0 configs unchanged)',
-    pickCodexFallback(['gpt-5.6-sol'], SLUGS) === 'gpt-5.6-sol');
+    pickCodexFallback(['gpt-5.6-sol'], SLUGS)?.model === 'gpt-5.6-sol');
+  check('...and declares no effort, so a plain entry runs at the backend default',
+    pickCodexFallback(['gpt-5.6-sol'], SLUGS)?.effort === undefined);
   check('...and gives the claude end nothing, so one-way stays one-way unless asked',
     pickClaudeFallback(['gpt-5.6-sol'], SLUGS) === null);
   check('an empty chain selects nothing at either end (failover stays opt-in)',
     pickCodexFallback([], SLUGS) === null && pickClaudeFallback([], SLUGS) === null);
+
+  // dario#1260 — the codex end now reads the same effort suffix the Claude end
+  // has honoured since #1161. Before this, a suffixed entry matched no slug and
+  // was silently skipped: the operator's failover simply never fired.
+  check('a codex entry may carry an effort suffix, and the SLUG is what gets sent',
+    pickCodexFallback(['gpt-5.6-sol:low'], SLUGS)?.model === 'gpt-5.6-sol');
+  check('...and the effort it declared is carried, not dropped',
+    pickCodexFallback(['gpt-5.6-sol:low'], SLUGS)?.effort === 'low');
+  check('the Cursor-style hyphen spelling works too (#419 parity)',
+    pickCodexFallback(['gpt-5.6-sol-high'], SLUGS)?.effort === 'high');
+  // The as-written-wins half of the rule. A slug that genuinely ends in an
+  // effort word is a real id, not a suffixed one, and re-reading it would route
+  // a request to a DIFFERENT model than the operator named.
+  check('a slug that really ends in an effort word is taken as written',
+    pickCodexFallback(['gpt-test-high'], ['gpt-test-high', 'gpt-test'])?.model === 'gpt-test-high');
+  check('...and declares no effort, because no suffix was ever parsed off it',
+    pickCodexFallback(['gpt-test-high'], ['gpt-test-high', 'gpt-test'])?.effort === undefined);
+  // Priority is the operator's, per entry: a listed first entry wins even
+  // though a later one would also match after stripping.
+  check('chain order still decides, suffix or not',
+    pickCodexFallback(['gpt-5.5', 'gpt-5.6-sol:max'], SLUGS)?.model === 'gpt-5.5');
+  check('a suffix on a model the account does not list selects nothing',
+    pickCodexFallback(['gpt-9.9-nope:high'], SLUGS) === null);
 
   // Second Read finding, 2026-08-30. "Not a codex slug" is not "the pool can
   // serve it": a typo would have been swapped in and 404'd, turning a

--- a/test/codex-effort-suffix.mjs
+++ b/test/codex-effort-suffix.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+// dario#1260 — an effort suffix on a CODEX model name.
+//
+// dario#419 let a client that cannot set `output_config.effort` choose one by
+// model name (`opus-4-8:high`, Cursor-style `claude-opus-4-8-high`). It only
+// ever worked on the Claude half. Probed live 2026-09-07 against the ChatGPT
+// plan:
+//
+//     claude-sonnet-5:high   -> 200, served claude-sonnet-5
+//     gpt-5.6-terra:high     -> 400 model_unroutable
+//
+// because routing matches the model against each provider's list BEFORE the
+// suffix is stripped, so the suffixed name matched nothing at all.
+//
+// The two strip sites in proxy.ts skip OpenAI-shaped names ON PURPOSE: an
+// openai-compat backend may serve a model whose real id ends in `-high`, and a
+// blind strip there would rewrite a legitimate name against a catalog dario
+// cannot see. Codex is the one provider that publishes its routable set, so
+// the fix is a THIRD site, after discovery, with the guard that makes it
+// decidable: strip only when the name as written matches no slug and the
+// stripped name matches one. That is the same as-written-wins rule
+// resolveClaudeTarget already uses for chain entries (dario#1161).
+//
+// Asserted at the WIRE, not at the parser — the objection that made #1161's
+// first revision inadequate. Every check below reads the body the codex stub
+// actually received, so deleting the propagation fails the file.
+//
+// Hermetic: a real proxy on loopback, HOME in a mkdtemp'd dir with one pool
+// seat and one codex account, a local codex stub that records request bodies.
+
+import { createServer } from 'node:http';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { freePort } from './helpers/free-port.mjs';
+
+let pass = 0, fail = 0;
+const check = (name, cond, detail) => {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else { console.log(`  FAIL ${name}${detail ? ' :: ' + detail : ''}`); fail++; }
+};
+const header = (n) => console.log(`\n=== ${n} ===`);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const PROXY_PORT = await freePort();
+const CHAIN_PROXY_PORT = await freePort();
+const CODEX_PORT = await freePort();
+
+const LISTED_SLUG = 'gpt-5.6-sol';
+// A slug whose REAL name ends in an effort word. The account lists it, so it
+// must be routed exactly as written and never re-read as `gpt-test` + `high`.
+// Both spellings the suffix parser accepts are covered: this one is the
+// hyphen form, which is the one that can collide with a real id.
+const TRAP_SLUG = 'gpt-test-high';
+
+// ── stub ChatGPT backend: discovery + a recorded /responses SSE ────────────
+const codexSeen = { models: 0, responses: 0, bodies: [] };
+const codexStub = createServer((req, res) => {
+  if (req.url.startsWith('/models')) {
+    codexSeen.models++;
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      models: [
+        { slug: LISTED_SLUG, visibility: 'list' },
+        { slug: TRAP_SLUG, visibility: 'list' },
+      ],
+    }));
+    return;
+  }
+  if (req.url.startsWith('/responses')) {
+    codexSeen.responses++;
+    const chunks = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => {
+      try { codexSeen.bodies.push(JSON.parse(Buffer.concat(chunks).toString('utf8'))); }
+      catch { codexSeen.bodies.push(null); }
+      res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+      res.write('data: {"type":"response.created","response":{"id":"resp_1"}}\n\n');
+      res.write('data: {"type":"response.output_text.delta","delta":"hi from codex"}\n\n');
+      res.write('data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1}}}\n\n');
+      res.end();
+    });
+    return;
+  }
+  res.writeHead(404).end();
+});
+await new Promise((r) => codexStub.listen(CODEX_PORT, '127.0.0.1', r));
+
+const tmpHome = await mkdtemp(join(tmpdir(), 'dario-effort-suffix-'));
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+process.env.DARIO_CODEX_BASE_URL = `http://127.0.0.1:${CODEX_PORT}`;
+delete process.env.ANTHROPIC_UPSTREAM_API_KEY;
+
+await mkdir(join(tmpHome, '.dario', 'accounts'), { recursive: true });
+await writeFile(join(tmpHome, '.dario', 'accounts', 'main.json'), JSON.stringify({
+  alias: 'main', accessToken: 'claude-access-token', refreshToken: 'claude-refresh-token',
+  expiresAt: Date.now() + 6 * 3_600_000, scopes: ['user:inference'], deviceId: 'dev-1', accountUuid: 'uuid-1',
+}));
+await mkdir(join(tmpHome, '.dario', 'codex-accounts'), { recursive: true });
+await writeFile(join(tmpHome, '.dario', 'codex-accounts', 'live.json'), JSON.stringify({
+  alias: 'live', accessToken: 'codex-access-token', refreshToken: 'codex-refresh-token',
+  expiresAt: Date.now() + 6 * 3_600_000,
+}));
+
+const { startProxy } = await import('../dist/proxy.js');
+
+// Anthropic seam. Nothing here SHOULD be reached by a codex-bound request; the
+// call counter is asserted so a regression that quietly routes to the pool
+// instead of the subscription is caught rather than passing as "a 200".
+const anthropic = { calls: 0, rateLimit: false };
+const fakeFetch = async (url, init) => {
+  const target = String(url);
+  if (target.includes('/v1/models')) {
+    return new Response(JSON.stringify({ data: [{ id: 'claude-sonnet-5', type: 'model' }] }), {
+      status: 200, headers: { 'content-type': 'application/json' },
+    });
+  }
+  if (!target.includes('/v1/messages')) {
+    return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+  }
+  anthropic.calls++;
+  // Armed only for the fallback-chain block below: the codex end of a chain is
+  // reached from the mid-flight 429 recovery, so the pool has to be genuinely
+  // out of capacity for that leg to run at all.
+  if (anthropic.rateLimit) {
+    return new Response(JSON.stringify({ type: 'error', error: { type: 'rate_limit_error', message: 'stub 429' } }), {
+      status: 429, headers: { 'content-type': 'application/json', 'retry-after': '60' },
+    });
+  }
+  return new Response(JSON.stringify({
+    id: 'msg_1', type: 'message', role: 'assistant', model: 'claude-sonnet-5',
+    content: [{ type: 'text', text: 'served by the claude pool' }], stop_reason: 'end_turn',
+    usage: { input_tokens: 1, output_tokens: 1 },
+  }), { status: 200, headers: { 'content-type': 'application/json' } });
+};
+
+const common = { host: '127.0.0.1', verbose: false, noLiveCapture: true, fetchImpl: fakeFetch };
+await startProxy({ ...common, port: PROXY_PORT });
+// A second proxy whose FALLBACK CHAIN carries the suffix, for the other half
+// of the fix: the operator-configured spelling, not the client-sent one.
+await startProxy({
+  ...common, port: CHAIN_PROXY_PORT,
+  poolFallbackModel: `${LISTED_SLUG}:low`,
+});
+for (const port of [PROXY_PORT, CHAIN_PROXY_PORT]) {
+  for (let i = 0; i < 50; i++) {
+    try { await fetch(`http://127.0.0.1:${port}/health`); break; } catch { await sleep(100); }
+  }
+}
+
+const post = async (port, model) => {
+  const res = await fetch(`http://127.0.0.1:${port}/v1/messages`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model, max_tokens: 16, messages: [{ role: 'user', content: 'ping' }] }),
+  });
+  return { status: res.status, text: await res.text(), headers: res.headers };
+};
+const lastBody = () => codexSeen.bodies[codexSeen.bodies.length - 1];
+
+// ---------------------------------------------------------------------------
+header('a suffixed codex model routes to the subscription instead of 400ing');
+{
+  const before = anthropic.calls;
+  const r = await post(PROXY_PORT, `${LISTED_SLUG}:low`);
+
+  // The regression this file exists for: this exact request answered
+  // 400 `model_unroutable` without ever reaching an upstream.
+  check('the request is not refused locally', r.status === 200, `${r.status} ${r.text.slice(0, 200)}`);
+  check('...and no model_unroutable verdict is attached',
+    r.headers.get('x-dario-upstream-rejection') === null,
+    String(r.headers.get('x-dario-upstream-rejection')));
+  check('the subscription served it, not the Claude pool',
+    codexSeen.responses === 1 && anthropic.calls === before,
+    `codex=${codexSeen.responses} anthropic=${anthropic.calls - before}`);
+
+  // THE WIRE. The suffix is a dario-side spelling; the backend 400s on a slug
+  // it does not list, so it must not survive into the outbound request.
+  check('the OUTBOUND model is the bare slug, suffix stripped',
+    lastBody()?.model === LISTED_SLUG, String(lastBody()?.model));
+  check('the OUTBOUND request carries the named reasoning effort',
+    lastBody()?.reasoning?.effort === 'low', JSON.stringify(lastBody()?.reasoning));
+}
+
+// ---------------------------------------------------------------------------
+header('the same slug WITHOUT a suffix is untouched');
+{
+  const r = await post(PROXY_PORT, LISTED_SLUG);
+  check('still served by the subscription', r.status === 200 && codexSeen.responses === 2,
+    `${r.status} codex=${codexSeen.responses}`);
+  check('the model is unchanged', lastBody()?.model === LISTED_SLUG, String(lastBody()?.model));
+  // No suffix and no thinking budget means dario forces nothing and the
+  // backend default applies — the behaviour every existing caller has today.
+  check('no effort is forced onto a request that named none',
+    lastBody()?.reasoning?.effort === undefined, JSON.stringify(lastBody()?.reasoning));
+}
+
+// ---------------------------------------------------------------------------
+header('a slug that really ends in an effort word is taken as written');
+{
+  // The guard's whole purpose. `gpt-test-high` IS the model. Re-reading it as
+  // `gpt-test` + effort `high` would route the request to a different model
+  // than the client named — silently, and with a plausible-looking 200.
+  const r = await post(PROXY_PORT, TRAP_SLUG);
+  check('served, not mangled', r.status === 200 && codexSeen.responses === 3,
+    `${r.status} codex=${codexSeen.responses}`);
+  check('the OUTBOUND model is the full slug, nothing stripped off it',
+    lastBody()?.model === TRAP_SLUG, String(lastBody()?.model));
+  check('...and no effort was invented from its name',
+    lastBody()?.reasoning?.effort === undefined, JSON.stringify(lastBody()?.reasoning));
+}
+
+// ---------------------------------------------------------------------------
+header('a suffix on a model NO provider lists is still refused (#1236 intact)');
+{
+  // The narrowness of the fix. Stripping must not turn model_unroutable into a
+  // request spent against a slug the account does not have.
+  const r = await post(PROXY_PORT, 'gpt-9.9-nope:high');
+  check('refused locally with 400', r.status === 400, `${r.status} ${r.text.slice(0, 160)}`);
+  check('...with the machine-readable verdict',
+    r.headers.get('x-dario-upstream-rejection') === 'model_unroutable',
+    String(r.headers.get('x-dario-upstream-rejection')));
+  check('and no upstream request was spent on it', codexSeen.responses === 3,
+    `codex=${codexSeen.responses}`);
+}
+
+// ---------------------------------------------------------------------------
+header('a FALLBACK CHAIN entry may carry the suffix too');
+{
+  // The operator's half (mirror of dario#1161 on the Claude side). Before this
+  // the entry matched no slug, so it was skipped in silence and the failover
+  // the operator configured simply never fired.
+  const seenBefore = codexSeen.responses;
+  anthropic.rateLimit = true;
+  const r = await post(CHAIN_PROXY_PORT, 'claude-sonnet-5');
+  anthropic.rateLimit = false;
+  check('the chain entry was selected at all', codexSeen.responses === seenBefore + 1,
+    `codex=${codexSeen.responses} status=${r.status}`);
+  check('the substituted model is the bare slug', lastBody()?.model === LISTED_SLUG,
+    String(lastBody()?.model));
+  check("...at the entry's own effort, not the backend default",
+    lastBody()?.reasoning?.effort === 'low', JSON.stringify(lastBody()?.reasoning));
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+codexStub.close();
+process.exit(fail === 0 ? 0 : 1);

--- a/test/effort-flag.mjs
+++ b/test/effort-flag.mjs
@@ -220,6 +220,21 @@ header('parseEffortSuffix — dario#419 effort-via-model-name');
     (() => { const r = parseEffortSuffix('claude-opus-4-8-turbo'); return r.model === 'claude-opus-4-8-turbo' && r.effort === undefined; })());
   check('bare effort word "high" not stripped to empty',
     (() => { const r = parseEffortSuffix('high'); return r.model === 'high' && r.effort === undefined; })());
+
+  // dario#1261 review (Redline). `client` is in VALID_EFFORT_VALUES, so it is a
+  // legal --effort/DARIO_EFFORT value, but it is deliberately NOT in
+  // SUFFIX_EFFORTS. As a suffix it would be a no-op ("leave the client's own
+  // choice alone"), and accepting it would let a model genuinely named
+  // `...-client` be stripped to a name no backend lists. The docs claimed it
+  // was a nameable level; this pins the real contract so the two cannot drift.
+  check('`client` is a config value but NOT a model-name suffix',
+    (() => { const r = parseEffortSuffix('gpt-5.6-terra:client');
+             return r.model === 'gpt-5.6-terra:client' && r.effort === undefined; })());
+  check('...in the hyphen spelling too, so a `-client` model name survives',
+    (() => { const r = parseEffortSuffix('some-model-client');
+             return r.model === 'some-model-client' && r.effort === undefined; })());
+  check('...while it remains a legal --effort value',
+    VALID_EFFORT_VALUES.includes('client'));
 }
 
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Addresses #1260.

## The bug

#419 let a client that cannot set `output_config.effort` choose a reasoning level by naming it in the model (`opus-4-8:high`, or Cursor's hyphen spelling `claude-opus-4-8-high`). Only the Claude half ever honoured it. Probed live against the ChatGPT plan on 2026-09-07:

| model sent | result |
|---|---|
| `claude-sonnet-5` | 200 |
| `claude-sonnet-5:high` | 200, served `claude-sonnet-5` |
| `gpt-5.6-terra:high` | **400 `model_unroutable`** |

Routing matches the model against each provider's list *before* the suffix is stripped, so `gpt-5.6-terra:high` matched nothing — the account lists `gpt-5.6-terra`.

## Why the fix is a third strip site, not a change to the existing two

The two strip sites in `proxy.ts` skip OpenAI-shaped names deliberately, and that comment is right: an openai-compat backend may serve a model whose real id ends in `-high` or `-low`, and stripping there would rewrite a legitimate name against a catalog dario cannot see.

Codex is the one provider that publishes its routable set, so the ambiguity is decidable there and nowhere else. The strip now also happens after model discovery, guarded by the rule that makes it safe:

> strip only when the name **as written** matches no slug **and** the stripped name matches one.

That is the same as-written-wins rule `resolveClaudeTarget` has applied to chain entries since #1161. It also makes this change strictly additive — the only requests whose routing changes are the ones that answer 400 `model_unroutable` today, because a name that already routes is never re-read.

## What is in here

- **A suffixed Codex model routes to the subscription.** The suffix is stripped from the outbound body (the backend 400s on a slug it does not list) and the level is sent as `reasoning.effort`.
- **A slug that genuinely ends in an effort word is routed exactly as written**, and no effort is invented from its name.
- **A model no provider lists is still refused locally** with `x-dario-upstream-rejection: model_unroutable` and no upstream request spent (#1236 intact).
- **`pickCodexFallback` learns the same rule.** A `--pool-fallback` entry naming a Codex model with a suffix matched no slug and was skipped in silence — no error, no log, just a failover the operator configured that never fired. It now carries the declared effort into the failover request, mirroring the Claude end since #1161.
- **The per-request fallback chain is selected from the stripped name.** A per-model spec is keyed on the model being routed; keying it on a name still carrying a dario-side suffix would miss the operator's own entry for that model.
- **`reasoning.effort` accepts the levels the backend actually has.** The thinking-budget mapping only ever produced `low`/`medium`/`high`; a named effort can now be `none`, `minimal`, `xhigh` or `max`. dario's own `ultracode` tier maps to `max`, the nearest upstream equivalent, rather than being dropped; `client` forces nothing.
- **Documented** in `docs/configuration.md`, where the suffix was not written down at all before.

## On `REASONING_HEADROOM`

Widening the reachable levels needed reservations for `xhigh` and `max`. They are set **above** the measured trend rather than on it, because under-reserving is the failure the table exists to prevent: reasoning eats the whole budget, the response comes back `incomplete`, and the turn arrives empty. Both values are clamped by `RESPONSES_MAX_OUTPUT_CAP` anyway.

Measured through dario on one identical prompt, same model, only the level changing:

| level | output tokens | wall time |
|---|---|---|
| low | 1,982 | 18.2s |
| high | 3,947 | 34.8s |
| max | 11,160 | 99.9s |

Worth stating plainly in the docs, and it is: reasoning is billed as output, so `max` is a real cost increase on every request that names it, and on a long agent loop it can push a run into its own timeout. This PR does not raise anyone's effort — it only makes the level nameable per request.

## Tests

`test/codex-effort-suffix.mjs` (new, 17 checks) drives the **real handler** against a Codex stub that records request bodies, and every assertion reads the body the stub actually received. That is the standard #1161's review established: picker-level assertions all pass with the propagation line deleted, so they prove nothing. Deleting the propagation fails this file.

It covers the suffixed model, the same slug without a suffix (nothing forced), the real-id-ends-in-an-effort-word trap, the still-refused unlisted model, and a fallback chain entry carrying the suffix.

`test/codex-backend.mjs` gained 8 picker checks for `pickCodexFallback`, including chain ordering and the as-written-wins case.

Full suite: **191/191 pass**. Build clean.

## Follow-up not in here

The `ticket_ops` churn and the uncached system prompt (#1259) are separate. #1259 in particular needs a measurement of verdict quality before it becomes a patch, not just a cache-hit number.
