### PR TITLE
The ledger: what it would have cost on the metered API (v6.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,39 @@ checklist.
 
 ## [Unreleased]
 
+## [6.5.0] - 2026-09-12
+
+### Added
+
+- **The ledger: what it would have cost.** `/analytics` forgot on every restart, so "what has dario
+  saved me" was never answerable past the last few hours. `src/ledger.ts` keeps one row per UTC day,
+  per model, per billing bucket in `~/.dario/ledger.json` (`ledger-<port>.json` off the default port,
+  so a second instance sharing the home does not overwrite it): a request count and the four token
+  buckets, never a price. Rows are priced at read time at the rate in effect on their day, so a pricing
+  correction (#1047, #1048) reprices history instead of freezing the old number in. Only 2xx rows
+  count; traffic metered anyway (an API key upstream, Anthropic's paid `extra_usage`) sits in its own
+  column and is reported as spent, not saved. Writes are debounced and durable (`durableWriteFile`),
+  the shutdown hook flushes, a file that will not parse is moved aside rather than overwritten, days
+  past 730 roll off. `dario usage` opens with the number — with the proxy down it reads the file —
+  `/analytics` carries it as `lifetime`, `GET /analytics/ledger` is the per-day table, the TUI
+  Analytics tab shows it as **API-equivalent**. `dario usage --card[=file.svg]` writes the headline as
+  a 640×320 share card. `--no-ledger` / `DARIO_LEDGER=0` turns it off, `DARIO_LEDGER_PATH` moves it.
+  The test runner pins the path to a temp dir so a suite run never touches the operator's file.
+  [docs/api-equivalent-spend.md](docs/api-equivalent-spend.md).
+- **OpenAI rates for the ChatGPT leg.** A `gpt-*` row used to fall through to the Claude fallback and
+  price a ChatGPT-plan request at Sonnet 4.6's rate. `OPENAI_PRICING` (src/analytics.ts) carries
+  OpenAI's published standard-tier rates for the codex models (gpt-5.5, gpt-5.6-luna/sol/terra,
+  gpt-5.4 family, gpt-5.3-codex, gpt-6-astra), read off developers.openai.com/api/docs/pricing on
+  2026-09-11; unknown `gpt-*` ids take gpt-5.6-terra's rate. `pricingRateFor` also strips an effort
+  suffix (`gpt-5.6-terra:high`) before lookup. Kept apart from `PRICING` so `check-pricing-drift.mjs`
+  keeps diffing the Claude table against Anthropic's page; nothing watches the OpenAI table yet.
+- `test/ledger.mjs` (57: bucket rule, per-day folding, prune, tolerant parse, pricing by day and
+  provider, trailing windows, the text block, the card's escaping, open / debounced flush / reopen /
+  corrupt-file move-aside) and `test/ledger-wiring.mjs` (21: a real `startProxy` with a Claude stub
+  switching claims and a codex stub — `lifetime` on `/analytics`, the file on disk, `/analytics/ledger`,
+  `dario usage` with and without a proxy, `--card`, `--json`, a fresh proxy opening on the same file,
+  `--no-ledger`).
+
 ## [6.4.0] - 2026-09-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 <p><strong>One local endpoint. Every AI tool you own. The subscriptions you already pay for.</strong></p>
 
-<sub><code>npm i -g @askalf/dario</code> · <strong>0</strong> runtime deps · <a href="https://www.npmjs.com/package/@askalf/dario">SLSA-attested</a> every release · nothing phones home · ~35k lines you can read in a weekend · independent, unofficial, third-party (<a href="DISCLAIMER.md">DISCLAIMER.md</a>)</sub>
+<sub><code>npm i -g @askalf/dario</code> · <strong>0</strong> runtime deps · <a href="https://www.npmjs.com/package/@askalf/dario">SLSA-attested</a> every release · nothing phones home · ~36k lines you can read in a weekend · independent, unofficial, third-party (<a href="DISCLAIMER.md">DISCLAIMER.md</a>)</sub>
 
 <sub><a href="#start-in-60-seconds">Start</a> · <a href="#point-your-tools-at-it">Your tools</a> · <a href="#what-it-does-with-a-request">Routing</a> · <a href="#two-plans-one-endpoint">Two plans</a> · <a href="#many-seats-one-endpoint">Pool</a> · <a href="#it-tracks-a-moving-target">Drift</a> · <a href="#trust--transparency">Trust</a> · <a href="#will-my-account-get-suspended">Risk</a> · <a href="#commands">Commands</a> · <a href="#faq">FAQ</a> · <a href="docs/returning.md">Coming back after a while?</a></sub>
 
@@ -373,6 +373,20 @@ Type `dario` with no arguments for a full-screen control panel: live request str
 
 <sub>Both screenshots are rendered from the real TUI against a fixture proxy by <a href="scripts/readme/tui.mjs"><code>scripts/readme/tui.mjs</code></a>, so a layout change shows up here instead of rotting a mock-up. The numbers are illustrative; the pixels are not.</sub>
 
+### What it would have cost
+
+The rolling window forgets on every restart; the **ledger** does not. Since 6.5 dario keeps one small row per day, per model, per billing bucket in `~/.dario/ledger.json` — request counts and the four token buckets, never a price — and prices them at read time from the published API rate cards (Anthropic's, and OpenAI's for the ChatGPT leg), so a pricing correction reprices history instead of freezing the old number in. `dario usage` opens with it, `/analytics` carries it as `lifetime`, the TUI shows it as **API-equivalent**, and it reads from the file when the proxy is down:
+
+```
+  API-equivalent spend (since 2026-09-11, 3 days, 1,515 requests):
+    $413 would have been billed on the metered API — covered by subscriptions
+      Claude       $388   1,204 reqs   (Opus 5 $301 · Sonnet 5 $86.68)
+      ChatGPT    $24.75     311 reqs   (gpt-5.6-terra $24.75)
+    Today $48.20 · Last 7d $413 · Last 30d $413
+```
+
+Only served requests count. Traffic that was metered anyway — an API key upstream, or Anthropic's paid `extra_usage` overage — is kept in its own column and reported as spent, not saved. `dario usage --card` writes the headline as a 640×320 SVG you can drop in a README or a post; `--no-ledger` / `DARIO_LEDGER=0` turns the file off, `DARIO_LEDGER_PATH` moves it, and `GET /analytics/ledger` is the per-day table behind the number. Details: [api-equivalent-spend.md](./docs/api-equivalent-spend.md).
+
 ## It tracks a moving target
 
 Claude Code's request shape changes between releases — new betas, tool renames, per-model thinking configs — usually with no subscriber-facing note. dario doesn't *guess* that shape: it captures it live from your own installed `claude` binary on every startup, diffs it against each upstream release, and replays it faithfully. That's why your subscription routes the same through dario as it does through Claude Code itself: the request that leaves your machine *is* the shape your plan expects. Details: [wire-fidelity.md](./docs/wire-fidelity.md) · [#13](https://github.com/askalf/dario/discussions/13) · [#14](https://github.com/askalf/dario/discussions/14).
@@ -492,7 +506,7 @@ Longer version, with specifics: [#68](https://github.com/askalf/dario/discussion
 | `dario accounts list` / `add` / `remove` / `check <alias>` | Pool management; `check` sends one pinned request per model through the running proxy (admin API on) |
 | `dario backend list` / `add` / `remove` | OpenAI-compatible API-key backends |
 | `dario codex list` / `add` / `remove` | ChatGPT accounts (the long form of `dario add altman`) |
-| `dario usage` · `dario config` · `dario status` | Burn rate for the last hour · effective config, redacted · token health |
+| `dario usage` · `dario config` · `dario status` | Lifetime API-equivalent spend + burn rate for the last hour (`--card` writes the share card) · effective config, redacted · token health |
 | `dario resume` · `dario refresh` · `dario logout` · `dario upgrade` | Clear an overage halt · force a token refresh · delete credentials · safe self-update |
 | `dario mcp` · `dario subagent install` / `remove` / `status` | Reach dario from inside any MCP client, or from inside a Claude Code session, read-only |
 
@@ -503,7 +517,7 @@ Longer version, with specifics: [#68](https://github.com/askalf/dario/discussion
 | `GET /health` · `GET /livez` | Serviceability (503 when not) · liveness. `/health?probe=1` sends one real request |
 | `GET /status` · `GET /accounts` · `GET /analytics` | OAuth detail · per-seat utilization and grant age · per-account / per-model stats and burn rate |
 | `POST /v1/messages/count_tokens` · `POST /v1/complete` | Token counting and the legacy Text Completions shape |
-| `GET /analytics/stream` · `GET /codex` | Live analytics over SSE · ChatGPT-seat status, read without spending or exposing a token |
+| `GET /analytics/stream` · `GET /analytics/ledger` · `GET /codex` | Live analytics over SSE · the ledger's per-day table · ChatGPT-seat status, read without spending or exposing a token |
 | `/admin/*` | Provisioning, `GET /admin/accounts`, `POST /admin/resume`; only with `DARIO_ADMIN=1` ([admin API](./docs/admin-api.md)) |
 
 Flags: [commands.md](./docs/commands.md), plus `dario --help` for the ones it doesn't list yet (`--effort`, `--max-tokens`, `--model-alias`, `--fast-model`, session rotation, concurrency caps, the pacing knobs behind `--stealth`) · env vars grouped by task, for Docker / k8s / systemd: [configuration.md](./docs/configuration.md) · SDK examples: [usage.md](./docs/usage.md).

--- a/docs/api-equivalent-spend.md
+++ b/docs/api-equivalent-spend.md
@@ -1,0 +1,116 @@
+# API-equivalent spend — the ledger
+
+What the traffic dario has served would have cost on the metered API, kept
+across restarts. `dario usage` opens with it; `/analytics` carries it as
+`lifetime`; the TUI's Analytics tab shows it as **API-equivalent**.
+
+## Why a file
+
+`/analytics` is a rolling in-memory window: 10k records, gone on restart. It
+answers "what is this costing me right now" and could never answer the
+question a subscription user actually has — what has this saved me since I
+set it up. The ledger is the persistent half. It is deliberately small: one
+row per UTC day, per model, per billing bucket, holding a request count and
+the four token buckets (input, output, cache read, cache write). Nothing else.
+
+It never stores a price. Rows are priced when read, at the rate in effect on
+the row's day, from the same tables the rolling window uses (`PRICING` for
+Claude, `OPENAI_PRICING` for the ChatGPT leg, both in `src/analytics.ts`).
+Pricing has been wrong twice in this repo (#1047, #1048); a stored dollar
+figure would have frozen the wrong number in, a stored token count gets
+repriced the moment the table is fixed.
+
+## What counts
+
+Only responses with a 2xx status. A 429 carries no tokens and a 5xx bills
+nothing.
+
+Two columns per row:
+
+- **covered** — served against a subscription: every Anthropic subscription
+  claim (`five_hour`, `seven_day`, their `_fallback` and `_overage_included`
+  forms), the ChatGPT leg, and a 2xx that carried no claim at all (a stream
+  cut before the headers were read, api-key mode without the header). The
+  API-equivalent cost of this column is the headline — the invoice that never
+  arrived.
+- **metered** — billed per token anyway: an API key upstream (`api`) or
+  Anthropic's paid overage (`overage` → `extra_usage`). That money was spent.
+  It is reported on its own line ("Paid per token on top") and never counted
+  as saved.
+
+A mid-stream continuation (6.1) is two upstream requests and records as two
+rows, one per provider, each with the tokens that leg actually consumed.
+
+## Where it lives
+
+`~/.dario/ledger.json` for a proxy on the default port; `ledger-<port>.json`
+for any other, so two instances sharing a home (a live-test rig next to
+production) do not overwrite each other. `DARIO_LEDGER_PATH=<file>` moves it;
+`--no-ledger` / `DARIO_LEDGER=0` turns it off, after which `/analytics`
+reports `lifetime: null`, `/analytics/ledger` is a 404 and `dario usage` says
+so.
+
+Writes are debounced (3 s after the last record) and durable — temp file,
+fsync, rename, directory fsync, the same path the credential store uses
+(#790). The shutdown hook flushes what the debounce still holds, so a
+`docker rm -f` loses at most the last few seconds. A file that will not parse
+is moved aside as `ledger.json.corrupt-<ts>` and the ledger starts fresh; it
+is never overwritten in place. Days past 730 roll off the front.
+
+The test suite pins `DARIO_LEDGER_PATH` to a temp directory, so a suite run
+does not add stub traffic to the operator's file.
+
+## Reading it
+
+```
+$ dario usage
+  API-equivalent spend (since 2026-09-11, 3 days, 1,515 requests):
+    $413 would have been billed on the metered API — covered by subscriptions
+      Claude       $388   1,204 reqs   (Opus 5 $301 · Sonnet 5 $86.68)
+      ChatGPT    $24.75     311 reqs   (gpt-5.6-terra $24.75)
+    Today $48.20 · Last 7d $413 · Last 30d $413
+    Paid per token on top (API key / extra usage): $1.10
+```
+
+The proxy's view is preferred (it holds records the debounce has not flushed
+yet); with no proxy on the port, the command reads the file the proxy on that
+port would write. `--card[=file.svg]` renders the headline as a 640×320 SVG
+(default `dario-api-equivalent.svg`) — plain system monospace, nothing to
+fetch, so it looks the same in a README and a screenshot. `--json` is the raw
+`/analytics` payload, `lifetime` included.
+
+`GET /analytics` → `lifetime`:
+
+```json
+{
+  "path": "/root/.dario/ledger.json",
+  "since": "2026-09-11T02:14:09.000Z",
+  "days": 3,
+  "requests": 1515,
+  "apiEquivalentCost": 412.87,
+  "meteredCost": 1.1,
+  "tokens": { "input": 1204000, "output": 388000, "cacheRead": 91200000, "cacheCreate": 4100000 },
+  "perProvider": { "anthropic": { "requests": 1204, "apiEquivalentCost": 388.12 }, "openai": { "requests": 311, "apiEquivalentCost": 24.75 } },
+  "perModel": { "claude-opus-5": { "provider": "anthropic", "requests": 900, "apiEquivalentCost": 301.44, "meteredCost": 1.1, "...": "token totals" } },
+  "recent": { "today": 48.2, "last7d": 412.87, "last30d": 412.87 }
+}
+```
+
+`GET /analytics/ledger` is the file itself: `{ path, version, since, updated,
+days: { "YYYY-MM-DD": { "<model>": { covered: {…}, metered: {…} } } } }`.
+
+## Pricing on the ChatGPT leg
+
+Before 6.5 a `gpt-*` row fell through to the Claude fallback rate and the
+"would-be API cost" of a ChatGPT-plan request was Anthropic's Sonnet 4.6
+price for a model Anthropic does not sell. `OPENAI_PRICING` carries OpenAI's
+published standard-tier rates for the models the codex backend serves, read
+off `developers.openai.com/api/docs/pricing` on 2026-09-11. OpenAI charges
+nothing to write a cache entry, so cache-write tokens (which the codex path
+never reports anyway) are priced at the input rate. Unknown `gpt-*` ids take
+gpt-5.6-terra's rate, dario's default codex model.
+
+`scripts/check-pricing-drift.mjs` watches the Claude table against
+Anthropic's page. Nothing watches the OpenAI table yet — an entry that is
+correct today goes wrong the moment OpenAI changes it, and the only signal
+would be this number moving.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "6.4.0",
+  "version": "6.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "6.4.0",
+      "version": "6.5.0",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "6.4.0",
+  "version": "6.5.0",
   "description": "Use your Claude and ChatGPT subscriptions in Cursor, Cline, Aider, Claude Code and the Agent SDK — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint: either plan answers either wire shape, with automatic failover when one hits its limit.",
   "type": "module",
   "bin": {

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -228,7 +228,7 @@ export function isNonSubscriptionBilling(claim: string | null | undefined): bool
 
 // Anthropic pricing (per 1M tokens, USD). Not authoritative — used for
 // rough burn-rate display in the /analytics summary.
-interface Rate { input: number; output: number; cacheRead: number; cacheCreate: number }
+export interface Rate { input: number; output: number; cacheRead: number; cacheCreate: number }
 interface PricingEntry extends Rate {
   /**
    * Optional promotional pricing in effect through `until` (inclusive, UTC
@@ -281,15 +281,61 @@ export const PRICING: Record<string, PricingEntry> = {
 };
 
 /**
+ * OpenAI's published per-1M-token rates for the models the codex backend
+ * serves, standard tier, read off developers.openai.com/api/docs/pricing on
+ * 2026-09-11. Kept apart from PRICING because scripts/check-pricing-drift.mjs
+ * diffs that table against Anthropic's page and would report every row here
+ * as "absent upstream". OpenAI charges nothing to write a cache entry, so
+ * cacheCreate is the input rate (the codex path reports no cache writes
+ * anyway — `cached_tokens` lands in cacheReadTokens, the rest in inputTokens).
+ *
+ * Before this table every `gpt-*` row was priced at the sonnet-4-6 fallback:
+ * a ChatGPT-plan request showed up in "would-be API cost" at Anthropic's
+ * rate for a model Anthropic does not sell. Nothing watches this table yet.
+ */
+export const OPENAI_PRICING: Record<string, Rate> = {
+  'gpt-6-astra': { input: 10, output: 50, cacheRead: 1, cacheCreate: 10 },
+  'gpt-5.6-sol': { input: 4, output: 20, cacheRead: 0.4, cacheCreate: 4 },
+  'gpt-5.6-terra': { input: 2, output: 12, cacheRead: 0.2, cacheCreate: 2 },
+  'gpt-5.6-luna': { input: 0.2, output: 1.2, cacheRead: 0.02, cacheCreate: 0.2 },
+  'gpt-5.5': { input: 5, output: 30, cacheRead: 0.5, cacheCreate: 5 },
+  'gpt-5.4': { input: 2.5, output: 15, cacheRead: 0.25, cacheCreate: 2.5 },
+  'gpt-5.4-mini': { input: 0.75, output: 4.5, cacheRead: 0.075, cacheCreate: 0.75 },
+  'gpt-5.4-nano': { input: 0.2, output: 1.25, cacheRead: 0.02, cacheCreate: 0.2 },
+  'gpt-5.3-codex': { input: 1.75, output: 14, cacheRead: 0.175, cacheCreate: 1.75 },
+};
+
+/** The unknown-model rate on the OpenAI side: dario's default codex model. */
+const OPENAI_FALLBACK_MODEL = 'gpt-5.6-terra';
+
+export type PricingProvider = 'anthropic' | 'openai';
+
+/**
+ * Which price list a model id belongs to. Every id the codex backend serves
+ * starts `gpt-`; the rest of the pattern covers the older OpenAI families a
+ * `--model-alias` might name. Anything else is priced as Claude.
+ */
+export function providerOfModel(model: string): PricingProvider {
+  return /^(gpt-|o\d|codex|chatgpt)/i.test(model) ? 'openai' : 'anthropic';
+}
+
+/**
  * The per-1M-token rate for `model` in effect at `atMs` (epoch ms): the intro
  * rate while within its window, otherwise the standard rate. A trailing context
  * tag (`claude-sonnet-5[1m]`, `claude-opus-4-7[1m]`) is stripped before lookup —
  * the [1m] ids used to fall through to the sonnet fallback and bill at the wrong
- * family's rate. Unknown models fall back to the sonnet-4-6 rate. Exported for
- * tests.
+ * family's rate — and so are an effort suffix (`gpt-5.6-terra:high`) and the
+ * dated form the response echoes (`claude-haiku-4-5-20251001`, which priced
+ * at the sonnet fallback until the ledger's first live run caught it).
+ * Unknown Claude models fall back to the sonnet-4-6 rate, unknown OpenAI
+ * models to gpt-5.6-terra's. Exported for tests.
  */
 export function pricingRateFor(model: string, atMs: number): Rate {
-  const baseModel = model.replace(/\[[^\]]*\]$/, '');
+  const baseModel = model.replace(/\[[^\]]*\]$/, '').replace(/:[a-z]+$/i, '').replace(/-\d{8}$/, '');
+  if (providerOfModel(baseModel) === 'openai') {
+    const rate = OPENAI_PRICING[baseModel] ?? OPENAI_PRICING[OPENAI_FALLBACK_MODEL]!;
+    return { ...rate };
+  }
   const entry = PRICING[baseModel] ?? PRICING['claude-sonnet-4-6']!;
   if (entry.intro && atMs <= Date.parse(`${entry.intro.until}T23:59:59.999Z`)) {
     const { until: _until, ...introRate } = entry.intro;
@@ -298,18 +344,31 @@ export function pricingRateFor(model: string, atMs: number): Rate {
   return { input: entry.input, output: entry.output, cacheRead: entry.cacheRead, cacheCreate: entry.cacheCreate };
 }
 
+/**
+ * USD the four token buckets would bill at `model`'s rate in effect at `atMs`.
+ * The ledger prices its per-day rows through this too, so a pricing
+ * correction reprices history instead of freezing the old number in.
+ */
+export function costOfTokens(
+  model: string,
+  atMs: number,
+  t: { inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheCreateTokens: number },
+): number {
+  const p = pricingRateFor(model, atMs);
+  return (
+    (t.inputTokens * p.input) +
+    (t.outputTokens * p.output) +
+    (t.cacheReadTokens * p.cacheRead) +
+    (t.cacheCreateTokens * p.cacheCreate)
+  ) / 1_000_000;
+}
+
 function estimateCost(record: RequestRecord): number {
   // Price each record at the rate effective at ITS OWN timestamp, so a window
   // that spans a pricing cutover (no model currently has one — Sonnet 5's
   // scheduled increase was cancelled and its $2/$10 made permanent)
   // estimates each side correctly rather than repricing history at today's rate.
-  const p = pricingRateFor(record.model, record.timestamp);
-  return (
-    (record.inputTokens * p.input) +
-    (record.outputTokens * p.output) +
-    (record.cacheReadTokens * p.cacheRead) +
-    (record.cacheCreateTokens * p.cacheCreate)
-  ) / 1_000_000;
+  return costOfTokens(record.model, record.timestamp, record);
 }
 
 export class Analytics extends EventEmitter {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,8 @@
 // just want `parsePositiveIntEnv`) doesn't trigger a Bun relaunch or any
 // other startup side effect.
 
-import { unlink } from 'node:fs/promises';
+import { unlink, writeFile } from 'node:fs/promises';
+import { formatLedgerSummary, formatUsd, renderLedgerCard, readLedgerFile, resolveLedgerPath, summarizeLedger, type LedgerSummary } from './ledger.js';
 import { loadAllAccounts as loadAllAccountsForIdentity, regenerateClientIdentity } from './accounts.js';
 import { maskEmail } from './pool.js';
 import { realpathSync, readFileSync } from 'node:fs';
@@ -665,6 +666,11 @@ async function proxy() {
   const midstreamContinue = !(args.includes('--no-midstream-continue')
     || ['0', 'false', 'no', 'off'].includes((process.env['DARIO_MIDSTREAM_CONTINUE'] ?? '').toLowerCase()));
 
+  // --no-ledger / DARIO_LEDGER=0 — do not keep the lifetime ledger (v6.5).
+  // On by default; see ProxyOptions.ledger.
+  const ledger = !(args.includes('--no-ledger')
+    || ['0', 'false', 'no', 'off'].includes((process.env['DARIO_LEDGER'] ?? '').toLowerCase()));
+
   // --preserve-output-format — carry the client body's `output_config.format`
   // (structured-output JSON schema) through to upstream instead of dropping it
   // during the CC rebuild. See ProxyOptions.preserveOutputFormat for rationale.
@@ -691,7 +697,7 @@ async function proxy() {
     process.exit(1);
   }
 
-  await startProxy({ port, host, verbose, verboseBodies, model, fastModel, noClaudeAuth, passthrough, preserveTools, hybridTools, mergeTools, noAutoDetect, strictTls, pacingMinMs, pacingJitterMs, thinkTimeBaseMs, thinkTimePerTokenMs, thinkTimeJitterMs, thinkTimeMaxMs, sessionStartMinMs, sessionStartJitterMs, stealth, drainOnClose, sessionIdleRotateMs, sessionRotateJitterMs, sessionMaxAgeMs, sessionPerClient, preserveOrchestrationTags, noLiveCapture, strictTemplate, maxConcurrent, maxQueued, queueTimeoutMs, maxConcurrentPerConsumer, poolStrategy, poolSharedState, poolSharedStateIntervalMs, effort, maxTokens, poolFallbackModel, modelAliases, logFile, passthroughBetas, skipFields, systemPrompt, overageGuardEnabled, overageGuardBehavior, overageGuardCooldownMs, overageGuardNotifyOs, honorClientThinking, preserveOutputFormat, midstreamContinue });
+  await startProxy({ port, host, verbose, verboseBodies, model, fastModel, noClaudeAuth, passthrough, preserveTools, hybridTools, mergeTools, noAutoDetect, strictTls, pacingMinMs, pacingJitterMs, thinkTimeBaseMs, thinkTimePerTokenMs, thinkTimeJitterMs, thinkTimeMaxMs, sessionStartMinMs, sessionStartJitterMs, stealth, drainOnClose, sessionIdleRotateMs, sessionRotateJitterMs, sessionMaxAgeMs, sessionPerClient, preserveOrchestrationTags, noLiveCapture, strictTemplate, maxConcurrent, maxQueued, queueTimeoutMs, maxConcurrentPerConsumer, poolStrategy, poolSharedState, poolSharedStateIntervalMs, effort, maxTokens, poolFallbackModel, modelAliases, logFile, passthroughBetas, skipFields, systemPrompt, overageGuardEnabled, overageGuardBehavior, overageGuardCooldownMs, overageGuardNotifyOs, honorClientThinking, preserveOutputFormat, midstreamContinue, ledger });
 }
 
 /**
@@ -1644,7 +1650,12 @@ async function help() {
                              rate-limit snapshot from Anthropic, see
                              \`dario doctor --usage\`. --port=N to target
                              a non-default port; --json for the raw
-                             /analytics payload.
+                             /analytics payload. Above the window: the
+                             lifetime API-equivalent spend from the
+                             ledger (read from disk when the proxy is
+                             down). --card[=file.svg] writes a share
+                             card of that number (default
+                             dario-api-equivalent.svg). (v6.5)
     dario upgrade            npm install -g @askalf/dario@latest with a
                              pre-flight current-vs-latest check.
 
@@ -1765,6 +1776,14 @@ async function help() {
                              fallback entry for the other provider,
                              the stream ends truncated as before.
                              Env: DARIO_MIDSTREAM_CONTINUE=0. (v6.1)
+    --no-ledger              Do not keep the lifetime ledger
+                             (~/.dario/ledger.json): per-day, per-model
+                             token totals that let /analytics and
+                             \`dario usage\` say what the traffic would
+                             have cost on the metered API since the
+                             first request, across restarts. Env:
+                             DARIO_LEDGER=0; DARIO_LEDGER_PATH=<file>
+                             moves it. (v6.5)
     --session-idle-rotate=MS Idle ms before an account's session id
                              rotates (default: 900000 = 15 min).
                              Real CC rotates once per conversation, not
@@ -2391,6 +2410,9 @@ async function usage() {
       ? parseInt(process.env['DARIO_USAGE_PORT']!, 10)
       : 3456;
   const asJson = args.includes('--json');
+  // --card / --card=<file>: write the share card (SVG) of the lifetime number.
+  const cardArg = args.find(a => a === '--card' || a.startsWith('--card='));
+  const cardPath = cardArg ? (cardArg.includes('=') ? cardArg.slice('--card='.length) : 'dario-api-equivalent.svg') : null;
 
   const url = `http://127.0.0.1:${port}/analytics`;
   let payload: Record<string, unknown> | null = null;
@@ -2406,12 +2428,36 @@ async function usage() {
     connectError = err instanceof Error ? err.message : String(err);
   }
 
+  // The lifetime number does not need a running proxy: the ledger is a file.
+  // Prefer the proxy's view (it holds records not yet flushed); fall back to
+  // reading the file this port's proxy would write.
+  let lifetime: LedgerSummary | null = (payload?.lifetime as LedgerSummary | null | undefined) ?? null;
+  let lifetimeNote: string | null = null;
+  if (!payload) {
+    const ledgerPath = resolveLedgerPath(port);
+    const { file, error } = await readLedgerFile(ledgerPath);
+    if (file) lifetime = summarizeLedger(file, ledgerPath);
+    else if (error) lifetimeNote = `ledger at ${ledgerPath} unreadable: ${error}`;
+    else lifetimeNote = `no ledger at ${ledgerPath} yet — it appears after the first request through a proxy on this port`;
+  } else if (payload.lifetime === null) {
+    lifetimeNote = 'ledger disabled on this proxy (--no-ledger)';
+  }
+
+  if (cardPath) {
+    if (!lifetime) {
+      console.error(`  No lifetime numbers to draw${lifetimeNote ? ` (${lifetimeNote})` : ''}.`);
+      process.exit(1);
+    }
+    await writeFile(cardPath, renderLedgerCard(lifetime), 'utf8');
+    if (!asJson) console.log(`  Wrote ${cardPath} — ${formatUsd(lifetime.apiEquivalentCost)} API-equivalent since ${lifetime.since.slice(0, 10)}.`);
+  }
+
   if (asJson) {
     if (payload) {
       process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
       return;
     }
-    process.stdout.write(JSON.stringify({ error: 'proxy not reachable', port, detail: connectError }, null, 2) + '\n');
+    process.stdout.write(JSON.stringify({ error: 'proxy not reachable', port, detail: connectError, lifetime }, null, 2) + '\n');
     process.exit(1);
   }
 
@@ -2419,6 +2465,14 @@ async function usage() {
   console.log('  dario — Usage');
   console.log('  ─────────────');
   console.log('');
+
+  if (lifetime) {
+    for (const line of formatLedgerSummary(lifetime)) console.log(line);
+    console.log('');
+  } else if (lifetimeNote) {
+    console.log(`  API-equivalent spend: ${lifetimeNote}.`);
+    console.log('');
+  }
 
   if (!payload) {
     console.log(`  Proxy not reachable on http://127.0.0.1:${port} (${connectError ?? 'no response'}).`);

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -1,0 +1,465 @@
+/**
+ * The ledger — what the traffic dario has served would have cost on the
+ * metered API, kept across restarts.
+ *
+ * /analytics is a rolling in-memory window: it forgets on every restart and
+ * caps at 10k records, so the one number a subscription user actually wants
+ * — "what has this saved me" — was never answerable past the last few hours.
+ * The ledger keeps one small row per (UTC day, model, bucket): a request
+ * count and the four token buckets. It never stores a price. Rows are priced
+ * at read time through `costOfTokens` at the day's own timestamp, so a
+ * pricing correction (#1047, #1048 — both happened) reprices history instead
+ * of freezing the wrong number in.
+ *
+ * Two buckets per row. `covered` is traffic a subscription paid for — the
+ * API-equivalent cost of that is the headline, the invoice that never
+ * arrived. `metered` is traffic billed per token anyway (an API key, or
+ * Anthropic's paid `extra_usage` overage) — that money was spent, and it is
+ * reported separately rather than counted as saved. Only 2xx responses
+ * count: a 429 carries no tokens and a 5xx bills nothing.
+ *
+ * On disk: `~/.dario/ledger.json` for the default port, `ledger-<port>.json`
+ * for any other, so two instances sharing a home (the box's live-test rig
+ * runs one on :3999 next to production) do not overwrite each other's file.
+ * Writes are debounced and durable (`durableWriteFile`); the shutdown hook
+ * flushes what the debounce still holds, so at most the last few seconds
+ * before a SIGKILL are lost.
+ */
+
+import { readFile, mkdir, rename } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import { durableWriteFile } from './durable-write.js';
+import { billingBucketFromClaim, costOfTokens, providerOfModel, type PricingProvider, type RequestRecord } from './analytics.js';
+
+export const LEDGER_VERSION = 1;
+/** The default proxy port; any other port gets its own ledger file. */
+const DEFAULT_PORT = 3456;
+/** Days kept before the oldest roll off — two years at one row per model per day. */
+export const LEDGER_MAX_DAYS = 730;
+/** How long after the last record the file is rewritten. */
+export const LEDGER_FLUSH_DELAY_MS = 3_000;
+
+export type LedgerBucket = 'covered' | 'metered';
+
+export interface LedgerCell {
+  requests: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreateTokens: number;
+}
+
+export type LedgerRow = Partial<Record<LedgerBucket, LedgerCell>>;
+
+export interface LedgerFile {
+  version: number;
+  /** ISO timestamp of the first record the ledger ever saw. */
+  since: string;
+  /** ISO timestamp of the last write. */
+  updated: string;
+  /** `YYYY-MM-DD` (UTC) → model id → per-bucket totals. */
+  days: Record<string, Record<string, LedgerRow>>;
+}
+
+export interface LedgerModelSummary {
+  provider: PricingProvider;
+  requests: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreateTokens: number;
+  /** API-equivalent cost of this model's covered traffic, USD. */
+  apiEquivalentCost: number;
+  /** What this model's metered traffic cost at list price, USD. */
+  meteredCost: number;
+}
+
+export interface LedgerSummary {
+  /** Where the file lives — so `dario usage` can say what it read. */
+  path: string;
+  since: string;
+  /** Distinct UTC days with traffic. */
+  days: number;
+  /** Covered + metered, 2xx only. */
+  requests: number;
+  /**
+   * The headline: what subscription-covered traffic would have been billed
+   * on the metered API at today's list prices, USD.
+   */
+  apiEquivalentCost: number;
+  /** What metered traffic (API key, paid overage) actually cost at list price, USD. */
+  meteredCost: number;
+  /** Covered token totals. */
+  tokens: { input: number; output: number; cacheRead: number; cacheCreate: number };
+  perProvider: Record<PricingProvider, { requests: number; apiEquivalentCost: number }>;
+  perModel: Record<string, LedgerModelSummary>;
+  /** apiEquivalentCost over the trailing windows, UTC days. */
+  recent: { today: number; last7d: number; last30d: number };
+}
+
+export function ledgerPathFor(port: number, home: string = homedir()): string {
+  return join(home, '.dario', port === DEFAULT_PORT ? 'ledger.json' : `ledger-${port}.json`);
+}
+
+/**
+ * `DARIO_LEDGER_PATH` names the file; `DARIO_LEDGER=0` (or `--no-ledger`)
+ * turns the ledger off. Off, /analytics reports `lifetime: null` and the
+ * usage command says so.
+ */
+export function resolveLedgerPath(port: number, env: NodeJS.ProcessEnv = process.env): string {
+  const explicit = env['DARIO_LEDGER_PATH'];
+  return explicit && explicit.trim().length > 0 ? explicit.trim() : ledgerPathFor(port);
+}
+
+export function ledgerDisabledByEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  return ['0', 'false', 'no', 'off'].includes((env['DARIO_LEDGER'] ?? '').toLowerCase());
+}
+
+const emptyCell = (): LedgerCell => ({ requests: 0, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0 });
+
+export function emptyLedger(now: number = Date.now()): LedgerFile {
+  const iso = new Date(now).toISOString();
+  return { version: LEDGER_VERSION, since: iso, updated: iso, days: {} };
+}
+
+/** UTC calendar day of an epoch-ms timestamp. */
+export function dayKey(atMs: number): string {
+  return new Date(atMs).toISOString().slice(0, 10);
+}
+
+/** Noon UTC of a day key — inside any intro window that ends that day. */
+function dayMs(day: string): number {
+  return Date.parse(`${day}T12:00:00Z`);
+}
+
+/**
+ * Which bucket a record lands in, or null when it should not be counted.
+ * `api` and `extra_usage` are metered; every subscription claim, the codex
+ * claim, and an absent claim on a 2xx (stream aborts, api-key mode without
+ * the header) are covered — the request was served, and nothing says it was
+ * billed per token.
+ */
+export function ledgerBucketFor(record: Pick<RequestRecord, 'status' | 'claim'>): LedgerBucket | null {
+  if (record.status < 200 || record.status >= 300) return null;
+  const bucket = billingBucketFromClaim(record.claim);
+  return bucket === 'api' || bucket === 'extra_usage' ? 'metered' : 'covered';
+}
+
+function isCell(v: unknown): v is LedgerCell {
+  if (!v || typeof v !== 'object') return false;
+  const c = v as Record<string, unknown>;
+  return ['requests', 'inputTokens', 'outputTokens', 'cacheReadTokens', 'cacheCreateTokens']
+    .every((k) => typeof c[k] === 'number' && Number.isFinite(c[k] as number) && (c[k] as number) >= 0);
+}
+
+/**
+ * Parse a ledger file's text, keeping only well-formed rows. A file that is
+ * not a ledger at all throws; the caller moves it aside and starts fresh.
+ */
+export function parseLedger(text: string): LedgerFile {
+  const raw = JSON.parse(text) as Partial<LedgerFile>;
+  if (!raw || typeof raw !== 'object' || raw.version !== LEDGER_VERSION || !raw.days || typeof raw.days !== 'object') {
+    throw new Error('not a dario ledger');
+  }
+  const days: LedgerFile['days'] = {};
+  for (const [day, models] of Object.entries(raw.days)) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(day) || !models || typeof models !== 'object') continue;
+    const clean: Record<string, LedgerRow> = {};
+    for (const [model, row] of Object.entries(models as Record<string, LedgerRow>)) {
+      if (!row || typeof row !== 'object') continue;
+      const r: LedgerRow = {};
+      if (isCell(row.covered)) r.covered = { ...row.covered };
+      if (isCell(row.metered)) r.metered = { ...row.metered };
+      if (r.covered || r.metered) clean[model] = r;
+    }
+    if (Object.keys(clean).length > 0) days[day] = clean;
+  }
+  const since = typeof raw.since === 'string' && !Number.isNaN(Date.parse(raw.since)) ? raw.since : new Date().toISOString();
+  const updated = typeof raw.updated === 'string' && !Number.isNaN(Date.parse(raw.updated)) ? raw.updated : since;
+  return { version: LEDGER_VERSION, since, updated, days };
+}
+
+/** Add one record's tokens to the file in place. Returns false when it was not counted. */
+export function addToLedger(file: LedgerFile, record: RequestRecord): boolean {
+  const bucket = ledgerBucketFor(record);
+  if (!bucket) return false;
+  const day = dayKey(record.timestamp);
+  const model = record.model || 'unknown';
+  const models = (file.days[day] ??= {});
+  const row = (models[model] ??= {});
+  const cell = (row[bucket] ??= emptyCell());
+  cell.requests += 1;
+  cell.inputTokens += record.inputTokens;
+  cell.outputTokens += record.outputTokens;
+  cell.cacheReadTokens += record.cacheReadTokens;
+  cell.cacheCreateTokens += record.cacheCreateTokens;
+  if (Date.parse(file.since) > record.timestamp) file.since = new Date(record.timestamp).toISOString();
+  pruneLedger(file);
+  return true;
+}
+
+/** Drop the oldest days past LEDGER_MAX_DAYS. */
+export function pruneLedger(file: LedgerFile, maxDays: number = LEDGER_MAX_DAYS): void {
+  const days = Object.keys(file.days).sort();
+  for (const day of days.slice(0, Math.max(0, days.length - maxDays))) delete file.days[day];
+}
+
+// Six places, not the window's four: a handful of gpt-5.6-luna requests is
+// real money in the millionths and "$0 for 2 requests" reads as free.
+const round = (usd: number): number => Math.round(usd * 1_000_000) / 1_000_000;
+
+export function summarizeLedger(file: LedgerFile, path: string, now: number = Date.now()): LedgerSummary {
+  const today = dayKey(now);
+  const cutoff7 = dayKey(now - 6 * 86_400_000);
+  const cutoff30 = dayKey(now - 29 * 86_400_000);
+  const perModel: Record<string, LedgerModelSummary> = {};
+  const perProvider: LedgerSummary['perProvider'] = {
+    anthropic: { requests: 0, apiEquivalentCost: 0 },
+    openai: { requests: 0, apiEquivalentCost: 0 },
+  };
+  const tokens = { input: 0, output: 0, cacheRead: 0, cacheCreate: 0 };
+  let requests = 0;
+  let covered = 0;
+  let metered = 0;
+  const recent = { today: 0, last7d: 0, last30d: 0 };
+
+  for (const [day, models] of Object.entries(file.days)) {
+    const at = dayMs(day);
+    for (const [model, row] of Object.entries(models)) {
+      const m = (perModel[model] ??= {
+        provider: providerOfModel(model), requests: 0,
+        inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0,
+        apiEquivalentCost: 0, meteredCost: 0,
+      });
+      if (row.covered) {
+        const cost = costOfTokens(model, at, row.covered);
+        covered += cost;
+        m.apiEquivalentCost += cost;
+        m.requests += row.covered.requests;
+        m.inputTokens += row.covered.inputTokens;
+        m.outputTokens += row.covered.outputTokens;
+        m.cacheReadTokens += row.covered.cacheReadTokens;
+        m.cacheCreateTokens += row.covered.cacheCreateTokens;
+        tokens.input += row.covered.inputTokens;
+        tokens.output += row.covered.outputTokens;
+        tokens.cacheRead += row.covered.cacheReadTokens;
+        tokens.cacheCreate += row.covered.cacheCreateTokens;
+        perProvider[m.provider].requests += row.covered.requests;
+        perProvider[m.provider].apiEquivalentCost += cost;
+        requests += row.covered.requests;
+        if (day === today) recent.today += cost;
+        if (day >= cutoff7) recent.last7d += cost;
+        if (day >= cutoff30) recent.last30d += cost;
+      }
+      if (row.metered) {
+        const cost = costOfTokens(model, at, row.metered);
+        metered += cost;
+        m.meteredCost += cost;
+        m.requests += row.metered.requests;
+        requests += row.metered.requests;
+      }
+    }
+  }
+  for (const m of Object.values(perModel)) {
+    m.apiEquivalentCost = round(m.apiEquivalentCost);
+    m.meteredCost = round(m.meteredCost);
+  }
+  for (const p of Object.values(perProvider)) p.apiEquivalentCost = round(p.apiEquivalentCost);
+
+  return {
+    path,
+    since: file.since,
+    days: Object.keys(file.days).length,
+    requests,
+    apiEquivalentCost: round(covered),
+    meteredCost: round(metered),
+    tokens,
+    perProvider,
+    perModel,
+    recent: { today: round(recent.today), last7d: round(recent.last7d), last30d: round(recent.last30d) },
+  };
+}
+
+/**
+ * Read a ledger file for display without a running proxy (`dario usage`
+ * when the proxy is down). Missing file → null; unreadable → null with the
+ * reason, never a throw.
+ */
+export async function readLedgerFile(path: string): Promise<{ file: LedgerFile | null; error?: string }> {
+  let text: string;
+  try {
+    text = await readFile(path, 'utf8');
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    return code === 'ENOENT' ? { file: null } : { file: null, error: (err as Error).message };
+  }
+  try {
+    return { file: parseLedger(text) };
+  } catch (err) {
+    return { file: null, error: (err as Error).message };
+  }
+}
+
+export class Ledger {
+  private file: LedgerFile;
+  private dirty = false;
+  private timer: NodeJS.Timeout | null = null;
+  private writing: Promise<void> = Promise.resolve();
+  private closed = false;
+
+  private constructor(readonly path: string, file: LedgerFile, private readonly log: (line: string) => void) {
+    this.file = file;
+  }
+
+  /**
+   * Load the ledger at `path`, or start one. A file that cannot be parsed is
+   * moved aside (`<path>.corrupt-<ts>`) rather than overwritten, so a bad
+   * write never silently zeroes two years of history.
+   */
+  static async open(path: string, log: (line: string) => void = () => {}): Promise<Ledger> {
+    const { file, error } = await readLedgerFile(path);
+    if (file) return new Ledger(path, file, log);
+    if (error) {
+      const aside = `${path}.corrupt-${Date.now()}`;
+      try { await rename(path, aside); } catch { /* best effort — the next flush overwrites */ }
+      log(`[dario] ledger: could not read ${path} (${error}); moved aside to ${aside}, starting fresh`);
+    }
+    return new Ledger(path, emptyLedger(), log);
+  }
+
+  /** Count a request. Returns false when it was not ledger material. */
+  add(record: RequestRecord): boolean {
+    if (this.closed) return false;
+    const counted = addToLedger(this.file, record);
+    if (counted) this.scheduleFlush();
+    return counted;
+  }
+
+  summary(now: number = Date.now()): LedgerSummary {
+    return summarizeLedger(this.file, this.path, now);
+  }
+
+  /** The raw per-day table, for /analytics/ledger. */
+  snapshot(): LedgerFile {
+    return JSON.parse(JSON.stringify(this.file)) as LedgerFile;
+  }
+
+  private scheduleFlush(): void {
+    this.dirty = true;
+    if (this.timer) return;
+    this.timer = setTimeout(() => { this.timer = null; void this.flush(); }, LEDGER_FLUSH_DELAY_MS);
+    this.timer.unref();
+  }
+
+  /** Write now if anything changed. Serialized; a failure is logged, not thrown. */
+  flush(): Promise<void> {
+    if (!this.dirty) return this.writing;
+    this.dirty = false;
+    if (this.timer) { clearTimeout(this.timer); this.timer = null; }
+    this.file.updated = new Date().toISOString();
+    const text = JSON.stringify(this.file);
+    this.writing = this.writing.then(async () => {
+      try {
+        await mkdir(dirname(this.path), { recursive: true, mode: 0o700 });
+        await durableWriteFile(this.path, text, 0o600);
+      } catch (err) {
+        this.dirty = true;
+        this.log(`[dario] ledger: write to ${this.path} failed: ${(err as Error).message}`);
+      }
+    });
+    return this.writing;
+  }
+
+  /** Final flush for the shutdown hook. */
+  async close(): Promise<void> {
+    await this.flush();
+    this.closed = true;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Presentation — the number, formatted for a terminal and for a share card
+// ─────────────────────────────────────────────────────────────────────────
+
+export function formatUsd(usd: number): string {
+  if (usd >= 100) return `$${Math.round(usd).toLocaleString('en-US')}`;
+  if (usd >= 1) return `$${usd.toFixed(2)}`;
+  if (usd === 0) return '$0';
+  if (usd < 0.0001) return '<$0.0001';
+  return `$${usd.toFixed(usd >= 0.01 ? 2 : 4)}`;
+}
+
+/** `claude-opus-5` → `Opus 5`, `claude-haiku-4-5-20251001` → `Haiku 4.5`, `gpt-5.6-terra` → `gpt-5.6-terra`. */
+export function shortModelName(model: string): string {
+  const m = /^claude-([a-z]+)-(\d+)(?:-(\d+))?(?:-\d{8})?(\[[^\]]*\])?$/i.exec(model);
+  if (!m) return model;
+  const family = m[1]!.charAt(0).toUpperCase() + m[1]!.slice(1);
+  return `${family} ${m[2]}${m[3] ? `.${m[3]}` : ''}${m[4] ?? ''}`;
+}
+
+const providerLabel: Record<PricingProvider, string> = { anthropic: 'Claude', openai: 'ChatGPT' };
+
+/**
+ * The block `dario usage` prints above the rolling window. Two-space indent
+ * to match the rest of that command's output.
+ */
+export function formatLedgerSummary(s: LedgerSummary): string[] {
+  const since = s.since.slice(0, 10);
+  const lines: string[] = [];
+  lines.push(`  API-equivalent spend (since ${since}, ${s.days} day${s.days === 1 ? '' : 's'}, ${s.requests.toLocaleString('en-US')} request${s.requests === 1 ? '' : 's'}):`);
+  lines.push(`    ${formatUsd(s.apiEquivalentCost)} would have been billed on the metered API — covered by subscriptions`);
+  const providers = (Object.entries(s.perProvider) as [PricingProvider, { requests: number; apiEquivalentCost: number }][])
+    .filter(([, p]) => p.requests > 0)
+    .sort((a, b) => b[1].apiEquivalentCost - a[1].apiEquivalentCost);
+  for (const [provider, p] of providers) {
+    const models = Object.entries(s.perModel)
+      .filter(([, m]) => m.provider === provider && m.apiEquivalentCost > 0)
+      .sort((a, b) => b[1].apiEquivalentCost - a[1].apiEquivalentCost)
+      .slice(0, 4)
+      .map(([id, m]) => `${shortModelName(id)} ${formatUsd(m.apiEquivalentCost)}`);
+    lines.push(`      ${providerLabel[provider].padEnd(8)} ${formatUsd(p.apiEquivalentCost).padStart(9)}   ${p.requests.toLocaleString('en-US')} req${p.requests === 1 ? '' : 's'}${models.length > 0 ? `   (${models.join(' · ')})` : ''}`);
+  }
+  lines.push(`    Today ${formatUsd(s.recent.today)} · Last 7d ${formatUsd(s.recent.last7d)} · Last 30d ${formatUsd(s.recent.last30d)}`);
+  if (s.meteredCost > 0) lines.push(`    Paid per token on top (API key / extra usage): ${formatUsd(s.meteredCost)}`);
+  return lines;
+}
+
+const escapeXml = (s: string): string => s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]!));
+
+/**
+ * A share card: one SVG, 640×320, dark, the number in the middle. Plain
+ * system monospace so it renders the same in a README, a tweet screenshot
+ * and an <img> tag with nothing to fetch.
+ */
+export function renderLedgerCard(s: LedgerSummary): string {
+  const providers = (Object.entries(s.perProvider) as [PricingProvider, { requests: number; apiEquivalentCost: number }][])
+    .filter(([, p]) => p.requests > 0)
+    .sort((a, b) => b[1].apiEquivalentCost - a[1].apiEquivalentCost)
+    .map(([provider, p]) => `${providerLabel[provider]} ${formatUsd(p.apiEquivalentCost)}`)
+    .join('   ·   ');
+  const since = s.since.slice(0, 10);
+  const headline = formatUsd(s.apiEquivalentCost);
+  const size = headline.length > 9 ? 56 : headline.length > 7 ? 68 : 80;
+  const meta = `${s.requests.toLocaleString('en-US')} requests  ·  since ${since}  ·  ${s.days} day${s.days === 1 ? '' : 's'}`;
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="640" height="320" viewBox="0 0 640 320" role="img" aria-label="${escapeXml(headline)} of API-equivalent usage covered by subscriptions through dario">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#7c3aed"/>
+      <stop offset="1" stop-color="#db2777"/>
+    </linearGradient>
+    <clipPath id="card"><rect width="640" height="320" rx="20"/></clipPath>
+  </defs>
+  <rect width="640" height="320" rx="20" fill="#0a0a0f"/>
+  <rect x="0" y="0" width="640" height="6" fill="url(#accent)" clip-path="url(#card)"/>
+  <g font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace" fill="#e5e7eb">
+    <text x="40" y="66" font-size="15" fill="#9ca3af" letter-spacing="2">API-EQUIVALENT SPEND · COVERED BY SUBSCRIPTIONS</text>
+    <text x="40" y="160" font-size="${size}" font-weight="700" fill="#ffffff">${escapeXml(headline)}</text>
+    <text x="40" y="200" font-size="17" fill="#d1d5db">would have been billed on the metered API</text>
+    <text x="40" y="244" font-size="15" fill="#a78bfa">${escapeXml(providers)}</text>
+    <text x="40" y="284" font-size="13" fill="#6b7280">${escapeXml(meta)}</text>
+    <text x="600" y="284" font-size="13" fill="#6b7280" text-anchor="end">dario</text>
+  </g>
+</svg>
+`;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -16,6 +16,7 @@ import { AccountPool, computeStickyKey, parseRateLimits, modelFamily, isInAuthCo
 import { backfillIdentity } from './accounts.js';
 import { PoolSync, DEFAULT_POOL_SYNC_INTERVAL_MS } from './pool-sync.js';
 import { Analytics, billingBucketFromClaim, formatUsageLogLine, SUBSCRIPTION_CLAIMS, consumerFromHeader, consumerFromBody, CONSUMER_HEADER, type RequestRecord, CODEX_CLAIM } from './analytics.js';
+import { Ledger, resolveLedgerPath, ledgerDisabledByEnv } from './ledger.js';
 import { OverageGuard, buildHaltErrorBody, type HaltState } from './overage-guard.js';
 import { notify as osNotify } from './notify.js';
 import { grantAge, grantThresholds, worstGrantLevel, describeGrantAge, type GrantLevel } from './refresh-grant.js';
@@ -1033,6 +1034,14 @@ interface ProxyOptions {
    * it off; with no fallback chain it is inert and says so on the first miss.
    */
   midstreamContinue?: boolean;
+  /**
+   * Keep the lifetime ledger (v6.5, src/ledger.ts): per-day, per-model token
+   * totals on disk, priced at read time, so /analytics and `dario usage` can
+   * say what the traffic would have cost on the metered API since the first
+   * request — across restarts. On by default; `--no-ledger` /
+   * `DARIO_LEDGER=0` turns it off, `DARIO_LEDGER_PATH` moves the file.
+   */
+  ledger?: boolean;
   sessionIdleRotateMs?: number;    // Idle ms before session-id rotates (v3.28, direction #1 — default 15min)
   sessionRotateJitterMs?: number;  // Uniform jitter on idle threshold (v3.28 — default 0)
   sessionMaxAgeMs?: number;        // Hard cap on session-id lifetime (v3.28 — default off)
@@ -1770,6 +1779,17 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
   // : null` — that gated the /analytics endpoint, but burn-rate /
   // per-request visibility is useful for a pool of one too.
   const analytics = new Analytics();
+  // The lifetime ledger rides the same record stream analytics emits, so
+  // every site that records a request feeds it without a second call. Off,
+  // /analytics reports `lifetime: null`.
+  const ledgerOn = opts.ledger !== false && !ledgerDisabledByEnv();
+  const ledger: Ledger | null = ledgerOn ? await Ledger.open(resolveLedgerPath(port), (line) => console.log(line)) : null;
+  if (ledger) {
+    analytics.on('record', (r: RequestRecord) => { ledger.add(r); });
+    if (verbose) console.log(`[dario] ledger: ${ledger.path}`);
+  } else {
+    console.log('[dario] ledger: disabled (--no-ledger)');
+  }
   // Per-alias request counts for GET /codex — the pool has requestCount per
   // account; the codex accounts had nothing until now.
   const codexRequestCounts = new Map<string, number>();
@@ -2843,7 +2863,20 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
       // `queue` rides along the summary (dario#905): request-queue.ts always
       // documented snapshot() as "exposed for /analytics", but it was never
       // actually wired in, so slot exhaustion was invisible from outside.
-      res.end(JSON.stringify({ ...analytics.summary(), queue: queue.snapshot() }));
+      res.end(JSON.stringify({ ...analytics.summary(), queue: queue.snapshot(), lifetime: ledger ? ledger.summary() : null }));
+      return;
+    }
+
+    // The ledger's per-day table, for anyone charting it. `lifetime` on
+    // /analytics is the summary; this is the data behind it.
+    if (urlPath === '/analytics/ledger' && req.method === 'GET') {
+      if (!ledger) {
+        res.writeHead(404, JSON_HEADERS);
+        res.end(JSON.stringify({ error: 'ledger disabled', hint: 'start without --no-ledger / DARIO_LEDGER=0' }));
+        return;
+      }
+      res.writeHead(200, JSON_HEADERS);
+      res.end(JSON.stringify({ path: ledger.path, ...ledger.snapshot() }));
       return;
     }
 
@@ -5678,7 +5711,7 @@ export async function startProxy(opts: ProxyOptions = {}): Promise<void> {
     // Flush tokens first (best-effort, bounded), then close the server. The
     // flush is fire-and-forget under the same 5s force-exit guard below so a
     // hung fsync can't wedge shutdown.
-    void flushPoolTokens().finally(() => {
+    void Promise.all([flushPoolTokens(), ledger?.close()]).finally(() => {
       server.close(() => process.exit(0));
     });
     // Force exit after 5s if connections (or the flush) don't complete.

--- a/src/tui/tabs/analytics.ts
+++ b/src/tui/tabs/analytics.ts
@@ -16,6 +16,7 @@ import type { Tab, TabContext } from '../tab.js';
 import { fg, dim, brand, progressBar, pad, truncate } from '../render.js';
 import { renderKvRow } from '../layout.js';
 import { fitPanels, type Panel } from '../panels.js';
+import { formatUsd } from '../../ledger.js';
 
 /** Subset of AnalyticsSummary the Analytics tab actually renders. */
 interface SummaryShape {
@@ -34,6 +35,8 @@ interface SummaryShape {
   perModel: Record<string, { requests: number; totalInputTokens: number; totalOutputTokens: number }>;
   utilization: { lastUtil5h: number; lastUtil7d: number };
   perAccount: Record<string, { requests: number; currentUtil5h: number; currentUtil7d: number; lastClaim: string }>;
+  /** The ledger's lifetime view (v6.5); null when the proxy runs --no-ledger, absent on older proxies. */
+  lifetime?: { apiEquivalentCost: number; since: string; recent: { today: number } } | null;
 }
 
 export interface AnalyticsState {
@@ -149,13 +152,21 @@ export const AnalyticsTab: Tab<AnalyticsState> = {
       `${Math.round(s.window.avgLatencyMs)}ms`, w - 4));
     counters.push('  ' + renderKvRow('Subscription %',
       `${s.window.subscriptionPercent.toFixed(0)}%`, w - 4));
-    // Headline numbers — the two that answer "is this costing me money?"
+    // The ledger's number: what everything since the first request would
+    // have been billed on the metered API. Lifetime, not the window.
+    const lifetimeRow = s.lifetime
+      ? '  ' + renderKvRow('API-equivalent',
+        `${formatUsd(s.lifetime.apiEquivalentCost)}  ${dim(`lifetime, ${formatUsd(s.lifetime.recent.today)} today, since ${s.lifetime.since.slice(0, 10)}`)}`, w - 4)
+      : null;
+    if (lifetimeRow) counters.push(lifetimeRow);
+    // Headline numbers — the ones that answer "is this costing me money?"
     // survive as the collapsed form.
     panels.push({
       lines: counters,
       collapsed: ['',
         '  ' + renderKvRow('Requests', `${s.window.requests}  ${dim(`(${rpm.toFixed(1)}/min)`)}`, w - 4),
-        '  ' + renderKvRow('Subscription %', `${s.window.subscriptionPercent.toFixed(0)}%`, w - 4)],
+        '  ' + renderKvRow('Subscription %', `${s.window.subscriptionPercent.toFixed(0)}%`, w - 4),
+        ...(lifetimeRow ? [lifetimeRow] : [])],
       priority: 1,
     });
 

--- a/test/all.test.mjs
+++ b/test/all.test.mjs
@@ -74,10 +74,13 @@ const files = readdirSync(__dirname)
 //
 // Files that genuinely exercise the live-cache path (test/live-fingerprint.mjs)
 // assign their own override in-process, which wins over this inherited value.
-const suiteTemplateCache = join(
-  mkdtempSync(join(tmpdir(), 'dario-suite-template-')), 'cc-template.live.json',
-);
-const childEnv = { ...process.env, DARIO_LIVE_TEMPLATE_CACHE: suiteTemplateCache };
+const suiteTmp = mkdtempSync(join(tmpdir(), 'dario-suite-template-'));
+const suiteTemplateCache = join(suiteTmp, 'cc-template.live.json');
+// Same rule for the ledger (v6.5): a suite run must not add its stub traffic
+// to the operator's ~/.dario/ledger*.json, so every proxy a test starts
+// writes its ledger here instead. Files that test the ledger itself point
+// it at their own path in-process.
+const childEnv = { ...process.env, DARIO_LIVE_TEMPLATE_CACHE: suiteTemplateCache, DARIO_LEDGER_PATH: join(suiteTmp, 'ledger.json') };
 
 // One file, one subprocess. Returns { code, out }.
 const runFile = (f) => new Promise((resolve, reject) => {

--- a/test/ledger-wiring.mjs
+++ b/test/ledger-wiring.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+// The ledger through a real startProxy: Claude pool traffic (stubbed
+// upstream, subscription and api claims), codex traffic (stubbed backend),
+// /analytics.lifetime, /analytics/ledger, the file on disk, the number
+// surviving a restart, `dario usage` reading it with and without a proxy,
+// --card, and --no-ledger / DARIO_LEDGER=0.
+
+import { createServer } from 'node:http';
+import { spawn } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, writeFile, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { freePort } from './helpers/free-port.mjs';
+
+let pass = 0, fail = 0;
+const check = (name, cond, detail) => {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else { console.log(`  FAIL ${name}${detail !== undefined ? ' :: ' + String(detail).slice(0, 500) : ''}`); fail++; }
+};
+const header = (n) => console.log(`\n=== ${n} ===`);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const here = dirname(fileURLToPath(import.meta.url));
+const CLI = join(here, '..', 'dist', 'cli.js');
+
+const PROXY_PORT = await freePort();
+const CODEX_PORT = await freePort();
+const BASE = `http://127.0.0.1:${PROXY_PORT}`;
+const CODEX_SLUG = 'gpt-5.6-terra';
+const CLAUDE_MODEL = 'claude-opus-5';
+const sse = (type, obj) => `event: ${type}\ndata: ${JSON.stringify({ type, ...obj })}\n\n`;
+
+// ---- codex stub: one buffered response with 1M output tokens ---------------
+const codexStub = createServer((req, res) => {
+  if (req.url.startsWith('/models')) { res.writeHead(200, { 'Content-Type': 'application/json' }); res.end(JSON.stringify({ models: [{ slug: CODEX_SLUG, visibility: 'list' }] })); return; }
+  const parts = [];
+  req.on('data', (c) => parts.push(c));
+  req.on('end', () => {
+    res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+    const ev = (type, obj, seq) => res.write(`event: ${type}\ndata: ${JSON.stringify({ type, sequence_number: seq, ...obj })}\n\n`);
+    const msg = { id: 'msg_x', type: 'message', status: 'completed', role: 'assistant', content: [{ type: 'output_text', text: 'hi', annotations: [] }] };
+    const full = { id: 'resp_x', object: 'response', created_at: 1, status: 'completed', model: CODEX_SLUG, output: [msg], usage: { input_tokens: 0, output_tokens: 1_000_000, total_tokens: 1_000_000, input_tokens_details: { cached_tokens: 0 }, output_tokens_details: { reasoning_tokens: 0 } } };
+    ev('response.created', { response: { ...full, status: 'in_progress', output: [] } }, 0);
+    ev('response.output_item.added', { output_index: 0, item: { ...msg, status: 'in_progress', content: [] } }, 1);
+    ev('response.content_part.added', { item_id: 'msg_x', output_index: 0, content_index: 0, part: { type: 'output_text', text: '', annotations: [] } }, 2);
+    ev('response.output_text.delta', { item_id: 'msg_x', output_index: 0, content_index: 0, delta: 'hi' }, 3);
+    ev('response.output_text.done', { item_id: 'msg_x', output_index: 0, content_index: 0, text: 'hi' }, 4);
+    ev('response.content_part.done', { item_id: 'msg_x', output_index: 0, content_index: 0, part: { type: 'output_text', text: 'hi', annotations: [] } }, 5);
+    ev('response.output_item.done', { output_index: 0, item: msg }, 6);
+    ev('response.completed', { response: full }, 7);
+    res.end();
+  });
+});
+await new Promise((r) => codexStub.listen(CODEX_PORT, '127.0.0.1', r));
+
+// ---- Claude stub: the claim header decides the bucket ----------------------
+// 1M input tokens per request so the numbers are round: opus-5 → $5 each.
+let claudeClaim = 'five_hour';
+let claudeStatus = 200;
+const fakeFetch = async (url, init) => {
+  const target = String(url);
+  if (target.includes('/v1/models')) return new Response(JSON.stringify({ data: [{ id: CLAUDE_MODEL, type: 'model' }] }), { status: 200, headers: { 'content-type': 'application/json' } });
+  const body = JSON.parse(typeof init.body === 'string' ? init.body : Buffer.from(init.body).toString('utf-8'));
+  const headers = { 'content-type': body.stream ? 'text/event-stream' : 'application/json', 'anthropic-ratelimit-unified-representative-claim': claudeClaim, 'anthropic-ratelimit-unified-5h-utilization': '0.1', 'anthropic-ratelimit-unified-7d-utilization': '0.2' };
+  if (claudeStatus !== 200) return new Response(JSON.stringify({ type: 'error', error: { type: 'overloaded_error', message: 'busy' } }), { status: claudeStatus, headers: { ...headers, 'content-type': 'application/json' } });
+  if (!body.stream) {
+    return new Response(JSON.stringify({ id: 'msg_buf', type: 'message', role: 'assistant', model: CLAUDE_MODEL, content: [{ type: 'text', text: 'buffered' }], stop_reason: 'end_turn', usage: { input_tokens: 1_000_000, output_tokens: 0 } }), { status: 200, headers });
+  }
+  const text = [
+    sse('message_start', { message: { id: 'msg_01A', type: 'message', role: 'assistant', model: CLAUDE_MODEL, content: [], stop_reason: null, usage: { input_tokens: 1_000_000, output_tokens: 0 } } }),
+    sse('content_block_start', { index: 0, content_block: { type: 'text', text: '' } }),
+    sse('content_block_delta', { index: 0, delta: { type: 'text_delta', text: 'streamed' } }),
+    sse('content_block_stop', { index: 0 }),
+    sse('message_delta', { delta: { stop_reason: 'end_turn', stop_sequence: null }, usage: { output_tokens: 0 } }),
+    sse('message_stop', {}),
+  ].join('');
+  return new Response(text, { status: 200, headers });
+};
+
+// ---- home + proxy --------------------------------------------------------------
+const tmpHome = await mkdtemp(join(tmpdir(), 'dario-ledger-wiring-'));
+process.env.HOME = tmpHome; process.env.USERPROFILE = tmpHome;
+process.env.DARIO_CODEX_BASE_URL = `http://127.0.0.1:${CODEX_PORT}`;
+process.env.DARIO_IGNORE_CC_CREDENTIALS = '1';
+delete process.env.DARIO_LEDGER; delete process.env.DARIO_LEDGER_PATH;
+const LEDGER = join(tmpHome, '.dario', `ledger-${PROXY_PORT}.json`);
+await mkdir(join(tmpHome, '.dario', 'accounts'), { recursive: true });
+await writeFile(join(tmpHome, '.dario', 'accounts', 'main.json'), JSON.stringify({ alias: 'main', accessToken: 'claude-access-token', refreshToken: 'claude-refresh-token', expiresAt: Date.now() + 6 * 3_600_000, scopes: ['user:inference'], deviceId: 'dev-1', accountUuid: 'uuid-1' }));
+await mkdir(join(tmpHome, '.dario', 'codex-accounts'), { recursive: true });
+await writeFile(join(tmpHome, '.dario', 'codex-accounts', 'live.json'), JSON.stringify({ alias: 'live', accessToken: 'codex-access-token', refreshToken: 'codex-refresh-token', expiresAt: Date.now() + 6 * 3_600_000 }));
+const { startProxy } = await import('../dist/proxy.js');
+const { LEDGER_FLUSH_DELAY_MS } = await import('../dist/ledger.js');
+// The overage guard (#288) halts the proxy on an `api` claim by design; this
+// test needs one api-claimed request to land in the metered column.
+const proxyOpts = { host: '127.0.0.1', verbose: false, noLiveCapture: true, fetchImpl: fakeFetch, overageGuardEnabled: false };
+await startProxy({ ...proxyOpts, port: PROXY_PORT });
+for (let i = 0; i < 50; i++) { try { await fetch(`${BASE}/health`); break; } catch { await sleep(100); } }
+
+const post = (model, stream) => fetch(`${BASE}/v1/messages`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ model, max_tokens: 64, stream, messages: [{ role: 'user', content: 'hello' }] }) });
+const analytics = async () => (await fetch(`${BASE}/analytics`)).json();
+const runCli = (args, env = {}) => new Promise((resolve) => {
+  const p = spawn(process.execPath, [CLI, ...args], { env: { ...process.env, ...env }, cwd: tmpHome });
+  let out = ''; p.stdout.on('data', (d) => { out += d; }); p.stderr.on('data', (d) => { out += d; });
+  p.on('close', (code) => resolve({ code, out }));
+});
+
+header('before any traffic');
+{
+  const a = await analytics();
+  check('/analytics.lifetime is present and empty', a.lifetime && a.lifetime.requests === 0 && a.lifetime.apiEquivalentCost === 0 && a.lifetime.path === LEDGER, JSON.stringify(a.lifetime));
+  let exists = true; try { await stat(LEDGER); } catch { exists = false; }
+  check('no file yet — nothing to write', !exists);
+}
+
+header('traffic: two covered Claude requests, one api-keyed, one 5xx, one codex');
+{
+  const r1 = await post(CLAUDE_MODEL, true); await r1.text();
+  const r2 = await post(CLAUDE_MODEL, false); await r2.text();
+  claudeClaim = 'api';
+  const r3 = await post(CLAUDE_MODEL, false); await r3.text();
+  claudeClaim = 'five_hour'; claudeStatus = 529;
+  const r4 = await post(CLAUDE_MODEL, false); await r4.text();
+  claudeStatus = 200;
+  const r5 = await post(CODEX_SLUG, false); const j5 = await r5.json();
+  if (r5.status !== 200) console.log('codex leg:', JSON.stringify(j5).slice(0, 400));
+  check('the requests went through as expected', r1.status === 200 && r2.status === 200 && r3.status === 200 && r4.status >= 500 && r5.status === 200 && j5.usage.output_tokens === 1_000_000, [r1.status, r2.status, r3.status, r4.status, r5.status].join(','));
+  const a = await analytics();
+  const l = a.lifetime;
+  check('lifetime: 4 counted (the 5xx is not), $22 API-equivalent = 2 × $5 opus + $12 terra, $5 metered', l.requests === 4 && l.apiEquivalentCost === 22 && l.meteredCost === 5, JSON.stringify(l));
+  check('perProvider splits Claude $10 / ChatGPT $12', l.perProvider.anthropic.apiEquivalentCost === 10 && l.perProvider.anthropic.requests === 2 && l.perProvider.openai.apiEquivalentCost === 12 && l.perProvider.openai.requests === 1, JSON.stringify(l.perProvider));
+  check('perModel: opus-5 carries the metered $5 too; terra is openai', l.perModel[CLAUDE_MODEL].meteredCost === 5 && l.perModel[CLAUDE_MODEL].apiEquivalentCost === 10 && l.perModel[CODEX_SLUG].provider === 'openai', JSON.stringify(l.perModel));
+  check('recent.today carries all of it', l.recent.today === 22 && l.recent.last7d === 22 && l.recent.last30d === 22, JSON.stringify(l.recent));
+  check('the rolling window still prices the same records (window estimatedCost = 27 incl. the api-keyed one)', a.window.estimatedCost === 27, a.window.estimatedCost);
+}
+
+header('/analytics/ledger and the file on disk');
+{
+  await sleep(LEDGER_FLUSH_DELAY_MS + 500);
+  const raw = JSON.parse(await readFile(LEDGER, 'utf8'));
+  const day = new Date().toISOString().slice(0, 10);
+  check('the file holds per-day, per-model, per-bucket token totals — no prices', raw.version === 1 && raw.days[day][CLAUDE_MODEL].covered.requests === 2 && raw.days[day][CLAUDE_MODEL].covered.inputTokens === 2_000_000 && raw.days[day][CLAUDE_MODEL].metered.requests === 1 && raw.days[day][CODEX_SLUG].covered.outputTokens === 1_000_000 && !JSON.stringify(raw).includes('cost'), JSON.stringify(raw));
+  const res = await fetch(`${BASE}/analytics/ledger`);
+  const j = await res.json();
+  check('GET /analytics/ledger returns the same table with its path', res.status === 200 && j.path === LEDGER && JSON.stringify(j.days) === JSON.stringify(raw.days), JSON.stringify(j).slice(0, 200));
+}
+
+header('dario usage: the headline above the window, --card, --json');
+{
+  const { code, out } = await runCli(['usage', `--port=${PROXY_PORT}`]);
+  check('prints the API-equivalent block first', code === 0 && out.includes('API-equivalent spend (since') && out.includes('$22.00 would have been billed on the metered API') && out.includes('Claude') && out.includes('$10.00') && out.includes('ChatGPT') && out.includes('$12.00') && out.includes('Paid per token on top (API key / extra usage): $5.00'), out);
+  check('the block precedes the rolling window', out.indexOf('API-equivalent spend') < out.indexOf('Window:'), out);
+  const card = await runCli(['usage', `--port=${PROXY_PORT}`, '--card=card.svg']);
+  const svg = await readFile(join(tmpHome, 'card.svg'), 'utf8');
+  check('--card writes the SVG with the number', card.code === 0 && card.out.includes('Wrote card.svg — $22.00 API-equivalent') && svg.includes('>$22.00<') && svg.includes('Claude $10.00') && svg.includes('ChatGPT $12.00'), card.out + svg.slice(0, 200));
+  const json = await runCli(['usage', `--port=${PROXY_PORT}`, '--json']);
+  check('--json carries lifetime', json.code === 0 && JSON.parse(json.out).lifetime.apiEquivalentCost === 22, json.out.slice(0, 200));
+}
+
+header('restart: the number survives; a proxy that is down still answers from the file');
+{
+  const deadPort = await freePort();
+  const { code, out } = await runCli(['usage', `--port=${deadPort}`]);
+  check('no proxy on that port, no ledger for it: says so, exits 1', code === 1 && out.includes(`no ledger at ${join(tmpHome, '.dario', `ledger-${deadPort}.json`)} yet`) && out.includes('Proxy not reachable'), out);
+  const viaFile = await runCli(['usage', `--port=${deadPort}`], { DARIO_LEDGER_PATH: LEDGER });
+  check('with the file named, the lifetime block prints from disk even though the proxy is unreachable', viaFile.code === 1 && viaFile.out.includes('$22.00 would have been billed') && viaFile.out.includes('Proxy not reachable'), viaFile.out);
+  const cardDown = await runCli(['usage', `--port=${deadPort}`, '--card=down.svg'], { DARIO_LEDGER_PATH: LEDGER });
+  check('--card works from the file too', (await readFile(join(tmpHome, 'down.svg'), 'utf8')).includes('>$22.00<'), cardDown.out);
+  // A second proxy on a fresh port, pointed at the same file, opens with the totals.
+  const port2 = await freePort();
+  process.env.DARIO_LEDGER_PATH = LEDGER;
+  await startProxy({ ...proxyOpts, port: port2 });
+  for (let i = 0; i < 50; i++) { try { await fetch(`http://127.0.0.1:${port2}/health`); break; } catch { await sleep(100); } }
+  const a2 = await (await fetch(`http://127.0.0.1:${port2}/analytics`)).json();
+  check('a fresh proxy reading the file starts from $22, not $0 — the window is empty, the ledger is not', a2.lifetime.apiEquivalentCost === 22 && a2.lifetime.requests === 4 && a2.window.requests === 0, JSON.stringify({ lifetime: a2.lifetime.apiEquivalentCost, window: a2.window.requests }));
+  delete process.env.DARIO_LEDGER_PATH;
+}
+
+header('off: --no-ledger / DARIO_LEDGER=0');
+{
+  const port3 = await freePort();
+  await startProxy({ ...proxyOpts, port: port3, ledger: false });
+  for (let i = 0; i < 50; i++) { try { await fetch(`http://127.0.0.1:${port3}/health`); break; } catch { await sleep(100); } }
+  const r = await fetch(`http://127.0.0.1:${port3}/v1/messages`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ model: CLAUDE_MODEL, max_tokens: 64, messages: [{ role: 'user', content: 'hello' }] }) }); await r.text();
+  const a3 = await (await fetch(`http://127.0.0.1:${port3}/analytics`)).json();
+  const lg = await fetch(`http://127.0.0.1:${port3}/analytics/ledger`);
+  check('lifetime is null, /analytics/ledger is 404, the window still counts', a3.lifetime === null && lg.status === 404 && a3.window.requests === 1, JSON.stringify({ lifetime: a3.lifetime, status: lg.status }));
+  await sleep(LEDGER_FLUSH_DELAY_MS + 300);
+  let exists = true; try { await stat(join(tmpHome, '.dario', `ledger-${port3}.json`)); } catch { exists = false; }
+  check('no file written', !exists);
+  const { out } = await runCli(['usage', `--port=${port3}`]);
+  check('dario usage says the ledger is disabled', out.includes('ledger disabled on this proxy (--no-ledger)'), out);
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+codexStub.close();
+process.exit(fail === 0 ? 0 : 1);

--- a/test/ledger.mjs
+++ b/test/ledger.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+// Unit tests for src/ledger.ts — the lifetime ledger behind "what would this
+// have cost on the metered API". Pure functions first (bucket rule, add,
+// prune, parse, summarize, formatting, the card), then the Ledger class
+// against a temp dir (open, debounced flush, corrupt file moved aside).
+
+import { mkdtemp, readFile, readdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  Ledger, LEDGER_VERSION, LEDGER_MAX_DAYS, LEDGER_FLUSH_DELAY_MS,
+  addToLedger, dayKey, emptyLedger, formatLedgerSummary, formatUsd, ledgerBucketFor, ledgerPathFor,
+  parseLedger, pruneLedger, readLedgerFile, renderLedgerCard, resolveLedgerPath, shortModelName, summarizeLedger,
+} from '../dist/ledger.js';
+import { OPENAI_PRICING, PRICING, costOfTokens, pricingRateFor, providerOfModel } from '../dist/analytics.js';
+
+let pass = 0, fail = 0;
+const check = (label, cond, detail) => {
+  if (cond) { console.log(`  ✅ ${label}`); pass++; }
+  else { console.log(`  ❌ ${label}${detail !== undefined ? ' :: ' + String(detail).slice(0, 400) : ''}`); fail++; }
+};
+const header = (l) => console.log(`\n=== ${l} ===`);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const near = (a, b, eps = 1e-9) => Math.abs(a - b) < eps;
+
+const T = Date.parse('2026-09-11T15:00:00Z');
+const rec = (over = {}) => ({
+  timestamp: T, account: 'main', model: 'claude-opus-5',
+  inputTokens: 1000, outputTokens: 500, cacheReadTokens: 20000, cacheCreateTokens: 2000, thinkingTokens: 0,
+  claim: 'five_hour', util5h: 0.1, util7d: 0.2, overageUtil: 0, latencyMs: 10, status: 200, isStream: true, isOpenAI: false,
+  ...over,
+});
+
+header('pricing: OpenAI rows, provider split, suffixes, fallbacks');
+{
+  check('gpt-* is the openai provider; claude-* and unknown ids are anthropic',
+    providerOfModel('gpt-5.6-terra') === 'openai' && providerOfModel('claude-opus-5') === 'anthropic' && providerOfModel('mystery') === 'anthropic' && providerOfModel('o3') === 'openai');
+  const terra = pricingRateFor('gpt-5.6-terra', T);
+  check('gpt-5.6-terra is priced from the OpenAI table, not the sonnet fallback', terra.input === 2 && terra.output === 12 && terra.cacheRead === 0.2, JSON.stringify(terra));
+  check('an effort suffix is stripped before lookup', JSON.stringify(pricingRateFor('gpt-5.6-sol:high', T)) === JSON.stringify(OPENAI_PRICING['gpt-5.6-sol']));
+  check('unknown gpt model → gpt-5.6-terra rate; unknown claude → sonnet-4-6 rate',
+    JSON.stringify(pricingRateFor('gpt-9-nova', T)) === JSON.stringify(OPENAI_PRICING['gpt-5.6-terra'])
+    && pricingRateFor('claude-mystery-9', T).input === PRICING['claude-sonnet-4-6'].input);
+  check('[1m] tag still stripped on the Claude side', pricingRateFor('claude-sonnet-5[1m]', T).input === 2);
+  check('the dated id a response echoes prices as its family (live 2026-09-12: claude-haiku-4-5-20251001 was at the sonnet fallback)', pricingRateFor('claude-haiku-4-5-20251001', T).input === 1 && pricingRateFor('claude-haiku-4-5-20251001', T).output === 5);
+  check('OpenAI cache writes cost the input rate (no separate write charge)', Object.values(OPENAI_PRICING).every((r) => r.cacheCreate === r.input));
+  const c = costOfTokens('claude-opus-5', T, { inputTokens: 1_000_000, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0 });
+  check('costOfTokens: 1M opus-5 input tokens = $5', c === 5, c);
+}
+
+header('bucket rule: 2xx only; api/extra_usage are metered, everything else covered');
+{
+  check('five_hour → covered', ledgerBucketFor({ status: 200, claim: 'five_hour' }) === 'covered');
+  check('codex claim → covered', ledgerBucketFor({ status: 200, claim: 'chatgpt_subscription' }) === 'covered');
+  check('overage-included → covered (it is $0 out of pocket)', ledgerBucketFor({ status: 200, claim: 'seven_day_overage_included' }) === 'covered');
+  check('absent claim on a 2xx → covered', ledgerBucketFor({ status: 200, claim: 'unknown' }) === 'covered');
+  check('api → metered', ledgerBucketFor({ status: 200, claim: 'api' }) === 'metered');
+  check('overage (paid extra usage) → metered', ledgerBucketFor({ status: 200, claim: 'overage' }) === 'metered');
+  check('429 / 500 / 0 are not counted', ledgerBucketFor({ status: 429, claim: 'five_hour' }) === null && ledgerBucketFor({ status: 500, claim: 'five_hour' }) === null && ledgerBucketFor({ status: 0, claim: 'five_hour' }) === null);
+}
+
+header('addToLedger: per UTC day, per model, per bucket; since moves back');
+{
+  const f = emptyLedger(T + 60_000);
+  check('a 200 is counted', addToLedger(f, rec()) === true);
+  check('a 429 is not', addToLedger(f, rec({ status: 429 })) === false);
+  addToLedger(f, rec({ inputTokens: 1 }));
+  addToLedger(f, rec({ claim: 'api', inputTokens: 7 }));
+  addToLedger(f, rec({ model: 'gpt-5.6-terra', claim: 'chatgpt_subscription', timestamp: Date.parse('2026-09-12T01:00:00Z'), cacheReadTokens: 0, cacheCreateTokens: 0 }));
+  const day = f.days['2026-09-11'];
+  check('two covered opus rows folded into one cell', day['claude-opus-5'].covered.requests === 2 && day['claude-opus-5'].covered.inputTokens === 1001 && day['claude-opus-5'].covered.cacheReadTokens === 40000, JSON.stringify(day));
+  check('the api-claimed one sits in metered', day['claude-opus-5'].metered.requests === 1 && day['claude-opus-5'].metered.inputTokens === 7);
+  check('the next UTC day is its own key', f.days['2026-09-12']['gpt-5.6-terra'].covered.requests === 1);
+  check('since moved back to the first record', f.since === new Date(T).toISOString(), f.since);
+  check('dayKey is UTC', dayKey(Date.parse('2026-09-11T23:59:59Z')) === '2026-09-11' && dayKey(Date.parse('2026-09-12T00:00:00Z')) === '2026-09-12');
+}
+
+header('prune: the oldest days roll off past the cap');
+{
+  const f = emptyLedger(T);
+  for (let i = 0; i < LEDGER_MAX_DAYS + 5; i++) addToLedger(f, rec({ timestamp: T - i * 86_400_000 }));
+  check(`${LEDGER_MAX_DAYS} days kept, the 5 oldest dropped`, Object.keys(f.days).length === LEDGER_MAX_DAYS && !f.days[dayKey(T - (LEDGER_MAX_DAYS + 4) * 86_400_000)] && f.days[dayKey(T)]);
+  const g = emptyLedger(T);
+  addToLedger(g, rec()); addToLedger(g, rec({ timestamp: T - 86_400_000 })); addToLedger(g, rec({ timestamp: T - 2 * 86_400_000 }));
+  pruneLedger(g, 2);
+  check('pruneLedger(maxDays) keeps the newest', Object.keys(g.days).sort().join(',') === `${dayKey(T - 86_400_000)},${dayKey(T)}`);
+}
+
+header('parseLedger: tolerant of junk rows, strict about the envelope');
+{
+  const f = emptyLedger(T); addToLedger(f, rec());
+  const rt = parseLedger(JSON.stringify(f));
+  check('round-trips', JSON.stringify(rt) === JSON.stringify(f));
+  const junk = { version: LEDGER_VERSION, since: 'garbage', days: {
+    '2026-09-11': { 'claude-opus-5': { covered: { requests: 1, inputTokens: 1, outputTokens: 1, cacheReadTokens: 0, cacheCreateTokens: 0 }, metered: { requests: 'x' } }, 'bad': 'row', 'empty': {} },
+    'not-a-day': { 'claude-opus-5': { covered: { requests: 1, inputTokens: 1, outputTokens: 1, cacheReadTokens: 0, cacheCreateTokens: 0 } } },
+    '2026-09-10': { 'claude-opus-5': { covered: { requests: -1, inputTokens: 1, outputTokens: 1, cacheReadTokens: 0, cacheCreateTokens: 0 } } },
+  } };
+  const p = parseLedger(JSON.stringify(junk));
+  check('keeps the good cell, drops the malformed metered cell, bad rows, bad day keys, negative counts',
+    Object.keys(p.days).join(',') === '2026-09-11' && Object.keys(p.days['2026-09-11']).join(',') === 'claude-opus-5' && p.days['2026-09-11']['claude-opus-5'].metered === undefined && p.days['2026-09-11']['claude-opus-5'].covered.requests === 1, JSON.stringify(p));
+  check('an unparseable since becomes now-ish, not NaN', !Number.isNaN(Date.parse(p.since)));
+  let threw = null;
+  try { parseLedger(JSON.stringify({ version: 99, days: {} })); } catch (e) { threw = e.message; }
+  check('wrong version throws', threw === 'not a dario ledger', threw);
+  try { threw = null; parseLedger('{"hello":1}'); } catch (e) { threw = e.message; }
+  check('not a ledger throws', threw === 'not a dario ledger', threw);
+}
+
+header('summarizeLedger: priced at the day, split by provider, trailing windows');
+{
+  const f = emptyLedger(T);
+  // Opus 5 on Sept 11: 1k in, 500 out, 20k cache read, 2k cache write → at $5/$25/$0.5/$6.25 per 1M
+  addToLedger(f, rec());
+  // Same day, API-keyed: metered, must not count as saved.
+  addToLedger(f, rec({ claim: 'api', inputTokens: 1_000_000, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0 }));
+  // 8 days ago, ChatGPT: 1M output tokens on terra → $12
+  addToLedger(f, rec({ model: 'gpt-5.6-terra', claim: 'chatgpt_subscription', timestamp: T - 8 * 86_400_000, inputTokens: 0, outputTokens: 1_000_000, cacheReadTokens: 0, cacheCreateTokens: 0 }));
+  // 40 days ago, Sonnet 5: 1M input → $2
+  addToLedger(f, rec({ model: 'claude-sonnet-5', timestamp: T - 40 * 86_400_000, inputTokens: 1_000_000, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0 }));
+  const s = summarizeLedger(f, '/tmp/ledger.json', T);
+  const opus = (1000 * 5 + 500 * 25 + 20000 * 0.5 + 2000 * 6.25) / 1e6;  // 0.04
+  check('apiEquivalentCost = opus + terra + sonnet covered rows', near(s.apiEquivalentCost, opus + 12 + 2, 1e-4), s.apiEquivalentCost);
+  const tiny = emptyLedger(T); addToLedger(tiny, rec({ model: 'gpt-5.6-luna', claim: 'chatgpt_subscription', inputTokens: 13, outputTokens: 5, cacheReadTokens: 0, cacheCreateTokens: 0 }));
+  check('millionths survive the rounding (13 in + 5 out on luna = $0.0000086, live 2026-09-12)', summarizeLedger(tiny, 'p', T).apiEquivalentCost === 0.000009, summarizeLedger(tiny, 'p', T).apiEquivalentCost);
+  check('meteredCost = the API-keyed 1M input at $5', s.meteredCost === 5, s.meteredCost);
+  check('requests counts both buckets; days counts distinct days', s.requests === 4 && s.days === 3);
+  check('perProvider: anthropic vs openai', near(s.perProvider.anthropic.apiEquivalentCost, opus + 2, 1e-4) && s.perProvider.openai.apiEquivalentCost === 12 && s.perProvider.openai.requests === 1);
+  check('perModel carries provider, tokens and both costs', s.perModel['claude-opus-5'].provider === 'anthropic' && s.perModel['claude-opus-5'].meteredCost === 5 && near(s.perModel['claude-opus-5'].apiEquivalentCost, opus, 1e-4) && s.perModel['gpt-5.6-terra'].provider === 'openai' && s.perModel['gpt-5.6-terra'].outputTokens === 1_000_000);
+  check('covered tokens exclude the metered row', s.tokens.input === 1000 + 1_000_000 && s.tokens.output === 500 + 1_000_000 && s.tokens.cacheRead === 20000, JSON.stringify(s.tokens));
+  check('recent: today = opus only; 7d = same (terra is 8 days back); 30d adds terra; sonnet at 40d in none', near(s.recent.today, opus, 1e-4) && near(s.recent.last7d, opus, 1e-4) && near(s.recent.last30d, opus + 12, 1e-4), JSON.stringify(s.recent));
+  check('since and path pass through', s.since === f.since && s.path === '/tmp/ledger.json');
+  const empty = summarizeLedger(emptyLedger(T), 'p', T);
+  check('an empty ledger summarizes to zeros', empty.apiEquivalentCost === 0 && empty.requests === 0 && empty.days === 0 && Object.keys(empty.perModel).length === 0);
+}
+
+header('presentation: formatUsd, model names, the text block, the card');
+{
+  check('formatUsd scales its precision', formatUsd(0) === '$0' && formatUsd(0.0000086) === '<$0.0001' && formatUsd(0.0042) === '$0.0042' && formatUsd(0.05) === '$0.05' && formatUsd(3.14159) === '$3.14' && formatUsd(1234.5) === '$1,235');
+  check('shortModelName', shortModelName('claude-opus-5') === 'Opus 5' && shortModelName('claude-sonnet-4-6') === 'Sonnet 4.6' && shortModelName('claude-haiku-4-5[1m]') === 'Haiku 4.5[1m]' && shortModelName('claude-haiku-4-5-20251001') === 'Haiku 4.5' && shortModelName('gpt-5.6-terra') === 'gpt-5.6-terra');
+  const f = emptyLedger(T);
+  addToLedger(f, rec({ inputTokens: 1_000_000, outputTokens: 1_000_000, cacheReadTokens: 0, cacheCreateTokens: 0 }));
+  addToLedger(f, rec({ model: 'gpt-5.6-terra', claim: 'chatgpt_subscription', inputTokens: 1_000_000, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0 }));
+  addToLedger(f, rec({ claim: 'api', inputTokens: 1_000_000, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0 }));
+  const s = summarizeLedger(f, 'p', T);
+  const lines = formatLedgerSummary(s);
+  const text = lines.join('\n');
+  check('headline names the total, the day count and the request count', lines[0].includes('since 2026-09-11, 1 day, 3 requests') && lines[1].includes('$32.00 would have been billed on the metered API'), text);
+  check('one row per provider with its models, biggest first', lines[2].trim().startsWith('Claude') && lines[2].includes('$30.00') && lines[2].includes('Opus 5 $30.00') && lines[3].trim().startsWith('ChatGPT') && lines[3].includes('gpt-5.6-terra $2.00'), text);
+  check('trailing windows and the metered line', text.includes('Today $32.00 · Last 7d $32.00 · Last 30d $32.00') && text.includes('Paid per token on top (API key / extra usage): $5.00'), text);
+  const noMetered = formatLedgerSummary(summarizeLedger((() => { const g = emptyLedger(T); addToLedger(g, rec()); return g; })(), 'p', T));
+  check('no metered line when nothing was metered', !noMetered.join('\n').includes('Paid per token'));
+  const svg = renderLedgerCard(s);
+  check('the card is one SVG with the number, both providers and the meta line', svg.startsWith('<svg xmlns="http://www.w3.org/2000/svg"') && svg.includes('>$32.00<') && svg.includes('Claude $30.00   ·   ChatGPT $2.00') && svg.includes('3 requests  ·  since 2026-09-11  ·  1 day') && svg.includes('>dario<'), svg.slice(0, 300));
+  const evil = summarizeLedger(f, 'p', T); evil.perProvider.openai.requests = 1; evil.since = '<script>alert(1)</script>';
+  check('template-sourced text is escaped', !renderLedgerCard(evil).includes('<script>') && renderLedgerCard(evil).includes('&lt;script&gt;'));
+}
+
+header('paths: default port → ledger.json, other ports → ledger-<port>.json, env override');
+{
+  check('ledgerPathFor', ledgerPathFor(3456, '/h').replace(/\\/g, '/') === '/h/.dario/ledger.json' && ledgerPathFor(3999, '/h').replace(/\\/g, '/') === '/h/.dario/ledger-3999.json');
+  check('DARIO_LEDGER_PATH wins', resolveLedgerPath(3456, { DARIO_LEDGER_PATH: '/x/l.json' }) === '/x/l.json' && resolveLedgerPath(3999, { DARIO_LEDGER_PATH: '  ' }).endsWith('ledger-3999.json'));
+}
+
+header('Ledger class: open fresh, debounced flush, reopen, corrupt file moved aside');
+{
+  const dir = await mkdtemp(join(tmpdir(), 'dario-ledger-'));
+  const path = join(dir, 'nested', 'ledger.json');
+  const logs = [];
+  const l = await Ledger.open(path, (line) => logs.push(line));
+  check('a missing file opens empty', l.summary(T).requests === 0 && l.path === path);
+  check('add counts and schedules a write', l.add(rec()) === true && l.add(rec({ status: 429 })) === false);
+  const before = await readLedgerFile(path);
+  check('nothing on disk before the debounce fires', before.file === null && before.error === undefined);
+  await sleep(LEDGER_FLUSH_DELAY_MS + 400);
+  const after = await readLedgerFile(path);
+  check('the file appears after the debounce, directory created', after.file !== null && after.file.days['2026-09-11']['claude-opus-5'].covered.requests === 1, JSON.stringify(after));
+  l.add(rec());
+  await l.close();
+  const closed = await readLedgerFile(path);
+  check('close() flushes what the debounce still held', closed.file.days['2026-09-11']['claude-opus-5'].covered.requests === 2);
+  check('after close, add is refused', l.add(rec()) === false);
+  const l2 = await Ledger.open(path);
+  check('reopening sees the same totals — the number survives a restart', l2.summary(T).requests === 2 && l2.summary(T).since === closed.file.since);
+  check('snapshot is a copy', (() => { const s = l2.snapshot(); s.days = {}; return l2.summary(T).requests === 2; })());
+  check('no temp files left behind', (await readdir(join(dir, 'nested'))).join(',') === 'ledger.json');
+
+  await writeFile(path, '{ this is not json');
+  const l3 = await Ledger.open(path, (line) => logs.push(line));
+  const files = await readdir(join(dir, 'nested'));
+  check('a corrupt file is moved aside, not overwritten, and logged', l3.summary(T).requests === 0 && files.some((f) => f.startsWith('ledger.json.corrupt-')) && !files.includes('ledger.json') && logs.some((m) => m.includes('moved aside')), files.join(','));
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## What

`/analytics` is a rolling in-memory window: it forgets on every restart and caps at 10k records. The number a subscription user actually wants — what has this saved me since I set it up — was never answerable past the last few hours. This adds the **ledger**: a small persistent file that lets `dario usage`, `/analytics` and the TUI say what the traffic would have cost on the metered API, across restarts, with a share card for the headline.

## How

- `src/ledger.ts` keeps one row per UTC day, per model, per billing bucket in `~/.dario/ledger.json` (`ledger-<port>.json` off the default port, so a second instance sharing the home does not overwrite it): a request count and the four token buckets. **It never stores a price.** Rows are priced at read time at the rate in effect on their day (`costOfTokens` / `pricingRateFor`), so a pricing correction (#1047, #1048) reprices history instead of freezing the old number in.
- Two columns per row. **covered** — served against a subscription (every subscription claim, the codex claim, a 2xx with no claim): the API-equivalent cost of this is the headline. **metered** — billed per token anyway (`api`, `extra_usage`): reported as spent, never as saved. Only 2xx rows count.
- Writes are debounced (3 s) and durable (`durableWriteFile`, the credential-store path); the shutdown hook flushes; an unparseable file is moved aside as `.corrupt-<ts>` rather than overwritten; days past 730 roll off.
- Surfaces: `dario usage` opens with the block below and reads the file when the proxy is down (`--card[=file.svg]` writes the headline as a 640×320 SVG; `--json` carries `lifetime`); `GET /analytics` gains `lifetime`; `GET /analytics/ledger` is the per-day table; the TUI Analytics tab gets an **API-equivalent** row. `--no-ledger` / `DARIO_LEDGER=0` turns it off, `DARIO_LEDGER_PATH` moves it.
- `OPENAI_PRICING` (src/analytics.ts): OpenAI's published standard-tier rates for the codex models, read off developers.openai.com/api/docs/pricing on 2026-09-11. Before this a `gpt-*` row fell through to the Claude fallback and priced a ChatGPT-plan request at Sonnet 4.6's rate. Kept as a separate table so `check-pricing-drift.mjs` keeps diffing `PRICING` against Anthropic's page. `pricingRateFor` also strips an effort suffix and the dated id a response echoes (`claude-haiku-4-5-20251001`) — see below.
- `test/all.test.mjs` pins `DARIO_LEDGER_PATH` to a temp dir, the same rule as the template cache: a suite run must not add stub traffic to the operator's file.

```
  API-equivalent spend (since 2026-09-12, 1 day, 4 requests):
    $0.0025 would have been billed on the metered API — covered by subscriptions
      Claude     $0.0025   2 reqs   (Haiku 4.5 $0.0025)
      ChatGPT   <$0.0001   2 reqs
    Today $0.0025 · Last 7d $0.0025 · Last 30d $0.0025
```

## Verified live

Branch build run on the box as a second instance on :3999 next to production, sharing its `~/.dario`:

- One Claude request (haiku) and one ChatGPT request (gpt-5.6-luna) through it: `/analytics.lifetime` counted both by provider; `ledger-3999.json` appeared after the debounce with the two rows and no prices.
- The first run caught a real bug: the record's model was the dated id the response echoes, `claude-haiku-4-5-20251001`, which `pricingRateFor` did not match and priced at the sonnet fallback ($0.0035 instead of $0.0012). Fixed by stripping `-YYYYMMDD` before lookup; because the file holds tokens, not dollars, restarting on the fixed build repriced the rows already on disk — the design point, demonstrated.
- SIGTERM flushed; the restarted instance opened with the totals and an empty window; `dario usage --port=3999` printed the block above the window, `--card` wrote the SVG (rendered and eyeballed), and with the proxy stopped `dario usage` printed the same block from the file. Rig torn down, the test ledger removed from the shared home.

## Tests

- `test/ledger.mjs` (59): bucket rule, per-day folding, prune, tolerant parse, pricing by day and provider, trailing windows, the text block, the card's escaping, `Ledger.open` / debounced flush / reopen / corrupt-file move-aside; OpenAI rates, provider split, suffix stripping, fallbacks.
- `test/ledger-wiring.mjs` (21): a real `startProxy` with a Claude stub switching claims and a codex stub — `lifetime` on `/analytics`, the file on disk, `/analytics/ledger`, `dario usage` with and without a proxy, `--card`, `--json`, a fresh proxy opening on the same file, `--no-ledger`.
- Full suite: 205 files pass.

## Trade-offs and unknowns

- **Nothing watches `OPENAI_PRICING`.** The Claude table has `check-pricing-drift.mjs`; the OpenAI rates are correct as of 2026-09-11 and will go wrong silently when OpenAI moves them. Extending the watcher to the OpenAI page is a follow-up; the page is fetchable.
- **A 2xx with no claim counts as covered.** That is a stream cut before the headers were read, or api-key mode without the header. The alternative (dropping it) undercounts real traffic; the doc says which way it leans.
- **Two proxies writing one file** is last-writer-wins. The per-port default covers the one real case (a test rig next to production); `DARIO_LEDGER_PATH` is there for anything else.
- Version: 6.6.0 (minor — a new file on disk and a new endpoint). Was 6.5.0; #1288 took that slot while this was under review, so the branch merged master and renumbered.
