### PR TITLE
The Claude Code wire-drift feed: a page, RSS and JSON Feed from git history

### DIFF
--- a/.github/workflows/drift-feed.yml
+++ b/.github/workflows/drift-feed.yml
@@ -1,0 +1,73 @@
+name: Claude Code wire-drift feed
+
+# Publishes docs/drift-feed (page + RSS + JSON Feed) to GitHub Pages: every
+# change to what Claude Code sends on the wire, as the template watcher
+# observed it. Built from git history alone (scripts/drift-feed.mjs walks the
+# commits that touched src/cc-template-data.json), so there is nothing to
+# commit — a template rebake lands on master, this rebuilds and redeploys.
+#
+# Runs on every master push that touches the template or the generator, once
+# a day as a backstop, and on demand. Never from a fork (see #1039).
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - src/cc-template-data.json
+      - scripts/drift-feed.mjs
+      - .github/workflows/drift-feed.yml
+  schedule:
+    - cron: '23 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: drift-feed-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    if: github.repository == 'askalf/dario'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: askalf/checkout-with-retry@115a6407547e9711edbc2e915838d495cad9583f  # v1.1.0
+        with:
+          # The feed IS the history: every commit that touched the template.
+          fetch-depth: 0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+      - name: Build the feed from git history
+        run: |
+          node scripts/drift-feed.mjs --out dist-feed/drift-feed --site "https://askalf.github.io/dario/drift-feed"
+          # The Pages root: nothing lives there yet but this feed.
+          echo '<!doctype html><meta charset="utf-8"><meta http-equiv="refresh" content="0; url=drift-feed/"><title>dario</title><a href="drift-feed/">Claude Code wire drift</a>' > dist-feed/index.html
+          touch dist-feed/.nojekyll
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: dist-feed
+
+  deploy:
+    needs: build
+    if: github.repository == 'askalf/dario'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+      # configure-pages' enablement reads the repo to create the site.
+      contents: read
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      # Creates the Pages site on first run (source: GitHub Actions) — the
+      # workflow token can, a personal token could not.
+      - uses: actions/configure-pages@v5
+        with:
+          enablement: true
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ checklist.
 
 ## [Unreleased]
 
+### Added
+
+- **The Claude Code wire-drift feed** — <https://askalf.github.io/dario/drift-feed/>: every change to what
+  Claude Code sends on the wire, as the template watcher observed it, as a page + RSS + JSON Feed.
+  Built from git history alone (`scripts/drift-feed.mjs` walks the commits that touched
+  `src/cc-template-data.json` and diffs consecutive snapshots: beta flags, tools and tool schemas,
+  headers, body field order, the system prompt and its variants with a bracketed excerpt of the
+  changed span) and deployed to GitHub Pages by `.github/workflows/drift-feed.yml` on every template
+  change, daily, and on demand. A release-number change inside a header (`user-agent`) is a version
+  label, not a wire change; a release that changed nothing on the wire still gets a line saying so.
+  `test/drift-feed.mjs` pins the diff.
+
 ## [6.2.1] - 2026-09-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -556,6 +556,8 @@ Full FAQ, including per-tool 401s and Team/Enterprise plans: [faq.md](./docs/faq
 
 ## Deep dives
 
+- [Claude Code wire drift](https://askalf.github.io/dario/drift-feed/) — every change to what Claude Code sends on the wire, as the template watcher observed it; [RSS](https://askalf.github.io/dario/drift-feed/feed.xml) · [JSON Feed](https://askalf.github.io/dario/drift-feed/feed.json)
+
 - [#183 — Modifying Claude Code's system prompt doesn't change billing; stripping its constraints recovers 1.2–2.8× output](https://github.com/askalf/dario/discussions/183)
 - [#68 — dario vs LiteLLM / OpenRouter / Kong AI Gateway (when each wins)](https://github.com/askalf/dario/discussions/68)
 - [#14 — Template replay: why we replay the shape instead of matching signals](https://github.com/askalf/dario/discussions/14)

--- a/docs/drift-monitor.md
+++ b/docs/drift-monitor.md
@@ -1,5 +1,11 @@
 # Drift monitor
 
+> **The feed:** every change the watcher has ever observed, as a page with
+> RSS and JSON Feed — <https://askalf.github.io/dario/drift-feed/>. Rebuilt
+> from git history on every template change (`scripts/drift-feed.mjs`,
+> `.github/workflows/drift-feed.yml`); a "nothing changed on the wire" line is
+> a Claude Code release the watcher checked and found identical.
+
 Dario's bundled CC template (`src/cc-template-data.json`) is the wire-shape
 fallback the proxy uses when it can't fingerprint a live CC install. For that
 fallback to be honest, the bundle has to keep up with what real CC is actually

--- a/scripts/drift-feed.mjs
+++ b/scripts/drift-feed.mjs
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+// The Claude Code wire-drift feed — every change to what Claude Code sends on
+// the wire, as the template watcher observed it, published as a page + RSS +
+// JSON Feed. Read from git history alone: each commit that touched
+// src/cc-template-data.json is one observation, and the diff between
+// consecutive observations is one entry. Nothing is captured here and nothing
+// is stored; a redeploy rebuilds the whole feed from `git log`.
+//
+//   node scripts/drift-feed.mjs [--out docs/drift-feed] [--site https://…]
+//
+// The diff itself is pure (`diffTemplates`) so test/drift-feed.mjs can pin
+// what an entry says without a git repository.
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { pathToFileURL } from 'node:url';
+
+export const TEMPLATE_PATH = 'src/cc-template-data.json';
+const REPO = 'https://github.com/askalf/dario';
+
+// ---------------------------------------------------------------------------
+//  Pure: two template snapshots → what changed
+// ---------------------------------------------------------------------------
+
+const splitBetas = (s) => (typeof s === 'string' ? s.split(',').map((b) => b.trim()).filter(Boolean) : []);
+const setDiff = (before, after) => ({ added: after.filter((x) => !before.includes(x)), removed: before.filter((x) => !after.includes(x)) });
+const hash = (v) => createHash('sha256').update(JSON.stringify(v ?? null)).digest('hex').slice(0, 10);
+
+/**
+ * What changed between two bundled templates, in the terms a reader cares
+ * about. `wire` is false when only the version label / capture stamp moved —
+ * a Claude Code release that changed nothing on the wire is worth a line too.
+ */
+export function diffTemplates(before, after) {
+  const a = after ?? {};
+  // The first snapshot has nothing to differ from: one line, not a wall of "added".
+  if (!before) return { version: a._version ?? null, previousVersion: null, versionChanged: true, captured: a._captured ?? null, wire: false, first: true, changes: [] };
+  const b = before;
+  const changes = [];
+  const push = (kind, text, detail) => changes.push(detail === undefined ? { kind, text } : { kind, text, detail });
+
+  const betas = setDiff(splitBetas(b.anthropic_beta), splitBetas(a.anthropic_beta));
+  for (const x of betas.added) push('beta', `beta flag added: \`${x}\``);
+  for (const x of betas.removed) push('beta', `beta flag removed: \`${x}\``);
+
+  const toolsB = Array.isArray(b.tool_names) ? b.tool_names : [];
+  const toolsA = Array.isArray(a.tool_names) ? a.tool_names : [];
+  const tools = setDiff(toolsB, toolsA);
+  for (const x of tools.added) push('tool', `tool added: \`${x}\``);
+  for (const x of tools.removed) push('tool', `tool removed: \`${x}\``);
+  const schemaB = new Map((Array.isArray(b.tools) ? b.tools : []).map((t) => [t?.name, hash(t)]));
+  const schemaA = new Map((Array.isArray(a.tools) ? a.tools : []).map((t) => [t?.name, hash(t)]));
+  const reschemaed = [...schemaA.keys()].filter((n) => schemaB.has(n) && schemaB.get(n) !== schemaA.get(n));
+  if (reschemaed.length > 0) push('tool', `${reschemaed.length} tool schema${reschemaed.length === 1 ? '' : 's'} changed: ${reschemaed.map((n) => `\`${n}\``).join(', ')}`);
+
+  // A header whose only difference is the release number inside it
+  // (`user-agent: claude-cli/2.1.268` → `2.1.269`) is the version label, not
+  // a wire change; it would otherwise flag every release.
+  const versionOnly = (x, y) => typeof b._version === 'string' && typeof a._version === 'string' && String(x).split(b._version).join(a._version) === String(y);
+  const hdrB = b.header_values ?? {};
+  const hdrA = a.header_values ?? {};
+  for (const k of Object.keys(hdrA)) {
+    if (!(k in hdrB)) push('header', `header added: \`${k}: ${String(hdrA[k])}\``);
+    else if (String(hdrA[k]) !== String(hdrB[k]) && !versionOnly(hdrB[k], hdrA[k])) push('header', `header \`${k}\`: \`${String(hdrB[k])}\` → \`${String(hdrA[k])}\``);
+  }
+  for (const k of Object.keys(hdrB)) if (!(k in hdrA)) push('header', `header removed: \`${k}\``);
+  const orderB = Array.isArray(b.header_order) ? b.header_order : [];
+  const orderA = Array.isArray(a.header_order) ? a.header_order : [];
+  if (orderB.length > 0 && orderA.length > 0 && orderB.join('|') !== orderA.join('|') && setDiff(orderB, orderA).added.length === 0 && setDiff(orderB, orderA).removed.length === 0) push('header', 'header order changed');
+
+  const bodyB = Array.isArray(b.body_field_order) ? b.body_field_order : [];
+  const bodyA = Array.isArray(a.body_field_order) ? a.body_field_order : [];
+  if (bodyB.length > 0 && bodyA.length > 0 && bodyB.join('|') !== bodyA.join('|')) push('body', `body field order changed: ${bodyA.join(', ')}`);
+
+  const spB = typeof b.system_prompt === 'string' ? b.system_prompt : '';
+  const spA = typeof a.system_prompt === 'string' ? a.system_prompt : '';
+  if (spB !== spA) {
+    const delta = spA.length - spB.length;
+    push('prompt', `system prompt changed (${delta >= 0 ? '+' : ''}${delta} chars, now ${spA.length})`, firstDifference(spB, spA));
+  }
+  const varB = b.system_prompt_variants ?? {};
+  const varA = a.system_prompt_variants ?? {};
+  const variants = setDiff(Object.keys(varB), Object.keys(varA));
+  for (const x of variants.added) push('prompt', `system prompt variant added: \`${x}\``);
+  for (const x of variants.removed) push('prompt', `system prompt variant removed: \`${x}\``);
+  for (const k of Object.keys(varA)) {
+    if (!(k in varB) || hash(varA[k]) === hash(varB[k])) continue;
+    const vb = typeof varB[k] === 'string' ? varB[k] : JSON.stringify(varB[k]);
+    const va = typeof varA[k] === 'string' ? varA[k] : JSON.stringify(varA[k]);
+    const delta = va.length - vb.length;
+    push('prompt', `system prompt variant \`${k}\` changed (${delta >= 0 ? '+' : ''}${delta} chars, now ${va.length})`, firstDifference(vb, va));
+  }
+
+  if ((b.agent_identity ?? '') !== (a.agent_identity ?? '') && a.agent_identity !== undefined) push('prompt', `agent identity line: \`${String(a.agent_identity).slice(0, 80)}\``);
+
+  const versionB = b._version ?? null;
+  const versionA = a._version ?? null;
+  return {
+    version: versionA,
+    previousVersion: versionB,
+    versionChanged: versionA !== versionB,
+    captured: a._captured ?? null,
+    wire: changes.length > 0,
+    changes,
+  };
+}
+
+/**
+ * The changed span between two strings, with a little context on each side and
+ * the span itself bracketed «…», so a one-character edit is visible as such.
+ */
+function firstDifference(before, after) {
+  let i = 0;
+  while (i < before.length && i < after.length && before[i] === after[i]) i++;
+  let j = 0;
+  while (j < before.length - i && j < after.length - i && before[before.length - 1 - j] === after[after.length - 1 - j]) j++;
+  const spanB = before.slice(i, before.length - j);
+  const spanA = after.slice(i, after.length - j);
+  const ctxL = before.slice(Math.max(0, i - 40), i);
+  const ctxR = before.slice(before.length - j, before.length - j + 40);
+  const show = (span) => `${ctxL}«${span}»${ctxR}`.replace(/\n/g, '⏎').replace(/[ \t]+/g, ' ').trim();
+  const whitespaceOnly = spanB.trim() === '' && spanA.trim() === '';
+  return { before: show(spanB), after: show(spanA), whitespaceOnly };
+}
+
+// ---------------------------------------------------------------------------
+//  History → entries
+// ---------------------------------------------------------------------------
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 });
+}
+
+/** Every commit that touched the template, oldest first: { sha, date, subject, pr }. */
+export function templateCommits() {
+  const out = git(['log', '--reverse', '--format=%H%x1f%aI%x1f%s', '--', TEMPLATE_PATH]);
+  return out.split('\n').filter(Boolean).map((line) => {
+    const [sha, date, subject] = line.split('\x1f');
+    const pr = /\(#(\d+)\)\s*$/.exec(subject)?.[1] ?? null;
+    return { sha, date, subject, pr };
+  });
+}
+
+function templateAt(sha) {
+  try { return JSON.parse(git(['show', `${sha}:${TEMPLATE_PATH}`])); } catch { return null; }
+}
+
+/** Entries newest first. */
+export function buildEntries() {
+  const commits = templateCommits();
+  const entries = [];
+  let prev = null;
+  for (const c of commits) {
+    const cur = templateAt(c.sha);
+    if (!cur) continue;
+    const d = diffTemplates(prev, cur);
+    // A version-label refresh keeps the last bake's capture stamp; showing it
+    // again would read as a fresh capture. Only a new capture carries it.
+    if (prev && d.captured === (prev._captured ?? null)) d.captured = null;
+    prev = cur;
+    if (!d.versionChanged && !d.wire) continue;   // a commit that touched the file without moving the template
+    entries.push({ ...d, sha: c.sha, date: c.date, subject: c.subject, pr: c.pr });
+  }
+  return entries.reverse();
+}
+
+// ---------------------------------------------------------------------------
+//  Rendering
+// ---------------------------------------------------------------------------
+
+const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+const md = (s) => esc(s).replace(/`([^`]+)`/g, '<code>$1</code>');
+
+export function entryTitle(e) {
+  const v = e.version ? `Claude Code ${e.version}` : 'Claude Code';
+  if (e.first) return `${v} — first template observed`;
+  if (!e.wire) return `${v} shipped — nothing changed on the wire`;
+  const kinds = [...new Set(e.changes.map((c) => c.kind))];
+  const what = kinds.map((k) => ({ beta: 'beta flags', tool: 'tools', header: 'headers', body: 'body order', prompt: 'system prompt' })[k] ?? k).join(', ');
+  return `${v}: ${what} changed on the wire`;
+}
+
+export function entryId(e) { return `${REPO}/commit/${e.sha}`; }
+
+function entryHtml(e) {
+  const when = new Date(e.date).toISOString().slice(0, 16).replace('T', ' ') + 'Z';
+  const cap = e.captured ? new Date(e.captured).toISOString().slice(0, 16).replace('T', ' ') + 'Z' : null;
+  const link = e.pr ? `${REPO}/pull/${e.pr}` : entryId(e);
+  const items = e.changes.map((c) => `<li class="${esc(c.kind)}">${md(c.text)}${c.detail ? `<details><summary>excerpt</summary><pre>- ${esc(c.detail.before)}\n+ ${esc(c.detail.after)}</pre></details>` : ''}</li>`).join('');
+  return `<article class="${e.wire ? 'wire' : 'quiet'}" id="${esc(e.sha.slice(0, 10))}">
+  <h2><a href="#${esc(e.sha.slice(0, 10))}">${esc(entryTitle(e))}</a></h2>
+  <p class="meta">observed ${esc(when)}${cap ? ` · captured ${esc(cap)}` : ''}${e.previousVersion && e.versionChanged ? ` · ${esc(e.previousVersion)} → ${esc(e.version)}` : ''} · <a href="${esc(link)}">${e.pr ? `#${esc(e.pr)}` : esc(e.sha.slice(0, 10))}</a></p>
+  ${items ? `<ul>${items}</ul>` : ''}
+</article>`;
+}
+
+export function renderHtml(entries, site) {
+  const wire = entries.filter((e) => e.wire).length;
+  const first = entries.at(-1);
+  const style = `
+:root{color-scheme:light dark;--bg:#fff;--fg:#111;--mute:#666;--line:#e5e5e5;--accent:#7c3aed;--code:#f3f0ff}
+@media(prefers-color-scheme:dark){:root{--bg:#0a0a0f;--fg:#eaeaea;--mute:#9a9a9a;--line:#26262e;--accent:#a78bfa;--code:#1a1526}}
+body{margin:0;background:var(--bg);color:var(--fg);font:15px/1.55 system-ui,-apple-system,Segoe UI,Roboto,sans-serif}
+main{max-width:52rem;margin:0 auto;padding:2rem 1.25rem 4rem}
+h1{font-size:1.6rem;margin:0 0 .25rem}h2{font-size:1.05rem;margin:0 0 .25rem}h2 a{color:inherit;text-decoration:none}
+.lede,.meta{color:var(--mute);margin:.25rem 0}.meta{font-size:.85rem}
+nav a{margin-right:1rem}article{padding:1rem 0;border-top:1px solid var(--line)}article.quiet h2{color:var(--mute);font-weight:500}
+ul{margin:.5rem 0 0;padding-left:1.25rem}li{margin:.2rem 0}code{background:var(--code);padding:.05rem .3rem;border-radius:3px;font-size:.9em}
+pre{white-space:pre-wrap;word-break:break-word;background:var(--code);padding:.5rem .75rem;border-radius:4px;font-size:.8rem}details{margin:.25rem 0}summary{cursor:pointer;color:var(--mute);font-size:.85rem}
+li.beta::marker{color:var(--accent)}a{color:var(--accent)}footer{margin-top:2rem;color:var(--mute);font-size:.85rem}`;
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Claude Code wire drift</title>
+<link rel="alternate" type="application/rss+xml" title="Claude Code wire drift" href="feed.xml">
+<link rel="alternate" type="application/feed+json" title="Claude Code wire drift" href="feed.json">
+<style>${style}</style></head><body><main>
+<h1>Claude Code wire drift</h1>
+<p class="lede">Every change to what Claude Code sends on the wire — beta flags, headers, tools, the system prompt — as <a href="${REPO}">dario</a>'s template watcher observed it. The watcher captures a live Claude Code install every 30 minutes and re-bakes dario's bundled template when the shape moves; this page is that history, rebuilt from git on every publish. ${entries.length} entries, ${wire} wire changes${first ? `, since ${esc(new Date(first.date).toISOString().slice(0, 10))}` : ''}.</p>
+<nav><a href="feed.xml">RSS</a><a href="feed.json">JSON Feed</a><a href="${REPO}/blob/master/docs/drift-monitor.md">how the watcher works</a><a href="${REPO}/blob/master/${TEMPLATE_PATH}">the template</a></nav>
+${entries.map(entryHtml).join('\n')}
+<footer>Generated by <code>scripts/drift-feed.mjs</code> from the commits that touched <code>${TEMPLATE_PATH}</code>. A "nothing changed on the wire" line is a Claude Code release the watcher checked and found identical on the wire.${site ? ` Canonical: <a href="${esc(site)}">${esc(site)}</a>.` : ''}</footer>
+</main></body></html>
+`;
+}
+
+export function renderRss(entries, site) {
+  const base = site ? site.replace(/\/$/, '') : `${REPO}/tree/master/docs/drift-feed`;
+  const item = (e) => `<item>
+<title>${esc(entryTitle(e))}</title>
+<link>${esc(base)}/#${esc(e.sha.slice(0, 10))}</link>
+<guid isPermaLink="false">${esc(entryId(e))}</guid>
+<pubDate>${new Date(e.date).toUTCString()}</pubDate>
+<description>${esc(e.changes.length ? e.changes.map((c) => c.text).join('\n') : `Claude Code ${e.version ?? ''} — no wire change observed.`)}</description>
+</item>`;
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel>
+<title>Claude Code wire drift</title>
+<link>${esc(base)}/</link>
+<description>Every change to what Claude Code sends on the wire, as dario's template watcher observed it.</description>
+<lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+${entries.slice(0, 100).map(item).join('\n')}
+</channel></rss>
+`;
+}
+
+export function renderJsonFeed(entries, site) {
+  const base = site ? site.replace(/\/$/, '') : `${REPO}/tree/master/docs/drift-feed`;
+  return JSON.stringify({
+    version: 'https://jsonfeed.org/version/1.1',
+    title: 'Claude Code wire drift',
+    home_page_url: `${base}/`,
+    feed_url: `${base}/feed.json`,
+    description: "Every change to what Claude Code sends on the wire, as dario's template watcher observed it.",
+    items: entries.slice(0, 200).map((e) => ({
+      id: entryId(e),
+      url: `${base}/#${e.sha.slice(0, 10)}`,
+      title: entryTitle(e),
+      date_published: e.date,
+      content_text: e.changes.length ? e.changes.map((c) => c.text).join('\n') : `Claude Code ${e.version ?? ''} — no wire change observed.`,
+      _dario: { version: e.version, previous_version: e.previousVersion, captured: e.captured, wire: e.wire, changes: e.changes, commit: e.sha, pr: e.pr },
+    })),
+  }, null, 2) + '\n';
+}
+
+// ---------------------------------------------------------------------------
+//  CLI
+// ---------------------------------------------------------------------------
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const args = process.argv.slice(2);
+  const arg = (name, dflt) => { const i = args.indexOf(name); return i >= 0 && args[i + 1] ? args[i + 1] : dflt; };
+  const out = arg('--out', 'docs/drift-feed');
+  const site = arg('--site', process.env.DRIFT_FEED_SITE ?? '');
+  const entries = buildEntries();
+  mkdirSync(out, { recursive: true });
+  writeFileSync(join(out, 'index.html'), renderHtml(entries, site));
+  writeFileSync(join(out, 'feed.xml'), renderRss(entries, site));
+  writeFileSync(join(out, 'feed.json'), renderJsonFeed(entries, site));
+  writeFileSync(join(out, '.nojekyll'), '');
+  console.log(`drift feed: ${entries.length} entries (${entries.filter((e) => e.wire).length} wire changes) → ${out}/`);
+}

--- a/test/drift-feed.mjs
+++ b/test/drift-feed.mjs
@@ -1,0 +1,91 @@
+// Unit tests for scripts/drift-feed.mjs — the pure diff behind the Claude Code
+// wire-drift feed. Two template snapshots in, a list of human-readable changes
+// out; the git walk and the renderers are exercised by generating the real
+// feed in CI (drift-feed.yml), not here.
+
+import { diffTemplates, entryTitle, renderRss, renderJsonFeed, renderHtml } from '../scripts/drift-feed.mjs';
+
+let pass = 0, fail = 0;
+const check = (label, cond, detail) => {
+  if (cond) { console.log(`  ✅ ${label}`); pass++; }
+  else { console.log(`  ❌ ${label}${detail !== undefined ? ' :: ' + String(detail).slice(0, 300) : ''}`); fail++; }
+};
+const header = (l) => console.log(`\n=== ${l} ===`);
+
+const base = {
+  _version: '2.1.268', _captured: '2026-09-10T00:00:00Z',
+  anthropic_beta: 'claude-code-20250219,interleaved-thinking-2025-05-14',
+  tool_names: ['Bash', 'Read'],
+  tools: [{ name: 'Bash', input_schema: { properties: { command: {} } } }, { name: 'Read', input_schema: {} }],
+  header_values: { 'user-agent': 'claude-cli/2.1.268 (external, sdk-cli)', 'x-app': 'cli', 'anthropic-version': '2023-06-01' },
+  header_order: ['accept', 'user-agent', 'x-app'],
+  body_field_order: ['model', 'messages', 'system'],
+  system_prompt: 'You are an interactive agent.\nBe terse.\n',
+  system_prompt_variants: { 'opus-5': 'Opus text.', 'sonnet-5': 'Sonnet text.' },
+  agent_identity: 'You are a Claude agent.',
+};
+const clone = () => JSON.parse(JSON.stringify(base));
+
+header('a release that changed nothing on the wire');
+{
+  const next = clone();
+  next._version = '2.1.269'; next._captured = '2026-09-11T00:00:00Z';
+  next.header_values['user-agent'] = 'claude-cli/2.1.269 (external, sdk-cli)';
+  const d = diffTemplates(base, next);
+  check('version moved, nothing on the wire', d.versionChanged && d.wire === false && d.changes.length === 0, JSON.stringify(d.changes));
+  check('title says so', entryTitle({ ...d, sha: 'abc' }) === 'Claude Code 2.1.269 shipped — nothing changed on the wire');
+  check('the user-agent release number alone is not a header change', !d.changes.some((c) => c.kind === 'header'));
+}
+
+header('a real wire change');
+{
+  const next = clone();
+  next._version = '2.1.270';
+  next.anthropic_beta = 'claude-code-20250219,mid-conversation-tool-changes-2026-07-01';
+  next.tool_names = ['Bash', 'Read', 'Workflow'];
+  next.tools = [{ name: 'Bash', input_schema: { properties: { command: {}, timeout: {} } } }, { name: 'Read', input_schema: {} }, { name: 'Workflow', input_schema: {} }];
+  next.header_values['x-app'] = 'cli-v2';
+  next.header_values['x-new'] = '1';
+  delete next.header_values['anthropic-version'];
+  next.body_field_order = ['model', 'system', 'messages'];
+  next.system_prompt = 'You are an interactive agent.\nBe terse and kind.\n';
+  next.system_prompt_variants = { 'opus-5': 'Opus text, revised.', 'fable': 'Fable text.' };
+  const d = diffTemplates(base, next);
+  const texts = d.changes.map((c) => c.text);
+  check('wire change with every kind represented', d.wire && ['beta', 'tool', 'header', 'body', 'prompt'].every((k) => d.changes.some((c) => c.kind === k)), texts.join(' | '));
+  check('betas added and removed by name', texts.includes('beta flag added: `mid-conversation-tool-changes-2026-07-01`') && texts.includes('beta flag removed: `interleaved-thinking-2025-05-14`'));
+  check('tool added; changed schema counted by name', texts.includes('tool added: `Workflow`') && texts.includes('1 tool schema changed: `Bash`'));
+  check('header value change, addition, removal', texts.some((t) => t.startsWith('header `x-app`: `cli` → `cli-v2`')) && texts.includes('header added: `x-new: 1`') && texts.includes('header removed: `anthropic-version`'));
+  check('body field order', texts.includes('body field order changed: model, system, messages'));
+  const sp = d.changes.find((c) => c.text.startsWith('system prompt changed'));
+  check('system prompt delta with a bracketed excerpt of the changed span', sp && sp.text.includes('+9 chars') && sp.detail.before.includes('«') && sp.detail.after.includes('and kind') && sp.detail.whitespaceOnly === false, JSON.stringify(sp));
+  check('variants: added, removed, changed with delta', texts.includes('system prompt variant added: `fable`') && texts.includes('system prompt variant removed: `sonnet-5`') && texts.some((t) => t.startsWith('system prompt variant `opus-5` changed (+9 chars')));
+  check('title lists the kinds', entryTitle({ ...d, sha: 'x' }) === 'Claude Code 2.1.270: beta flags, tools, headers, body order, system prompt changed on the wire', entryTitle({ ...d, sha: 'x' }));
+}
+
+header('whitespace-only prompt edits are called out');
+{
+  const next = clone();
+  next.system_prompt = base.system_prompt.trimEnd();
+  const d = diffTemplates(base, next);
+  const sp = d.changes.find((c) => c.kind === 'prompt');
+  check('-1 char, whitespace only', d.wire && sp.text.includes('-1 chars') && sp.detail.whitespaceOnly === true, JSON.stringify(sp));
+}
+
+header('first observation and renderers');
+{
+  const d = diffTemplates(null, base);
+  check('the first snapshot is a single first-observation entry, not a wall of "added"', d.first === true && d.versionChanged && d.version === '2.1.268' && d.changes.length === 0 && entryTitle({ ...d, sha: 'x' }) === 'Claude Code 2.1.268 — first template observed', JSON.stringify(d));
+  const entries = [{ ...diffTemplates(base, { ...clone(), _version: '2.1.269', anthropic_beta: base.anthropic_beta + ',x-2026' }), sha: 'deadbeefcafe', date: '2026-09-11T12:00:00Z', subject: 'auto-rebake (#1)', pr: '1' }];
+  const rss = renderRss(entries, 'https://example.test/feed');
+  check('RSS: one item with guid, link anchor, escaped description', rss.includes('<item>') && rss.includes('<guid isPermaLink="false">https://github.com/askalf/dario/commit/deadbeefcafe</guid>') && rss.includes('https://example.test/feed/#deadbeefca') && rss.includes('beta flag added: `x-2026`'), rss.slice(0, 400));
+  const jf = JSON.parse(renderJsonFeed(entries, 'https://example.test/feed'));
+  check('JSON Feed 1.1 with the structured change list under _dario', jf.version === 'https://jsonfeed.org/version/1.1' && jf.items[0]._dario.changes[0].kind === 'beta' && jf.items[0].url === 'https://example.test/feed/#deadbeefca');
+  const html = renderHtml(entries, 'https://example.test/feed');
+  check('HTML: title, feed links, the entry, no raw <script>', html.includes('<title>Claude Code wire drift</title>') && html.includes('href="feed.xml"') && html.includes('id="deadbeefca"') && html.includes('<code>x-2026</code>') && !html.includes('<script'));
+  const evil = [{ ...diffTemplates(base, { ...clone(), _version: '<img src=x onerror=1>', anthropic_beta: base.anthropic_beta + ',<b>' }), sha: 'abc', date: '2026-09-11T12:00:00Z', subject: 's', pr: null }];
+  check('HTML escapes template-sourced text', !renderHtml(evil, '').includes('<img src=x') && renderHtml(evil, '').includes('&lt;img'));
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## The Claude Code wire-drift feed

dario's template watcher already knows, every 30 minutes, whether what Claude Code sends on the wire has moved. This publishes that knowledge: **every change the watcher has ever observed, as a page with RSS and JSON Feed**, rebuilt from git history on every template change.

`https://askalf.github.io/dario/drift-feed/` (live once this merges and the first deploy runs)

`scripts/drift-feed.mjs` walks the commits that touched `src/cc-template-data.json` and diffs consecutive snapshots into the terms a reader cares about: beta flags added/removed by name, tools added/removed and schemas changed by name, header values added/removed/changed, body field order, the system prompt and each variant with its char delta and a bracketed «excerpt» of the changed span (whitespace-only edits called out). Two rules keep it honest: a release number inside a header (`user-agent: claude-cli/2.1.268 → .269`) is a version label, not a wire change; and a release that changed nothing on the wire still gets a line saying so — that is information too.

Today: **120 entries, 62 wire changes, since 2026-04-12.** Sample of what it reads like:

> **Claude Code 2.1.265: beta flags, tools, system prompt changed on the wire** — beta flag added: `mid-conversation-tool-changes-2026-07-01` · 1 tool schema changed: `Bash` · system prompt changed (−1 chars) *(whitespace only)* · …
> **Claude Code 2.1.235: system prompt changed on the wire** — system prompt changed (−51 chars): `…hand off mid-task.⏎«⏎<total_tokens>15000000 tokens left</total_tokens>⏎»` → `…hand off mid-task.⏎«»`

`.github/workflows/drift-feed.yml` builds it (fetch-depth 0) and deploys to GitHub Pages on every master push touching the template or the generator, daily as a backstop, and on demand. Nothing is committed — the feed *is* the history. `actions/configure-pages` with `enablement: true` creates the Pages site on the first run (a personal token could not: 403 on `POST /pages`); if org policy blocks that too, enabling Pages by hand (Settings → Pages → Source: GitHub Actions) once is the whole setup.

## Evidence

- `test/drift-feed.mjs` 17: a version-only release, a wire change with every kind, the whitespace-only case, the first observation (one line, not a wall of "added"), the three renderers, and HTML escaping of template-sourced text.
- Generated locally from this checkout and rendered in a fresh headless Chrome: light/dark, quiet version entries dimmed, wire changes with their change lists and expandable excerpts.
- No `src/` change; nothing releases. New actions in tag form per CLAUDE.md (Dependabot pins them Monday).

## Trade-offs

- The excerpt shows the *first* changed span only; a prompt edit in two places shows one. The diff link goes to the rebake PR for the rest.
- `_captured` on a version-label refresh is the previous bake's stamp; the page hides it there rather than show a stale "captured" time.
- The 2.1.235 entry exposes a capture artefact (`<total_tokens>` injected into the baked prompt that day) — that is what the watcher committed, and the feed reports history as it is.
