### PR TITLE
Sponsors, kept honest by a script (v6.6.3)

### DIFF
--- a/.github/workflows/cc-drift-auto-release.yml
+++ b/.github/workflows/cc-drift-auto-release.yml
@@ -465,6 +465,9 @@ jobs:
       - name: Extract release notes from CHANGELOG
         id: notes
         if: steps.gate.outputs.proceed == 'true'
+        env:
+          # For scripts/sponsors.mjs — public sponsorships only, read access is enough.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # Pull the section for this version from CHANGELOG.md so the
         # GitHub release body shows what was in the bump, not a generic
         # "see changelog" link.
@@ -480,6 +483,15 @@ jobs:
           set -eo pipefail
           VERSION="${{ steps.ver.outputs.version }}"
           node scripts/extract-release-notes.mjs "$VERSION" --file CHANGELOG.md > release-notes.md
+          # The sponsor tiers promise a thank-you in every release's notes.
+          # Best-effort by design: the script prints nothing and exits 0 on
+          # any failure, so a GraphQL hiccup never blocks a release.
+          thanks=$(node scripts/sponsors.mjs --thanks || true)
+          if [ -n "$thanks" ]; then
+            printf '
+%s
+' "$thanks" >> release-notes.md
+          fi
           echo "--- release-notes.md ---"
           cat release-notes.md
 

--- a/.github/workflows/cc-drift-auto-release.yml
+++ b/.github/workflows/cc-drift-auto-release.yml
@@ -488,9 +488,7 @@ jobs:
           # any failure, so a GraphQL hiccup never blocks a release.
           thanks=$(node scripts/sponsors.mjs --thanks || true)
           if [ -n "$thanks" ]; then
-            printf '
-%s
-' "$thanks" >> release-notes.md
+            printf '\n%s\n' "$thanks" >> release-notes.md
           fi
           echo "--- release-notes.md ---"
           cat release-notes.md

--- a/.github/workflows/sponsors-readme.yml
+++ b/.github/workflows/sponsors-readme.yml
@@ -76,6 +76,9 @@ jobs:
             exit 0
           fi
           gh label create no-changelog --color EDEDED --description "No CHANGELOG entry required" --force >/dev/null 2>&1 || true
+          # The body is literal prose: the $ and backticks in it are copy, not
+          # shell expansions, so the single quotes are deliberate.
+          # shellcheck disable=SC2016
           gh pr create --head "$branch" --base master --label no-changelog \
             --title "README: sponsors block refreshed" \
             --body "$(printf '%s\n' \

--- a/.github/workflows/sponsors-readme.yml
+++ b/.github/workflows/sponsors-readme.yml
@@ -1,0 +1,84 @@
+name: Sponsors README sync
+
+# The $25+ sponsor tiers promise a line in the README. This keeps that
+# promise without anyone remembering to: once a day, rebuild the marked
+# block from the public sponsor list (scripts/sponsors.mjs) and open a PR
+# when it changed. A PR, not a push — README changes go through review like
+# everything else, and a sponsor list is public copy. Never from a fork.
+#
+# Private sponsors are never named: the query asks for public sponsorships
+# only. Someone who sponsors privately and later goes public shows up on the
+# next run.
+
+on:
+  schedule:
+    # 06:41 UTC daily — off the hour, clear of the drift watchers (:00/:15/:27/:47) and the pricing watch (:23).
+    - cron: '41 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sponsors-readme
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    if: github.repository == 'askalf/dario'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: askalf/checkout-with-retry@115a6407547e9711edbc2e915838d495cad9583f  # v1.1.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+
+      - name: Rebuild the README sponsors block
+        id: sync
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # --write exits 1 when the sponsor list could not be read, so a
+          # broken read never becomes an empty list in a PR.
+          node scripts/sponsors.mjs --readme --write
+          if git diff --quiet -- README.md; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "README sponsors block unchanged."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git diff -- README.md
+          fi
+
+      - name: Open or refresh the PR
+        if: steps.sync.outputs.changed == 'true'
+        env:
+          # A PAT when one is configured, so the PR's checks run (GITHUB_TOKEN
+          # pushes do not trigger workflows); GITHUB_TOKEN otherwise.
+          GH_TOKEN: ${{ secrets.DARIO_DRIFT_BOT_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          branch="bot/sponsors-readme"
+          git config user.email "actions@github.com"
+          git config user.name "sponsors-readme[bot]"
+          git checkout -B "$branch"
+          git add README.md
+          git commit -m "README: sponsors block refreshed $(date -u +%Y-%m-%dT%H:%MZ)"
+          # One long-lived branch, force-pushed: the block is derived state,
+          # so the newest run is the only one worth reviewing.
+          git push --force origin "$branch"
+          existing="$(gh pr list --head "$branch" --base master --state open --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            echo "refreshed #$existing"
+            exit 0
+          fi
+          gh label create no-changelog --color EDEDED --description "No CHANGELOG entry required" --force >/dev/null 2>&1 || true
+          gh pr create --head "$branch" --base master --label no-changelog \
+            --title "README: sponsors block refreshed" \
+            --body "$(printf '%s\n' \
+              'The public sponsor list changed; this is the README block rebuilt from it by `scripts/sponsors.mjs` (the $25+ tiers promise a line here). Private sponsors are never named.' \
+              '' \
+              '_Auto-filed by `sponsors-readme.yml`._')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ checklist.
 
 ## [Unreleased]
 
+## [6.6.3] - 2026-09-12
+
+### Added
+
+- **Sponsors, kept honest by a script.** The GitHub Sponsors tiers promise a thank-you in every
+  release's notes and, from $25/month, a line in the README. `scripts/sponsors.mjs` reads the public
+  sponsor list (never private ones — the query does not ask) and renders both: the auto-release
+  workflow appends the thank-you to the release body, best-effort so a GraphQL hiccup never blocks a
+  release, and `sponsors-readme.yml` rebuilds the marked README block daily and opens a PR when it
+  changed. `test/sponsors.mjs` (19) covers the renderers, marker replacement and the fetch's failure
+  handling.
+
 ## [6.6.2] - 2026-09-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -663,6 +663,14 @@ Two easy ways to help beyond code: **star the repo**, the clearest signal this i
 | [@anupamme](https://github.com/anupamme) | Refresh-lock ownership by server-issued lock id ([#1059](https://github.com/askalf/dario/pull/1059)) |
 | [@LiveNathan](https://github.com/LiveNathan) | Never send or stamp empty text blocks ([#1067](https://github.com/askalf/dario/pull/1067)), empty final user turn from CC's stream-interruption retry ([#1092](https://github.com/askalf/dario/issues/1092), as [@NathanLively](https://github.com/NathanLively)) |
 
+### Sponsors
+
+<!-- sponsors:start -->
+dario is funded by its users through [GitHub Sponsors](https://github.com/sponsors/askalf) — the live-test seats it is checked against before every release are the biggest line item. Sponsors at $25/month and up are listed here.
+<!-- sponsors:end -->
+
+<sub>This block and the thank-you in each release's notes come from <a href="scripts/sponsors.mjs"><code>scripts/sponsors.mjs</code></a>, which reads the public sponsor list; <code>sponsors-readme.yml</code> opens a PR when it changes. Private sponsors are never named.</sub>
+
 ## Disclaimers
 
 **dario is an independent, unofficial, third-party project.** Not affiliated with, endorsed by, or sponsored by Anthropic, OpenAI, or any vendor referenced here. Provided as-is, no warranty. You are solely responsible for compliance with your subscription's terms, the security of your credentials, and the content you send through the proxy. Not for safety-critical, regulated, or production environments without your own review. Full text: [DISCLAIMER.md](DISCLAIMER.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askalf/dario",
-  "version": "6.6.2",
+  "version": "6.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askalf/dario",
-      "version": "6.6.2",
+      "version": "6.6.3",
       "license": "MIT",
       "bin": {
         "dario": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askalf/dario",
-  "version": "6.6.2",
+  "version": "6.6.3",
   "description": "Use your Claude and ChatGPT subscriptions in Cursor, Cline, Aider, Claude Code and the Agent SDK — at subscription pricing, not per-token API bills. One local Anthropic + OpenAI-compatible endpoint: either plan answers either wire shape, with automatic failover when one hits its limit.",
   "type": "module",
   "bin": {

--- a/scripts/sponsors.mjs
+++ b/scripts/sponsors.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+/**
+ * Sponsors — the two places the GitHub Sponsors tiers promise a name.
+ *
+ * The tiers on github.com/sponsors/askalf say: every sponsor gets a
+ * thank-you in the release notes, and the $25+ tiers get their name in the
+ * README. A promise kept by memory is a promise broken within a month, so
+ * both come from one query here:
+ *
+ *   node scripts/sponsors.mjs --thanks            release-notes block (stdout)
+ *   node scripts/sponsors.mjs --readme            README block (stdout)
+ *   node scripts/sponsors.mjs --readme --write    rewrite the README block in place
+ *
+ * Reads the maintainer's ACTIVE, PUBLIC sponsorships through the GraphQL
+ * API (`GH_TOKEN` / `GITHUB_TOKEN`, or `gh auth token`). Private sponsors
+ * are never named — the query does not even ask for them. The release path
+ * is best-effort: any failure prints nothing and exits 0, because a release
+ * must never fail on a thank-you. `--write` exits 1 on a failure, since a
+ * bot commit built on a broken read would silently empty the list.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+export const MAINTAINER = 'askalf';
+export const README_START = '<!-- sponsors:start -->';
+export const README_END = '<!-- sponsors:end -->';
+/** Tiers at or above this monthly amount are the ones that promised a README line. */
+export const README_TIER_MIN_USD = 25;
+
+const QUERY = `query($login: String!) {
+  user(login: $login) {
+    sponsorshipsAsMaintainer(first: 100, activeOnly: true, includePrivate: false) {
+      nodes {
+        isOneTimePayment
+        tier { monthlyPriceInDollars isOneTime }
+        sponsorEntity {
+          __typename
+          ... on User { login name }
+          ... on Organization { login name }
+        }
+      }
+    }
+  }
+}`;
+
+/**
+ * Normalise the API's sponsorship nodes into what the renderers need.
+ * A node without a login (a deleted account, an unexpected entity type) is
+ * dropped rather than rendered as "undefined".
+ */
+export function normalizeSponsors(nodes) {
+  const out = [];
+  for (const n of Array.isArray(nodes) ? nodes : []) {
+    const e = n && n.sponsorEntity;
+    if (!e || typeof e.login !== 'string' || e.login.length === 0) continue;
+    const monthly = n.tier && typeof n.tier.monthlyPriceInDollars === 'number' ? n.tier.monthlyPriceInDollars : 0;
+    const oneTime = Boolean(n.isOneTimePayment || (n.tier && n.tier.isOneTime));
+    out.push({ login: e.login, name: typeof e.name === 'string' && e.name.trim() ? e.name.trim() : null, monthly, oneTime });
+  }
+  // Highest tier first, then by login, so the order is stable between runs.
+  return out.sort((a, b) => (b.monthly - a.monthly) || a.login.localeCompare(b.login));
+}
+
+const mention = (s) => `[@${s.login}](https://github.com/${s.login})`;
+
+/**
+ * The release-notes block. Empty string when there is nobody to thank, so
+ * the workflow can append it unconditionally.
+ */
+export function renderThanks(sponsors) {
+  if (sponsors.length === 0) return '';
+  const names = sponsors.map(mention);
+  const list = names.length === 1 ? names[0]
+    : names.length === 2 ? `${names[0]} and ${names[1]}`
+    : `${names.slice(0, -1).join(', ')}, and ${names[names.length - 1]}`;
+  return `**Thanks to the sponsors behind this release:** ${list}. [Sponsor dario](https://github.com/sponsors/${MAINTAINER}).\n`;
+}
+
+/**
+ * The README block: the sponsors whose tier promised a line, or a single
+ * sentence pointing at the listing when there are none yet. Always wrapped
+ * in the markers so `--write` can find it again.
+ */
+export function renderReadmeBlock(sponsors) {
+  const named = sponsors.filter((s) => !s.oneTime && s.monthly >= README_TIER_MIN_USD);
+  const lines = [README_START];
+  if (named.length === 0) {
+    lines.push(`dario is funded by its users through [GitHub Sponsors](https://github.com/sponsors/${MAINTAINER}) — the live-test seats it is checked against before every release are the biggest line item. Sponsors at $${README_TIER_MIN_USD}/month and up are listed here.`);
+  } else {
+    lines.push(`dario is funded by its users through [GitHub Sponsors](https://github.com/sponsors/${MAINTAINER}). Thank you:`);
+    lines.push('');
+    for (const s of named) lines.push(`- ${mention(s)}${s.name ? ` — ${s.name}` : ''}`);
+  }
+  lines.push(README_END);
+  return lines.join('\n');
+}
+
+/** Replace the marked block in README text; throws when the markers are missing. */
+export function replaceReadmeBlock(readme, block) {
+  const a = readme.indexOf(README_START);
+  const b = readme.indexOf(README_END);
+  if (a === -1 || b === -1 || b < a) throw new Error(`README is missing the ${README_START} … ${README_END} markers`);
+  return readme.slice(0, a) + block + readme.slice(b + README_END.length);
+}
+
+function token() {
+  const env = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+  if (env) return env;
+  try { return execFileSync('gh', ['auth', 'token'], { encoding: 'utf8' }).trim(); } catch { return null; }
+}
+
+export async function fetchSponsors(login = MAINTAINER, fetchImpl = fetch) {
+  const t = token();
+  if (!t) throw new Error('no GitHub token (GH_TOKEN / GITHUB_TOKEN / gh auth)');
+  const res = await fetchImpl('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: { authorization: `bearer ${t}`, 'content-type': 'application/json', 'user-agent': 'dario-sponsors' },
+    body: JSON.stringify({ query: QUERY, variables: { login } }),
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!res.ok) throw new Error(`GraphQL HTTP ${res.status}`);
+  const json = await res.json();
+  const nodes = json && json.data && json.data.user && json.data.user.sponsorshipsAsMaintainer && json.data.user.sponsorshipsAsMaintainer.nodes;
+  if (!Array.isArray(nodes)) throw new Error(`unexpected GraphQL shape: ${JSON.stringify(json).slice(0, 200)}`);
+  return normalizeSponsors(nodes);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const thanks = args.includes('--thanks');
+  const readme = args.includes('--readme');
+  const write = args.includes('--write');
+  if (!thanks && !readme) {
+    console.error('usage: sponsors.mjs --thanks | --readme [--write]');
+    process.exit(2);
+  }
+  let sponsors;
+  try {
+    sponsors = await fetchSponsors();
+  } catch (err) {
+    console.error(`sponsors: ${err.message}`);
+    // A release must never fail on a thank-you; a README rewrite must
+    // never be built on a failed read.
+    process.exit(write ? 1 : 0);
+  }
+  if (thanks) process.stdout.write(renderThanks(sponsors));
+  if (readme) {
+    const block = renderReadmeBlock(sponsors);
+    if (!write) { process.stdout.write(block + '\n'); return; }
+    const path = resolve(fileURLToPath(new URL('../README.md', import.meta.url)));
+    const before = readFileSync(path, 'utf8');
+    const after = replaceReadmeBlock(before, block);
+    if (after !== before) { writeFileSync(path, after); console.error('sponsors: README block updated'); }
+    else console.error('sponsors: README block unchanged');
+  }
+}
+
+function isMainModule() {
+  if (!process.argv[1]) return false;
+  try { return resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url)); }
+  catch { return false; }
+}
+
+if (isMainModule()) await main();

--- a/test/sponsors.mjs
+++ b/test/sponsors.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+// Tests for scripts/sponsors.mjs — the renderers behind the release-notes
+// thank-you and the README block, and the fetch's handling of the API.
+// Pure: fixtures in, markdown out; the one network path takes a fetchImpl.
+
+import { normalizeSponsors, renderThanks, renderReadmeBlock, replaceReadmeBlock, fetchSponsors, README_START, README_END, README_TIER_MIN_USD }
+  from '../scripts/sponsors.mjs';
+
+let pass = 0, fail = 0;
+const check = (name, cond, detail) => {
+  if (cond) { console.log(`  OK ${name}`); pass++; }
+  else { console.log(`  FAIL ${name}${detail !== undefined ? ' :: ' + String(detail).slice(0, 300) : ''}`); fail++; }
+};
+const header = (n) => console.log(`\n=== ${n} ===`);
+
+const node = (login, monthly, extra = {}) => ({
+  isOneTimePayment: false,
+  tier: { monthlyPriceInDollars: monthly, isOneTime: false },
+  sponsorEntity: { __typename: 'User', login, name: null },
+  ...extra,
+});
+
+header('normalizeSponsors: stable order, junk dropped');
+{
+  const s = normalizeSponsors([
+    node('zed', 5), node('amy', 100, { sponsorEntity: { __typename: 'Organization', login: 'amy', name: 'Amy Corp' } }),
+    node('bob', 25), node('cat', 25),
+    { isOneTimePayment: true, tier: { monthlyPriceInDollars: 50, isOneTime: true }, sponsorEntity: { __typename: 'User', login: 'dan', name: '  ' } },
+    { sponsorEntity: null }, { sponsorEntity: { __typename: 'User' } }, null,
+  ]);
+  check('highest tier first, then login; deleted / nameless entities dropped', s.map((x) => x.login).join(',') === 'amy,dan,bob,cat,zed', s.map((x) => x.login).join(','));
+  check('org name kept, blank name is null, one-time flagged', s[0].name === 'Amy Corp' && s[1].name === null && s[1].oneTime === true && s[2].oneTime === false);
+  check('empty input → empty list', normalizeSponsors(undefined).length === 0 && normalizeSponsors([]).length === 0);
+}
+
+header('renderThanks: the release-notes line');
+{
+  check('nobody → empty string (the workflow appends unconditionally)', renderThanks([]) === '');
+  const one = renderThanks(normalizeSponsors([node('amy', 5)]));
+  check('one sponsor', one === '**Thanks to the sponsors behind this release:** [@amy](https://github.com/amy). [Sponsor dario](https://github.com/sponsors/askalf).\n', one);
+  const two = renderThanks(normalizeSponsors([node('amy', 5), node('bob', 5)]));
+  check('two sponsors: "and"', two.includes('[@amy](https://github.com/amy) and [@bob](https://github.com/bob).'), two);
+  const three = renderThanks(normalizeSponsors([node('amy', 5), node('bob', 5), node('cat', 5)]));
+  check('three: Oxford comma', three.includes('[@amy](https://github.com/amy), [@bob](https://github.com/bob), and [@cat](https://github.com/cat).'), three);
+  check('one-time sponsors are thanked too', renderThanks(normalizeSponsors([node('dan', 50, { isOneTimePayment: true })])).includes('@dan'));
+}
+
+header('renderReadmeBlock: the $25+ monthly tiers, wrapped in markers');
+{
+  const empty = renderReadmeBlock([]);
+  check('no sponsors → the pointer sentence, inside the markers', empty.startsWith(README_START) && empty.endsWith(README_END) && empty.includes(`Sponsors at $${README_TIER_MIN_USD}/month and up are listed here`), empty);
+  const block = renderReadmeBlock(normalizeSponsors([
+    node('amy', 100, { sponsorEntity: { __typename: 'Organization', login: 'amy', name: 'Amy Corp' } }),
+    node('bob', 25), node('zed', 5),
+    node('dan', 50, { isOneTimePayment: true }),
+  ]));
+  check('$100 and $25 listed, highest first, with the name when there is one', block.includes('- [@amy](https://github.com/amy) — Amy Corp\n- [@bob](https://github.com/bob)'), block);
+  check('the $5 tier and a one-time $50 are not listed (the tier promised no README line)', !block.includes('@zed') && !block.includes('@dan'), block);
+  check('markers on both ends', block.startsWith(README_START) && block.endsWith(README_END));
+}
+
+header('replaceReadmeBlock');
+{
+  const readme = `# dario\n\nintro\n\n### Sponsors\n\n${README_START}\nold\n${README_END}\n\n## License\n`;
+  const out = replaceReadmeBlock(readme, renderReadmeBlock([]));
+  check('replaces exactly the marked block, leaves the rest', out.startsWith('# dario\n\nintro\n\n### Sponsors\n\n') && out.endsWith('\n\n## License\n') && !out.includes('\nold\n') && out.includes('Sponsors at $'), out);
+  check('idempotent', replaceReadmeBlock(out, renderReadmeBlock([])) === out);
+  let threw = false;
+  try { replaceReadmeBlock('# no markers here', renderReadmeBlock([])); } catch { threw = true; }
+  check('missing markers throw (never append blindly)', threw);
+}
+
+header('fetchSponsors: token, shape, failure');
+{
+  process.env.GH_TOKEN = 'test-token';
+  const calls = [];
+  const okFetch = async (url, init) => { calls.push({ url, init }); return new Response(JSON.stringify({ data: { user: { sponsorshipsAsMaintainer: { nodes: [node('amy', 25)] } } } }), { status: 200 }); };
+  const got = await fetchSponsors('askalf', okFetch);
+  const body = JSON.parse(calls[0].init.body);
+  check('POSTs the GraphQL query with the bearer token, public-only', calls[0].url === 'https://api.github.com/graphql' && calls[0].init.headers.authorization === 'bearer test-token' && body.variables.login === 'askalf' && body.query.includes('includePrivate: false') && body.query.includes('activeOnly: true'));
+  check('normalised result', got.length === 1 && got[0].login === 'amy' && got[0].monthly === 25);
+  let err = null;
+  try { await fetchSponsors('askalf', async () => new Response('nope', { status: 502 })); } catch (e) { err = e.message; }
+  check('HTTP failure throws (the caller decides: release = swallow, --write = fail)', err === 'GraphQL HTTP 502', err);
+  err = null;
+  try { await fetchSponsors('askalf', async () => new Response(JSON.stringify({ errors: [{ message: 'x' }] }), { status: 200 })); } catch (e) { err = e.message; }
+  check('an unexpected shape throws rather than reading as "no sponsors"', err && err.startsWith('unexpected GraphQL shape'), err);
+  delete process.env.GH_TOKEN;
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## What

The GitHub Sponsors profile for askalf went up today (pending Stripe). Its tiers promise two things this repo has to deliver: a thank-you in every release's notes, and, from $25/month, a line in the README. A promise kept by memory is broken within a month, so both come from one script.

## How

- `scripts/sponsors.mjs` — one GraphQL query for the maintainer's **active, public** sponsorships (`includePrivate: false`; private sponsors are never named, the query does not ask). Two renderers: `--thanks` (the release-notes line, empty string when there is nobody) and `--readme` (the marked block; `--write` rewrites it in place between `<!-- sponsors:start/end -->`). Highest tier first, then login, so output is stable between runs.
- `cc-drift-auto-release.yml` — appends the thank-you to `release-notes.md` after the CHANGELOG extraction. **Best-effort by design:** any failure prints nothing and exits 0, so a GraphQL hiccup never blocks a release. The step gets `GITHUB_TOKEN` (read access is enough for public sponsorships).
- `sponsors-readme.yml` — daily, rebuilds the README block and opens/refreshes a PR (`bot/sponsors-readme`, force-pushed: derived state, only the newest run is worth reviewing) when it changed. A PR, not a push — the sponsor list is public copy and goes through review like everything else. `--write` exits 1 on a failed read, so an API outage can never turn into an empty list in a PR. Uses `DARIO_DRIFT_BOT_PAT || GITHUB_TOKEN` like the template watcher so the PR's checks run.
- README gains a `### Sponsors` section with the marked block and a one-line note on where it comes from.

## Verified

- `node scripts/sponsors.mjs --readme` and `--thanks` run live against the real listing (currently zero sponsors → pointer sentence / empty thank-you; exit 0).
- `--readme --write` against the real README: "block unchanged" (idempotent).
- Both workflow steps pass `bash -n`; YAML parses; actions are the SHA-pinned ones already in use.
- `test/sponsors.mjs` (19): normalisation and ordering, the one/two/three-name thank-you, the README block's tier cut-off (a $5 tier and a one-time $50 are thanked but not listed), marker replacement (idempotent, throws without markers), and the fetch's failure handling (HTTP error and an unexpected shape both throw — the caller decides).
- Full suite: 212 files pass.

## Why a version

No `src/` change, but the release body is the artefact this changes — v6.6.3's release notes are the first run of the hook (it will be empty until the first sponsor). That is the live test.
