### PR TITLE
Web search on the ChatGPT plan for Anthropic-shape clients (v6.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ checklist.
 
 ## [Unreleased]
 
+## [6.4.0] - 2026-09-12
+
+### Added
+
+- **Web search on the ChatGPT plan for Anthropic-shape clients.** A `/v1/messages` request that
+  declares Anthropic's hosted `web_search_20260209` (or `_20250305`) tool used to lose it on the codex
+  leg — the translator skipped every tool without an `input_schema`. It now becomes the backend's own
+  hosted `web_search` tool (`allowed_domains` → `filters.allowed_domains`, `user_location` carried;
+  `blocked_domains` and `max_uses` have no equivalent and are dropped), and the request asks for
+  `web_search_call.action.sources`. On the way back a `web_search_call` item becomes a
+  `server_tool_use` block (`{query}` for a search, `{url}` for an opened page) followed by a
+  `web_search_tool_result` block listing the searched pages, and each `url_citation` annotation
+  becomes a `citations_delta` (`web_search_result_location`, cited text cut from the streamed text)
+  on the text block — streamed, and folded the same way into the buffered message. Probed and then
+  verified live on the ChatGPT backend (2026-09-12): `include: web_search_call.action.sources` is
+  honoured, `search` / `open_page` actions, `url_citation` annotations. Codex accepts `include` now
+  (`CODEX_SUPPORTED_FIELDS`). The Claude pool is unchanged: the CC template presents Claude Code's
+  own client-side `WebSearch`, so a hosted server tool does not reach Anthropic there.
+- `test/codex-web-search-wiring.mjs` (12: a real `startProxy` and a codex stub speaking the probed
+  shapes — streamed blocks, indices, the citation's span, the folded message) plus the translator
+  tests for the tool mapping and the stream mapping (search with sources, open_page, no sources).
+
 ## [6.3.0] - 2026-09-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,15 @@ checklist.
   on the text block — streamed, and folded the same way into the buffered message. Probed and then
   verified live on the ChatGPT backend (2026-09-12): `include: web_search_call.action.sources` is
   honoured, `search` / `open_page` actions, `url_citation` annotations. Codex accepts `include` now
-  (`CODEX_SUPPORTED_FIELDS`). The Claude pool is unchanged: the CC template presents Claude Code's
-  own client-side `WebSearch`, so a hosted server tool does not reach Anthropic there.
-- `test/codex-web-search-wiring.mjs` (12: a real `startProxy` and a codex stub speaking the probed
-  shapes — streamed blocks, indices, the citation's span, the folded message) plus the translator
-  tests for the tool mapping and the stream mapping (search with sources, open_page, no sources).
+  (`CODEX_SUPPORTED_FIELDS`). Forcing the search (`tool_choice: {type: "tool", name: "web_search"}`)
+  travels as the backend's hosted-tool choice `{type: "web_search"}` — the flattened function form
+  names a function the request never declared and the backend 400s it. The Claude pool is unchanged:
+  the CC template presents Claude Code's own client-side `WebSearch`, so a hosted server tool does not
+  reach Anthropic there.
+- `test/codex-web-search-wiring.mjs` (13: a real `startProxy` and a codex stub speaking the probed
+  shapes — streamed blocks, indices, the citation's span, the folded message, the forced choice) plus
+  the translator tests for the tool mapping, the forced choice and the stream mapping (search with
+  sources, open_page, no sources).
 
 ## [6.3.0] - 2026-09-12
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ The tool doesn't know. The backend doesn't know. dario is the seam.
 
 A ChatGPT Plus or Pro plan is served on **all three** of dario's endpoints: any client that speaks `/v1/chat/completions` or `/v1/responses` can use it (Codex CLI, the OpenAI SDKs, the Agents SDK, your scripts), and so can any client that speaks `/v1/messages` (Claude Code, the Anthropic SDKs, agent runtimes). The harness never needs to know which subscription is behind it — and the symmetry holds: Codex CLI runs on a Claude plan the same way.
 
+An Anthropic-shape client that declares Anthropic's hosted `web_search_20260209` tool gets **real web search on the ChatGPT plan** (since 6.4): the plan's own search runs, and the client sees Anthropic's own blocks — `server_tool_use` with the query, `web_search_tool_result` listing the pages searched, the answer with `web_search_result_location` citations. `allowed_domains` and `user_location` carry over; `blocked_domains` and `max_uses` do not.
+
 ```bash
 dario add altman            # prints an authorize URL; paste the redirect URL back
 dario codex list

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ The tool doesn't know. The backend doesn't know. dario is the seam.
 
 A ChatGPT Plus or Pro plan is served on **all three** of dario's endpoints: any client that speaks `/v1/chat/completions` or `/v1/responses` can use it (Codex CLI, the OpenAI SDKs, the Agents SDK, your scripts), and so can any client that speaks `/v1/messages` (Claude Code, the Anthropic SDKs, agent runtimes). The harness never needs to know which subscription is behind it — and the symmetry holds: Codex CLI runs on a Claude plan the same way.
 
-An Anthropic-shape client that declares Anthropic's hosted `web_search_20260209` tool gets **real web search on the ChatGPT plan** (since 6.4): the plan's own search runs, and the client sees Anthropic's own blocks — `server_tool_use` with the query, `web_search_tool_result` listing the pages searched, the answer with `web_search_result_location` citations. `allowed_domains` and `user_location` carry over; `blocked_domains` and `max_uses` do not.
+An Anthropic-shape client that declares Anthropic's hosted `web_search_20260209` tool gets **real web search on the ChatGPT plan** (since 6.4): the plan's own search runs, and the client sees Anthropic's own blocks — `server_tool_use` with the query, `web_search_tool_result` listing the pages searched, the answer with `web_search_result_location` citations. `allowed_domains` and `user_location` carry over, and so does forcing the search with `tool_choice`; `blocked_domains` and `max_uses` do not.
 
 ```bash
 dario add altman            # prints an authorize URL; paste the redirect URL back

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "6.3.0",
+      "version": "6.4.0",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "description": "Use your Claude and ChatGPT subscriptions in Cursor, Cline, Aider, Claude Code and the Agent SDK — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint: either plan answers either wire shape, with automatic failover when one hits its limit.",
   "type": "module",
   "bin": {

--- a/src/anthropic-responses-translate.ts
+++ b/src/anthropic-responses-translate.ts
@@ -262,6 +262,20 @@ export interface ResponsesFunctionTool {
   strict?: boolean | null;
 }
 
+/**
+ * The Responses hosted web-search tool (v6.4). `filters.allowed_domains` and
+ * `user_location` are the two Anthropic web-search options it can carry;
+ * `blocked_domains` and `max_uses` have no equivalent and are dropped.
+ */
+export interface ResponsesWebSearchTool {
+  type: 'web_search';
+  filters?: { allowed_domains?: string[] };
+  user_location?: { type: 'approximate'; city?: string; region?: string; country?: string; timezone?: string };
+  search_context_size?: 'low' | 'medium' | 'high';
+}
+
+export type ResponsesTool = ResponsesFunctionTool | ResponsesWebSearchTool;
+
 export type ResponsesToolChoice =
   | 'auto'
   | 'none'
@@ -284,7 +298,9 @@ export interface ResponsesRequest {
   model: string;
   input: ResponsesInputItem[];
   instructions?: string;
-  tools?: ResponsesFunctionTool[];
+  tools?: ResponsesTool[];
+  /** `web_search_call.action.sources` — the searched URLs, which the Anthropic result block needs. */
+  include?: string[];
   tool_choice?: ResponsesToolChoice;
   parallel_tool_calls?: boolean;
   reasoning?: ResponsesReasoningConfig;
@@ -354,10 +370,31 @@ export interface ResponsesReasoningItem {
   status?: string;
 }
 
+/**
+ * A hosted web-search step as the backend reports it. `action.type` is
+ * `search` (with `query` and, when `include: web_search_call.action.sources`
+ * was asked for, `sources`), `open_page` (`url`) or `find_in_page`
+ * (`url`, `pattern`) — probed 2026-09-12 on the ChatGPT backend.
+ */
+export interface ResponsesWebSearchCallItem {
+  type: 'web_search_call';
+  id?: string;
+  status?: string;
+  action?: {
+    type?: string;
+    query?: string;
+    queries?: string[];
+    url?: string;
+    pattern?: string;
+    sources?: Array<{ type?: string; url?: string }>;
+  };
+}
+
 export type ResponsesOutputItem =
   | ResponsesMessageItem
   | ResponsesResponseFunctionCall
   | ResponsesReasoningItem
+  | ResponsesWebSearchCallItem
   | { type: string; [key: string]: unknown };
 
 export interface ResponsesUsage {
@@ -692,9 +729,28 @@ export function anthropicToResponsesRequest(
   if (instructions.length > 0) out.instructions = instructions;
 
   if (Array.isArray(body.tools)) {
-    const tools: ResponsesFunctionTool[] = [];
+    const tools: ResponsesTool[] = [];
+    let webSearch = false;
     for (const tool of body.tools) {
       if (!tool || typeof tool.name !== 'string') continue;
+      // Anthropic's hosted web search → the backend's hosted web search. The
+      // two options both sides speak travel; the rest is dropped. Asking for
+      // `action.sources` is what lets the result block name the pages it
+      // searched rather than come back empty.
+      const t = tool as unknown as { type?: string; allowed_domains?: unknown; user_location?: Record<string, unknown> };
+      if (typeof t.type === 'string' && t.type.startsWith('web_search') && !webSearch) {
+        webSearch = true;
+        const ws: ResponsesWebSearchTool = { type: 'web_search' };
+        if (Array.isArray(t.allowed_domains) && t.allowed_domains.length > 0) ws.filters = { allowed_domains: t.allowed_domains.filter((d): d is string => typeof d === 'string') };
+        const loc = t.user_location;
+        if (loc && typeof loc === 'object') {
+          const l: ResponsesWebSearchTool['user_location'] = { type: 'approximate' };
+          for (const k of ['city', 'region', 'country', 'timezone'] as const) if (typeof loc[k] === 'string') l[k] = loc[k] as string;
+          ws.user_location = l;
+        }
+        tools.push(ws);
+        continue;
+      }
       if (!tool.input_schema || typeof tool.input_schema !== 'object') continue;
       const fn: ResponsesFunctionTool = {
         type: 'function',
@@ -705,6 +761,7 @@ export function anthropicToResponsesRequest(
       tools.push(fn);
     }
     if (tools.length > 0) out.tools = tools;
+    if (webSearch) out.include = ['web_search_call.action.sources'];
   }
 
   const toolChoice = translateToolChoice(body.tool_choice);
@@ -915,7 +972,9 @@ export type ResponsesAnthropicStreamEvent =
       content_block:
         | { type: 'text'; text: string }
         | { type: 'thinking'; thinking: string }
-        | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> };
+        | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
+        | { type: 'server_tool_use'; id: string; name: 'web_search'; input: Record<string, unknown> }
+        | { type: 'web_search_tool_result'; tool_use_id: string; content: AnthropicWebSearchResult[] };
     }
   | {
       type: 'content_block_delta';
@@ -923,7 +982,8 @@ export type ResponsesAnthropicStreamEvent =
       delta:
         | { type: 'text_delta'; text: string }
         | { type: 'thinking_delta'; thinking: string }
-        | { type: 'input_json_delta'; partial_json: string };
+        | { type: 'input_json_delta'; partial_json: string }
+        | { type: 'citations_delta'; citation: AnthropicWebSearchCitation };
     }
   | { type: 'content_block_stop'; index: number }
   | {
@@ -937,6 +997,24 @@ export type ResponsesAnthropicStreamEvent =
       };
     }
   | { type: 'message_stop' };
+
+/** One searched page, as Anthropic's `web_search_tool_result` lists them. */
+export interface AnthropicWebSearchResult {
+  type: 'web_search_result';
+  url: string;
+  title: string;
+  encrypted_content: string;
+  page_age: string | null;
+}
+
+/** A citation on a text block, as Anthropic's `citations_delta` carries it. */
+export interface AnthropicWebSearchCitation {
+  type: 'web_search_result_location';
+  url: string;
+  title: string;
+  cited_text: string;
+  encrypted_index: string;
+}
 
 /**
  * One parsed Responses SSE event — a typed superset of the fields this
@@ -957,6 +1035,8 @@ export interface ResponsesStreamEvent {
   summary_index?: number;
   /** Text / argument / reasoning fragment on `*.delta` events. */
   delta?: string;
+  /** `output_text.annotation.added`: a url_citation over the item's text. */
+  annotation?: { type?: string; url?: string; title?: string; start_index?: number; end_index?: number };
   /** error event fields. */
   code?: string | null;
   message?: string;
@@ -1019,11 +1099,15 @@ export function responsesStreamToAnthropicSSE(
   let model = options.requestModel;
   let messageId = 'msg_responses_translate';
   let nextIndex = 0;
-  let open: { kind: 'text' | 'thinking' | 'tool'; index: number; outputIndex: number } | null = null;
+  let open: { kind: 'text' | 'thinking' | 'tool' | 'search'; index: number; outputIndex: number } | null = null;
   /** Responses `output_index` → the Anthropic block it maps to. */
-  const blockByOutputIndex = new Map<number, { kind: 'text' | 'thinking' | 'tool'; index: number }>();
+  const blockByOutputIndex = new Map<number, { kind: 'text' | 'thinking' | 'tool' | 'search'; index: number }>();
   let sawToolCall = false;
   let syntheticToolSeq = 0;
+  /** Text streamed per message item, so a url_citation's indices can be turned into cited_text. */
+  const textByOutputIndex = new Map<number, string>();
+  /** server_tool_use ids per web_search_call output index, for the result block. */
+  const searchIdByOutputIndex = new Map<number, string>();
 
   function ensureStarted(
     event: ResponsesStreamEvent | null,
@@ -1073,6 +1157,47 @@ export function responsesStreamToAnthropicSSE(
       content_block: { type: 'tool_use', id, name: strOr(fc.name), input: {} },
     });
     return index;
+  }
+
+  /**
+   * A hosted web-search step: a `server_tool_use` block opened at
+   * output_item.added, its input (query or url) written at output_item.done
+   * when the backend reveals the action, then a `web_search_tool_result`
+   * block listing the pages the step touched — the searched sources when the
+   * request asked for them, the opened page otherwise.
+   */
+  function openSearchBlock(item: ResponsesOutputItem | undefined, outputIndex: number, events: ResponsesAnthropicStreamEvent[]): number {
+    const index = nextIndex++;
+    open = { kind: 'search', index, outputIndex };
+    blockByOutputIndex.set(outputIndex, { kind: 'search', index });
+    const id = strOr((item as { id?: unknown } | undefined)?.id) || `srvtoolu_responses_${syntheticToolSeq++}`;
+    searchIdByOutputIndex.set(outputIndex, id);
+    events.push({ type: 'content_block_start', index, content_block: { type: 'server_tool_use', id, name: 'web_search', input: {} } });
+    return index;
+  }
+
+  function finishSearchBlock(item: ResponsesOutputItem | undefined, outputIndex: number, events: ResponsesAnthropicStreamEvent[]): void {
+    const ws = (item ?? {}) as ResponsesWebSearchCallItem;
+    const action = ws.action ?? {};
+    const input: Record<string, unknown> = action.type === 'search' || action.query
+      ? { query: strOr(action.query) || (Array.isArray(action.queries) ? strOr(action.queries[0]) : '') }
+      : action.url ? { url: strOr(action.url), ...(action.pattern ? { pattern: strOr(action.pattern) } : {}) } : {};
+    const blk = blockByOutputIndex.get(outputIndex);
+    if (blk && blk.kind === 'search') {
+      events.push({ type: 'content_block_delta', index: blk.index, delta: { type: 'input_json_delta', partial_json: JSON.stringify(input) } });
+    }
+    closeOpenBlock(events);
+    const results: AnthropicWebSearchResult[] = [];
+    const seen = new Set<string>();
+    const urls = Array.isArray(action.sources) ? action.sources.map((s) => strOr(s?.url)).filter(Boolean) : action.url ? [strOr(action.url)] : [];
+    for (const url of urls) {
+      if (seen.has(url)) continue;
+      seen.add(url);
+      results.push({ type: 'web_search_result', url, title: '', encrypted_content: '', page_age: null });
+    }
+    const index = nextIndex++;
+    events.push({ type: 'content_block_start', index, content_block: { type: 'web_search_tool_result', tool_use_id: searchIdByOutputIndex.get(outputIndex) ?? '', content: results } });
+    events.push({ type: 'content_block_stop', index });
   }
 
   function openThinkingBlock(outputIndex: number, events: ResponsesAnthropicStreamEvent[]): number {
@@ -1189,16 +1314,37 @@ export function responsesStreamToAnthropicSSE(
               : undefined;
           if (itemType === 'function_call') openToolBlock(event.item, outputIndex, events);
           else if (itemType === 'reasoning') openThinkingBlock(outputIndex, events);
+          else if (itemType === 'web_search_call') openSearchBlock(event.item, outputIndex, events);
           // message → nothing; the text block opens on the first delta.
           break;
         }
         case 'response.output_text.delta': {
           if (typeof event.delta === 'string' && event.delta.length > 0) {
-            const index = ensureTextBlock(numOr(event.output_index, 0), events);
+            const oi = numOr(event.output_index, 0);
+            const index = ensureTextBlock(oi, events);
+            textByOutputIndex.set(oi, (textByOutputIndex.get(oi) ?? '') + event.delta);
             events.push({
               type: 'content_block_delta',
               index,
               delta: { type: 'text_delta', text: event.delta },
+            });
+          }
+          break;
+        }
+        case 'response.output_text.annotation.added': {
+          // A url_citation over the message text → a citation on the text
+          // block, with the cited span cut from what has streamed so far.
+          const a = event.annotation;
+          if (a && a.type === 'url_citation' && typeof a.url === 'string') {
+            const oi = numOr(event.output_index, 0);
+            const index = ensureTextBlock(oi, events);
+            const text = textByOutputIndex.get(oi) ?? '';
+            const from = numOr(a.start_index, 0);
+            const to = numOr(a.end_index, from);
+            events.push({
+              type: 'content_block_delta',
+              index,
+              delta: { type: 'citations_delta', citation: { type: 'web_search_result_location', url: a.url, title: strOr(a.title), cited_text: text.slice(Math.max(0, from), Math.max(from, to)), encrypted_index: '' } },
             });
           }
           break;
@@ -1228,6 +1374,8 @@ export function responsesStreamToAnthropicSSE(
         }
         case 'response.output_item.done': {
           const outputIndex = numOr(event.output_index, 0);
+          const itemType = event.item && typeof event.item === 'object' ? (event.item as { type?: unknown }).type : undefined;
+          if (itemType === 'web_search_call') { finishSearchBlock(event.item, outputIndex, events); break; }
           if (open && open.outputIndex === outputIndex) closeOpenBlock(events);
           break;
         }
@@ -1333,13 +1481,14 @@ export function createAnthropicMessageAssembler(): {
           msg = { ...e.message, content: [] } as AnthropicResponseWithThinking;
         } else if (e.type === 'content_block_start') {
           blocks[e.index] = { ...(e.content_block as Record<string, unknown>) };
-          if (e.content_block.type === 'tool_use') partialJson.set(e.index, '');
+          if (e.content_block.type === 'tool_use' || e.content_block.type === 'server_tool_use') partialJson.set(e.index, '');
         } else if (e.type === 'content_block_delta') {
           const b = blocks[e.index] ?? (blocks[e.index] = {});
           const d = e.delta;
           if (d.type === 'text_delta') b.text = String(b.text ?? '') + d.text;
           else if (d.type === 'thinking_delta') b.thinking = String(b.thinking ?? '') + d.thinking;
           else if (d.type === 'input_json_delta') partialJson.set(e.index, (partialJson.get(e.index) ?? '') + d.partial_json);
+          else if (d.type === 'citations_delta') (b.citations = (Array.isArray(b.citations) ? b.citations : []) as unknown[]).push(d.citation);
         } else if (e.type === 'message_delta') {
           if (msg) {
             msg.stop_reason = e.delta.stop_reason;
@@ -1358,7 +1507,7 @@ export function createAnthropicMessageAssembler(): {
     message(fallbackModel) {
       for (const [i, raw] of partialJson) {
         const b = blocks[i];
-        if (!b || b.type !== 'tool_use') continue;
+        if (!b || (b.type !== 'tool_use' && b.type !== 'server_tool_use')) continue;
         b.input = safeParseArguments(raw);
       }
       const content = blocks.filter(Boolean) as unknown as AnthropicResponseWithThinking['content'];

--- a/src/anthropic-responses-translate.ts
+++ b/src/anthropic-responses-translate.ts
@@ -280,7 +280,9 @@ export type ResponsesToolChoice =
   | 'auto'
   | 'none'
   | 'required'
-  | { type: 'function'; name: string };
+  | { type: 'function'; name: string }
+  /** Force the hosted web search (the backend accepts `web_search` here, not a function name). */
+  | { type: 'web_search' };
 
 export interface ResponsesReasoningConfig {
   /**
@@ -627,6 +629,7 @@ function translateAssistantBlocks(blocks: AnthropicContentBlock[]): ResponsesInp
 
 function translateToolChoice(
   choice: AnthropicToolChoice | undefined,
+  webSearchName?: string,
 ): ResponsesToolChoice | undefined {
   if (!choice || typeof choice !== 'object') return undefined;
   switch (choice.type) {
@@ -637,7 +640,11 @@ function translateToolChoice(
     case 'any':
       return 'required';
     case 'tool':
-      // Responses forced form is FLATTENED: {type:'function', name}.
+      // Responses forced form is FLATTENED: {type:'function', name}. Forcing
+      // the hosted web search is its own shape — `{type:'function', name:
+      // 'web_search'}` names a function the request never declared and the
+      // backend 400s ("Tool choice 'function' not found in 'tools'").
+      if (typeof choice.name === 'string' && choice.name === webSearchName) return { type: 'web_search' };
       return typeof choice.name === 'string'
         ? { type: 'function', name: choice.name }
         : 'required';
@@ -728,6 +735,9 @@ export function anthropicToResponsesRequest(
   const instructions = flattenSystem(body.system);
   if (instructions.length > 0) out.instructions = instructions;
 
+  // The client's name for the hosted web search, once one is declared, so a
+  // forced tool_choice on it translates to the hosted-tool choice.
+  let webSearchName: string | undefined;
   if (Array.isArray(body.tools)) {
     const tools: ResponsesTool[] = [];
     let webSearch = false;
@@ -740,6 +750,7 @@ export function anthropicToResponsesRequest(
       const t = tool as unknown as { type?: string; allowed_domains?: unknown; user_location?: Record<string, unknown> };
       if (typeof t.type === 'string' && t.type.startsWith('web_search') && !webSearch) {
         webSearch = true;
+        webSearchName = tool.name;
         const ws: ResponsesWebSearchTool = { type: 'web_search' };
         if (Array.isArray(t.allowed_domains) && t.allowed_domains.length > 0) ws.filters = { allowed_domains: t.allowed_domains.filter((d): d is string => typeof d === 'string') };
         const loc = t.user_location;
@@ -764,7 +775,7 @@ export function anthropicToResponsesRequest(
     if (webSearch) out.include = ['web_search_call.action.sources'];
   }
 
-  const toolChoice = translateToolChoice(body.tool_choice);
+  const toolChoice = translateToolChoice(body.tool_choice, webSearchName);
   if (toolChoice !== undefined && out.tools) out.tool_choice = toolChoice;
   if (body.tool_choice?.disable_parallel_tool_use === true && out.tools) {
     out.parallel_tool_calls = false;

--- a/src/codex-backend.ts
+++ b/src/codex-backend.ts
@@ -870,6 +870,9 @@ export function createResponsesTranslator(model: string) {
 export const CODEX_SUPPORTED_FIELDS: readonly string[] = [
   'model', 'input', 'stream', 'store', 'instructions',
   'tools', 'tool_choice', 'parallel_tool_calls', 'reasoning',
+  // `web_search_call.action.sources` (v6.4): accepted by the backend, probed
+  // 2026-09-12 — the searched URLs the Anthropic result block lists.
+  'include',
   // Sent by the Codex CLI on every request (codex-rs ResponsesApiRequest), so
   // accepted by construction; see codexPromptCacheKey.
   'prompt_cache_key',

--- a/test/anthropic-responses-stream.test.mjs
+++ b/test/anthropic-responses-stream.test.mjs
@@ -372,3 +372,58 @@ test('createResponsesSSEParser.flush parses a trailing record with no terminatin
   assert.equal(evs.length, 1);
   assert.equal(evs[0].type, 'response.completed');
 });
+
+// ─────────────────────────────────────────────────────────────────────
+// Hosted web search (v6.4): web_search_call items → server_tool_use +
+// web_search_tool_result; url_citation annotations → citations_delta.
+// Shapes as probed on the ChatGPT backend on 2026-09-12.
+// ─────────────────────────────────────────────────────────────────────
+
+test('web_search_call (search, with sources) → server_tool_use {query} + web_search_tool_result listing the sources', () => {
+  const out = run([
+    { type: 'response.created', response: { id: 'resp_ws', model: 'gpt-5.6-terra' } },
+    { type: 'response.output_item.added', output_index: 0, item: { id: 'ws_1', type: 'web_search_call', status: 'in_progress' } },
+    { type: 'response.web_search_call.in_progress', output_index: 0, item_id: 'ws_1' },
+    { type: 'response.web_search_call.searching', output_index: 0, item_id: 'ws_1' },
+    { type: 'response.web_search_call.completed', output_index: 0, item_id: 'ws_1' },
+    { type: 'response.output_item.done', output_index: 0, item: { id: 'ws_1', type: 'web_search_call', status: 'completed', action: { type: 'search', query: 'openai newsroom', queries: ['openai newsroom'], sources: [{ type: 'url', url: 'https://openai.com/news/' }, { type: 'url', url: 'https://openai.com/news/research/' }, { type: 'url', url: 'https://openai.com/news/' }] } } },
+    { type: 'response.output_item.added', output_index: 1, item: { id: 'msg_1', type: 'message', role: 'assistant' } },
+    { type: 'response.output_text.delta', output_index: 1, delta: 'OpenAI posted ' },
+    { type: 'response.output_text.delta', output_index: 1, delta: 'a storage story.' },
+    { type: 'response.output_text.annotation.added', output_index: 1, annotation: { type: 'url_citation', url: 'https://openai.com/news/', title: 'OpenAI News', start_index: 14, end_index: 30 } },
+    { type: 'response.output_item.done', output_index: 1, item: { id: 'msg_1', type: 'message' } },
+    { type: 'response.completed', response: { id: 'resp_ws', status: 'completed', usage: { input_tokens: 5, output_tokens: 7 } } },
+  ]);
+  const types = out.map((e) => e.type + (e.content_block ? ':' + e.content_block.type : e.type === 'content_block_delta' ? ':' + e.delta.type : ''));
+  assert.deepEqual(types, [
+    'message_start',
+    'content_block_start:server_tool_use', 'content_block_delta:input_json_delta', 'content_block_stop',
+    'content_block_start:web_search_tool_result', 'content_block_stop',
+    'content_block_start:text', 'content_block_delta:text_delta', 'content_block_delta:text_delta', 'content_block_delta:citations_delta', 'content_block_stop',
+    'message_delta', 'message_stop',
+  ]);
+  assert.deepEqual(out[1].content_block, { type: 'server_tool_use', id: 'ws_1', name: 'web_search', input: {} });
+  assert.equal(out[2].delta.partial_json, '{"query":"openai newsroom"}');
+  const res = out[4].content_block;
+  assert.equal(res.tool_use_id, 'ws_1');
+  assert.deepEqual(res.content.map((r) => r.url), ['https://openai.com/news/', 'https://openai.com/news/research/'], 'sources listed once each');
+  assert.equal(res.content[0].type, 'web_search_result');
+  assert.deepEqual(out[9].delta.citation, { type: 'web_search_result_location', url: 'https://openai.com/news/', title: 'OpenAI News', cited_text: 'a storage story.', encrypted_index: '' });
+  const starts = out.filter((e) => e.type === 'content_block_start').map((e) => e.index);
+  assert.deepEqual(starts, [0, 1, 2], 'indices strictly increasing, one block open at a time');
+});
+
+test('web_search_call open_page → server_tool_use {url} and a one-entry result; no sources without include', () => {
+  const out = run([
+    { type: 'response.created', response: { id: 'resp_ws2', model: 'gpt-5.6-terra' } },
+    { type: 'response.output_item.added', output_index: 0, item: { id: 'ws_2', type: 'web_search_call' } },
+    { type: 'response.output_item.done', output_index: 0, item: { id: 'ws_2', type: 'web_search_call', status: 'completed', action: { type: 'open_page', url: 'https://openai.com/news/' } } },
+    { type: 'response.output_item.added', output_index: 1, item: { id: 'ws_3', type: 'web_search_call' } },
+    { type: 'response.output_item.done', output_index: 1, item: { id: 'ws_3', type: 'web_search_call', status: 'completed', action: { type: 'search', query: 'q' } } },
+    { type: 'response.completed', response: { id: 'resp_ws2', status: 'completed', usage: { input_tokens: 1, output_tokens: 1 } } },
+  ]);
+  const deltas = out.filter((e) => e.type === 'content_block_delta').map((e) => e.delta.partial_json);
+  assert.deepEqual(deltas, ['{"url":"https://openai.com/news/"}', '{"query":"q"}']);
+  const results = out.filter((e) => e.type === 'content_block_start' && e.content_block.type === 'web_search_tool_result').map((e) => e.content_block.content.map((r) => r.url));
+  assert.deepEqual(results, [['https://openai.com/news/'], []], 'the opened page is the result; a search without sources lists none');
+});

--- a/test/anthropic-responses-translate.test.mjs
+++ b/test/anthropic-responses-translate.test.mjs
@@ -262,6 +262,33 @@ test('tool_choice variants map to Responses spellings (forced form is FLATTENED)
   assert.equal(par.parallel_tool_calls, false);
 });
 
+test('forcing the hosted web search is the hosted-tool choice, not a function selection', () => {
+  // Live (2026-09-11, codex backend): {type:'function', name:'web_search'}
+  // 400s with "Tool choice 'function' not found in 'tools' parameter";
+  // {type:'web_search'} runs the search, alone or alongside function tools.
+  const base = { model: 'm', max_tokens: 1, messages: [{ role: 'user', content: 'x' }] };
+  const alone = anthropicToResponsesRequest(
+    { ...base, tools: [{ type: 'web_search_20260209', name: 'web_search' }], tool_choice: { type: 'tool', name: 'web_search' } },
+    'gpt-5.6-sol',
+  );
+  assert.deepEqual(alone.tool_choice, { type: 'web_search' });
+  const mixed = anthropicToResponsesRequest(
+    { ...base, tools: [{ name: 'f', input_schema: { type: 'object' } }, { type: 'web_search_20260209', name: 'search' }], tool_choice: { type: 'tool', name: 'search' } },
+    'gpt-5.6-sol',
+  );
+  assert.deepEqual(mixed.tool_choice, { type: 'web_search' }, "matched by the client's own name for the tool");
+  const fn = anthropicToResponsesRequest(
+    { ...base, tools: [{ name: 'f', input_schema: { type: 'object' } }, { type: 'web_search_20260209', name: 'web_search' }], tool_choice: { type: 'tool', name: 'f' } },
+    'gpt-5.6-sol',
+  );
+  assert.deepEqual(fn.tool_choice, { type: 'function', name: 'f' }, 'a forced function tool is still the flattened function form');
+  const noSearch = anthropicToResponsesRequest(
+    { ...base, tools: [{ name: 'web_search', input_schema: { type: 'object' } }], tool_choice: { type: 'tool', name: 'web_search' } },
+    'gpt-5.6-sol',
+  );
+  assert.deepEqual(noSearch.tool_choice, { type: 'function', name: 'web_search' }, 'a client FUNCTION that happens to be called web_search is a function');
+});
+
 test('tool_choice is dropped when there are no tools', () => {
   const out = anthropicToResponsesRequest(
     { model: 'm', max_tokens: 1, messages: [{ role: 'user', content: 'x' }], tool_choice: { type: 'any' } },

--- a/test/anthropic-responses-translate.test.mjs
+++ b/test/anthropic-responses-translate.test.mjs
@@ -51,7 +51,7 @@ test('system (string + array) flattens to top-level instructions, cache_control 
   assert.ok(!JSON.stringify(arrOut).includes('cache_control'), 'cache_control must not survive');
 });
 
-test('tools are FLATTENED function tools (not nested under .function); server tools skipped', () => {
+test('tools are FLATTENED function tools (not nested under .function); web search carried as the hosted tool', () => {
   const out = anthropicToResponsesRequest(
     {
       model: 'm',
@@ -68,15 +68,31 @@ test('tools are FLATTENED function tools (not nested under .function); server to
     },
     'gpt-5.6-sol',
   );
-  assert.equal(out.tools.length, 1, 'server tool without input_schema is skipped');
-  assert.deepEqual(out.tools[0], {
+  assert.equal(out.tools.length, 2, 'the web search server tool becomes the hosted web_search tool; the function tool follows');
+  assert.deepEqual(out.tools[0], { type: 'web_search' });
+  assert.deepEqual(out.include, ['web_search_call.action.sources'], 'sources are asked for so the result block can list them');
+  assert.deepEqual(out.tools[1], {
     type: 'function',
     name: 'get_weather',
     description: 'Get current weather',
     parameters: { type: 'object', properties: { city: { type: 'string' } }, required: ['city'] },
   });
   // no `.function` wrapper anywhere
-  assert.ok(!Object.prototype.hasOwnProperty.call(out.tools[0], 'function'));
+  assert.ok(!Object.prototype.hasOwnProperty.call(out.tools[1], 'function'));
+  // an unknown server tool (no input_schema, not web search) is still skipped, and no include is asked for
+  const other = anthropicToResponsesRequest({ model: 'm', max_tokens: 1, messages: [{ role: 'user', content: 'x' }], tools: [{ type: 'code_execution_20260521', name: 'code_execution' }] }, 'gpt-5.6-sol');
+  assert.equal(other.tools, undefined);
+  assert.equal(other.include, undefined);
+});
+
+test('web search options: allowed_domains → filters, user_location → approximate location; the rest dropped', () => {
+  const out = anthropicToResponsesRequest(
+    { model: 'm', max_tokens: 1, messages: [{ role: 'user', content: 'x' }],
+      tools: [{ type: 'web_search_20260209', name: 'web_search', max_uses: 3, allowed_domains: ['openai.com', 'anthropic.com'], blocked_domains: ['x.com'], user_location: { type: 'approximate', city: 'Austin', region: 'TX', country: 'US', timezone: 'America/Chicago' } }] },
+    'gpt-5.6-sol',
+  );
+  assert.deepEqual(out.tools, [{ type: 'web_search', filters: { allowed_domains: ['openai.com', 'anthropic.com'] }, user_location: { type: 'approximate', city: 'Austin', region: 'TX', country: 'US', timezone: 'America/Chicago' } }]);
+  assert.ok(!JSON.stringify(out).includes('blocked_domains') && !JSON.stringify(out).includes('max_uses'));
 });
 
 test('thinking → reasoning:{effort} at documented thresholds, summary:auto by default', () => {

--- a/test/codex-web-search-wiring.mjs
+++ b/test/codex-web-search-wiring.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+// Live-request proof of hosted web search on the codex leg (v6.4): an
+// Anthropic-shape client declares Anthropic's `web_search_20260209` server
+// tool, the request is served by a ChatGPT-subscription model, and the
+// client gets Anthropic's own blocks back — server_tool_use with the query,
+// web_search_tool_result with the searched pages, a text block with
+// web_search_result_location citations — streamed and buffered.
+//
+// Hermetic: temp HOME with one fake codex account, the ChatGPT backend is a
+// local stub speaking the shapes probed on the real backend on 2026-09-12.
+// What is real: the handler, the codex route, both translators, the folded
+// non-streaming body, and every byte the client receives.
+
+import { createServer } from 'node:http';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { freePort } from './helpers/free-port.mjs';
+
+let pass = 0, fail = 0;
+const check = (name, cond, detail) => {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else { console.log(`  FAIL ${name}${detail !== undefined ? ' :: ' + String(detail).slice(0, 500) : ''}`); fail++; }
+};
+const header = (n) => console.log(`\n=== ${n} ===`);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const PROXY_PORT = await freePort();
+const CODEX_PORT = await freePort();
+const BASE = `http://127.0.0.1:${PROXY_PORT}`;
+const SLUG = 'gpt-5.6-terra';
+
+const codexSeen = { bodies: [] };
+const codexStub = createServer((req, res) => {
+  if (req.url.startsWith('/models')) { res.writeHead(200, { 'Content-Type': 'application/json' }); res.end(JSON.stringify({ models: [{ slug: SLUG, visibility: 'list' }] })); return; }
+  if (!req.url.startsWith('/responses')) { res.writeHead(404).end(); return; }
+  const parts = [];
+  req.on('data', (c) => parts.push(c));
+  req.on('end', async () => {
+    const body = JSON.parse(Buffer.concat(parts).toString());
+    codexSeen.bodies.push(body);
+    res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+    let seq = 0;
+    const ev = (type, obj) => res.write(`data: ${JSON.stringify({ type, sequence_number: seq++, ...obj })}\n\n`);
+    ev('response.created', { response: { id: 'resp_ws', status: 'in_progress', model: SLUG, output: [] } });
+    ev('response.output_item.added', { output_index: 0, item: { id: 'ws_1', type: 'web_search_call', status: 'in_progress' } });
+    ev('response.web_search_call.in_progress', { output_index: 0, item_id: 'ws_1' });
+    ev('response.web_search_call.searching', { output_index: 0, item_id: 'ws_1' });
+    await sleep(5);
+    ev('response.web_search_call.completed', { output_index: 0, item_id: 'ws_1' });
+    ev('response.output_item.done', { output_index: 0, item: { id: 'ws_1', type: 'web_search_call', status: 'completed', action: { type: 'search', query: 'openai newsroom', queries: ['openai newsroom'], sources: [{ type: 'url', url: 'https://openai.com/news/' }, { type: 'url', url: 'https://openai.com/news/research/' }] } } });
+    ev('response.output_item.added', { output_index: 1, item: { id: 'msg_1', type: 'message', status: 'in_progress', role: 'assistant', content: [] } });
+    ev('response.content_part.added', { output_index: 1, item_id: 'msg_1', content_index: 0, part: { type: 'output_text', text: '', annotations: [] } });
+    for (const t of ['The latest ', 'post is about ', 'storage.']) { ev('response.output_text.delta', { output_index: 1, item_id: 'msg_1', content_index: 0, delta: t }); await sleep(2); }
+    ev('response.output_text.annotation.added', { output_index: 1, item_id: 'msg_1', content_index: 0, annotation_index: 0, annotation: { type: 'url_citation', url: 'https://openai.com/news/', title: 'OpenAI News', start_index: 11, end_index: 33 } });
+    ev('response.output_text.done', { output_index: 1, item_id: 'msg_1', content_index: 0, text: 'The latest post is about storage.' });
+    ev('response.output_item.done', { output_index: 1, item: { id: 'msg_1', type: 'message', status: 'completed', role: 'assistant', content: [{ type: 'output_text', text: 'The latest post is about storage.', annotations: [] }] } });
+    ev('response.completed', { response: { id: 'resp_ws', status: 'completed', model: SLUG, output: [], usage: { input_tokens: 20, output_tokens: 9, total_tokens: 29, input_tokens_details: { cached_tokens: 0 } } } });
+    res.end();
+  });
+});
+await new Promise((r) => codexStub.listen(CODEX_PORT, '127.0.0.1', r));
+
+const tmpHome = await mkdtemp(join(tmpdir(), 'dario-websearch-'));
+process.env.HOME = tmpHome; process.env.USERPROFILE = tmpHome;
+process.env.DARIO_CODEX_BASE_URL = `http://127.0.0.1:${CODEX_PORT}`;
+process.env.DARIO_IGNORE_CC_CREDENTIALS = '1';
+await mkdir(join(tmpHome, '.dario', 'codex-accounts'), { recursive: true });
+await writeFile(join(tmpHome, '.dario', 'codex-accounts', 'live.json'), JSON.stringify({ alias: 'live', accessToken: 'codex-access-token', refreshToken: 'codex-refresh-token', expiresAt: Date.now() + 6 * 3_600_000 }));
+const { startProxy } = await import('../dist/proxy.js');
+await startProxy({ port: PROXY_PORT, host: '127.0.0.1', verbose: false, noLiveCapture: true, noClaudeAuth: true });
+for (let i = 0; i < 50; i++) { try { await fetch(`${BASE}/health`); break; } catch { await sleep(100); } }
+
+const request = (stream) => ({ model: SLUG, max_tokens: 200, stream, system: 'Cite sources.',
+  messages: [{ role: 'user', content: 'What is new on the OpenAI newsroom?' }],
+  tools: [{ type: 'web_search_20260209', name: 'web_search', allowed_domains: ['openai.com'], max_uses: 2, user_location: { type: 'approximate', country: 'US' } }] });
+const parse = (text) => text.split('\n').filter((l) => l.startsWith('data:')).map((l) => { try { return JSON.parse(l.slice(5)); } catch { return null; } }).filter(Boolean);
+
+header('streamed: Anthropic web search on the ChatGPT plan');
+{
+  const res = await fetch(`${BASE}/v1/messages`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(request(true)) });
+  const events = parse(await res.text());
+  const sent = codexSeen.bodies.at(-1);
+  check('200 stream, one backend request', res.status === 200 && codexSeen.bodies.length === 1, res.status);
+  check('the backend got the hosted tool with allowed_domains as filters and the location; max_uses dropped; sources asked for', JSON.stringify(sent.tools) === JSON.stringify([{ type: 'web_search', filters: { allowed_domains: ['openai.com'] }, user_location: { type: 'approximate', country: 'US' } }]) && JSON.stringify(sent.include) === JSON.stringify(['web_search_call.action.sources']) && !JSON.stringify(sent).includes('max_uses'), JSON.stringify({ tools: sent.tools, include: sent.include }));
+  const blocks = events.filter((e) => e.type === 'content_block_start').map((e) => e.content_block);
+  check('blocks: server_tool_use, web_search_tool_result, text — indices 0,1,2', blocks.map((b) => b.type).join(',') === 'server_tool_use,web_search_tool_result,text' && events.filter((e) => e.type === 'content_block_start').map((e) => e.index).join(',') === '0,1,2', blocks.map((b) => b.type).join(','));
+  check('server_tool_use carries the backend item id and name web_search; its input arrives as one input_json_delta', blocks[0].id === 'ws_1' && blocks[0].name === 'web_search' && events.some((e) => e.type === 'content_block_delta' && e.index === 0 && e.delta.partial_json === '{"query":"openai newsroom"}'));
+  check('web_search_tool_result references it and lists the two searched pages', blocks[1].tool_use_id === 'ws_1' && blocks[1].content.map((r) => r.url).join(',') === 'https://openai.com/news/,https://openai.com/news/research/' && blocks[1].content[0].type === 'web_search_result');
+  const cit = events.find((e) => e.type === 'content_block_delta' && e.delta.type === 'citations_delta');
+  check('the citation lands on the text block with the cited span cut from the streamed text', cit && cit.index === 2 && cit.delta.citation.type === 'web_search_result_location' && cit.delta.citation.url === 'https://openai.com/news/' && cit.delta.citation.cited_text === 'post is about storage.', JSON.stringify(cit));
+  check('one message_delta with end_turn and one message_stop', events.filter((e) => e.type === 'message_delta').length === 1 && events.find((e) => e.type === 'message_delta').delta.stop_reason === 'end_turn' && events.filter((e) => e.type === 'message_stop').length === 1);
+  const opens = []; let bad = false;
+  for (const e of events) { if (e.type === 'content_block_start') { if (opens.length) bad = true; opens.push(e.index); } if (e.type === 'content_block_stop') opens.pop(); }
+  check('one block open at a time', !bad && opens.length === 0);
+}
+
+header('buffered: the folded message carries the same blocks and the citation');
+{
+  const res = await fetch(`${BASE}/v1/messages`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(request(false)) });
+  const j = await res.json();
+  check('200 JSON', res.status === 200 && j.type === 'message', res.status);
+  check('content: server_tool_use (input parsed), web_search_tool_result, text', j.content.map((b) => b.type).join(',') === 'server_tool_use,web_search_tool_result,text' && j.content[0].input.query === 'openai newsroom' && j.content[1].content.length === 2, JSON.stringify(j.content).slice(0, 300));
+  check('text block carries the citation', Array.isArray(j.content[2].citations) && j.content[2].citations[0].url === 'https://openai.com/news/' && j.content[2].text === 'The latest post is about storage.', JSON.stringify(j.content[2]).slice(0, 300));
+  check('stop_reason end_turn, usage from the terminal event', j.stop_reason === 'end_turn' && j.usage.output_tokens === 9);
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+codexStub.close();
+process.exit(fail === 0 ? 0 : 1);

--- a/test/codex-web-search-wiring.mjs
+++ b/test/codex-web-search-wiring.mjs
@@ -105,6 +105,17 @@ header('buffered: the folded message carries the same blocks and the citation');
   check('stop_reason end_turn, usage from the terminal event', j.stop_reason === 'end_turn' && j.usage.output_tokens === 9);
 }
 
+header('forced: tool_choice on the hosted tool reaches the backend as the hosted-tool choice');
+{
+  // Live (2026-09-11): the backend 400s a {type:'function', name:'web_search'}
+  // choice ("Tool choice 'function' not found in 'tools' parameter") and runs
+  // the search on {type:'web_search'} — alone or next to function tools.
+  const body = { ...request(false), tools: [...request(false).tools, { name: 'lookup', description: 'd', input_schema: { type: 'object' } }], tool_choice: { type: 'tool', name: 'web_search' } };
+  const res = await fetch(`${BASE}/v1/messages`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+  const sent = codexSeen.bodies.at(-1);
+  check('200 with the hosted-tool choice on the wire, next to the function tool', res.status === 200 && JSON.stringify(sent.tool_choice) === JSON.stringify({ type: 'web_search' }) && sent.tools.length === 2 && sent.tools[1].type === 'function', JSON.stringify({ status: res.status, tool_choice: sent.tool_choice, tools: sent.tools.map((t) => t.type) }));
+}
+
 console.log(`\n${pass} passed, ${fail} failed`);
 codexStub.close();
 process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## Web search on the ChatGPT plan for Anthropic-shape clients

An Anthropic-shape client (Claude Code, the Anthropic SDKs, agent runtimes) that declares Anthropic's hosted `web_search_20260209` tool used to lose it on the codex leg — the translator skipped every tool without an `input_schema`. Now the plan's own search runs and the client sees **Anthropic's own blocks**:

```
server_tool_use        {"query":"site:openai.com/newsroom OpenAI newsroom"}
web_search_tool_result https://openai.com/news/company-announcements/ | https://openai.com/news/ | …
text                   The most recent OpenAI Newsroom post is "Rapidly scaling online storage…" ([openai.com](…))
                       citations: [{ type: web_search_result_location, url, title, cited_text }]
```

That is the live result through this build on the box (`allowed_domains: ['openai.com']` honoured — every source is openai.com), streamed and buffered.

**Request:** `web_search_*` → the backend's hosted `web_search` (`allowed_domains` → `filters.allowed_domains`, `user_location` carried; `blocked_domains` / `max_uses` have no equivalent, dropped), plus `include: ["web_search_call.action.sources"]` so the result block can list the pages. `include` joins `CODEX_SUPPORTED_FIELDS`.

**Response:** a `web_search_call` item → `server_tool_use` (`{query}` for a `search`, `{url}` for an `open_page`) written when `output_item.done` reveals the action, then a `web_search_tool_result` listing the sources (deduplicated; the opened page for `open_page`; none when the backend sent none). Each `url_citation` annotation → `citations_delta` on the text block, `cited_text` cut from the text streamed so far. The buffered message folds the same way (the assembler now keeps `server_tool_use` input and text-block citations).

Shapes were **probed on the real ChatGPT backend first** (2026-09-12, `dario-midstream-spike/probe-websearch.mjs`): `include` is honoured; actions are `search` (`query`, `queries`, `sources`) and `open_page` (`url`); `response.web_search_call.{in_progress,searching,completed}` are status-only; `response.completed` carries an empty message (the known fold-from-deltas rule).

## Evidence

- `test/anthropic-responses-translate.test.mjs` 20 (tool mapping with options; an unknown server tool still skipped, no `include`).
- `test/anthropic-responses-stream.test.mjs` 14 (search with sources → blocks + citation with the exact span; open_page; a search without sources lists none; one block open at a time, indices increasing).
- `test/codex-web-search-wiring.mjs` 12 — a real `startProxy` and a codex stub speaking the probed shapes: the backend receives the mapped tool + `include`, the client receives the three blocks in order with the citation's span, and the folded message matches.
- Full suite 203/203. Bumped to 6.4.0.

## Not in this PR

- **The Claude pool is unchanged.** The CC template presents Claude Code's client-side `WebSearch`, so a hosted server tool does not reach Anthropic on that path — probed: a `web_search_20260209` request on `claude-sonnet-5` comes back as a client `tool_use`. Making Anthropic's hosted search run on the subscription path is a template question, not a translation one.
- `web_fetch` has no mapping; an `open_page` action is reported under `web_search` (that is what the client declared).
- `encrypted_content` / `encrypted_index` are empty strings — the backend has no equivalent; SDKs accept the shape.
