### PR TITLE
The pricing watcher was blind for ten days, and now watches OpenAI too (v6.6.2)

### DIFF
--- a/.github/workflows/pricing-drift-watch.yml
+++ b/.github/workflows/pricing-drift-watch.yml
@@ -1,6 +1,8 @@
 name: Pricing drift watch
 
-# Diffs dario's PRICING table against Anthropic's published rates.
+# Diffs dario's PRICING table against Anthropic's published rates, and (since
+# 6.6.1) OPENAI_PRICING against OpenAI's — the rates behind every ChatGPT-leg
+# row in the ledger.
 #
 # WHY. PRICING encodes external facts with no natural expiry. An entry is
 # correct when written, has a passing test, and then goes silently wrong the
@@ -23,13 +25,16 @@ name: Pricing drift watch
 # EXIT CODES (scripts/check-pricing-drift.mjs):
 #   0 aligned  -> close any open issue
 #   1 drift    -> open/refresh the issue
-#   2 could not determine -> WARN AND PASS, never treated as drift
+#   2 could not fetch -> WARN AND PASS, never treated as drift
+#   3 fetched but could not read -> open/refresh the issue: the watcher is BLIND
 #
-# Exit 2 covers every way of not knowing: network failure, the page moving, a
-# renamed column, a parse too thin to trust. That distinction is the whole
-# design — a watcher that reports "aligned" because it could not read anything
-# is worse than no watcher, since the first sign of trouble is a wrong number
-# in front of a user.
+# Exit 2 is the transient case: network failure, the page unreachable. Exit 3
+# is the page's shape changing under the parser — a renamed column, a parse
+# too thin to trust. It used to share exit 2, and on 2026-09-02 Anthropic
+# renamed one column: ten daily runs answered "could not determine" as a
+# warning in this log, nothing was filed, and the table sat unwatched. A
+# watcher that cannot read the page is as blind as one reporting "aligned"
+# from nothing, so that case is filed now, on the same issue drift uses.
 
 on:
   schedule:
@@ -106,10 +111,36 @@ jobs:
             --json number --jq '.[0].number // empty')"
 
           if [ "$status" = "2" ]; then
-            # Could not determine. Do NOT touch the issue in either direction:
+            # Could not fetch. Do NOT touch the issue in either direction:
             # opening one would be a false alarm, and closing one would silently
             # retract a real finding because the page happened to be unreachable.
             echo "::warning::pricing drift could not be determined — see the report above. Neither opening nor closing an issue."
+            exit 0
+          fi
+
+          if [ "$status" = "3" ]; then
+            # Fetched, not understood: the published page changed shape and the
+            # parser no longer finds its table. Not drift — but not nothing
+            # either: until the parser is fixed, no drift can be seen. File it.
+            {
+              echo "\`scripts/check-pricing-drift.mjs\` fetched a published pricing page but could not read it — the watcher is blind on that provider until the parser is updated, and any real drift there goes unseen."
+              echo
+              echo '\`\`\`json'
+              cat pricing-drift.json
+              echo '\`\`\`'
+              echo
+              echo "**Fix:** compare the page against \`parsePricingTable\` / \`parseOpenAiPricingTable\` (column names, heading, cell format), update the parser, then re-run \`node scripts/check-pricing-drift.mjs\` (exit 0 = aligned, 1 = drift, 3 = still blind)."
+              echo
+              echo "_Auto-filed by \`pricing-drift-watch.yml\`._"
+            } > body.md
+            if [ -n "$existing" ]; then
+              gh issue comment "$existing" --repo "$REPO" --body-file body.md
+              echo "refreshed #$existing (blind)"
+            else
+              gh issue create --repo "$REPO" --label pricing-drift \
+                --title "Pricing watch is blind: a published pricing page changed shape" \
+                --body-file body.md
+            fi
             exit 0
           fi
 
@@ -127,15 +158,15 @@ jobs:
 
           # status == 1: drift.
           {
-            echo "\`scripts/check-pricing-drift.mjs\` found dario's \`PRICING\` table out of sync with [Anthropic's published rates](https://platform.claude.com/docs/en/about-claude/pricing)."
+            echo "\`scripts/check-pricing-drift.mjs\` found a dario price table out of sync with the published rates ([Anthropic](https://platform.claude.com/docs/en/about-claude/pricing) for \`PRICING\`, [OpenAI](https://developers.openai.com/api/docs/pricing) for \`OPENAI_PRICING\`; each row names its provider)."
             echo
-            echo "Every row below feeds \`estimatedCost\` in \`/analytics\`, the TUI's cost column and \`dario doctor\`. A wrong rate here is not cosmetic — it is a number users quote."
+            echo "Every row below feeds \`estimatedCost\` in \`/analytics\`, the ledger's API-equivalent spend, the TUI's cost column and \`dario doctor\`. A wrong rate here is not cosmetic — it is a number users quote."
             echo
             echo '```json'
             cat pricing-drift.json
             echo '```'
             echo
-            echo "**Fix:** update \`PRICING\` in \`src/analytics.ts\` to match the \`published\` column, then re-run \`node scripts/check-pricing-drift.mjs\` (exit 0 = aligned). If a rate genuinely should differ from the published one, say why in a comment beside the entry — an unexplained divergence will be re-reported here every day."
+            echo "**Fix:** update \`PRICING\` / \`OPENAI_PRICING\` in \`src/analytics.ts\` to match the \`published\` column, then re-run \`node scripts/check-pricing-drift.mjs\` (exit 0 = aligned). If a rate genuinely should differ from the published one, say why in a comment beside the entry — an unexplained divergence will be re-reported here every day."
             echo
             echo "_Auto-filed by \`pricing-drift-watch.yml\`._"
           } > body.md

--- a/.github/workflows/pricing-drift-watch.yml
+++ b/.github/workflows/pricing-drift-watch.yml
@@ -125,9 +125,9 @@ jobs:
             {
               echo "\`scripts/check-pricing-drift.mjs\` fetched a published pricing page but could not read it — the watcher is blind on that provider until the parser is updated, and any real drift there goes unseen."
               echo
-              echo '\`\`\`json'
+              echo '```json'
               cat pricing-drift.json
-              echo '\`\`\`'
+              echo '```'
               echo
               echo "**Fix:** compare the page against \`parsePricingTable\` / \`parseOpenAiPricingTable\` (column names, heading, cell format), update the parser, then re-run \`node scripts/check-pricing-drift.mjs\` (exit 0 = aligned, 1 = drift, 3 = still blind)."
               echo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ checklist.
 
 ## [Unreleased]
 
+## [6.6.2] - 2026-09-12
+
+### Fixed
+
+- **The pricing watcher was blind for ten days, and now watches OpenAI too.** On 2026-09-02
+  Anthropic renamed one column of its pricing table ("Cache hits & refreshes" → "Cache hits and
+  refreshes"); `check-pricing-drift.mjs` matched headers by exact name, so every daily run since
+  answered "could not determine" — exit 2, a `::warning` in a workflow log nobody reads, nothing
+  filed — which is the silent-stop failure the script's own header warns about. Header names now
+  fold `&`/`and`, case and spacing (`headerKey`); the footnote marker the page flattens into a cell
+  (`$0.25 / MTok1`, Fable 5.1) no longer drops the row; and a page that is fetched but not
+  understood is its own exit code (3) that the workflow files on the `pricing-drift` issue, leaving
+  exit 2 for a fetch that failed. `OPENAI_PRICING` (6.6.0) is watched the same way against
+  `developers.openai.com/api/docs/pricing.md` — the standard table's short-context columns, found by
+  its heading since the batch and fast-mode tables carry the same headers — and the first watched
+  run corrected it: the 5.6 family and gpt-6-astra list a cache-write price of 1.25× input, which
+  shipped as the input rate; `gpt-5.3-codex` is not in the standard table and is dropped. Both
+  providers report clean against today's pages. `test/pricing-drift.mjs` (60) covers the rename,
+  the footnote, the OpenAI parser (heading, `-` cells, context-length suffixes, every way of not
+  knowing) and the shared diff.
+
 ## [6.6.1] - 2026-09-12
 
 ### Added

--- a/docs/api-equivalent-spend.md
+++ b/docs/api-equivalent-spend.md
@@ -110,7 +110,12 @@ nothing to write a cache entry, so cache-write tokens (which the codex path
 never reports anyway) are priced at the input rate. Unknown `gpt-*` ids take
 gpt-5.6-terra's rate, dario's default codex model.
 
-`scripts/check-pricing-drift.mjs` watches the Claude table against
-Anthropic's page. Nothing watches the OpenAI table yet — an entry that is
-correct today goes wrong the moment OpenAI changes it, and the only signal
-would be this number moving.
+`scripts/check-pricing-drift.mjs` watches both tables daily
+(`pricing-drift-watch.yml`): `PRICING` against Anthropic's page,
+`OPENAI_PRICING` against OpenAI's `pricing.md` (the standard table's
+short-context columns, found by its heading — the batch and fast-mode tables
+below it carry the same headers). The first watched run corrected the table:
+the 5.6 family and gpt-6-astra list a cache-write price of 1.25× input, which
+6.6.0 had as the input rate. A page the watcher can fetch but no longer
+understand is filed as an issue, not logged as a warning — that is how the
+Anthropic side went unwatched for ten days in September 2026.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "6.6.1",
+  "version": "6.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "6.6.1",
+      "version": "6.6.2",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "6.6.1",
+  "version": "6.6.2",
   "description": "Use your Claude and ChatGPT subscriptions in Cursor, Cline, Aider, Claude Code and the Agent SDK — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint: either plan answers either wire shape, with automatic failover when one hits its limit.",
   "type": "module",
   "bin": {

--- a/scripts/check-pricing-drift.mjs
+++ b/scripts/check-pricing-drift.mjs
@@ -41,6 +41,13 @@ import { dirname, join, resolve } from 'node:path';
 const SOURCE = 'https://platform.claude.com/docs/en/about-claude/pricing.md';
 const HUMAN_SOURCE = 'https://platform.claude.com/docs/en/about-claude/pricing';
 
+// OpenAI's page has the same `.md` route (per its own llms.txt note). This
+// feeds OPENAI_PRICING — the rates behind every ChatGPT-leg row in the ledger
+// (v6.6) — which shipped unwatched; a table written from the page one day
+// is exactly what this file exists to distrust.
+const OPENAI_SOURCE = 'https://developers.openai.com/api/docs/pricing.md';
+const OPENAI_HUMAN_SOURCE = 'https://developers.openai.com/api/docs/pricing';
+
 /**
  * Column header -> the PRICING field it feeds. Matched by NAME, never by
  * position: a column reorder upstream would otherwise silently map cache-read
@@ -51,6 +58,20 @@ const COLUMNS = {
   'output tokens': 'output',
   'cache hits & refreshes': 'cacheRead',
   '5m cache writes': 'cacheCreate',
+};
+
+/**
+ * OpenAI's standard table, column header -> field. Matched by NAME like the
+ * Anthropic one. "Short context" is the <272K tier — the one every codex
+ * request dario serves falls in; the long-context premium is not modelled.
+ * A `-` in the cache-writes column means no separate write price, which is
+ * what OPENAI_PRICING encodes as cacheCreate = input.
+ */
+const OPENAI_COLUMNS = {
+  'short context input': 'input',
+  'short context cached input': 'cacheRead',
+  'short context cache writes': 'cacheCreate',
+  'short context output': 'output',
 };
 
 /**
@@ -150,6 +171,81 @@ export function parsePricingTable(markdown) {
   return rates;
 }
 
+/** "$12.50" -> 12.5; "-" -> null (no price in that cell); anything else -> undefined. */
+export function openAiPriceFromCell(cell) {
+  const t = String(cell).trim();
+  if (t === '-' || t === '—') return null;
+  const m = /^\$\s*([0-9]+(?:\.[0-9]+)?)$/.exec(t);
+  return m ? Number(m[1]) : undefined;
+}
+
+/** "gpt-5.5 (<272K context length)" -> "gpt-5.5". Anything not gpt-/o-shaped -> null. */
+export function openAiModelIdFromCell(cell) {
+  const id = String(cell).replace(/\([^)]*\)/g, '').replace(/\*+/g, '').trim().toLowerCase();
+  return /^(gpt-|o\d|codex)/.test(id) ? id : null;
+}
+
+/**
+ * Pure parse of OpenAI's pricing markdown into { modelId: {input, output,
+ * cacheRead, cacheCreate} } from the STANDARD table only. Batch and fast-mode
+ * tables carry the same headers, so the standard one is found by the heading
+ * above it, not by header content alone. Throws on anything that would make
+ * a silent wrong answer possible.
+ */
+export function parseOpenAiPricingTable(markdown) {
+  const lines = String(markdown).split('\n');
+  const headingIdx = lines.findIndex((l) => /^#{2,4}\s+standard pricing/i.test(l.trim()));
+  if (headingIdx === -1) {
+    throw new Error('could not find the "Standard pricing" heading — the published page shape has probably changed');
+  }
+  let headerIdx = -1;
+  let colIndex = null;
+  for (let i = headingIdx + 1; i < lines.length; i++) {
+    if (/^#{2,4}\s/.test(lines[i].trim())) break;  // the next section: no table under this heading
+    if (!lines[i].includes('|')) continue;
+    const cells = lines[i].split('|').map((c) => c.trim().toLowerCase());
+    const found = {};
+    for (const [header, field] of Object.entries(OPENAI_COLUMNS)) {
+      const at = cells.indexOf(header);
+      if (at !== -1) found[field] = at;
+    }
+    if (Object.keys(found).length === Object.keys(OPENAI_COLUMNS).length) { headerIdx = i; colIndex = found; break; }
+    throw new Error(`the standard table no longer carries all of: ${Object.keys(OPENAI_COLUMNS).join(', ')}`);
+  }
+  if (headerIdx === -1) throw new Error('no table under the "Standard pricing" heading');
+
+  const rates = {};
+  for (let i = headerIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.includes('|')) {
+      if (Object.keys(rates).length > 0) break;
+      continue;
+    }
+    if (/^\s*\|?[\s:|-]+\|?\s*$/.test(line)) continue;
+    const cells = line.split('|').map((c) => c.trim());
+    const id = openAiModelIdFromCell(cells[1] ?? '');
+    if (!id) continue;
+    const rate = {};
+    let ok = true;
+    for (const [field, at] of Object.entries(colIndex)) {
+      const v = openAiPriceFromCell(cells[at] ?? '');
+      if (v === undefined) { ok = false; break; }
+      rate[field] = v;
+    }
+    if (!ok || rate.input === null || rate.output === null) continue;  // a row without a base price
+    if (rate.cacheRead === null) rate.cacheRead = rate.input;
+    if (rate.cacheCreate === null) rate.cacheCreate = rate.input;
+    rates[id] = rate;
+  }
+  if (Object.keys(rates).length < MIN_PUBLISHED_ROWS) {
+    throw new Error(
+      `parsed only ${Object.keys(rates).length} OpenAI model rows (expected >= ${MIN_PUBLISHED_ROWS}) ` +
+      '— refusing to report "aligned" from a parse this thin',
+    );
+  }
+  return rates;
+}
+
 /**
  * Compare dario's table against the published one. Only models dario actually
  * prices are checked; the published table listing models dario does not model
@@ -226,64 +322,73 @@ export function staleIntroWindows(pricing, nowMs) {
   return stale;
 }
 
+/** Fetch one published page as markdown, or throw with a reason that names the failure. */
+async function fetchMarkdown(url) {
+  const res = await fetch(url, { signal: AbortSignal.timeout(20_000) });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const markdown = await res.text();
+  // If the .md route ever starts serving the app shell, say so rather than
+  // failing later with a confusing "table shape changed".
+  if (/^\s*<!DOCTYPE/i.test(markdown)) throw new Error('got HTML, not markdown — the .md route may have moved');
+  return markdown;
+}
+
+/**
+ * One provider's check: { status: 'clean' | 'drift' | 'infra_error', ... }.
+ * Network failure and an unparseable page are NOT drift — they are "could
+ * not determine", and never a quiet "aligned".
+ */
+async function checkProvider(name, { source, humanSource, table, parse, extraDrift }) {
+  const out = { provider: name, source: humanSource, modelsChecked: Object.keys(table).length };
+  let markdown;
+  try { markdown = await fetchMarkdown(source); }
+  catch (err) { return { ...out, status: 'infra_error', error: `could not fetch published pricing: ${err.message}` }; }
+  let published;
+  try { published = parse(markdown); }
+  catch (err) { return { ...out, status: 'infra_error', error: `could not parse published pricing: ${err.message}` }; }
+  const ours = Object.fromEntries(Object.entries(table).map(([id, e]) => [id, comparable(e)]));
+  const drift = [...diffPricing(ours, published), ...(extraDrift ?? [])].map((d) => ({ provider: name, ...d }));
+  return { ...out, modelsPublished: Object.keys(published).length, drift, status: drift.length === 0 ? 'clean' : 'drift' };
+}
+
 async function main() {
   const here = dirname(fileURLToPath(import.meta.url));
-  const report = { checkedAt: new Date().toISOString(), source: HUMAN_SOURCE };
+  const report = { checkedAt: new Date().toISOString(), source: HUMAN_SOURCE, openaiSource: OPENAI_HUMAN_SOURCE };
 
-  let PRICING;
+  let PRICING, OPENAI_PRICING;
   try {
     // pathToFileURL, not a bare path: a Windows absolute path ("C:\…") is not
     // a valid ESM specifier and the loader rejects it as an unknown protocol.
-    ({ PRICING } = await import(pathToFileURL(resolve(join(here, '..', 'dist', 'analytics.js'))).href));
+    ({ PRICING, OPENAI_PRICING } = await import(pathToFileURL(resolve(join(here, '..', 'dist', 'analytics.js'))).href));
     if (!PRICING || typeof PRICING !== 'object') throw new Error('PRICING is not an object');
+    if (!OPENAI_PRICING || typeof OPENAI_PRICING !== 'object') throw new Error('OPENAI_PRICING is not an object');
   } catch (err) {
     console.log(JSON.stringify({ ...report, status: 'infra_error',
       error: `could not load dist/analytics.js — run \`npm run build\` first: ${err.message}` }, null, 2));
     process.exit(2);
   }
 
-  let markdown;
-  try {
-    const res = await fetch(SOURCE, { signal: AbortSignal.timeout(20_000) });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    markdown = await res.text();
-    // If the .md route ever starts serving the app shell, say so rather than
-    // failing later with a confusing "table shape changed".
-    if (/^\s*<!DOCTYPE/i.test(markdown)) {
-      throw new Error('got HTML, not markdown — the .md route may have moved');
-    }
-  } catch (err) {
-    // Network failure is NOT drift. Exit 2 so a flaky fetch never churns the
-    // issue or, worse, reports "aligned" because nothing came back.
-    console.log(JSON.stringify({ ...report, status: 'infra_error',
-      error: `could not fetch published pricing: ${err.message}` }, null, 2));
-    process.exit(2);
-  }
-
-  let published;
-  try {
-    published = parsePricingTable(markdown);
-  } catch (err) {
-    console.log(JSON.stringify({ ...report, status: 'infra_error',
-      error: `could not parse published pricing: ${err.message}` }, null, 2));
-    process.exit(2);
-  }
-
-  const ours = Object.fromEntries(
-    Object.entries(PRICING).map(([id, e]) => [id, comparable(e)]),
-  );
   // A rate that no longer matches, and a promotional window that has lapsed,
   // are both "PRICING no longer describes reality" — one report, one exit code.
-  const drift = [...diffPricing(ours, published), ...staleIntroWindows(PRICING, Date.now())];
-
+  const providers = [
+    await checkProvider('anthropic', { source: SOURCE, humanSource: HUMAN_SOURCE, table: PRICING, parse: parsePricingTable, extraDrift: staleIntroWindows(PRICING, Date.now()) }),
+    await checkProvider('openai', { source: OPENAI_SOURCE, humanSource: OPENAI_HUMAN_SOURCE, table: OPENAI_PRICING, parse: parseOpenAiPricingTable }),
+  ];
+  const drift = providers.flatMap((p) => p.drift ?? []);
+  const undetermined = providers.filter((p) => p.status === 'infra_error');
+  // Drift anywhere is actionable and wins; otherwise a provider that could not
+  // be read means the whole run could not say "aligned".
+  const status = drift.length > 0 ? 'drift' : undetermined.length > 0 ? 'infra_error' : 'clean';
   console.log(JSON.stringify({
     ...report,
-    modelsChecked: Object.keys(ours).length,
-    modelsPublished: Object.keys(published).length,
+    modelsChecked: providers.reduce((n, p) => n + p.modelsChecked, 0),
+    modelsPublished: providers.reduce((n, p) => n + (p.modelsPublished ?? 0), 0),
+    providers,
     drift,
-    status: drift.length === 0 ? 'clean' : 'drift',
+    ...(undetermined.length > 0 ? { error: undetermined.map((p) => `${p.provider}: ${p.error}`).join('; ') } : {}),
+    status,
   }, null, 2));
-  process.exit(drift.length === 0 ? 0 : 1);
+  process.exit(status === 'drift' ? 1 : status === 'infra_error' ? 2 : 0);
 }
 
 function isMainModule() {

--- a/scripts/check-pricing-drift.mjs
+++ b/scripts/check-pricing-drift.mjs
@@ -28,7 +28,9 @@
  * small parse. Exit 2 is "could not determine", which the workflow treats as a
  * skipped run rather than as clean.
  *
- * Exit codes: 0 = aligned, 1 = drift, 2 = could not determine.
+ * Exit codes: 0 = aligned, 1 = drift, 2 = could not fetch (transient — a
+ * warning), 3 = fetched but could not read (the page's shape changed — the
+ * watcher is blind until someone looks, so the workflow files it).
  * JSON report to stdout in all cases.
  */
 
@@ -52,13 +54,25 @@ const OPENAI_HUMAN_SOURCE = 'https://developers.openai.com/api/docs/pricing';
  * Column header -> the PRICING field it feeds. Matched by NAME, never by
  * position: a column reorder upstream would otherwise silently map cache-read
  * prices onto cache-write fields and report "aligned".
+ *
+ * Names are compared through `headerKey`: lower-cased, `&` read as `and`,
+ * whitespace collapsed. On 2026-09-02 Anthropic's column went from "Cache
+ * hits & refreshes" to "Cache hits and refreshes" and this watcher spent ten
+ * days answering "could not determine" — a warning in a workflow log nobody
+ * reads — which is the silent-stop failure its own header warns about. The
+ * workflow now files that case too (exit 3, below).
  */
 const COLUMNS = {
   'base input tokens': 'input',
   'output tokens': 'output',
-  'cache hits & refreshes': 'cacheRead',
+  'cache hits and refreshes': 'cacheRead',
   '5m cache writes': 'cacheCreate',
 };
+
+/** A table header cell, normalised for matching against COLUMNS / OPENAI_COLUMNS. */
+export function headerKey(cell) {
+  return String(cell).toLowerCase().replace(/&/g, 'and').replace(/\s+/g, ' ').trim();
+}
 
 /**
  * OpenAI's standard table, column header -> field. Matched by NAME like the
@@ -100,9 +114,14 @@ export function modelIdFromDisplayName(cell) {
   return name.toLowerCase().replace(/[\s.]+/g, '-').replace(/-+$/, '');
 }
 
-/** "$12.50 / MTok" -> 12.5. Returns null when the cell is not a price. */
+/**
+ * "$12.50 / MTok" -> 12.5. Returns null when the cell is not a price. A
+ * trailing footnote marker ("$0.25 / MTok1" — the page's superscript "1"
+ * flattened into the markdown) is tolerated; the unit itself is not
+ * negotiable.
+ */
 export function priceFromCell(cell) {
-  const m = /^\$\s*([0-9]+(?:\.[0-9]+)?)\s*\/\s*MTok$/i.exec(String(cell).trim());
+  const m = /^\$\s*([0-9]+(?:\.[0-9]+)?)\s*\/\s*MTok(?:\s*\*?\d)?$/i.exec(String(cell).trim());
   return m ? Number(m[1]) : null;
 }
 
@@ -122,7 +141,7 @@ export function parsePricingTable(markdown) {
   let colIndex = null;
   for (let i = 0; i < lines.length; i++) {
     if (!lines[i].includes('|')) continue;
-    const cells = lines[i].split('|').map((c) => c.trim().toLowerCase());
+    const cells = lines[i].split('|').map(headerKey);
     const found = {};
     for (const [header, field] of Object.entries(COLUMNS)) {
       const at = cells.indexOf(header);
@@ -203,7 +222,7 @@ export function parseOpenAiPricingTable(markdown) {
   for (let i = headingIdx + 1; i < lines.length; i++) {
     if (/^#{2,4}\s/.test(lines[i].trim())) break;  // the next section: no table under this heading
     if (!lines[i].includes('|')) continue;
-    const cells = lines[i].split('|').map((c) => c.trim().toLowerCase());
+    const cells = lines[i].split('|').map(headerKey);
     const found = {};
     for (const [header, field] of Object.entries(OPENAI_COLUMNS)) {
       const at = cells.indexOf(header);
@@ -342,10 +361,10 @@ async function checkProvider(name, { source, humanSource, table, parse, extraDri
   const out = { provider: name, source: humanSource, modelsChecked: Object.keys(table).length };
   let markdown;
   try { markdown = await fetchMarkdown(source); }
-  catch (err) { return { ...out, status: 'infra_error', error: `could not fetch published pricing: ${err.message}` }; }
+  catch (err) { return { ...out, status: 'infra_error', kind: 'fetch', error: `could not fetch published pricing: ${err.message}` }; }
   let published;
   try { published = parse(markdown); }
-  catch (err) { return { ...out, status: 'infra_error', error: `could not parse published pricing: ${err.message}` }; }
+  catch (err) { return { ...out, status: 'infra_error', kind: 'parse', error: `could not parse published pricing: ${err.message}` }; }
   const ours = Object.fromEntries(Object.entries(table).map(([id, e]) => [id, comparable(e)]));
   const drift = [...diffPricing(ours, published), ...(extraDrift ?? [])].map((d) => ({ provider: name, ...d }));
   return { ...out, modelsPublished: Object.keys(published).length, drift, status: drift.length === 0 ? 'clean' : 'drift' };
@@ -376,9 +395,11 @@ async function main() {
   ];
   const drift = providers.flatMap((p) => p.drift ?? []);
   const undetermined = providers.filter((p) => p.status === 'infra_error');
-  // Drift anywhere is actionable and wins; otherwise a provider that could not
-  // be read means the whole run could not say "aligned".
-  const status = drift.length > 0 ? 'drift' : undetermined.length > 0 ? 'infra_error' : 'clean';
+  const blind = undetermined.some((p) => p.kind === 'parse');
+  // Drift anywhere is actionable and wins. A page that was fetched but not
+  // understood is next: the watcher is blind on that provider until someone
+  // looks, and that is a finding, not a flake. A fetch failure alone is.
+  const status = drift.length > 0 ? 'drift' : blind ? 'blind' : undetermined.length > 0 ? 'infra_error' : 'clean';
   console.log(JSON.stringify({
     ...report,
     modelsChecked: providers.reduce((n, p) => n + p.modelsChecked, 0),
@@ -388,7 +409,7 @@ async function main() {
     ...(undetermined.length > 0 ? { error: undetermined.map((p) => `${p.provider}: ${p.error}`).join('; ') } : {}),
     status,
   }, null, 2));
-  process.exit(status === 'drift' ? 1 : status === 'infra_error' ? 2 : 0);
+  process.exit(status === 'drift' ? 1 : status === 'blind' ? 3 : status === 'infra_error' ? 2 : 0);
 }
 
 function isMainModule() {

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -282,27 +282,30 @@ export const PRICING: Record<string, PricingEntry> = {
 
 /**
  * OpenAI's published per-1M-token rates for the models the codex backend
- * serves, standard tier, read off developers.openai.com/api/docs/pricing on
- * 2026-09-11. Kept apart from PRICING because scripts/check-pricing-drift.mjs
- * diffs that table against Anthropic's page and would report every row here
- * as "absent upstream". OpenAI charges nothing to write a cache entry, so
- * cacheCreate is the input rate (the codex path reports no cache writes
- * anyway — `cached_tokens` lands in cacheReadTokens, the rest in inputTokens).
+ * serves — the standard tier's short-context (<272K) columns of
+ * developers.openai.com/api/docs/pricing. Kept apart from PRICING because
+ * scripts/check-pricing-drift.mjs diffs each table against its own page
+ * (this one since 6.6.1; it shipped unwatched in 6.6.0, and the first watched
+ * run found the cache-write column wrong: the 5.6 family and gpt-6-astra
+ * charge 1.25× input to write a cache entry, the older families list no
+ * write price, encoded here as cacheCreate = input). The codex path reports
+ * no cache writes anyway — `cached_tokens` lands in cacheReadTokens, the
+ * rest in inputTokens — so the column is for correctness, not for a number
+ * anyone has seen yet.
  *
  * Before this table every `gpt-*` row was priced at the sonnet-4-6 fallback:
  * a ChatGPT-plan request showed up in "would-be API cost" at Anthropic's
- * rate for a model Anthropic does not sell. Nothing watches this table yet.
+ * rate for a model Anthropic does not sell.
  */
 export const OPENAI_PRICING: Record<string, Rate> = {
-  'gpt-6-astra': { input: 10, output: 50, cacheRead: 1, cacheCreate: 10 },
-  'gpt-5.6-sol': { input: 4, output: 20, cacheRead: 0.4, cacheCreate: 4 },
-  'gpt-5.6-terra': { input: 2, output: 12, cacheRead: 0.2, cacheCreate: 2 },
-  'gpt-5.6-luna': { input: 0.2, output: 1.2, cacheRead: 0.02, cacheCreate: 0.2 },
+  'gpt-6-astra': { input: 10, output: 50, cacheRead: 1, cacheCreate: 12.5 },
+  'gpt-5.6-sol': { input: 4, output: 20, cacheRead: 0.4, cacheCreate: 5 },
+  'gpt-5.6-terra': { input: 2, output: 12, cacheRead: 0.2, cacheCreate: 2.5 },
+  'gpt-5.6-luna': { input: 0.2, output: 1.2, cacheRead: 0.02, cacheCreate: 0.25 },
   'gpt-5.5': { input: 5, output: 30, cacheRead: 0.5, cacheCreate: 5 },
   'gpt-5.4': { input: 2.5, output: 15, cacheRead: 0.25, cacheCreate: 2.5 },
   'gpt-5.4-mini': { input: 0.75, output: 4.5, cacheRead: 0.075, cacheCreate: 0.75 },
   'gpt-5.4-nano': { input: 0.2, output: 1.25, cacheRead: 0.02, cacheCreate: 0.2 },
-  'gpt-5.3-codex': { input: 1.75, output: 14, cacheRead: 0.175, cacheCreate: 1.75 },
 };
 
 /** The unknown-model rate on the OpenAI side: dario's default codex model. */

--- a/test/ledger.mjs
+++ b/test/ledger.mjs
@@ -43,7 +43,7 @@ header('pricing: OpenAI rows, provider split, suffixes, fallbacks');
     && pricingRateFor('claude-mystery-9', T).input === PRICING['claude-sonnet-4-6'].input);
   check('[1m] tag still stripped on the Claude side', pricingRateFor('claude-sonnet-5[1m]', T).input === 2);
   check('the dated id a response echoes prices as its family (live 2026-09-12: claude-haiku-4-5-20251001 was at the sonnet fallback)', pricingRateFor('claude-haiku-4-5-20251001', T).input === 1 && pricingRateFor('claude-haiku-4-5-20251001', T).output === 5);
-  check('OpenAI cache writes cost the input rate (no separate write charge)', Object.values(OPENAI_PRICING).every((r) => r.cacheCreate === r.input));
+  check('OpenAI cache writes: 1.25x input on the 5.6 family and astra (the published column), the input rate where the page lists none', OPENAI_PRICING['gpt-5.6-terra'].cacheCreate === 2.5 && OPENAI_PRICING['gpt-6-astra'].cacheCreate === 12.5 && OPENAI_PRICING['gpt-5.5'].cacheCreate === OPENAI_PRICING['gpt-5.5'].input);
   const c = costOfTokens('claude-opus-5', T, { inputTokens: 1_000_000, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0 });
   check('costOfTokens: 1M opus-5 input tokens = $5', c === 5, c);
 }

--- a/test/pricing-drift.mjs
+++ b/test/pricing-drift.mjs
@@ -13,7 +13,8 @@
 // awkward parts: markdown links inside model cells, $0.50 and $12.50 cells,
 // and a retired model dario does not price.
 
-import { parsePricingTable, priceFromCell, modelIdFromDisplayName, diffPricing, staleIntroWindows }
+import { parsePricingTable, priceFromCell, modelIdFromDisplayName, diffPricing, staleIntroWindows, headerKey,
+  parseOpenAiPricingTable, openAiPriceFromCell, openAiModelIdFromCell }
   from '../scripts/check-pricing-drift.mjs';
 
 let pass = 0, fail = 0;
@@ -54,6 +55,11 @@ header('cell parsing');
   // A unit change would silently halve or double every number. Reject it.
   check('a different unit is NOT parsed as a price', priceFromCell('$5 / KTok') === null);
   check('a bare number is NOT parsed', priceFromCell('5') === null);
+  // The page's superscript footnote flattens into the cell ("$0.25 / MTok1",
+  // live 2026-09-12 on Fable 5.1); the row must still parse.
+  check('a trailing footnote marker is tolerated', priceFromCell('$0.25 / MTok1') === 0.25 && priceFromCell('$0.25 / MTok *1') === 0.25);
+  check('but not a second unit', priceFromCell('$0.25 / MTok / day') === null);
+  check('headerKey: "&" reads as "and", case and spacing fold', headerKey('Cache Hits & Refreshes') === 'cache hits and refreshes' && headerKey('  Cache hits and   refreshes ') === 'cache hits and refreshes');
 }
 
 header('model name -> dario id');
@@ -93,6 +99,12 @@ header('columns are matched by NAME, not position');
     r['claude-sonnet-5'].cacheCreate === 2.5 && r['claude-sonnet-5'].cacheRead === 0.2);
 }
 
+header('the 2026-09-02 rename: "&" became "and" and the watcher went blind for ten days');
+{
+  const r = parsePricingTable(DOC.replace('Cache Hits & Refreshes', 'Cache hits and refreshes'));
+  check('both spellings parse to the same table', r['claude-opus-5'].cacheRead === 0.5 && Object.keys(r).length === 10);
+}
+
 header('every way of NOT knowing throws — never a quiet "aligned"');
 {
   check('a renamed column throws',
@@ -118,6 +130,43 @@ header('picking the RIGHT table when several look alike');
   const r = parsePricingTable([DOC, '', '### Batch processing', '', batch].join('\n'));
   check('reads the model table, not the batch table', r['claude-sonnet-5'].input === 2);
   check('batch rates did not overwrite', r['claude-sonnet-5'].output === 10);
+}
+
+header("OpenAI's page: the standard table, by heading; '-' cells; context-length suffixes");
+{
+  const OH = '| Model | Short context input | Short context cached input | Short context cache writes | Short context output | Long context input | Long context cached input | Long context cache writes | Long context output |';
+  const OS = '| --- | --- | --- | --- | --- | --- | --- | --- | --- |';
+  const rows = (mult) => [
+    `| gpt-6-astra | $${10 * mult} | $${1 * mult} | $${12.5 * mult} | $${50 * mult} | $20 | $2 | $25 | $75 |`,
+    `| gpt-5.6-terra | $${2 * mult} | $${0.2 * mult} | $${2.5 * mult} | $${12 * mult} | $4 | $0.40 | $5 | $18 |`,
+    `| gpt-5.6-luna | $0.20 | $0.02 | $0.25 | $1.20 | - | - | - | - |`,
+    `| gpt-5.5 (<272K context length) | $5.00 | $0.50 | - | $30.00 | $10.00 | $1.00 | - | $45.00 |`,
+    `| gpt-5.5-pro (<272K context length) | $30.00 | - | - | $180.00 | - | - | - | - |`,
+    `| gpt-5.4-mini | $0.75 | $0.075 | - | $4.50 | - | - | - | - |`,
+    `| gpt-5.4-nano | $0.20 | $0.02 | - | $1.25 | - | - | - | - |`,
+    `| gpt-5 | $1.25 | $0.125 | - | $10.00 | - | - | - | - |`,
+    `| gpt-4o | $2.50 | $1.25 | - | $10.00 | - | - | - | - |`,
+    `| o3 | $2.00 | $0.50 | - | $8.00 | - | - | - | - |`,
+  ];
+  const page = (standard, batch = rows(0.5)) => ['# Pricing', '', 'Flagship models', '', '### Standard pricing data', '', OH, OS, ...standard, '', 'Batch', '', '### Batch pricing data', '', OH, OS, ...batch, ''].join('\n');
+  const r = parseOpenAiPricingTable(page(rows(1)));
+  check('reads the STANDARD table, not the batch one that carries the same headers below it', r['gpt-5.6-terra'].input === 2 && r['gpt-5.6-terra'].output === 12 && r['gpt-6-astra'].input === 10, JSON.stringify(r['gpt-5.6-terra']));
+  check('short-context cache writes are cacheCreate (the 5.6 family and astra charge 1.25× input)', r['gpt-5.6-terra'].cacheCreate === 2.5 && r['gpt-5.6-luna'].cacheCreate === 0.25 && r['gpt-6-astra'].cacheCreate === 12.5);
+  check("a '-' in cache writes means no write price: cacheCreate = input", r['gpt-5.5'].cacheCreate === 5 && r['gpt-5.4-mini'].cacheCreate === 0.75);
+  check("a '-' in cached input: cacheRead = input (the pro tiers)", r['gpt-5.5-pro'].cacheRead === 30 && r['gpt-5.5-pro'].cacheCreate === 30);
+  check('the context-length suffix is stripped from the id', r['gpt-5.5'] && r['gpt-5.5'].input === 5 && !Object.keys(r).some((k) => k.includes('272K')));
+  check('o-series and gpt-4o rows parse; ten rows in all', r['o3'].output === 8 && r['gpt-4o'].cacheRead === 1.25 && Object.keys(r).length === 10, Object.keys(r).join(','));
+  check('cells: "$12.50" -> 12.5, "-" -> null, junk -> undefined', openAiPriceFromCell('$12.50') === 12.5 && openAiPriceFromCell('-') === null && openAiPriceFromCell('$5 / MTok') === undefined && openAiPriceFromCell('') === undefined);
+  check('ids: gpt-/o-/codex- only, suffix and emphasis stripped', openAiModelIdFromCell('gpt-5.5 (<272K context length)') === 'gpt-5.5' && openAiModelIdFromCell('**o3-pro**') === 'o3-pro' && openAiModelIdFromCell('Model') === null && openAiModelIdFromCell('Claude Opus 5') === null);
+  // Every way of not knowing throws, as on the Anthropic side.
+  check('no "Standard pricing" heading throws', throws(() => parseOpenAiPricingTable(page(rows(1)).replace('### Standard pricing data', '### Prices')), /Standard pricing/));
+  check('a renamed column under the heading throws', throws(() => parseOpenAiPricingTable(page(rows(1)).replace('Short context cache writes', 'Cache write')), /no longer carries/));
+  check('a heading with no table under it throws', throws(() => parseOpenAiPricingTable('### Standard pricing data\n\nmoved\n\n### Batch pricing data\n\n' + OH + '\n' + OS + '\n' + rows(1).join('\n')), /no table under/));
+  check('a thin parse throws', throws(() => parseOpenAiPricingTable(page(rows(1).slice(0, 2))), /only 2 OpenAI model rows/));
+  check('HTML throws', throws(() => parseOpenAiPricingTable('<!DOCTYPE html><html></html>')));
+  // The diff is shared: an OpenAI row dario prices that the page dropped is reported like an Anthropic one.
+  const d = diffPricing({ 'gpt-5.6-terra': { input: 2, output: 12, cacheRead: 0.2, cacheCreate: 2 }, 'gpt-5.3-codex': { input: 1.75, output: 14, cacheRead: 0.175, cacheCreate: 1.75 } }, r);
+  check('diff reports the wrong cache-write rate and the row absent upstream', d.length === 2 && d.some((x) => x.model === 'gpt-5.6-terra' && x.field === 'cacheCreate' && x.ours === 2 && x.published === 2.5) && d.some((x) => x.model === 'gpt-5.3-codex' && x.field === '*'), JSON.stringify(d));
 }
 
 header('diff');


### PR DESCRIPTION
## What

Two things found while closing the trade-off #1295 documented ("nothing watches the OpenAI table"):

1. **The Anthropic pricing watcher has been blind since 2026-09-02.** Anthropic renamed one column ("Cache hits & refreshes" → "Cache hits and refreshes"). `check-pricing-drift.mjs` matches headers by name, exactly, so every daily run for ten days answered "could not determine" — exit 2, a `::warning` in a workflow log, nothing filed. That is the silent-stop failure the script's own header warns about, and the workflow's design ("exit 2 = warn and pass") is what let it happen: a page the watcher fetched but could not read was treated like a flaky network.
2. **`OPENAI_PRICING` shipped in 6.6.0 with the cache-write column wrong.** The summary I read the rates from omitted that column; the raw page says the 5.6 family and gpt-6-astra charge 1.25× input to write a cache entry. The codex path reports no cache writes, so no number anyone saw was affected — but the table was wrong, and the watcher is what should have said so.

## How

- `headerKey`: header cells fold `&`/`and`, case and spacing before matching (both parsers). Both the old and the new Anthropic spelling parse to the same table (test).
- `priceFromCell` tolerates the footnote marker the page flattens into a cell (`$0.25 / MTok1` on Fable 5.1 today); a second unit is still rejected.
- Exit codes split: **2 = could not fetch** (transient, warn as before) vs **3 = fetched but could not read** (the page changed shape — the watcher is blind). The workflow files exit 3 on the same `pricing-drift` issue, with a body that says which parser to look at. Exit 2 keeps its no-touch rule (never open on a flake, never close a real finding because the page was unreachable).
- `parseOpenAiPricingTable`: OpenAI's `pricing.md` (the same `.md` route Anthropic has), the **standard** table's short-context columns. Found by the `### Standard pricing data` heading, not by header content — the batch and fast-mode tables below it carry identical headers. `-` in cached-input / cache-writes = no separate price = the input rate (what the table encodes); `(<272K context length)` is stripped from ids; every way of not knowing throws.
- `checkProvider` runs both tables; one report with a `providers` array and a flat `drift` list where each row names its provider. Drift anywhere wins (1), then blind (3), then fetch failure (2), then clean (0).
- `OPENAI_PRICING` corrected: cacheCreate 12.5 / 5 / 2.5 / 0.25 for astra / sol / terra / luna; `gpt-5.3-codex` dropped (it is under "Specialized models", not the standard table, and the codex backend does not list it for the plan anyway).

## Verified

`node scripts/check-pricing-drift.mjs` against today's live pages:

```
clean 16 52
  anthropic clean 8 17 []
  openai clean 8 35 []
exit 0
```

Before the header fix the same run reported `anthropic: infra_error — could not find a pricing table carrying all of: …` — the exact text of every daily run since 2026-09-02 (checked run logs: 09-01 clean, 09-02 through 09-11 `infra_error`).

## Tests

`test/pricing-drift.mjs` (60): the rename (both spellings), the footnote marker, `headerKey`, the OpenAI parser (standard-not-batch by heading, `-` cells, pro tiers, suffix stripping, ten mixed rows, no heading / renamed column / empty heading / thin / HTML all throw), the shared diff reporting a wrong cache-write rate and a row absent upstream. `test/ledger.mjs` updated for the corrected cache-write rates. Full suite: 211 files pass.

Version 6.6.2 (fix; a corrected table and a watcher that files what it cannot read).
