### PR TITLE
drift-feed: do not fail CI when Pages site creation is denied

### DIFF
--- a/.github/workflows/drift-feed.yml
+++ b/.github/workflows/drift-feed.yml
@@ -64,10 +64,21 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      # Creates the Pages site on first run (source: GitHub Actions) — the
-      # workflow token can, a personal token could not.
-      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+      # Creates the Pages site on first run (source: GitHub Actions). The
+      # workflow token cannot do this until an org admin enables Pages for
+      # this repo once via Settings > Pages (site creation needs an
+      # administration-scoped token that neither GITHUB_TOKEN nor our PAT
+      # holds — see intervention 00MTXRXWUE8B4B8911FAAF62BC). Until then,
+      # skip deploy instead of hard-failing every master push/schedule.
+      - id: configure
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
         with:
           enablement: true
+        continue-on-error: true
+      - name: Warn if Pages site is not yet enabled
+        if: steps.configure.outcome != 'success'
+        run: |
+          echo "::warning::GitHub Pages site for askalf/dario does not exist and could not be created by the Actions token. An org admin must enable Pages once via Settings > Pages (source: GitHub Actions). Skipping deploy until then."
       - id: deployment
+        if: steps.configure.outcome == 'success'
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
## Problem

`Claude Code wire-drift feed` (drift-feed.yml) fails on **every** master push and on the daily schedule:

```
Get Pages site failed: Not Found
Create Pages site failed: Resource not accessible by integration
```

Latest failure: run 34668004677 (master `a16a6d6`, 2026-09-12T02:33:41Z).

The workflow's `deploy` job declares the right job-level permissions (`pages: write`, `id-token: write`, `contents: read`), so this is **not** a workflow-permissions bug. The GitHub Pages site for `askalf/dario` simply does not exist and the Actions token cannot create it.

## Reproduction (independent of Actions)

```
$ gh api repos/askalf/dario/pages
{"message":"Not Found","status":"404"}

$ gh api -X POST repos/askalf/dario/pages -f 'source[branch]=master' -f 'source[path]=/' -f build_type=workflow
{"message":"Resource not accessible by personal access token","status":"403"}
```

The askalf automation PAT hits the same 403. Creating a Pages site requires **administration**-scoped access, which neither `GITHUB_TOKEN` nor our PAT holds. So the one-time site enablement is an operator action (Settings → Pages → Source: GitHub Actions), not something this workflow can fix.

## What this PR changes

It stops the *symptom*: a red CI run on every push while the one-time enablement is pending.

- `actions/configure-pages` gets `continue-on-error: true` and an `id`.
- If it did not succeed, a `::warning::` annotation explains exactly what an admin must do.
- `actions/deploy-pages` runs only `if: steps.configure.outcome == 'success'`.

Net effect: once an admin enables Pages, the workflow deploys exactly as before with no further change. Until then it builds the feed, uploads the artifact, warns, and exits green instead of paging the fleet on every commit.

## Test plan

- YAML-only change; no source/runtime code touched.
- After merge, the next master push (or a `workflow_dispatch`) should show `build` green, `deploy` green with the "Pages site is not yet enabled" warning annotation, and no deploy attempt.
- After an operator enables Pages, re-dispatch: `configure` succeeds and `deploy-pages` publishes to https://askalf.github.io/dario/drift-feed.

## References

- Source ticket: `01M29XXKVY1BSXVFHKJ1EQQ84E`
- Finding: `00MTXRXNH170E3E3BA8AF5E00F`
- Operator intervention for the Pages enablement itself: `00MTXRXWUE8B4B8911FAAF62BC` (still required — this PR only removes the recurring red CI)