### PR TITLE
Doctor reports continuation; a chaos tap to watch it happen (v6.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ checklist.
 
 ## [Unreleased]
 
+## [6.2.1] - 2026-09-12
+
+### Added
+
+- **`dario doctor` reports mid-stream continuation.** A `Continuation` row next to `Failover` says
+  which hops a dying stream can take on this host: same model then the chain (two hops), same
+  model only (no chain, or a chain with nowhere to go — pointing at the Failover row), or off.
+  Configuration only, like Failover; `continuationReadiness()` is pure and every branch is tested.
+- **`DARIO_CHAOS_CUT_AFTER=<chars>`** kills the first streamed answer after that many characters
+  (`DARIO_CHAOS_CUT_STREAMS=<n>` for the first n), from dario's side, the way a real reset does, so
+  the continuation can be watched on demand with any client. Spares resumes; applied to the Claude
+  and the codex leg alike; warns loudly at startup. A demo and test affordance, never a default.
+
 ## [6.2.0] - 2026-09-11
 
 ### Changed

--- a/docs/midstream-continuation.md
+++ b/docs/midstream-continuation.md
@@ -134,6 +134,32 @@ is never closed with a synthetic `end_turn`; only the resume's own
 | `--pool-fallback=…` | where the second hop goes; without an entry for the other provider a stream gets the same-model resume only |
 
 On by default: it only ever acts where the alternative is a broken stream.
+`dario doctor` reports which hops this host can take:
+
+```
+[ OK ]  Continuation  on: a dying stream resumes on the same model, then on gpt-5.6-sol → claude-sonnet-5 (two hops)
+[ OK ]  Continuation  on: a dying stream resumes on the same model only — add --pool-fallback for a second hop on the other subscription
+[INFO]  Continuation  off — a stream that dies mid-answer ends truncated (unset DARIO_MIDSTREAM_CONTINUE / drop --no-midstream-continue)
+```
+
+## Seeing it happen
+
+Nothing about a healthy stream shows the feature, so there is a tap that
+kills one on purpose:
+
+```bash
+DARIO_CHAOS_CUT_AFTER=300 dario proxy
+```
+
+The first streamed answer dies after 300 characters — the upstream socket is
+cut from dario's side, exactly the failure a real reset produces — and the
+continuation finishes it. Point any client at the proxy, ask for something
+long, and watch the answer keep going past the cut; a raw `curl -N` shows the
+seam comment. `DARIO_CHAOS_CUT_STREAMS=3` cuts the first three instead of one.
+The tap spares resumes, so it shows the first hop — the same model finishing
+its own answer; the other subscription takes over only when that model cannot
+serve the resume. dario warns loudly at startup while the tap is set; it is a
+demo and test affordance, never a default.
 
 ## How it was proven
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "6.2.0",
+      "version": "6.2.1",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "Use your Claude and ChatGPT subscriptions in Cursor, Cline, Aider, Claude Code and the Agent SDK — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint: either plan answers either wire shape, with automatic failover when one hits its limit.",
   "type": "module",
   "bin": {

--- a/src/doctor-core.ts
+++ b/src/doctor-core.ts
@@ -69,6 +69,34 @@ export interface Check {
  * live request, and this release was built on the lesson that a green config is
  * not a working path.
  */
+/**
+ * Mid-stream continuation readiness (v6.2.1). Configuration only, like
+ * failoverReadiness: it says which of the two hops a dying stream can take on
+ * this host, not that either works. The first hop (the same model again) needs
+ * nothing; the second (the other subscription) needs the failover chain AND
+ * somewhere for it to go — the exact INERT state the Failover row exists for.
+ */
+export function continuationReadiness(input: {
+  enabled: boolean;
+  chain: readonly string[];
+  codexAccounts: number;
+}): { status: CheckStatus; detail: string } {
+  if (!input.enabled) {
+    return { status: 'info', detail: 'off — a stream that dies mid-answer ends truncated (unset DARIO_MIDSTREAM_CONTINUE / drop --no-midstream-continue)' };
+  }
+  const secondHop = input.chain.length > 0 && input.codexAccounts > 0;
+  if (secondHop) {
+    return { status: 'ok', detail: `on: a dying stream resumes on the same model, then on ${input.chain.join(' → ')} (two hops)` };
+  }
+  return {
+    status: 'ok',
+    detail: 'on: a dying stream resumes on the same model only — '
+      + (input.chain.length === 0
+        ? 'add --pool-fallback for a second hop on the other subscription'
+        : 'the chain has nowhere to go for a second hop (see Failover)'),
+  };
+}
+
 export function failoverReadiness(input: {
   chain: readonly string[];
   codexAccounts: number;
@@ -1294,6 +1322,9 @@ export async function runChecks(opts: RunChecksOptions = {}): Promise<Check[]> {
       backends: backends.map((b) => b.name),
     });
     checks.push({ status: verdict.status, label: 'Failover', detail: verdict.detail });
+    const midstreamEnabled = !['0', 'false', 'no', 'off'].includes((process.env.DARIO_MIDSTREAM_CONTINUE ?? '').toLowerCase());
+    const cont = continuationReadiness({ enabled: midstreamEnabled, chain, codexAccounts: codexAliases.length });
+    checks.push({ status: cont.status, label: 'Continuation', detail: cont.detail });
   } catch (err) {
     checks.push({ status: 'warn', label: 'Failover', detail: `check failed: ${(err as Error).message}` });
   }

--- a/src/midstream.ts
+++ b/src/midstream.ts
@@ -915,6 +915,18 @@ export interface ChaosCutOptions {
 }
 
 /**
+ * The remaining-cuts counter, shared by every wrapper the proxy makes. The
+ * Claude leg and the codex leg wrap different fetch implementations, and a
+ * counter per wrapper would cut up to twice the promised number of streams
+ * (review finding on #1290): one budget for the proxy, not one per provider.
+ */
+export interface ChaosCutState { left: number }
+
+export function chaosCutState(o: ChaosCutOptions): ChaosCutState {
+  return { left: o.streams ?? 1 };
+}
+
+/**
  * Wraps an upstream fetch so that the first `streams` streamed answers die
  * after `afterChars` characters of text — the failure this module exists for,
  * on demand. A resume (its body carries the anchor quote) is never cut, so
@@ -924,8 +936,7 @@ export interface ChaosCutOptions {
  * dario proxy` then stream any request and watch the seam. Both providers'
  * text framing is recognised (`text_delta` / `response.output_text.delta`).
  */
-export function chaosCutFetch(inner: typeof fetch, o: ChaosCutOptions): typeof fetch {
-  let left = o.streams ?? 1;
+export function chaosCutFetch(inner: typeof fetch, o: ChaosCutOptions, state: ChaosCutState = chaosCutState(o)): typeof fetch {
   const log = o.log ?? ((l: string) => console.warn(`[dario] ${l}`));
   return async (input, init) => {
     const res = await inner(input, init);
@@ -933,8 +944,8 @@ export function chaosCutFetch(inner: typeof fetch, o: ChaosCutOptions): typeof f
     const isStream = /\/v1\/messages|\/responses/.test(url);
     const bodyText = typeof init?.body === 'string' ? init.body : init?.body instanceof Uint8Array ? new TextDecoder().decode(init.body) : '';
     const isResume = bodyText.includes(ANCHOR_OPEN);
-    if (!isStream || isResume || left <= 0 || res.status !== 200 || !res.body) return res;
-    left--;
+    if (!isStream || isResume || state.left <= 0 || res.status !== 200 || !res.body) return res;
+    state.left--;
     const reader = res.body.getReader();
     const dec = new TextDecoder();
     let text = '';
@@ -947,7 +958,7 @@ export function chaosCutFetch(inner: typeof fetch, o: ChaosCutOptions): typeof f
           try { text += JSON.parse(`"${m[1]}"`) as string; } catch { /* not a text fragment */ }
         }
         if (text.length >= o.afterChars) {
-          log(`CHAOS: cutting this stream after ${text.length} chars (${left} more to go)`);
+          log(`CHAOS: cutting this stream after ${text.length} chars (${state.left} more to go)`);
           await new Promise((r) => setTimeout(r, 30));   // let what is queued reach the reader first
           try { await reader.cancel(); } catch { /* already gone */ }
           c.error(new Error('chaos: read ECONNRESET'));

--- a/src/midstream.ts
+++ b/src/midstream.ts
@@ -902,6 +902,63 @@ export class MidstreamGuard {
   }
 }
 
+// ---------------------------------------------------------------------------
+//  Chaos: a stream that dies on purpose
+// ---------------------------------------------------------------------------
+
+export interface ChaosCutOptions {
+  /** Characters of answer text an upstream stream is allowed before it is cut. */
+  afterChars: number;
+  /** How many streams to cut before the tap goes quiet (default 1). */
+  streams?: number;
+  log?: (line: string) => void;
+}
+
+/**
+ * Wraps an upstream fetch so that the first `streams` streamed answers die
+ * after `afterChars` characters of text — the failure this module exists for,
+ * on demand. A resume (its body carries the anchor quote) is never cut, so
+ * the tap produces a primary death and lets the continuation play out.
+ *
+ * Demo and test affordance, never a default: `DARIO_CHAOS_CUT_AFTER=300
+ * dario proxy` then stream any request and watch the seam. Both providers'
+ * text framing is recognised (`text_delta` / `response.output_text.delta`).
+ */
+export function chaosCutFetch(inner: typeof fetch, o: ChaosCutOptions): typeof fetch {
+  let left = o.streams ?? 1;
+  const log = o.log ?? ((l: string) => console.warn(`[dario] ${l}`));
+  return async (input, init) => {
+    const res = await inner(input, init);
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    const isStream = /\/v1\/messages|\/responses/.test(url);
+    const bodyText = typeof init?.body === 'string' ? init.body : init?.body instanceof Uint8Array ? new TextDecoder().decode(init.body) : '';
+    const isResume = bodyText.includes(ANCHOR_OPEN);
+    if (!isStream || isResume || left <= 0 || res.status !== 200 || !res.body) return res;
+    left--;
+    const reader = res.body.getReader();
+    const dec = new TextDecoder();
+    let text = '';
+    const body = new ReadableStream<Uint8Array>({
+      async pull(c) {
+        const { done, value } = await reader.read();
+        if (done) { c.close(); return; }
+        c.enqueue(value);
+        for (const m of dec.decode(value, { stream: true }).matchAll(/"(?:text|delta)":"((?:[^"\\]|\\.)*)"/g)) {
+          try { text += JSON.parse(`"${m[1]}"`) as string; } catch { /* not a text fragment */ }
+        }
+        if (text.length >= o.afterChars) {
+          log(`CHAOS: cutting this stream after ${text.length} chars (${left} more to go)`);
+          await new Promise((r) => setTimeout(r, 30));   // let what is queued reach the reader first
+          try { await reader.cancel(); } catch { /* already gone */ }
+          c.error(new Error('chaos: read ECONNRESET'));
+        }
+      },
+      cancel() { reader.cancel().catch(() => {}); },
+    });
+    return new Response(body, { status: res.status, statusText: res.statusText, headers: res.headers });
+  };
+}
+
 /** Convenience for sites that hold a ServerResponse: the guard writes through `write`, ends through `res.end()`. */
 export function guardFor(res: ServerResponse, o: Omit<MidstreamGuardOptions, 'end'>): MidstreamGuard {
   return new MidstreamGuard({ ...o, end: () => { if (!res.writableEnded) res.end(); } });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -26,7 +26,7 @@ import { createTokenBucket } from './rate-limit.js';
 import { getOpenAIBackend, isOpenAIModel, forwardToOpenAI, type BackendCredentials } from './openai-backend.js';
 import { forwardToCodex, getCodexModelSlugs, peekCodexModelSlugs, isCodexModel, pickCodexFallback, pickClaudeTarget, CODEX_BACKEND_BASE_URL } from './codex-backend.js';
 import { effortForCodex } from './effort.js';
-import { MidstreamGuard, guardFor, loopbackBaseFor, chaosCutFetch, CONTINUATION_HEADER, MAX_CONTINUATION_DEPTH, continuationDepth, type ContinuationTarget } from './midstream.js';
+import { MidstreamGuard, guardFor, loopbackBaseFor, chaosCutFetch, chaosCutState, CONTINUATION_HEADER, MAX_CONTINUATION_DEPTH, continuationDepth, type ContinuationTarget } from './midstream.js';
 import { isClaudeServableModel } from './claude-model.js';
 import { MODEL_UNROUTABLE } from './upstream-rejection.js';
 import { readCompareTarget, teeResponse, runCompare, writeCompareRecord, COMPARE_RESULT_HEADER } from './compare.js';
@@ -1453,8 +1453,12 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
     ? { afterChars: chaosCutAfter, streams: Math.max(1, Number.parseInt(process.env.DARIO_CHAOS_CUT_STREAMS ?? '1', 10) || 1) }
     : null;
   if (chaosCut) console.warn(`[dario] ⚠  CHAOS: the first ${chaosCut.streams} streamed answer${chaosCut.streams === 1 ? '' : 's'} will be cut after ${chaosCut.afterChars} chars (DARIO_CHAOS_CUT_AFTER) — demo/test only`);
-  const upstreamFetch: typeof fetch = chaosCut ? chaosCutFetch(opts.fetchImpl ?? fetch, chaosCut) : (opts.fetchImpl ?? fetch);
-  const codexFetch: typeof fetch = chaosCut ? chaosCutFetch(fetch, chaosCut) : fetch;
+  // One cut budget for the whole proxy. The two legs wrap different fetch
+  // implementations (the Claude leg honours opts.fetchImpl, the codex leg is
+  // the global fetch), so the counter lives outside both wrappers.
+  const chaosState = chaosCut ? chaosCutState(chaosCut) : null;
+  const upstreamFetch: typeof fetch = chaosCut && chaosState ? chaosCutFetch(opts.fetchImpl ?? fetch, chaosCut, chaosState) : (opts.fetchImpl ?? fetch);
+  const codexFetch: typeof fetch = chaosCut && chaosState ? chaosCutFetch(fetch, chaosCut, chaosState) : fetch;
   const upstreamApiKey = (opts.upstreamApiKey ?? process.env.ANTHROPIC_UPSTREAM_API_KEY ?? '').trim();
   if (upstreamApiKey) console.error('[dario] upstream auth: per-token API key (x-api-key) — OAuth/Max + account pool bypassed');
   else if (ignoreCcCredentials()) console.error("[dario] DARIO_IGNORE_CC_CREDENTIALS: using ONLY dario's own credentials.json — Claude Code session token + keychain ignored (won't rotate a live `claude` session; run `dario login` if not authed)");

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -26,7 +26,7 @@ import { createTokenBucket } from './rate-limit.js';
 import { getOpenAIBackend, isOpenAIModel, forwardToOpenAI, type BackendCredentials } from './openai-backend.js';
 import { forwardToCodex, getCodexModelSlugs, peekCodexModelSlugs, isCodexModel, pickCodexFallback, pickClaudeTarget, CODEX_BACKEND_BASE_URL } from './codex-backend.js';
 import { effortForCodex } from './effort.js';
-import { MidstreamGuard, guardFor, loopbackBaseFor, CONTINUATION_HEADER, MAX_CONTINUATION_DEPTH, continuationDepth, type ContinuationTarget } from './midstream.js';
+import { MidstreamGuard, guardFor, loopbackBaseFor, chaosCutFetch, CONTINUATION_HEADER, MAX_CONTINUATION_DEPTH, continuationDepth, type ContinuationTarget } from './midstream.js';
 import { isClaudeServableModel } from './claude-model.js';
 import { MODEL_UNROUTABLE } from './upstream-rejection.js';
 import { readCompareTarget, teeResponse, runCompare, writeCompareRecord, COMPARE_RESULT_HEADER } from './compare.js';
@@ -1444,7 +1444,17 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
   // Upstream auth override: a per-token API key forwards to the standard API
   // pool via `x-api-key`, bypassing OAuth/Max + the account pool entirely.
   // Env-only so the key never lands in `ps`/argv. Default (empty) = OAuth/Max.
-  const upstreamFetch: typeof fetch = opts.fetchImpl ?? fetch;
+  // DARIO_CHAOS_CUT_AFTER=<chars> [DARIO_CHAOS_CUT_STREAMS=<n>]: the first n
+  // streamed answers die on purpose after that many characters, so the
+  // mid-stream continuation can be watched on demand. Demo and test only —
+  // loud at startup, never a default. Applied to the codex leg as well.
+  const chaosCutAfter = Number.parseInt(process.env.DARIO_CHAOS_CUT_AFTER ?? '', 10);
+  const chaosCut = Number.isFinite(chaosCutAfter) && chaosCutAfter > 0
+    ? { afterChars: chaosCutAfter, streams: Math.max(1, Number.parseInt(process.env.DARIO_CHAOS_CUT_STREAMS ?? '1', 10) || 1) }
+    : null;
+  if (chaosCut) console.warn(`[dario] ⚠  CHAOS: the first ${chaosCut.streams} streamed answer${chaosCut.streams === 1 ? '' : 's'} will be cut after ${chaosCut.afterChars} chars (DARIO_CHAOS_CUT_AFTER) — demo/test only`);
+  const upstreamFetch: typeof fetch = chaosCut ? chaosCutFetch(opts.fetchImpl ?? fetch, chaosCut) : (opts.fetchImpl ?? fetch);
+  const codexFetch: typeof fetch = chaosCut ? chaosCutFetch(fetch, chaosCut) : fetch;
   const upstreamApiKey = (opts.upstreamApiKey ?? process.env.ANTHROPIC_UPSTREAM_API_KEY ?? '').trim();
   if (upstreamApiKey) console.error('[dario] upstream auth: per-token API key (x-api-key) — OAuth/Max + account pool bypassed');
   else if (ignoreCcCredentials()) console.error("[dario] DARIO_IGNORE_CC_CREDENTIALS: using ONLY dario's own credentials.json — Claude Code session token + keychain ignored (won't rotate a live `claude` session; run `dario login` if not authed)");
@@ -3757,7 +3767,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
             const served = codexAvailable && await forwardToCodex(
               req, res, body, codexCreds, corsOrigin, SECURITY_HEADERS,
               upstreamTimeoutMs, verbose, isOpenAI ? 'openai' : 'anthropic',
-              fetch, canDefer,
+              codexFetch, canDefer,
               // Before this hook a codex request left no trace: nothing in
               // /analytics, nothing in the request log, no per-account count.
               // The dock (and anyone reading /analytics) saw a proxy that

--- a/test/doctor-formatter.mjs
+++ b/test/doctor-formatter.mjs
@@ -8,7 +8,7 @@
 // unit-testing execFileSync probes against fixtures when the whole
 // point is to reflect the current host.
 
-import { formatChecks, formatChecksJson, exitCodeFor, formatReset, failoverReadiness } from '../dist/doctor.js';
+import { formatChecks, formatChecksJson, exitCodeFor, formatReset, failoverReadiness, continuationReadiness } from '../dist/doctor.js';
 
 let pass = 0, fail = 0;
 function check(label, cond) {
@@ -141,6 +141,19 @@ header('formatReset — relative reset times');
   check('resets in 45m returns 45m', formatReset(1000000000 + 45 * 60, now) === '45m');
   check('resets in 69m returns 1h 9m', formatReset(1000000000 + 69 * 60, now) === '1h 9m');
   check('resets in 2d 3h returns 2d 3h', formatReset(1000000000 + (2 * 1440 + 3 * 60) * 60, now) === '2d 3h');
+}
+
+// ======================================================================
+header('continuationReadiness — which hops a dying stream can take');
+{
+  const c = (enabled, chain, codexAccounts) => continuationReadiness({ enabled, chain, codexAccounts });
+  check('off reports info and says the stream ends truncated', c(false, ['gpt-5.6-sol'], 1).status === 'info' && c(false, [], 0).detail.includes('truncated'));
+  const two = c(true, ['gpt-5.6-sol', 'claude-sonnet-5'], 1);
+  check('chain + codex account → two hops, naming the chain', two.status === 'ok' && two.detail.includes('two hops') && two.detail.includes('gpt-5.6-sol → claude-sonnet-5'));
+  const one = c(true, [], 0);
+  check('no chain → same model only, with the fix named', one.status === 'ok' && one.detail.includes('same model only') && one.detail.includes('--pool-fallback'));
+  const inert = c(true, ['gpt-5.6-sol'], 0);
+  check('chain with nowhere to go → same model only, pointing at Failover', inert.status === 'ok' && inert.detail.includes('same model only') && inert.detail.includes('Failover'));
 }
 
 // ======================================================================

--- a/test/midstream-continuation-wiring.mjs
+++ b/test/midstream-continuation-wiring.mjs
@@ -156,6 +156,8 @@ await writeFile(join(tmpHome, '.dario', 'codex-accounts', 'live.json'), JSON.str
 const logs = [];
 const origLog = console.log;
 console.log = (...a) => { logs.push(a.join(' ')); origLog(...a); };
+const origWarn = console.warn;
+console.warn = (...a) => { logs.push(a.join(' ')); origWarn(...a); };
 
 const { startProxy } = await import('../dist/proxy.js');
 const common = { host: '127.0.0.1', verbose: false, noLiveCapture: true, poolFallbackModel: `${CODEX_SLUG},claude:${CLAUDE_MODEL}`, fetchImpl: fakeFetch, maxConcurrent: 1 };
@@ -359,6 +361,25 @@ header('K. a request at the maximum continuation depth is never resumed');
   const { res, frames } = await streamMessages(CLAUDE_MODEL, BASE, '/v1/messages', { 'x-dario-continuation': '2' });
   const a = assembleAnthropic(frames);
   check('depth-2 request: truncated, no further hop', res.status === 200 && !a.ok && delta(b).a === 1 && delta(b).c === 0, JSON.stringify(delta(b)));
+}
+
+header('L. DARIO_CHAOS_CUT_AFTER — a stream dies on demand and is finished by the continuation');
+{
+  const CHAOS_PORT = await freePort();
+  process.env.DARIO_CHAOS_CUT_AFTER = '60';
+  await startProxy({ ...common, port: CHAOS_PORT });
+  delete process.env.DARIO_CHAOS_CUT_AFTER;
+  for (let i = 0; i < 50; i++) { try { await fetch(`http://127.0.0.1:${CHAOS_PORT}/health`); break; } catch { await sleep(100); } }
+  anthropicPlan = ['serve', 'serve']; codexPlan = [];
+  const b = counts();
+  const { res, frames, seams } = await streamMessages(CLAUDE_MODEL, `http://127.0.0.1:${CHAOS_PORT}`);
+  const a = assembleAnthropic(frames);
+  check('startup warned', logs.some((l) => /CHAOS: the first 1 streamed answer will be cut after 60 chars/.test(l)));
+  check('the tap cut the healthy stream, the continuation finished it: ONE valid message, Claude ×2', res.status === 200 && a.ok && delta(b).a === 2, a.errors.join('; ') + ' ' + JSON.stringify(delta(b)));
+  check('text = the cut prefix + the resume (anchor trimmed)', a.text.startsWith(PARTIAL_CLAUDE.slice(0, 60)) && a.text.endsWith(CONT_CLAUDE) && !a.text.includes(PARTIAL_CLAUDE.slice(0, 40) + PARTIAL_CLAUDE.slice(0, 40)), a.text);
+  check('one seam, same model', seams.length === 1 && seams[0].includes('(same model)'), seams.join(' / '));
+  const again = await streamMessages(CLAUDE_MODEL, `http://127.0.0.1:${CHAOS_PORT}`);
+  check('the next stream is untouched (one cut, then quiet)', assembleAnthropic(again.frames).ok && again.seams.length === 0, again.seams.join(' / '));
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/test/midstream.mjs
+++ b/test/midstream.mjs
@@ -10,7 +10,7 @@
 import {
   SseFrameSplitter, parseFrame, formatFrame, ClientStreamState, ANCHOR_OPEN, ANCHOR_CLOSE,
   anchorOf, findAnchor, tailOverlap, fixSeam, insideCodeFence,
-  buildResumeBody, resumeNotice, Splicer, MidstreamGuard, loopbackBaseFor, ANCHOR_CHARS, continuationDepth, MAX_CONTINUATION_DEPTH,
+  buildResumeBody, resumeNotice, Splicer, MidstreamGuard, loopbackBaseFor, ANCHOR_CHARS, continuationDepth, MAX_CONTINUATION_DEPTH, chaosCutFetch,
 } from '../dist/midstream.js';
 
 let pass = 0, fail = 0;
@@ -526,6 +526,35 @@ header('MidstreamGuard — client gone → no resume');
   g.write(anthropicPrefix('abc def ghi jkl').join(''));
   const outcome = await g.finish();
   check('ended, no loopback', outcome === 'ended' && ended === 1 && fetched === 0);
+}
+
+header('chaosCutFetch — the first N streams die after M chars; resumes are spared');
+{
+  const text = 'abcdefghij'.repeat(20);   // 200 chars
+  const serve = () => new Response(new ReadableStream({
+    async start(c) {
+      const enc = new TextEncoder();
+      c.enqueue(enc.encode(ev('message_start', { message: { id: 'm', model: 'x', role: 'assistant', content: [], usage: {} } })));
+      c.enqueue(enc.encode(ev('content_block_start', { index: 0, content_block: { type: 'text', text: '' } })));
+      for (const t of text.match(/.{1,10}/g)) { c.enqueue(enc.encode(ev('content_block_delta', { index: 0, delta: { type: 'text_delta', text: t } }))); await new Promise((r) => setTimeout(r, 1)); }
+      c.enqueue(enc.encode(ev('content_block_stop', { index: 0 })));
+      c.enqueue(enc.encode(ev('message_stop', {})));
+      c.close();
+    },
+  }), { status: 200, headers: { 'content-type': 'text/event-stream' } });
+  const logged = [];
+  const f = chaosCutFetch(async () => serve(), { afterChars: 50, streams: 1, log: (l) => logged.push(l) });
+  const drain = async (res) => { let out = ''; let err = null; const r = res.body.getReader(); const d = new TextDecoder(); try { while (true) { const { done, value } = await r.read(); if (done) break; out += d.decode(value, { stream: true }); } } catch (e) { err = e; } return { out, err }; };
+  const first = await drain(await f('https://api.anthropic.com/v1/messages', { method: 'POST', body: JSON.stringify({ messages: [] }) }));
+  check('first stream cut: errored after ≥50 chars and before the end', first.err !== null && /chaos/.test(first.err.message) && !first.out.includes('message_stop') && (first.out.match(/text_delta/g) ?? []).length >= 5, first.err?.message);
+  check('logged the cut', logged.length === 1 && /CHAOS: cutting this stream after \d+ chars/.test(logged[0]));
+  const second = await drain(await f('https://api.anthropic.com/v1/messages', { method: 'POST', body: JSON.stringify({ messages: [] }) }));
+  check('second stream untouched (only one to cut)', second.err === null && second.out.includes('message_stop'));
+  const g = chaosCutFetch(async () => serve(), { afterChars: 50, streams: 5, log: () => {} });
+  const resume = await drain(await g('https://api.anthropic.com/v1/messages', { method: 'POST', body: JSON.stringify({ messages: [{ role: 'user', content: 'x «tail» y' }] }) }));
+  check('a resume (anchor quote in the body) is never cut', resume.err === null && resume.out.includes('message_stop'));
+  const other = await drain(await g('https://api.anthropic.com/v1/models', { method: 'GET' }));
+  check('non-stream paths pass through', other.err === null);
 }
 
 header('loopbackBaseFor');

--- a/test/midstream.mjs
+++ b/test/midstream.mjs
@@ -10,7 +10,7 @@
 import {
   SseFrameSplitter, parseFrame, formatFrame, ClientStreamState, ANCHOR_OPEN, ANCHOR_CLOSE,
   anchorOf, findAnchor, tailOverlap, fixSeam, insideCodeFence,
-  buildResumeBody, resumeNotice, Splicer, MidstreamGuard, loopbackBaseFor, ANCHOR_CHARS, continuationDepth, MAX_CONTINUATION_DEPTH, chaosCutFetch,
+  buildResumeBody, resumeNotice, Splicer, MidstreamGuard, loopbackBaseFor, ANCHOR_CHARS, continuationDepth, MAX_CONTINUATION_DEPTH, chaosCutFetch, chaosCutState,
 } from '../dist/midstream.js';
 
 let pass = 0, fail = 0;
@@ -555,6 +555,15 @@ header('chaosCutFetch — the first N streams die after M chars; resumes are spa
   check('a resume (anchor quote in the body) is never cut', resume.err === null && resume.out.includes('message_stop'));
   const other = await drain(await g('https://api.anthropic.com/v1/models', { method: 'GET' }));
   check('non-stream paths pass through', other.err === null);
+  // Two wrappers (the Claude leg and the codex leg) sharing ONE budget: the
+  // second leg finds the budget spent by the first.
+  const opts = { afterChars: 50, streams: 1, log: () => {} };
+  const shared = chaosCutState(opts);
+  const claudeLeg = chaosCutFetch(async () => serve(), opts, shared);
+  const codexLeg = chaosCutFetch(async () => serve(), opts, shared);
+  const a1 = await drain(await claudeLeg('https://api.anthropic.com/v1/messages', { method: 'POST', body: '{}' }));
+  const c1 = await drain(await codexLeg('https://chatgpt.com/backend-api/codex/responses', { method: 'POST', body: '{}' }));
+  check('one budget across both legs: the Claude leg cut, the codex leg untouched', a1.err !== null && c1.err === null && shared.left === 0, `${a1.err?.message} / ${c1.err?.message} left=${shared.left}`);
 }
 
 header('loopbackBaseFor');


### PR DESCRIPTION
## Doctor reports continuation; a chaos tap to watch it happen

Two small things that make the feature from #1286/#1289 visible.

**`dario doctor` — a `Continuation` row next to `Failover`**, saying which hops a dying stream can take on this host:

```
[ OK ]  Continuation  on: a dying stream resumes on the same model, then on gpt-5.6-sol → claude-sonnet-5 (two hops)
[ OK ]  Continuation  on: a dying stream resumes on the same model only — add --pool-fallback for a second hop on the other subscription
[INFO]  Continuation  off — a stream that dies mid-answer ends truncated (unset DARIO_MIDSTREAM_CONTINUE / drop --no-midstream-continue)
```

Configuration only, like Failover: it does not claim a hop works. `continuationReadiness()` is pure; every branch is in `test/doctor-formatter.mjs`.

**`DARIO_CHAOS_CUT_AFTER=<chars>`** (`DARIO_CHAOS_CUT_STREAMS=<n>`) kills the first streamed answer after that many characters — from dario's side, the way a real reset does — so anyone can watch the continuation with any client:

```bash
DARIO_CHAOS_CUT_AFTER=300 dario proxy
```

`chaosCutFetch` wraps the upstream fetch for both the Claude leg and the codex leg, recognises both providers' text framing, spares resumes (so what you see is the first hop), and dario warns loudly at startup while it is set. It is the in-process form of the rig the live tests used on the box; it is a demo and test affordance, never a default.

## Evidence

- `test/midstream.mjs` 98 (`chaosCutFetch`: cut after N, logged, next stream untouched, resumes spared, non-stream paths pass through).
- `test/midstream-continuation-wiring.mjs` 48 (scenario L: a third proxy with the tap set, a healthy upstream, one cut, one valid message with a same-model seam, the following stream untouched).
- `test/doctor-formatter.mjs` 52.
- Full suite 199/199.
- Bumped to 6.2.1 in-PR.
