### PR TITLE
drift-feed: pin the Pages actions to commit SHAs

### DIFF
--- a/.github/workflows/drift-feed.yml
+++ b/.github/workflows/drift-feed.yml
@@ -47,7 +47,7 @@ jobs:
           # The Pages root: nothing lives there yet but this feed.
           echo '<!doctype html><meta charset="utf-8"><meta http-equiv="refresh" content="0; url=drift-feed/"><title>dario</title><a href="drift-feed/">Claude Code wire drift</a>' > dist-feed/index.html
           touch dist-feed/.nojekyll
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: dist-feed
 
@@ -66,8 +66,8 @@ jobs:
     steps:
       # Creates the Pages site on first run (source: GitHub Actions) — the
       # workflow token can, a personal token could not.
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
         with:
           enablement: true
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
The first drift-feed deploy (run 34667205982) failed at job setup: the org policy refuses tag-form actions at run time — "all actions must be pinned to a full-length commit SHA" — so the CLAUDE.md note about tag form on first commit does not survive the policy check. Pinned `upload-pages-artifact@v4`, `configure-pages@v5` and `deploy-pages@v4` to their tag commits. CI-only; no release.