### PR TITLE
gpt-5.6-luna reads as a tier instead of the first-written one (v6.0.47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ checklist.
 
 ## [Unreleased]
 
+## [6.0.47] - 2026-09-10
+
+### Fixed
+
+- **`gpt-5.6-luna` reads as a tier instead of falling through to whichever one is written first (#1272).** codex-drift-watch reported the account-visible model list as `gpt-5.5`, `gpt-5.6-luna`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-reserve`. The Codex rungs are a size ladder — `sol` (sun) > `terra` (earth) > `luna` (moon) — and `selectPoolFallbackModels` reads model *names* because the backend publishes a routable set and no tier metadata. `luna` matched none of the three tier tests, so a request naming it fell to `default` and, with no `default:` entry in the operator's map, to `tiers.values().next().value` — the first entry, i.e. whichever tier happened to be typed first. On an opus-first map that silently routed luna traffic to the **most expensive** rung. `luna` now joins `haiku|mini|small`. A genuinely unclassifiable slug (`gpt-reserve`) keeps the documented first-entry behaviour, which is unchanged. The wire contract itself did not drift — `codex-drift-watch` reported it passing for `gpt-5.6-sol`; only the model list moved.
+
+### Changed
+
+- **The tier-map doc example no longer names a model the account cannot serve.** `haiku:gpt-5.4-mini` → `haiku:gpt-5.6-luna`; `gpt-5.4-mini` is not on the account-visible list any more. This is a comment and a test fixture only — there is no hardcoded default tier map, and the `gpt-5.4-mini` entry in `proxy.ts`'s `OPENAI_MODEL_MAP` is the unrelated legacy OpenAI-name → Anthropic-model translation, which is untouched.
+
 
 ## [6.0.46] - 2026-09-10
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.46",
+  "version": "6.0.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "6.0.46",
+      "version": "6.0.47",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.46",
+  "version": "6.0.47",
   "description": "Use your Claude and ChatGPT subscriptions in Cursor, Cline, Aider, Claude Code and the Agent SDK — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint: either plan answers either wire shape, with automatic failover when one hits its limit.",
   "type": "module",
   "bin": {

--- a/src/pool-fallback-tier.ts
+++ b/src/pool-fallback-tier.ts
@@ -1,7 +1,15 @@
 /** Backward-compatible selection of a pool-fallback target for one request.
  * A bare value or comma-separated model chain retains the legacy meaning.
- * Tier maps use `tier:model`, e.g. `haiku:gpt-5.4-mini,sonnet:gpt-5.6-terra`.
+ * Tier maps use `tier:model`, e.g. `haiku:gpt-5.6-luna,sonnet:gpt-5.6-terra`.
  * Unknown models use `default`, or the first (normally cheapest) configured tier.
+ *
+ * The Codex rungs are named for a size ladder — `sol` (sun) > `terra` (earth) >
+ * `luna` (moon) — which is why the tier tests below read model NAMES rather
+ * than any stated capability: the backend publishes a routable set and no tier
+ * metadata, so the ladder is the only signal there is. `luna` was added when
+ * codex-drift-watch reported the account-visible list as `gpt-5.5`,
+ * `gpt-5.6-luna`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-reserve` (dario#1272);
+ * `gpt-5.4-mini`, the previous example here, is no longer on that list.
  */
 export function selectPoolFallbackModels(spec: string | undefined, requestedModel: string): string[] {
   const entries = (spec ?? '').trim().split(',').map((entry) => entry.trim()).filter(Boolean);
@@ -17,7 +25,7 @@ export function selectPoolFallbackModels(spec: string | undefined, requestedMode
     if (tier && model) tiers.set(tier, model);
   }
   const model = requestedModel.toLowerCase();
-  const tier = /haiku|mini|small/.test(model) ? 'haiku'
+  const tier = /haiku|mini|small|luna/.test(model) ? 'haiku'
     : /opus|sol|large/.test(model) ? 'opus'
     : /sonnet|terra|medium/.test(model) ? 'sonnet'
     : 'default';

--- a/test/pool-fallback-tier.mjs
+++ b/test/pool-fallback-tier.mjs
@@ -19,4 +19,23 @@ check('legacy chain remains unchanged', selectPoolFallbackModels('gpt-5.6-terra,
 check('provider-prefixed legacy single value remains unchanged', selectPoolFallbackModels('claude:opus:high', 'claude-haiku-4-5'), ['claude:opus:high']);
 check('provider-prefixed legacy chain remains unchanged', selectPoolFallbackModels('claude:opus:high,openai:gpt-5.6', 'claude-haiku-4-5'), ['claude:opus:high', 'openai:gpt-5.6']);
 
+// dario#1272 — codex-drift-watch reported the account-visible list as
+// gpt-5.5 / gpt-5.6-luna / gpt-5.6-sol / gpt-5.6-terra / gpt-reserve. `luna` is
+// the third rung of the sol > terra > luna ladder and matched none of the tier
+// tests, so a request naming it fell through to `default` and, with no
+// `default:` entry, to whichever tier happened to be written first — arbitrary,
+// and silent.
+// Deliberately written OPUS-FIRST. With the haiku rung listed first, an
+// unclassified luna falls through to the first entry and lands on the haiku
+// target anyway — the right answer for the wrong reason, so the assertion
+// would pass against the very bug it is meant to catch. Opus-first makes the
+// fallthrough land somewhere visibly wrong.
+const ladder = 'opus:gpt-5.6-sol,sonnet:gpt-5.6-terra,haiku:gpt-5.6-luna';
+check('luna reads as the economical rung', selectPoolFallbackModels(ladder, 'gpt-5.6-luna'), ['gpt-5.6-luna']);
+check('luna is not mistaken for the middle rung', selectPoolFallbackModels(ladder, 'gpt-5.6-terra'), ['gpt-5.6-terra']);
+check('luna is not mistaken for the top rung', selectPoolFallbackModels(ladder, 'gpt-5.6-sol'), ['gpt-5.6-sol']);
+// A genuinely unclassifiable slug keeps the documented first-entry behaviour.
+check('an unknown codex slug still falls to the first tier',
+  selectPoolFallbackModels(ladder, 'gpt-reserve'), ['gpt-5.6-sol']);
+
 if (failures) process.exit(1);


### PR DESCRIPTION
Addresses #1272.

## What actually drifted

`codex-drift-watch` fires on "wire-contract validation **or** the account-visible model list drifted", so the issue title doesn't say which. It was the list. The run log carries `Codex wire contract passed for gpt-5.6-sol.` — the contract is fine. The account now lists:

```
gpt-5.5   gpt-5.6-luna   gpt-5.6-sol   gpt-5.6-terra   gpt-reserve
```

Two things follow from that, one real and one cosmetic.

## The real one: luna has no tier

The Codex rungs are a size ladder — `sol` (sun) > `terra` (earth) > `luna` (moon) — and `selectPoolFallbackModels` classifies by model **name**, because the backend publishes a routable set and no tier metadata. `/v1/models` returns `gpt-5.6-luna` with nothing but `id`, `object`, `created`, `owned_by`.

`luna` matched none of `haiku|mini|small`, `opus|sol|large`, `sonnet|terra|medium`. So it fell to `'default'`, and with no `default:` entry in the operator's map, to:

```js
tiers.values().next().value   // the first entry — whichever tier was typed first
```

Map order is not meaningful to anyone writing one. On an **opus-first** map that silently sent luna traffic to the most expensive rung. Nothing logged it.

`luna` now joins the haiku test. The first-entry fallback for genuinely unclassifiable slugs (`gpt-reserve`) is documented behaviour on line 4 of that file and is unchanged.

⚠️ **The tier is inferred from the naming ladder, not from anything the backend states.** If luna turns out not to be the small rung, this is a one-word change — flagging it rather than burying it.

## The cosmetic one

The doc example and test fixture used `haiku:gpt-5.4-mini`, which is no longer on the account-visible list. Refreshed to `gpt-5.6-luna`.

To be clear about what this does **not** touch: there is no hardcoded default tier map — `selectPoolFallbackModels` parses an operator-supplied spec, so nothing was silently broken by the list changing. And the `gpt-5.4-mini` in `proxy.ts:847` is the unrelated legacy `OPENAI_MODEL_MAP` (OpenAI name → Anthropic model, for clients sending GPT names), left alone.

## Tests

Five new assertions in `test/pool-fallback-tier.mjs`.

The map in them is deliberately written **opus-first**, and that is the point. Written haiku-first — the natural way — an unclassified luna falls through to the haiku target *anyway*, so the assertion passes against the very bug it exists to catch. I found that by neutering the fix: with a haiku-first map only 1 of 4 luna assertions failed. Opus-first, the primary assertion fails loudly with `["gpt-5.6-sol"] !== ["gpt-5.6-luna"]`, which is also the real-world symptom.

Verified both directions: passes with the rung, fails without it.

196/196 suites green. `preflight` clean, README line-count guard ok at ~33k.
