### PR TITLE
Document the way out of a parked pool, and what it costs (v6.0.51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ checklist.
 
 ## [Unreleased]
 
+## [6.0.51] - 2026-09-11
+
+### Documentation
+
+- **How to reach extra usage once every seat is parked, and what it costs (#1282).** The parked
+  429 is decided from the seats’ own rate-limit verdicts before anything is sent, and the
+  overage-guard is reactive — it reads the `representative-claim` on a response that already came
+  back. Neither knob unlocks the other, so `DARIO_OVERAGE_GUARD=off` does not change the parked
+  answer; the reporter read that correctly off the source. What was missing is that the escape
+  already exists: a **seat pin** (`x-dario-account`) is assigned before the parked check runs, so a
+  pinned request goes upstream and the real status comes back. `multi-account-pool.md` now says so,
+  next to the two consequences that make it a deliberate choice — the default guard **halts the
+  proxy** behind a response that bills to anything but the subscription, and a successful pinned
+  response **un-parks that seat** for ordinary traffic. `--pool-fallback` is named as the different
+  answer it is: it keeps the gateway serving by going to another provider, never spending
+  Anthropic extra usage.
+
+### Added
+
+- `test/pool-parked-pinned-escape.mjs` — 21 assertions over the whole path: an ordinary request
+  answered locally with nothing upstream, a pinned request reaching upstream on its seat and
+  returning the real status, the seat leaving `rejected` afterwards, the guard halting behind it by
+  default, and the same probe staying survivable under `warn` and with the guard off.
+
+
 ## [6.0.50] - 2026-09-10
 
 ### Fixed

--- a/docs/multi-account-pool.md
+++ b/docs/multi-account-pool.md
@@ -106,6 +106,36 @@ curl http://localhost:3456/analytics    # per-account / per-model stats, burn ra
 
 **When every seat is parked.** A pool whose seats are all `rejected` inside live windows does not probe them again: dario answers the request itself with `429`, `retry-after` set to the earliest reset, `x-dario-upstream-rejection: pool_parked`, and nothing sent upstream. One log line marks the transition (`pool parked: all 6 seats are over their rate-limit windows, earliest resets in 21m`). Before 6.0.35 every such request re-probed the earliest-reset seat, so `rejectedCount` on that seat grew by one per request — a seat reading `rejected_count: 500` next to `request_count: 1` was that, not a seat that needed a re-login. With a `--pool-fallback` armed, the request goes to the fallback instead, as before.
 
+**Spending extra usage while the pool is parked (dario#1282).** The parked answer is decided
+from the seats' own rate-limit verdicts, before anything is sent. Disarming the overage-guard
+does **not** change it: the guard is reactive — it reads the `representative-claim` on a
+response that already came back — so the two knobs act at different moments and neither one
+unlocks the other. If the account has extra usage and you want a request to reach it anyway,
+pin the request to a seat:
+
+```bash
+curl -sS localhost:4000/v1/messages \
+  -H 'content-type: application/json' \
+  -H 'x-dario-account: <alias>' \
+  -H "x-dario-admin-token: $DARIO_ADMIN_TOKEN" \
+  -d '{"model":"claude-sonnet-5","max_tokens":16,"messages":[{"role":"user","content":"ping"}]}'
+```
+
+A pinned request is assigned its seat before the parked check runs, so it goes upstream and the
+real status comes back — which is the only way to learn what Anthropic does with a request into a
+spent window. Two consequences are worth knowing before you use it:
+
+- **The guard will halt the proxy on the way back.** A response billing to anything other than the
+  subscription halts dario by default, and every request after it — pinned or not — gets
+  `503 dario_overage_guard`. Pair the pin with `--overage-behavior=warn` (or the guard off) or the
+  answer costs you the proxy.
+- **A successful pinned response un-parks that seat for everyone.** Its snapshot is replaced by the
+  new response's, so the seat leaves `rejected` and ordinary traffic starts landing on it again
+  until the next 429. The pin opens the door; it does not hold it open for one request only.
+
+`--pool-fallback` is a different answer to the same situation: it keeps the gateway serving by
+sending the request to another provider, which means it never spends Anthropic extra usage.
+
 The proxy logs every parking as it happens, once per window: `rate limited (429) on account "spare": 5h 104%, 7d 25%, claim five_hour, resets in 37m — parked until the window rolls`. The re-probes the all-exhausted fallback makes of an already-parked seat are logged only under `-v`.
 
 `dario accounts list --live` prints the same view from the running proxy — status with its countdown, the reading and its age, requests served and 429s answered, the organization, shared windows, grant age — where the plain `dario accounts list` only knows what is on disk.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.50",
+  "version": "6.0.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "6.0.50",
+      "version": "6.0.51",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "6.0.50",
+  "version": "6.0.51",
   "description": "Use your Claude and ChatGPT subscriptions in Cursor, Cline, Aider, Claude Code and the Agent SDK — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint: either plan answers either wire shape, with automatic failover when one hits its limit.",
   "type": "module",
   "bin": {

--- a/test/pool-parked-pinned-escape.mjs
+++ b/test/pool-parked-pinned-escape.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+// dario#1282 — the only way out of a parked pool, and what it costs.
+//
+// THE REPORT. With every seat inside a live 5h window the proxy answers 429
+// locally (dario#1244 / 6.0.35) and nothing is sent upstream. An operator whose
+// account has extra usage available asked how to let a request reach it, and
+// read the code correctly: `POOL_PARKED` decides from the seats' own rate-limit
+// verdicts BEFORE any call, while the overage-guard is reactive — it reads the
+// `representative-claim` on a response that already came back. Neither knob
+// unlocks the other, so `DARIO_OVERAGE_GUARD=off` does not change the parked
+// answer.
+//
+// WHAT IS ACTUALLY TRUE. A seat pin is assigned at proxy.ts `poolAccount =
+// pinnedAccount` BEFORE `parkedUntil` is consulted, so a pinned request is the
+// documented escape: it goes upstream and the real status comes back. This
+// file pins that down, and pins down the two consequences that make it a
+// deliberate choice rather than a free probe:
+//
+//   1. the default guard HALTS the proxy the moment that response bills to
+//      anything but the subscription — 503 for everyone after it, pinned or not
+//   2. a successful pinned response UN-PARKS the seat for ordinary traffic,
+//      because its snapshot replaces the rejection
+//
+// Both are asserted here so neither can regress into a surprise.
+
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { freePort } from './helpers/free-port.mjs';
+
+const out = console.log.bind(console);
+let pass = 0, fail = 0;
+const check = (name, cond, detail) => {
+  if (cond) { out(`  OK ${name}`); pass++; }
+  else { out(`  FAIL ${name}${detail !== undefined ? ' :: ' + detail : ''}`); fail++; }
+};
+const header = (n) => out(`\n=== ${n} ===`);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * One proxy, two seats, both parked on a live window. `guard` picks the
+ * overage-guard behaviour under test. Returns the handles the assertions need.
+ */
+async function scenario(guard) {
+  const PORT = await freePort();
+  const ADMIN_TOKEN = 'parked-pin-admin-token';
+  const tmpHome = await mkdtemp(join(tmpdir(), 'dario-parked-pin-'));
+  process.env.HOME = tmpHome;
+  process.env.USERPROFILE = tmpHome;
+  process.env.DARIO_ADMIN = '1';
+  process.env.DARIO_ADMIN_TOKEN = ADMIN_TOKEN;
+  delete process.env.DARIO_API_KEY;
+  delete process.env.DARIO_CODEX_BASE_URL;
+  delete process.env.DARIO_POOL_FALLBACK;
+
+  await mkdir(join(tmpHome, '.dario', 'accounts'), { recursive: true });
+  const seat = (alias, token) => JSON.stringify({
+    alias, accessToken: token, refreshToken: `${token}-refresh`,
+    expiresAt: Date.now() + 6 * 3_600_000, scopes: ['user:inference'],
+    deviceId: `dev-${alias}`, accountUuid: `uuid-${alias}`,
+  });
+  await writeFile(join(tmpHome, '.dario', 'accounts', 'one.json'), seat('one', 'one-token'));
+  await writeFile(join(tmpHome, '.dario', 'accounts', 'two.json'), seat('two', 'two-token'));
+
+  const resetS = Math.floor(Date.now() / 1000) + 40 * 60;
+  const state = { mode: '429', calls: [] };
+
+  // After the pool parks, `mode` flips to '200': the stand-in for an account
+  // whose extra usage absorbs the request. A locally synthesised verdict can
+  // never see it; only a request that actually leaves can.
+  const fetchImpl = async (url, init) => {
+    if (String(url).includes('/v1/models')) {
+      return new Response(JSON.stringify({ data: [{ id: 'claude-sonnet-5', type: 'model' }] }),
+        { status: 200, headers: { 'content-type': 'application/json' } });
+    }
+    const h = init?.headers;
+    const pairs = Array.isArray(h) ? h : h instanceof Headers ? [...h.entries()] : Object.entries(h ?? {});
+    const bearer = String((pairs.find(([k]) => String(k).toLowerCase() === 'authorization') ?? [, ''])[1])
+      .replace(/^Bearer\s+/i, '');
+    state.calls.push(bearer);
+    if (state.mode === '200') {
+      return new Response(JSON.stringify({
+        id: 'msg_x', type: 'message', role: 'assistant',
+        content: [{ type: 'text', text: 'served from extra usage' }],
+        model: 'claude-sonnet-5', usage: { input_tokens: 1, output_tokens: 2 },
+      }), { status: 200, headers: {
+        'content-type': 'application/json',
+        'anthropic-ratelimit-unified-representative-claim': 'overage',
+        'anthropic-organization-id': 'org-1',
+      } });
+    }
+    return new Response(JSON.stringify({ type: 'error', error: { type: 'rate_limit_error', message: 'Error' } }),
+      { status: 429, headers: {
+        'content-type': 'application/json',
+        'anthropic-ratelimit-unified-status': 'rejected',
+        'anthropic-ratelimit-unified-5h-utilization': '1',
+        'anthropic-ratelimit-unified-representative-claim': 'five_hour',
+        'anthropic-ratelimit-unified-reset': String(resetS),
+        'anthropic-organization-id': 'org-1',
+      } });
+  };
+
+  const log = [];
+  for (const m of ['log', 'error', 'warn']) console[m] = (...a) => { log.push(a.map(String).join(' ')); };
+
+  const { startProxy } = await import('../dist/proxy.js');
+  const guardOpts = guard === 'warn' ? { overageGuardBehavior: 'warn' }
+    : guard === 'off' ? { overageGuardEnabled: false }
+      : {};
+  await startProxy({
+    host: '127.0.0.1', port: PORT, passthrough: false, verbose: false,
+    noLiveCapture: true, fetchImpl, ...guardOpts,
+  });
+  const BASE = `http://127.0.0.1:${PORT}`;
+  for (let i = 0; i < 50; i++) { try { await fetch(`${BASE}/health`); break; } catch { await sleep(100); } }
+
+  const post = (extra = {}) => fetch(`${BASE}/v1/messages`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json', ...extra },
+    body: JSON.stringify({
+      model: 'claude-sonnet-5', max_tokens: 16,
+      messages: [{ role: 'user', content: `c ${Math.random()}` }],
+    }),
+  });
+  const seatOne = async () =>
+    (await (await fetch(`${BASE}/accounts`)).json()).accounts.find((a) => a.alias === 'one');
+
+  // Park the pool: the first request tries both seats and both 429.
+  const first = await post(); await first.text();
+  return { state, post, seatOne, log, ADMIN_TOKEN, first };
+}
+
+// ── default guard: the pin gets out, and the answer costs the proxy ─────
+{
+  const { state, post, seatOne, ADMIN_TOKEN, first } = await scenario('default');
+
+  header('the pool parks, and an ordinary request is answered locally');
+  check('the first request 429s after trying both seats', first.status === 429 && new Set(state.calls).size === 2,
+    `${first.status} / ${state.calls.join(',')}`);
+  {
+    const before = state.calls.length;
+    const r = await post();
+    const body = await r.text();
+    check('ordinary request: 429', r.status === 429, r.status);
+    check('ordinary request: marker pool_parked',
+      r.headers.get('x-dario-upstream-rejection') === 'pool_parked', r.headers.get('x-dario-upstream-rejection'));
+    check('ordinary request: nothing sent upstream', state.calls.length === before, `${state.calls.length - before}`);
+    check('ordinary request: the body says so', body.includes('Nothing was sent upstream'), body.slice(0, 100));
+  }
+
+  header('a PINNED request is assigned its seat before the parked check — it goes upstream');
+  state.mode = '200';
+  {
+    const before = state.calls.length;
+    const r = await post({ 'x-dario-account': 'one', 'x-dario-admin-token': ADMIN_TOKEN });
+    const body = await r.text();
+    check('exactly one upstream call', state.calls.length === before + 1, `${state.calls.length - before}`);
+    check('on the pinned seat', state.calls[state.calls.length - 1] === 'one-token', state.calls[state.calls.length - 1]);
+    check('the client gets the REAL upstream status, not a synthesised 429', r.status === 200, r.status);
+    check('and the real body', body.includes('served from extra usage'), body.slice(0, 120));
+    check('no pool_parked marker on it', r.headers.get('x-dario-upstream-rejection') === null,
+      r.headers.get('x-dario-upstream-rejection'));
+  }
+
+  header('consequence 1: the successful response UN-PARKS the seat');
+  {
+    const one = await seatOne();
+    check('seat one has left `rejected`', one.status !== 'rejected', one.status);
+    check('and its action is no longer wait', one.action !== 'wait', one.action);
+  }
+
+  header('consequence 2: the default guard HALTS the proxy behind it');
+  {
+    const before = state.calls.length;
+    const r = await post();
+    const body = await r.text();
+    check('the next ORDINARY request is 503, not 200', r.status === 503, r.status);
+    check('and it names the guard', body.includes('dario_overage_guard'), body.slice(0, 120));
+    check('nothing was sent upstream for it', state.calls.length === before, `${state.calls.length - before}`);
+  }
+}
+
+// ── guard disarmed: the same probe, survivable ──────────────────────────
+for (const mode of ['warn', 'off']) {
+  const { state, post, ADMIN_TOKEN } = await scenario(mode);
+  header(`with the guard ${mode}, the pin is usable: no halt behind it`);
+  state.mode = '200';
+  {
+    const r = await post({ 'x-dario-account': 'one', 'x-dario-admin-token': ADMIN_TOKEN });
+    await r.text();
+    check(`pinned request still reaches upstream (${mode})`, r.status === 200, r.status);
+  }
+  {
+    const before = state.calls.length;
+    const r = await post();
+    await r.text();
+    check(`the next ordinary request is NOT 503 (${mode})`, r.status !== 503, r.status);
+    check(`and it reaches upstream on the un-parked seat (${mode})`,
+      state.calls.length === before + 1, `${state.calls.length - before}`);
+  }
+}
+
+out(`\n${fail === 0 ? 'ALL PASS' : `${fail} FAILED`} (${pass} passed)`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Closes the documentation half of #1282. **Docs and a test only — no behaviour changed.**

## What the report got right

Verified against 6.0.50 source, all three claims hold:

- `writePoolParked` (`proxy.ts:3097`, decided at `:3241`) answers from `pool.parkedUntil()` alone — nothing upstream.
- `overage-guard.ts` reads the `representative-claim` on a **completed** response record, so it structurally cannot fire pre-flight.
- The parked decision block contains no reference to the guard. The knobs are parsed in `cli.ts` and reach only `OverageGuard`.

So `DARIO_OVERAGE_GUARD=off` genuinely does not change the parked answer, and the docs do read as though it should.

## What it could not see from the code

**The escape it asks for already exists.** `poolAccount = pinnedAccount` lands at `proxy.ts:3230`, *before* `parkedUntil` is consulted at `:3241` — so a seat pin (`x-dario-account`) never reaches the short-circuit. `docs/admin-api.md` already describes the primitive ("no failover… the upstream status comes back as-is"); nothing connected it to the parked case.

## Two consequences, both measured

The new test asserts them so they cannot regress into a surprise:

| | |
|---|---|
| **The default guard halts the proxy behind it** | The moment the pinned response bills to anything but the subscription, every request after it — pinned or not — gets `503 dario_overage_guard`. The pin is only usable with `--overage-behavior=warn` or the guard off. |
| **A successful pinned response un-parks that seat** | Its snapshot replaces the rejection, so the seat leaves `rejected` and ordinary traffic lands on it again until the next 429. The pin opens the door; it does not hold it open for one request. |

That second one is the real subtlety: the two mechanisms are independent in the *parking* decision but joined in the *outcome*, which is a sharper statement than "the guard does not affect parking".

`--pool-fallback` is named in the docs as the different answer it is — it keeps the gateway serving by going to another provider, so it never spends Anthropic extra usage.

## Deliberately not done here

The report's second ask — a first-class `--pool-exhausted=<429|extra-usage>` — is a fair shape and is **not** in this PR. The primitive exists; what is missing is a non-admin, proxy-level flag, plus a decision on whether "one probe" should mean one request or, as today, the door left open. The reporter has offered to run a pinned request against a live five-seat pool with extra usage enabled and paste the real headers. That is the one input neither the code nor a synthetic upstream can supply, and it should settle the flag's semantics rather than have them guessed at.

## Verification

- `test/pool-parked-pinned-escape.mjs` — **21/21**, in-process against an injected upstream.
- Full suite **197/197**.
- `check:readme` (93 links) and `lint:pkg` clean.
- The synthetic 200 carries no rate-limit headers, so it replaces the seat snapshot with an empty one. A real extra-usage 200 may carry overage-bucket headers and leave a different state — called out in the issue thread rather than asserted here.
